### PR TITLE
Chore: Add a optional input to determine whether putting the latest tag on docker image

### DIFF
--- a/.github/workflows/ai-service-build-image.yaml
+++ b/.github/workflows/ai-service-build-image.yaml
@@ -1,8 +1,6 @@
 name: AI Service Build image
 
 on:
-  pull_request:
-    types: [ labeled ]
   workflow_dispatch:
     inputs:
       docker_image_tag_name:


### PR DESCRIPTION
This PR aims to add an option to put the `latest` tag on the docker image.
I think it would be like:
<img width="581" alt="image" src="https://github.com/Canner/WrenAI/assets/52045032/b50c57dc-4f83-46dd-b815-f2f5bfbcdff8">

Also, use the environment file to put the output variable instead of set-output command.

![image](https://github.com/Canner/WrenAI/assets/52045032/ec63b940-7006-4d9c-9832-12fb141f30bd)

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

## Screenshot
<img width="1802" alt="image" src="https://github.com/Canner/WrenAI/assets/52045032/75656862-e5e4-42e8-9d76-864ebb85c36a">
<img width="1802" alt="image" src="https://github.com/Canner/WrenAI/assets/52045032/aca137b6-9a4e-4bb4-87d5-d4ee1f701fca">
