### PR TITLE
Enhance the CI with label

### DIFF
--- a/.github/workflows/ai-service-ci.yaml
+++ b/.github/workflows/ai-service-ci.yaml
@@ -4,6 +4,8 @@
 name: AI Service CI
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     types: [ labeled ]
 
@@ -22,7 +24,7 @@ defaults:
 
 jobs:
   ci:
-    if: ${{ github.event.label.name == 'ci/ai-service' }}
+    if: ${{ github.event.label.name == 'ci/ai-service' || github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The goal is to improve the method for triggering CI workflows upon labeling PRs. Here are the key behaviors to note:
- Adding the `ci/ai-service` label will initiate the workflow for the AI service.
- Removing the `ci/ai-service` label will not trigger any action.
- If the `ci/ai-service` label is added while a workflow for this PR is already in progress, it will cancel the previous action.

There are the related documents of Github Action
- https://docs.github.com/en/actions/learn-github-actions/expressions#example
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=labeled#pull_request
- https://docs.github.com/en/actions/using-jobs/using-concurrency

## Screenshots
<img width="1097" alt="image" src="https://github.com/Canner/WrenAI/assets/52045032/0f3f778d-5d0e-49e2-9b17-21338054321e">
