### PR TITLE
fix(wren-ui): Update relationship selector validation logic and UI

### DIFF
--- a/wren-ui/src/components/modals/AddRelationModal.tsx
+++ b/wren-ui/src/components/modals/AddRelationModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { isEmpty } from 'lodash';
-import { Modal, Form, Select, Row, Col } from 'antd';
+import { Modal, Form, Select } from 'antd';
 import { ModalAction } from '@/hooks/useModalAction';
 import { ERROR_TEXTS } from '@/utils/error';
 import CombineFieldSelector from '@/components/selectors/CombineFieldSelector';
@@ -136,55 +136,49 @@ export default function RelationModal(props: Props) {
       centered
     >
       <Form form={form} preserve={false} layout="vertical">
-        <Row gutter={16}>
-          <Col span={12}>
-            <Form.Item
-              label="From"
-              name="fromField"
-              required
-              rules={[
-                {
-                  required: true,
-                  message: ERROR_TEXTS.ADD_RELATION.FROM_FIELD.REQUIRED,
-                },
-              ]}
-            >
-              <CombineFieldSelector
-                modelValue={modelValue}
-                modelDisabled={true}
-                onModelChange={fromCombineField.onModelChange}
-                modelOptions={fromCombineField.modelOptions}
-                fieldOptions={fromCombineField.fieldOptions}
-              />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="To"
-              name="toField"
-              required
-              rules={[
-                () => ({
-                  validator(_, value) {
-                    if (!value || !value.field) {
-                      return Promise.reject(
-                        ERROR_TEXTS.ADD_RELATION.TO_FIELD.REQUIRED,
-                      );
-                    }
+        <Form.Item
+          label="From"
+          name="fromField"
+          required
+          rules={[
+            {
+              required: true,
+              message: ERROR_TEXTS.ADD_RELATION.FROM_FIELD.REQUIRED,
+            },
+          ]}
+        >
+          <CombineFieldSelector
+            modelValue={modelValue}
+            modelDisabled={true}
+            onModelChange={fromCombineField.onModelChange}
+            modelOptions={fromCombineField.modelOptions}
+            fieldOptions={fromCombineField.fieldOptions}
+          />
+        </Form.Item>
+        <Form.Item
+          label="To"
+          name="toField"
+          required
+          rules={[
+            () => ({
+              validator(_, value) {
+                if (!value || !value.field) {
+                  return Promise.reject(
+                    ERROR_TEXTS.ADD_RELATION.TO_FIELD.REQUIRED,
+                  );
+                }
 
-                    return Promise.resolve();
-                  },
-                }),
-              ]}
-            >
-              <CombineFieldSelector
-                onModelChange={toCombineField.onModelChange}
-                modelOptions={toCombineModelOptions}
-                fieldOptions={toCombineField.fieldOptions}
-              />
-            </Form.Item>
-          </Col>
-        </Row>
+                return Promise.resolve();
+              },
+            }),
+          ]}
+        >
+          <CombineFieldSelector
+            onModelChange={toCombineField.onModelChange}
+            modelOptions={toCombineModelOptions}
+            fieldOptions={toCombineField.fieldOptions}
+          />
+        </Form.Item>
         <Form.Item
           label="Relation type"
           name="type"

--- a/wren-ui/src/components/selectors/CombineFieldSelector.tsx
+++ b/wren-ui/src/components/selectors/CombineFieldSelector.tsx
@@ -62,7 +62,7 @@ export default function CombineFieldSelector(props: Props) {
   return (
     <Input.Group className="d-flex" compact>
       <Select
-        style={{ width: 120 }}
+        style={{ width: '35%' }}
         options={modelOptions}
         onChange={changeModel}
         placeholder="Model"


### PR DESCRIPTION
## Description
Update relationship selector validation logic and UI

## Tasks
 - [x] For update mode, after the user changes to another Model, must be able to change back to the original Model.
 - [x] Fix  validate logic
 - [x] Update Relation Modal UI

### UI
#### before

![before](https://github.com/Canner/WrenAI/assets/42527625/b14245be-53bf-433b-a6bb-f7612c8bd07d)

#### After
![after](https://github.com/Canner/WrenAI/assets/42527625/ba8e72ed-a84d-4423-9407-bb1cba4f5c3c)

