### PR TITLE
feat(wren-ui): Support deploy with show status on modeling page 

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -92,6 +92,11 @@ export type CreateThreadResponseInput = {
   summary: Scalars['String'];
 };
 
+export type CreateViewInput = {
+  name: Scalars['String'];
+  responseId: Scalars['Int'];
+};
+
 export type CustomFieldInput = {
   expression: Scalars['String'];
   name: Scalars['String'];
@@ -168,6 +173,7 @@ export type DetailedThread = {
 export type Diagram = {
   __typename?: 'Diagram';
   models: Array<Maybe<DiagramModel>>;
+  views: Array<Maybe<DiagramView>>;
 };
 
 export type DiagramModel = {
@@ -213,6 +219,26 @@ export type DiagramModelRelationField = {
   toColumnName: Scalars['String'];
   toModelName: Scalars['String'];
   type: RelationType;
+};
+
+export type DiagramView = {
+  __typename?: 'DiagramView';
+  displayName: Scalars['String'];
+  fields: Array<Maybe<DiagramViewField>>;
+  id: Scalars['String'];
+  nodeType: NodeType;
+  referenceName: Scalars['String'];
+  statement: Scalars['String'];
+  viewId: Scalars['Int'];
+};
+
+export type DiagramViewField = {
+  __typename?: 'DiagramViewField';
+  displayName: Scalars['String'];
+  id: Scalars['String'];
+  nodeType: NodeType;
+  referenceName: Scalars['String'];
+  type: Scalars['String'];
 };
 
 export type DimensionInput = {
@@ -267,7 +293,7 @@ export type ModelInfo = {
 
 export type ModelSyncResponse = {
   __typename?: 'ModelSyncResponse';
-  isSyncronized: Scalars['Boolean'];
+  status: SyncStatus;
 };
 
 export type ModelWhereInput = {
@@ -281,16 +307,20 @@ export type Mutation = {
   createModel: Scalars['JSON'];
   createThread: Thread;
   createThreadResponse: ThreadResponse;
+  createView: ViewInfo;
   deleteModel: Scalars['Boolean'];
   deleteThread: Scalars['Boolean'];
+  deleteView: Scalars['Boolean'];
   deploy: Scalars['JSON'];
   previewData: Scalars['JSON'];
+  previewViewData: Scalars['JSON'];
   saveDataSource: DataSource;
   saveRelations: Scalars['JSON'];
   saveTables: Scalars['JSON'];
   startSampleDataset: Scalars['JSON'];
   updateModel: Scalars['JSON'];
   updateThread: Thread;
+  validateView: ViewValidationResponse;
 };
 
 
@@ -320,6 +350,11 @@ export type MutationCreateThreadResponseArgs = {
 };
 
 
+export type MutationCreateViewArgs = {
+  data: CreateViewInput;
+};
+
+
 export type MutationDeleteModelArgs = {
   where: ModelWhereInput;
 };
@@ -330,8 +365,18 @@ export type MutationDeleteThreadArgs = {
 };
 
 
+export type MutationDeleteViewArgs = {
+  where: ViewWhereUniqueInput;
+};
+
+
 export type MutationPreviewDataArgs = {
   where: PreviewDataInput;
+};
+
+
+export type MutationPreviewViewDataArgs = {
+  where: ViewWhereUniqueInput;
 };
 
 
@@ -364,6 +409,11 @@ export type MutationUpdateModelArgs = {
 export type MutationUpdateThreadArgs = {
   data: UpdateThreadInput;
   where: ThreadUniqueWhereInput;
+};
+
+
+export type MutationValidateViewArgs = {
+  data: ValidateViewInput;
 };
 
 export enum NodeType {
@@ -399,13 +449,15 @@ export type Query = {
   diagram: Diagram;
   listDataSourceTables: Array<CompactTable>;
   listModels: Array<ModelInfo>;
+  listViews: Array<ViewInfo>;
   model: DetailedModel;
-  modelSync?: Maybe<ModelSyncResponse>;
+  modelSync: ModelSyncResponse;
   onboardingStatus: OnboardingStatusResponse;
   suggestedQuestions: SuggestedQuestionResponse;
   thread: DetailedThread;
   threadResponse: ThreadResponse;
   threads: Array<Thread>;
+  view: ViewInfo;
 };
 
 
@@ -426,6 +478,11 @@ export type QueryThreadArgs = {
 
 export type QueryThreadResponseArgs = {
   responseId: Scalars['Int'];
+};
+
+
+export type QueryViewArgs = {
+  where: ViewWhereUniqueInput;
 };
 
 export type RecommandRelations = {
@@ -506,6 +563,12 @@ export type SuggestedQuestionResponse = {
   questions: Array<Maybe<SuggestedQuestion>>;
 };
 
+export enum SyncStatus {
+  IN_PROGRESS = 'IN_PROGRESS',
+  SYNCRONIZED = 'SYNCRONIZED',
+  UNSYNCRONIZED = 'UNSYNCRONIZED'
+}
+
 export type Task = {
   __typename?: 'Task';
   id: Scalars['String'];
@@ -555,4 +618,25 @@ export type UpdateModelInput = {
 
 export type UpdateThreadInput = {
   summary?: InputMaybe<Scalars['String']>;
+};
+
+export type ValidateViewInput = {
+  name: Scalars['String'];
+};
+
+export type ViewInfo = {
+  __typename?: 'ViewInfo';
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  statement: Scalars['String'];
+};
+
+export type ViewValidationResponse = {
+  __typename?: 'ViewValidationResponse';
+  message?: Maybe<Scalars['String']>;
+  valid: Scalars['Boolean'];
+};
+
+export type ViewWhereUniqueInput = {
+  id: Scalars['Int'];
 };

--- a/wren-ui/src/apollo/client/graphql/deploy.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/deploy.generated.ts
@@ -1,0 +1,80 @@
+import * as Types from './__types__';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type DeployMutationVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type DeployMutation = { __typename?: 'Mutation', deploy: any };
+
+export type DeployStatusQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type DeployStatusQuery = { __typename?: 'Query', modelSync: { __typename?: 'ModelSyncResponse', status: Types.SyncStatus } };
+
+
+export const DeployDocument = gql`
+    mutation Deploy {
+  deploy
+}
+    `;
+export type DeployMutationFn = Apollo.MutationFunction<DeployMutation, DeployMutationVariables>;
+
+/**
+ * __useDeployMutation__
+ *
+ * To run a mutation, you first call `useDeployMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeployMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deployMutation, { data, loading, error }] = useDeployMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useDeployMutation(baseOptions?: Apollo.MutationHookOptions<DeployMutation, DeployMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeployMutation, DeployMutationVariables>(DeployDocument, options);
+      }
+export type DeployMutationHookResult = ReturnType<typeof useDeployMutation>;
+export type DeployMutationResult = Apollo.MutationResult<DeployMutation>;
+export type DeployMutationOptions = Apollo.BaseMutationOptions<DeployMutation, DeployMutationVariables>;
+export const DeployStatusDocument = gql`
+    query DeployStatus {
+  modelSync {
+    status
+  }
+}
+    `;
+
+/**
+ * __useDeployStatusQuery__
+ *
+ * To run a query within a React component, call `useDeployStatusQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDeployStatusQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDeployStatusQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useDeployStatusQuery(baseOptions?: Apollo.QueryHookOptions<DeployStatusQuery, DeployStatusQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<DeployStatusQuery, DeployStatusQueryVariables>(DeployStatusDocument, options);
+      }
+export function useDeployStatusLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DeployStatusQuery, DeployStatusQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<DeployStatusQuery, DeployStatusQueryVariables>(DeployStatusDocument, options);
+        }
+export type DeployStatusQueryHookResult = ReturnType<typeof useDeployStatusQuery>;
+export type DeployStatusLazyQueryHookResult = ReturnType<typeof useDeployStatusLazyQuery>;
+export type DeployStatusQueryResult = Apollo.QueryResult<DeployStatusQuery, DeployStatusQueryVariables>;

--- a/wren-ui/src/apollo/client/graphql/deploy.ts
+++ b/wren-ui/src/apollo/client/graphql/deploy.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+
+export const DEPLOY = gql`
+  mutation Deploy {
+    deploy
+  }
+`;
+
+export const GET_DEPLOY_STATUS = gql`
+  query DeployStatus {
+    modelSync {
+      status
+    }
+  }
+`;

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -459,7 +459,7 @@ export const typeDefs = gql`
     # Modeling Page
     listModels: [ModelInfo!]!
     model(where: ModelWhereInput!): DetailedModel!
-    modelSync: ModelSyncResponse
+    modelSync: ModelSyncResponse!
     diagram: Diagram!
 
     # View

--- a/wren-ui/src/components/Deploy.tsx
+++ b/wren-ui/src/components/Deploy.tsx
@@ -1,0 +1,65 @@
+import { Button, Space, Typography } from 'antd';
+import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
+import WarningOutlined from '@ant-design/icons/WarningOutlined';
+import {
+  useDeployMutation,
+  useDeployStatusQuery,
+} from '@/apollo/client/graphql/deploy.generated';
+import { SyncStatus } from '@/apollo/client/graphql/__types__';
+
+const { Text } = Typography;
+
+const getDeployStatus = (deploying: boolean, status: SyncStatus) => {
+  const syncStatus = deploying ? SyncStatus.IN_PROGRESS : status;
+
+  return (
+    {
+      [SyncStatus.IN_PROGRESS]: (
+        <Space size={[4, 0]}>
+          <LoadingOutlined className="mr-1 gray-1" />
+          <Text className="gray-1">Deploying...</Text>
+        </Space>
+      ),
+      [SyncStatus.SYNCRONIZED]: (
+        <Space size={[4, 0]}>
+          <CheckCircleOutlined className="mr-1 green-7" />
+          <Text className="gray-1">Synced</Text>
+        </Space>
+      ),
+      [SyncStatus.UNSYNCRONIZED]: (
+        <Space size={[4, 0]}>
+          <WarningOutlined className="mr-1 gold-6" />
+          <Text className="gray-1">Undeployed changes</Text>
+        </Space>
+      ),
+    }[syncStatus] || ''
+  );
+};
+
+export default function Deploy() {
+  const [deployMutation, { loading: deploying }] = useDeployMutation();
+  const { data, loading } = useDeployStatusQuery({
+    pollInterval: 1000,
+  });
+  const status = data?.modelSync.status;
+
+  const disabled =
+    deploying ||
+    loading ||
+    [SyncStatus.SYNCRONIZED, SyncStatus.IN_PROGRESS].includes(status);
+
+  return (
+    <Space size={[8, 0]}>
+      {getDeployStatus(deploying, status)}
+      <Button
+        className={`adm-modeling-header-btn ${disabled ? '' : 'gray-10'}`}
+        disabled={disabled}
+        onClick={() => deployMutation()}
+        size="small"
+      >
+        Deploy
+      </Button>
+    </Space>
+  );
+}

--- a/wren-ui/src/components/HeaderBar.tsx
+++ b/wren-ui/src/components/HeaderBar.tsx
@@ -3,6 +3,7 @@ import { Button, Layout, Space } from 'antd';
 import styled from 'styled-components';
 import LogoBar from '@/components/LogoBar';
 import { Path } from '@/utils/enum';
+import Deploy from '@/components/Deploy';
 
 const { Header } = Layout;
 
@@ -34,12 +35,13 @@ export default function HeaderBar() {
   const router = useRouter();
   const { pathname } = router;
   const showNav = !pathname.startsWith(Path.Onboarding);
+  const isModeling = pathname.startsWith(Path.Modeling);
 
   return (
     <StyledHeader>
       <div
-        className="d-flex justify-space-between"
-        style={{ marginTop: -2, alignItems: 'self-end' }}
+        className="d-flex justify-space-between align-center"
+        style={{ marginTop: -2 }}
       >
         <Space size={[48, 0]}>
           <LogoBar />
@@ -64,6 +66,7 @@ export default function HeaderBar() {
             </Space>
           )}
         </Space>
+        {isModeling && <Deploy />}
       </div>
     </StyledHeader>
   );

--- a/wren-ui/src/components/HeaderBar.tsx
+++ b/wren-ui/src/components/HeaderBar.tsx
@@ -3,7 +3,7 @@ import { Button, Layout, Space } from 'antd';
 import styled from 'styled-components';
 import LogoBar from '@/components/LogoBar';
 import { Path } from '@/utils/enum';
-import Deploy from '@/components/Deploy';
+import Deploy from '@/components/deploy/Deploy';
 
 const { Header } = Layout;
 

--- a/wren-ui/src/components/deploy/Context.ts
+++ b/wren-ui/src/components/deploy/Context.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+import { DeployStatusQueryHookResult } from '@/apollo/client/graphql/deploy.generated';
+
+type ContextProps = DeployStatusQueryHookResult;
+
+export const DeployStatusContext = createContext<ContextProps>(
+  {} as ContextProps,
+);
+
+export function useDeployStatusContext() {
+  return useContext(DeployStatusContext);
+}

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -7,7 +7,9 @@ import SiderLayout from '@/components/layouts/SiderLayout';
 import MetadataDrawer from '@/components/pages/modeling/MetadataDrawer';
 import useDrawerAction from '@/hooks/useDrawerAction';
 import { ClickPayload } from '@/components/diagram/Context';
+import { DeployStatusContext } from '@/components/deploy/Context';
 import { useDiagramQuery } from '@/apollo/client/graphql/diagram.generated';
+import { useDeployStatusQuery } from '@/apollo/client/graphql/deploy.generated';
 
 const Diagram = dynamic(() => import('@/components/diagram'), { ssr: false });
 // https://github.com/vercel/next.js/issues/4957#issuecomment-413841689
@@ -24,6 +26,11 @@ export function Modeling() {
   const diagramRef = useRef(null);
 
   const { data } = useDiagramQuery();
+
+  // TODO: No matter which operation is performed, we must re-fetch the latest deploy status
+  const deployStatusQueryResult = useDeployStatusQuery({
+    fetchPolicy: 'no-cache',
+  });
 
   const diagramData = useMemo(() => {
     if (!data) return null;
@@ -64,26 +71,28 @@ export function Modeling() {
   };
 
   return (
-    <SiderLayout
-      loading={diagramData === null}
-      sidebar={{
-        data: diagramData,
-        onSelect,
-      }}
-    >
-      <DiagramWrapper>
-        <ForwardDiagram
-          ref={diagramRef}
-          data={diagramData}
-          onMoreClick={onMoreClick}
-          onNodeClick={onNodeClick}
+    <DeployStatusContext.Provider value={{ ...deployStatusQueryResult }}>
+      <SiderLayout
+        loading={diagramData === null}
+        sidebar={{
+          data: diagramData,
+          onSelect,
+        }}
+      >
+        <DiagramWrapper>
+          <ForwardDiagram
+            ref={diagramRef}
+            data={diagramData}
+            onMoreClick={onMoreClick}
+            onNodeClick={onNodeClick}
+          />
+        </DiagramWrapper>
+        <MetadataDrawer
+          {...metadataDrawer.state}
+          onClose={metadataDrawer.closeDrawer}
         />
-      </DiagramWrapper>
-      <MetadataDrawer
-        {...metadataDrawer.state}
-        onClose={metadataDrawer.closeDrawer}
-      />
-    </SiderLayout>
+      </SiderLayout>
+    </DeployStatusContext.Provider>
   );
 }
 

--- a/wren-ui/src/styles/components/button.less
+++ b/wren-ui/src/styles/components/button.less
@@ -26,3 +26,7 @@
 .adm-onboarding-btn {
   width: 130px;
 }
+
+.adm-modeling-header-btn {
+  width: 60px;
+}


### PR DESCRIPTION
## Description

- `Deploy` Button
    - Status: `Undeployed changes`, `Deploying`, `synced`
    - Connect API

### UI
![截圖 2024-04-12 上午9 58 23](https://github.com/Canner/WrenAI/assets/42527625/98207fc3-c2a1-49a7-ae25-28d240d97ac9)

![截圖 2024-04-12 上午9 58 10](https://github.com/Canner/WrenAI/assets/42527625/557e05d7-77b6-4dba-b99d-6c3343cd75ac)

![截圖 2024-04-12 上午9 57 44](https://github.com/Canner/WrenAI/assets/42527625/df24801c-892a-4b67-9eae-46fdd35b4dfc)


## Tasks
 - [x] Add **Deploy** Button
 - [x] Show sync status