### PR TITLE
feat(wren-ui/api): save columns when creating view

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
@@ -53,7 +53,7 @@ export interface IWrenEngineAdaptor {
   queryDuckdb(sql: string): Promise<QueryResponse>;
   patchConfig(config: Record<string, any>): Promise<void>;
   previewData(sql: string, limit?: number): Promise<QueryResponse>;
-  desribeStatement(sql: string): Promise<DescribeStatementResponse>;
+  describeStatement(sql: string): Promise<DescribeStatementResponse>;
 }
 
 export class WrenEngineAdaptor implements IWrenEngineAdaptor {
@@ -190,7 +190,7 @@ export class WrenEngineAdaptor implements IWrenEngineAdaptor {
     }
   }
 
-  public async desribeStatement(
+  public async describeStatement(
     sql: string,
   ): Promise<DescribeStatementResponse> {
     try {

--- a/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
@@ -42,6 +42,10 @@ export interface QueryResponse {
   data: any[][];
 }
 
+export interface DescribeStatementResponse {
+  columns: ColumnMetadata[];
+}
+
 export interface IWrenEngineAdaptor {
   deploy(deployData: deployData): Promise<DeployResponse>;
   initDatabase(sql: string): Promise<void>;
@@ -49,6 +53,7 @@ export interface IWrenEngineAdaptor {
   queryDuckdb(sql: string): Promise<QueryResponse>;
   patchConfig(config: Record<string, any>): Promise<void>;
   previewData(sql: string, limit?: number): Promise<QueryResponse>;
+  desribeStatement(sql: string): Promise<DescribeStatementResponse>;
 }
 
 export class WrenEngineAdaptor implements IWrenEngineAdaptor {
@@ -181,6 +186,19 @@ export class WrenEngineAdaptor implements IWrenEngineAdaptor {
       return res.data as QueryResponse;
     } catch (err: any) {
       logger.debug(`Got error when previewing data: ${err.message}`);
+      throw err;
+    }
+  }
+
+  public async desribeStatement(
+    sql: string,
+  ): Promise<DescribeStatementResponse> {
+    try {
+      // preview data with limit 1 to get column metadata
+      const res = await this.previewData(sql, 1);
+      return { columns: res.columns };
+    } catch (err: any) {
+      logger.debug(`Got error when describing statement: ${err.message}`);
       throw err;
     }
   }

--- a/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
@@ -150,6 +150,14 @@ export class DiagramResolver {
 
   private transformView(view: View): DiagramView {
     const properties = JSON.parse(view.properties);
+    const fields = (properties?.columns || []).map((column: any) => ({
+      id: uuidv4(),
+      nodeType: NodeType.FIELD,
+      type: column.type,
+      displayName: column.name,
+      referenceName: column.name,
+    }));
+
     return {
       id: uuidv4(),
       viewId: view.id,
@@ -157,6 +165,7 @@ export class DiagramResolver {
       statement: view.statement,
       referenceName: view.name,
       displayName: properties?.displayName || view.name,
+      fields,
     };
   }
 }

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -275,7 +275,8 @@ export class ModelResolver {
     const statement = format(constructCteSql(steps));
 
     // describe columns
-    const { columns } = await ctx.wrenEngineAdaptor.desribeStatement(statement);
+    const { columns } =
+      await ctx.wrenEngineAdaptor.describeStatement(statement);
     if (isEmpty(columns)) {
       throw new Error('Failed to describe statement');
     }

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -9,6 +9,7 @@ import { GenerateReferenceNameData } from '../services/modelService';
 import { DeployResponse } from '../services/deployService';
 import { constructCteSql } from '../services/askingService';
 import { format } from 'sql-formatter';
+import { isEmpty } from 'lodash';
 
 const logger = getLogger('ModelResolver');
 logger.level = 'debug';
@@ -273,9 +274,16 @@ export class ModelResolver {
     const steps = response.detail.steps;
     const statement = format(constructCteSql(steps));
 
+    // describe columns
+    const { columns } = await ctx.wrenEngineAdaptor.desribeStatement(statement);
+    if (isEmpty(columns)) {
+      throw new Error('Failed to describe statement');
+    }
+
     // properties
     const properties = {
       displayName: name,
+      columns,
     };
 
     // create view

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -251,6 +251,15 @@ export const typeDefs = gql`
     statement: String!
     displayName: String!
     referenceName: String!
+    fields: [DiagramViewField]!
+  }
+
+  type DiagramViewField {
+    id: String!
+    displayName: String!
+    referenceName: String!
+    type: String!
+    nodeType: NodeType!
   }
 
   type DiagramModel {

--- a/wren-ui/src/apollo/server/types/diagram.ts
+++ b/wren-ui/src/apollo/server/types/diagram.ts
@@ -20,6 +20,15 @@ export interface DiagramView {
   statement: string;
   displayName: string;
   referenceName: string;
+  fields: DiagramViewField[];
+}
+
+export interface DiagramViewField {
+  id: string;
+  displayName: string;
+  referenceName: string;
+  type: string;
+  nodeType: NodeType;
 }
 
 export interface DiagramModel {


### PR DESCRIPTION
## Description
* Add `columns` in view properties
* Add `fields` to view field in diagram API

### View field in diagram API
When querying
```graphql
query Diagram {
  diagram {
    views {
      displayName
      id
      nodeType
      referenceName
      statement
      viewId
      fields {
        displayName
        id
        nodeType
        referenceName
        type
      }
    }
  }
}
```

You'll get following response for `views`
```js
// ...
views: [
{
          "displayName": "view_3",
          "id": "c80d524c-a0a7-4d0a-a118-a6e63e0b41c8",
          "nodeType": "VIEW",
          "referenceName": "view_3",
          "statement": "-- Selecting specific columns from the customer table\nSELECT\n  c_custkey,\n  c_name,\n  c_address,\n  c_phone,\n  c_acctbal,\n  c_mktsegment,\n  c_comment\nFROM\n  customer",
          "viewId": 4,
          "fields": [
            {
              "displayName": "c_custkey",
              "id": "dae76223-d5a2-4898-95a8-c06bbbf3b550",
              "nodeType": "FIELD",
              "referenceName": "c_custkey",
              "type": "int8"
            },
            {
              "displayName": "c_name",
              "id": "26e09286-39bc-4315-9f11-6fddc6c7daa0",
              "nodeType": "FIELD",
              "referenceName": "c_name",
              "type": "varchar"
            },
            {
              "displayName": "c_address",
              "id": "4872a9fd-1c2f-4533-a409-b6c08e0315dd",
              "nodeType": "FIELD",
              "referenceName": "c_address",
              "type": "varchar"
            },
            {
              "displayName": "c_phone",
              "id": "242cb2da-28ff-4817-b4ca-360253ee4a1f",
              "nodeType": "FIELD",
              "referenceName": "c_phone",
              "type": "varchar"
            },
            {
              "displayName": "c_acctbal",
              "id": "4719be88-0c4f-4f94-b385-fea3051e6a04",
              "nodeType": "FIELD",
              "referenceName": "c_acctbal",
              "type": "float8"
            },
            {
              "displayName": "c_mktsegment",
              "id": "ef18b0e4-e0b2-43e8-85d4-b34fb1c7cf62",
              "nodeType": "FIELD",
              "referenceName": "c_mktsegment",
              "type": "varchar"
            },
            {
              "displayName": "c_comment",
              "id": "23fb2a51-9ddd-433e-8d62-5471d2e3211c",
              "nodeType": "FIELD",
              "referenceName": "c_comment",
              "type": "varchar"
            }
          ]
        }
]
// ...
```