### PR TITLE
Fix(wren-ui): list threads should in time desc order

### DIFF
--- a/wren-ui/src/apollo/server/repositories/threadRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/threadRepository.ts
@@ -8,7 +8,9 @@ export interface Thread {
   summary: string; // Thread summary
 }
 
-export interface IThreadRepository extends IBasicRepository<Thread> {}
+export interface IThreadRepository extends IBasicRepository<Thread> {
+  listAllTimeDescOrder(projectId: number): Promise<Thread[]>;
+}
 
 export class ThreadRepository
   extends BaseRepository<Thread>
@@ -16,5 +18,12 @@ export class ThreadRepository
 {
   constructor(knexPg: Knex) {
     super({ knexPg, tableName: 'thread' });
+  }
+
+  public async listAllTimeDescOrder(projectId: number): Promise<Thread[]> {
+    const threads = await this.knex(this.tableName)
+      .where(this.transformToDBData({ projectId }))
+      .orderBy('created_at', 'desc');
+    return threads.map((thread) => this.transformFromDBData(thread));
   }
 }

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -204,9 +204,7 @@ export class AskingResolver {
     _args: any,
     ctx: IContext,
   ): Promise<Thread[]> {
-    const askingService = ctx.askingService;
-    const project = await ctx.projectService.getCurrentProject();
-    const threads = await askingService.listThreads(project.id);
+    const threads = await ctx.askingService.listThreads();
     return threads;
   }
 

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -205,7 +205,8 @@ export class AskingResolver {
     ctx: IContext,
   ): Promise<Thread[]> {
     const askingService = ctx.askingService;
-    const threads = await askingService.listThreads();
+    const project = await ctx.projectService.getCurrentProject();
+    const threads = await askingService.listThreads(project.id);
     return threads;
   }
 

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -55,7 +55,7 @@ export interface IAskingService {
     input: Partial<AskingDetailTaskInput>,
   ): Promise<Thread>;
   deleteThread(threadId: number): Promise<void>;
-  listThreads(projectId: number): Promise<Thread[]>;
+  listThreads(): Promise<Thread[]>;
   createThreadResponse(
     threadId: number,
     input: AskingDetailTaskInput,
@@ -334,8 +334,9 @@ export class AskingService implements IAskingService {
     return thread;
   }
 
-  public async listThreads(projectId): Promise<Thread[]> {
-    return this.threadRepository.listAllTimeDescOrder(projectId);
+  public async listThreads(): Promise<Thread[]> {
+    const project = await this.projectService.getCurrentProject();
+    return await this.threadRepository.listAllTimeDescOrder(project.id);
   }
 
   public async updateThread(

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -55,7 +55,7 @@ export interface IAskingService {
     input: Partial<AskingDetailTaskInput>,
   ): Promise<Thread>;
   deleteThread(threadId: number): Promise<void>;
-  listThreads(): Promise<Thread[]>;
+  listThreads(projectId: number): Promise<Thread[]>;
   createThreadResponse(
     threadId: number,
     input: AskingDetailTaskInput,
@@ -334,8 +334,8 @@ export class AskingService implements IAskingService {
     return thread;
   }
 
-  public async listThreads(): Promise<Thread[]> {
-    return this.threadRepository.findAll();
+  public async listThreads(projectId): Promise<Thread[]> {
+    return this.threadRepository.listAllTimeDescOrder(projectId);
   }
 
   public async updateThread(


### PR DESCRIPTION
### Description
In the home page, the listed thread in the side bar should be in create time desc order



