### PR TITLE
chore(wren-ui): fix warning about sqlite does not support inserting default values

### DIFF
--- a/wren-ui/knexfile.js
+++ b/wren-ui/knexfile.js
@@ -14,5 +14,6 @@ if (process.env.DB_TYPE === 'pg') {
   module.exports = {
     client: 'better-sqlite3',
     connection: process.env.SQLITE_FILE || './db.sqlite3',
+    useNullAsDefault: true
   };
 }


### PR DESCRIPTION
## Description
We will see the warning when we use script to migrate, please refer to the screenshot below.

### Before
![截圖 2024-04-02 上午10 04 21](https://github.com/Canner/WrenAI/assets/42527625/a57c2bdc-b3e3-4b5f-8cc6-aa0263136606)

### After
![截圖 2024-04-02 上午10 23 22](https://github.com/Canner/WrenAI/assets/42527625/71d5cc17-9eee-48ff-a83f-f9a341f1f84e)

## Refer
 - https://knexjs.org/guide/query-builder.html#insert
 - https://stackoverflow.com/questions/41030694/how-does-knex-handle-default-values-in-sqlite