### PR TITLE
feat(wren-ui/api): add connectionInfo query API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ wren-launcher/dist
 
 ## temporary files
 .tmp
+
+## Docker
+docker/data

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -1,8 +1,5 @@
 version: '3'
 
-volumes:
-  data:
-
 networks:
   wren:
     driver: bridge
@@ -15,7 +12,7 @@ services:
     environment:
       DATA_PATH: /app/data
     volumes:
-      - data:/app/data
+      - ./data:/app/data
     command: /bin/sh /app/init.sh
 
   wren-engine:
@@ -27,7 +24,7 @@ services:
     ports:
       - ${WREN_ENGINE_PORT}:${WREN_ENGINE_PORT}
     volumes:
-      - data:/usr/src/app/etc
+      - ./data:/usr/src/app/etc
     networks:
       - wren
     depends_on:

--- a/wren-ui/src/apollo/server/config.ts
+++ b/wren-ui/src/apollo/server/config.ts
@@ -1,4 +1,5 @@
 import { pickBy } from 'lodash';
+import path from 'path';
 
 export interface IConfig {
   // database
@@ -20,6 +21,16 @@ export interface IConfig {
   // encryption
   encryptionPassword: string;
   encryptionSalt: string;
+
+  // sql protocol port
+  sqlProtocolPort?: number;
+
+  // username and password
+  username?: string;
+  password?: string;
+
+  // accounts config file path
+  accountsConfigFilepath?: string;
 }
 
 const defaultConfig = {
@@ -44,6 +55,19 @@ const defaultConfig = {
   // encryption
   encryptionPassword: 'sementic',
   encryptionSalt: 'layer',
+
+  // sql protocol port
+  sqlProtocolPort: 7432,
+
+  // username and password
+  username: 'wren-admin',
+  password: 'wren-admin-password',
+
+  // accounts config file path
+  accountsConfigFilepath: path.resolve(
+    process.cwd(),
+    '../docker/data/etc/accounts',
+  ),
 };
 
 const config = {
@@ -74,6 +98,16 @@ const config = {
   // encryption
   encryptionPassword: process.env.ENCRYPTION_PASSWORD,
   encryptionSalt: process.env.ENCRYPTION_SALT,
+
+  // sql protocol port
+  sqlProtocolPort: parseInt(process.env.SQL_PROTOCOL_PORT, 10),
+
+  // username and password
+  username: process.env.ADMIN_USERNAME,
+  password: process.env.ADMIN_PASSWORD,
+
+  // accounts config file path
+  accountsConfigFilepath: process.env.ACCOUNTS_CONFIG_FILEPATH,
 };
 
 export function getConfig(): IConfig {

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -3,11 +3,13 @@ import { ProjectResolver } from './resolvers/projectResolver';
 import { ModelResolver } from './resolvers/modelResolver';
 import { AskingResolver } from './resolvers/askingResolver';
 import { DiagramResolver } from './resolvers/diagramResolver';
+import { ConnectionInfoResolver } from './resolvers/connectionInfoResolver';
 
 const projectResolver = new ProjectResolver();
 const modelResolver = new ModelResolver();
 const askingResolver = new AskingResolver();
 const diagramResolver = new DiagramResolver();
+const connectionInfoResolver = new ConnectionInfoResolver();
 
 const resolvers = {
   JSON: GraphQLJSON,
@@ -32,6 +34,9 @@ const resolvers = {
     // Views
     listViews: modelResolver.listViews,
     view: modelResolver.getView,
+
+    // Connection Info
+    connectionInfo: connectionInfoResolver.connectionInfo,
   },
   Mutation: {
     deploy: modelResolver.deploy,

--- a/wren-ui/src/apollo/server/resolvers/connectionInfoResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/connectionInfoResolver.ts
@@ -1,0 +1,41 @@
+import { IContext } from '../types';
+import { getConfig } from '../config';
+import { isEmpty } from 'lodash';
+
+const config = getConfig();
+
+export interface ConnectionInfo {
+  port: number;
+  database: string;
+  schema: string;
+  username: string;
+  password: string;
+}
+
+export class ConnectionInfoResolver {
+  constructor() {
+    this.connectionInfo = this.connectionInfo.bind(this);
+  }
+
+  public async connectionInfo(
+    _root: any,
+    _args: any,
+    ctx: IContext,
+  ): Promise<ConnectionInfo> {
+    const project = await ctx.projectService.getCurrentProject();
+    const { accounts } = await ctx.configService.getAccountsConfig();
+
+    // validate accounts
+    if (isEmpty(accounts)) {
+      throw new Error('No accounts found');
+    }
+
+    return {
+      port: config.sqlProtocolPort,
+      database: project.catalog,
+      schema: project.schema,
+      username: accounts[0].username,
+      password: accounts[0].password,
+    };
+  }
+}

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -440,6 +440,15 @@ export const typeDefs = gql`
     questions: [SuggestedQuestion]!
   }
 
+  # SQL protocol connection information
+  type ConnectionInfo {
+    port: Int!
+    database: String!
+    schema: String!
+    username: String!
+    password: String!
+  }
+
   # Query and Mutation
   type Query {
     # On Boarding Steps
@@ -463,6 +472,9 @@ export const typeDefs = gql`
     threads: [Thread!]!
     thread(threadId: Int!): DetailedThread!
     threadResponse(responseId: Int!): ThreadResponse!
+
+    # Connection Info
+    connectionInfo: ConnectionInfo!
   }
 
   type Mutation {

--- a/wren-ui/src/apollo/server/services/configService.ts
+++ b/wren-ui/src/apollo/server/services/configService.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import { getLogger } from '@server/utils';
+
+const logger = getLogger('ConfigService');
+logger.level = 'debug';
+
+export interface Account {
+  username: string;
+  password: string;
+}
+
+export interface AccountsConfig {
+  accounts: Account[];
+}
+
+export interface IConfigService {
+  writeAccountsConfig(): void;
+  getAccountsConfig(): AccountsConfig;
+}
+
+export class ConfigService implements IConfigService {
+  private accounts: Account[] = [];
+  private accountsConfigFilepath: string;
+
+  constructor({
+    accounts,
+    accountsConfigFilepath,
+  }: {
+    accounts: Account[];
+    accountsConfigFilepath: string;
+  }) {
+    this.accounts = accounts;
+    this.accountsConfigFilepath = accountsConfigFilepath;
+  }
+
+  public initialize() {
+    // write file
+    // overwrite the accounts config file with the accounts
+    this.writeAccountsConfig();
+  }
+
+  public writeAccountsConfig() {
+    // write the accounts config to the file
+    const accountsConfig: AccountsConfig = {
+      accounts: this.accounts,
+    };
+
+    // make sure the directory exists
+    const dir = this.accountsConfigFilepath.split('/').slice(0, -1).join('/');
+    if (!fs.existsSync(dir)) {
+      logger.debug(`Creating directory: ${dir}`);
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // write the file
+    logger.debug(`Writing accounts config to: ${this.accountsConfigFilepath}`);
+    fs.writeFileSync(
+      this.accountsConfigFilepath,
+      this.formatAccountsConfigContent(accountsConfig),
+    );
+  }
+
+  public getAccountsConfig() {
+    // read the accounts config from the file
+    const content = fs.readFileSync(this.accountsConfigFilepath, 'utf8');
+    return this.parseAccountsConfigContent(content);
+  }
+
+  private formatAccountsConfigContent(accountsConfig: AccountsConfig): string {
+    // the format of the accounts config content is
+    // username: password per line
+    return accountsConfig.accounts
+      .map((account) => `${account.username}: ${account.password}`)
+      .join('\n');
+  }
+
+  private parseAccountsConfigContent(content: string): AccountsConfig {
+    // the format of the accounts config content is
+    // username: password per line
+    const accounts = content
+      .split('\n')
+      .map((line) => {
+        const [username, password] = line.split(':');
+        // remove leading and trailing spaces
+        return { username: username.trim(), password: password.trim() };
+      })
+      // filter out empty username or password
+      .filter((account) => account.username && account.password);
+    return { accounts };
+  }
+}

--- a/wren-ui/src/apollo/server/types/context.ts
+++ b/wren-ui/src/apollo/server/types/context.ts
@@ -9,6 +9,7 @@ import {
 } from '../repositories';
 import { IDeployLogRepository } from '../repositories/deployLogRepository';
 import { IAskingService } from '../services/askingService';
+import { IConfigService } from '../services/configService';
 import { IDeployService } from '../services/deployService';
 import { IMDLService } from '../services/mdlService';
 import { IModelService } from '../services/modelService';
@@ -26,6 +27,7 @@ export interface IContext {
   mdlService: IMDLService;
   deployService: IDeployService;
   askingService: IAskingService;
+  configService: IConfigService;
 
   // repository
   projectRepository: IProjectRepository;

--- a/wren-ui/src/pages/api/graphql.ts
+++ b/wren-ui/src/pages/api/graphql.ts
@@ -26,6 +26,7 @@ import { AskingService } from '@/apollo/server/services/askingService';
 import { ThreadRepository } from '@/apollo/server/repositories/threadRepository';
 import { ThreadResponseRepository } from '@/apollo/server/repositories/threadResponseRepository';
 import { defaultApolloErrorHandler } from '@/apollo/server/utils/error';
+import { ConfigService } from '@/apollo/server/services/configService';
 
 const serverConfig = getConfig();
 const logger = getLogger('APOLLO');
@@ -91,9 +92,19 @@ const bootstrapServer = async () => {
     threadRepository,
     threadResponseRepository,
   });
+  const configService = new ConfigService({
+    accounts: [
+      {
+        username: serverConfig.username,
+        password: serverConfig.password,
+      },
+    ],
+    accountsConfigFilepath: serverConfig.accountsConfigFilepath,
+  });
 
   // initialize services
   await askingService.initialize();
+  configService.initialize();
 
   const apolloServer: ApolloServer = new ApolloServer({
     typeDefs,
@@ -127,6 +138,7 @@ const bootstrapServer = async () => {
       mdlService,
       deployService,
       askingService,
+      configService,
 
       // repository
       projectRepository,


### PR DESCRIPTION
## Description
* Add `connectionInfo` query API
<img width="1074" alt="Screenshot 2024-04-15 at 5 31 04 AM" src="https://github.com/Canner/WrenAI/assets/1208829/fb6e250c-a3b7-40be-8bf4-f93c9a152261">

## Adding following env
* ACCOUNTS_CONFIG_FILEPATH: file path point to accounts file that wren-engine uses.
* ADMIN_USERNAME: admin username to connect to SQL protocol
* ADMIN_PASSWORD: admin password to connect to SQL protocol
* SQL_PROTOCOL_PORT: SQL protocol port

## Implementation
* During initialization of service, UI service will write `accounts` file to specified path (`ACCOUNTS_CONFIG_FILEPATH`)