### PR TITLE
chore(wren-ui): GetServerSideProps causes slow page initial load

### DIFF
--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -1,5 +1,5 @@
-import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
+import { useParams } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
 import { Path } from '@/utils/enum';
 import useHomeSidebar from '@/hooks/useHomeSidebar';
@@ -13,9 +13,11 @@ import {
 import useAskPrompt, { getIsFinished } from '@/hooks/useAskPrompt';
 import PromptThread from '@/components/pages/home/promptThread';
 
-export default function HomeThread({ threadId }) {
+export default function HomeThread() {
   const router = useRouter();
+  const params = useParams();
   const homeSidebar = useHomeSidebar();
+  const threadId = useMemo(() => Number(params?.id) || null, [params]);
   const askPrompt = useAskPrompt(threadId);
 
   const {
@@ -25,6 +27,7 @@ export default function HomeThread({ threadId }) {
   } = useThreadQuery({
     variables: { threadId },
     fetchPolicy: 'cache-and-network',
+    skip: threadId === null,
     onError: () => router.push(Path.Home),
   });
   const [createThreadResponse] = useCreateThreadResponseMutation({
@@ -108,11 +111,3 @@ export default function HomeThread({ threadId }) {
     </SiderLayout>
   );
 }
-
-export const getServerSideProps = (async (context) => {
-  return {
-    props: {
-      threadId: Number(context.params.id),
-    },
-  };
-}) as GetServerSideProps<{ threadId: number }>;


### PR DESCRIPTION
## Description

Next.js getServerSideProps will build a json file that needs to be loaded every time the user navigates to the dynamic route.
The json file might be large, so it will take extra time to load. After browser caching, it will become very fast to navigate.

Consider that we can actually use other ways to prevent the issue, so I decided to remove getServerSideProps and let the client side handle the condition of dynamic parameters.