### PR TITLE
Chore(wren-ui): prevent duplicated workflow triggered

### DIFF
--- a/.github/workflows/ui-lint.yaml
+++ b/.github/workflows/ui-lint.yaml
@@ -4,9 +4,6 @@
 name: Wren-UI Lint
 
 on:
-  push:
-    paths:
-      - 'wren-ui/**'
   pull_request:
     types: [ labeled ]
 

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -3,9 +3,6 @@
 name: Wren-UI Test
 
 on:
-  push:
-    paths:
-      - 'wren-ui/**'
   pull_request:
     types: [ labeled ]
 


### PR DESCRIPTION
### Description
Duplicate test & lint workflow was triggered when PR labeled

<img width="1203" alt="image" src="https://github.com/Canner/WrenAI/assets/38731840/d5ed59f1-7fee-4240-b876-fe4e88d1fce4">
