### PR TITLE
feat(wren-ui) Support save as View

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -224,11 +224,21 @@ export type DiagramModelRelationField = {
 export type DiagramView = {
   __typename?: 'DiagramView';
   displayName: Scalars['String'];
+  fields: Array<Maybe<DiagramViewField>>;
   id: Scalars['String'];
   nodeType: NodeType;
   referenceName: Scalars['String'];
   statement: Scalars['String'];
   viewId: Scalars['Int'];
+};
+
+export type DiagramViewField = {
+  __typename?: 'DiagramViewField';
+  displayName: Scalars['String'];
+  id: Scalars['String'];
+  nodeType: NodeType;
+  referenceName: Scalars['String'];
+  type: Scalars['String'];
 };
 
 export type DimensionInput = {

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -92,6 +92,11 @@ export type CreateThreadResponseInput = {
   summary: Scalars['String'];
 };
 
+export type CreateViewInput = {
+  name: Scalars['String'];
+  responseId: Scalars['Int'];
+};
+
 export type CustomFieldInput = {
   expression: Scalars['String'];
   name: Scalars['String'];
@@ -168,6 +173,7 @@ export type DetailedThread = {
 export type Diagram = {
   __typename?: 'Diagram';
   models: Array<Maybe<DiagramModel>>;
+  views: Array<Maybe<DiagramView>>;
 };
 
 export type DiagramModel = {
@@ -213,6 +219,16 @@ export type DiagramModelRelationField = {
   toColumnName: Scalars['String'];
   toModelName: Scalars['String'];
   type: RelationType;
+};
+
+export type DiagramView = {
+  __typename?: 'DiagramView';
+  displayName: Scalars['String'];
+  id: Scalars['String'];
+  nodeType: NodeType;
+  referenceName: Scalars['String'];
+  statement: Scalars['String'];
+  viewId: Scalars['Int'];
 };
 
 export type DimensionInput = {
@@ -267,7 +283,7 @@ export type ModelInfo = {
 
 export type ModelSyncResponse = {
   __typename?: 'ModelSyncResponse';
-  isSyncronized: Scalars['Boolean'];
+  status: SyncStatus;
 };
 
 export type ModelWhereInput = {
@@ -281,16 +297,20 @@ export type Mutation = {
   createModel: Scalars['JSON'];
   createThread: Thread;
   createThreadResponse: ThreadResponse;
+  createView: ViewInfo;
   deleteModel: Scalars['Boolean'];
   deleteThread: Scalars['Boolean'];
+  deleteView: Scalars['Boolean'];
   deploy: Scalars['JSON'];
   previewData: Scalars['JSON'];
+  previewViewData: Scalars['JSON'];
   saveDataSource: DataSource;
   saveRelations: Scalars['JSON'];
   saveTables: Scalars['JSON'];
   startSampleDataset: Scalars['JSON'];
   updateModel: Scalars['JSON'];
   updateThread: Thread;
+  validateView: ViewValidationResponse;
 };
 
 
@@ -320,6 +340,11 @@ export type MutationCreateThreadResponseArgs = {
 };
 
 
+export type MutationCreateViewArgs = {
+  data: CreateViewInput;
+};
+
+
 export type MutationDeleteModelArgs = {
   where: ModelWhereInput;
 };
@@ -330,8 +355,18 @@ export type MutationDeleteThreadArgs = {
 };
 
 
+export type MutationDeleteViewArgs = {
+  where: ViewWhereUniqueInput;
+};
+
+
 export type MutationPreviewDataArgs = {
   where: PreviewDataInput;
+};
+
+
+export type MutationPreviewViewDataArgs = {
+  where: ViewWhereUniqueInput;
 };
 
 
@@ -364,6 +399,11 @@ export type MutationUpdateModelArgs = {
 export type MutationUpdateThreadArgs = {
   data: UpdateThreadInput;
   where: ThreadUniqueWhereInput;
+};
+
+
+export type MutationValidateViewArgs = {
+  data: ValidateViewInput;
 };
 
 export enum NodeType {
@@ -399,6 +439,7 @@ export type Query = {
   diagram: Diagram;
   listDataSourceTables: Array<CompactTable>;
   listModels: Array<ModelInfo>;
+  listViews: Array<ViewInfo>;
   model: DetailedModel;
   modelSync?: Maybe<ModelSyncResponse>;
   onboardingStatus: OnboardingStatusResponse;
@@ -406,6 +447,7 @@ export type Query = {
   thread: DetailedThread;
   threadResponse: ThreadResponse;
   threads: Array<Thread>;
+  view: ViewInfo;
 };
 
 
@@ -426,6 +468,11 @@ export type QueryThreadArgs = {
 
 export type QueryThreadResponseArgs = {
   responseId: Scalars['Int'];
+};
+
+
+export type QueryViewArgs = {
+  where: ViewWhereUniqueInput;
 };
 
 export type RecommandRelations = {
@@ -506,6 +553,12 @@ export type SuggestedQuestionResponse = {
   questions: Array<Maybe<SuggestedQuestion>>;
 };
 
+export enum SyncStatus {
+  IN_PROGRESS = 'IN_PROGRESS',
+  SYNCRONIZED = 'SYNCRONIZED',
+  UNSYNCRONIZED = 'UNSYNCRONIZED'
+}
+
 export type Task = {
   __typename?: 'Task';
   id: Scalars['String'];
@@ -555,4 +608,25 @@ export type UpdateModelInput = {
 
 export type UpdateThreadInput = {
   summary?: InputMaybe<Scalars['String']>;
+};
+
+export type ValidateViewInput = {
+  name: Scalars['String'];
+};
+
+export type ViewInfo = {
+  __typename?: 'ViewInfo';
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  statement: Scalars['String'];
+};
+
+export type ViewValidationResponse = {
+  __typename?: 'ViewValidationResponse';
+  message?: Maybe<Scalars['String']>;
+  valid: Scalars['Boolean'];
+};
+
+export type ViewWhereUniqueInput = {
+  id: Scalars['Int'];
 };

--- a/wren-ui/src/apollo/client/graphql/diagram.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/diagram.generated.ts
@@ -3,6 +3,8 @@ import * as Types from './__types__';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
+export type ViewFieldFragment = { __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType };
+
 export type RelationFieldFragment = { __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelName: string, fromColumnName: string, toModelName: string, toColumnName: string };
 
 export type FieldFragment = { __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null };
@@ -10,8 +12,17 @@ export type FieldFragment = { __typename?: 'DiagramModelField', id: string, colu
 export type DiagramQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type DiagramQuery = { __typename?: 'Query', diagram: { __typename?: 'Diagram', models: Array<{ __typename?: 'DiagramModel', id: string, modelId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, sourceTableName: string, refSql: string, cached: boolean, refreshTime?: string | null, description?: string | null, fields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null } | null>, calculatedFields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null } | null>, relationFields: Array<{ __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelName: string, fromColumnName: string, toModelName: string, toColumnName: string } | null> } | null> } };
+export type DiagramQuery = { __typename?: 'Query', diagram: { __typename?: 'Diagram', models: Array<{ __typename?: 'DiagramModel', id: string, modelId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, sourceTableName: string, refSql: string, cached: boolean, refreshTime?: string | null, description?: string | null, fields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null } | null>, calculatedFields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null } | null>, relationFields: Array<{ __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelName: string, fromColumnName: string, toModelName: string, toColumnName: string } | null> } | null>, views: Array<{ __typename?: 'DiagramView', id: string, viewId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, statement: string, fields: Array<{ __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType } | null> } | null> } };
 
+export const ViewFieldFragmentDoc = gql`
+    fragment ViewField on DiagramViewField {
+  id
+  displayName
+  referenceName
+  type
+  nodeType
+}
+    `;
 export const RelationFieldFragmentDoc = gql`
     fragment RelationField on DiagramModelRelationField {
   id
@@ -63,10 +74,22 @@ export const DiagramDocument = gql`
         ...RelationField
       }
     }
+    views {
+      id
+      viewId
+      nodeType
+      displayName
+      referenceName
+      statement
+      fields {
+        ...ViewField
+      }
+    }
   }
 }
     ${FieldFragmentDoc}
-${RelationFieldFragmentDoc}`;
+${RelationFieldFragmentDoc}
+${ViewFieldFragmentDoc}`;
 
 /**
  * __useDiagramQuery__

--- a/wren-ui/src/apollo/client/graphql/diagram.ts
+++ b/wren-ui/src/apollo/client/graphql/diagram.ts
@@ -1,5 +1,15 @@
 import { gql } from '@apollo/client';
 
+const VIEW_FIELD = gql`
+  fragment ViewField on DiagramViewField {
+    id
+    displayName
+    referenceName
+    type
+    nodeType
+  }
+`;
+
 const RELATION_FIELD = gql`
   fragment RelationField on DiagramModelRelationField {
     id
@@ -53,8 +63,20 @@ export const DIAGRAM = gql`
           ...RelationField
         }
       }
+      views {
+        id
+        viewId
+        nodeType
+        displayName
+        referenceName
+        statement
+        fields {
+          ...ViewField
+        }
+      }
     }
   }
   ${FIELD}
   ${RELATION_FIELD}
+  ${VIEW_FIELD}
 `;

--- a/wren-ui/src/apollo/client/graphql/view.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/view.generated.ts
@@ -1,0 +1,250 @@
+import * as Types from './__types__';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type CreateViewMutationVariables = Types.Exact<{
+  data: Types.CreateViewInput;
+}>;
+
+
+export type CreateViewMutation = { __typename?: 'Mutation', createView: { __typename?: 'ViewInfo', id: number, name: string, statement: string } };
+
+export type DeleteViewMutationVariables = Types.Exact<{
+  where: Types.ViewWhereUniqueInput;
+}>;
+
+
+export type DeleteViewMutation = { __typename?: 'Mutation', deleteView: boolean };
+
+export type GetViewQueryVariables = Types.Exact<{
+  where: Types.ViewWhereUniqueInput;
+}>;
+
+
+export type GetViewQuery = { __typename?: 'Query', view: { __typename?: 'ViewInfo', id: number, name: string, statement: string } };
+
+export type ListViewsQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type ListViewsQuery = { __typename?: 'Query', listViews: Array<{ __typename?: 'ViewInfo', id: number, name: string, statement: string }> };
+
+export type PreviewViewDataMutationVariables = Types.Exact<{
+  where: Types.ViewWhereUniqueInput;
+}>;
+
+
+export type PreviewViewDataMutation = { __typename?: 'Mutation', previewViewData: any };
+
+export type ValidateViewMutationVariables = Types.Exact<{
+  data: Types.ValidateViewInput;
+}>;
+
+
+export type ValidateViewMutation = { __typename?: 'Mutation', validateView: { __typename?: 'ViewValidationResponse', valid: boolean, message?: string | null } };
+
+
+export const CreateViewDocument = gql`
+    mutation CreateView($data: CreateViewInput!) {
+  createView(data: $data) {
+    id
+    name
+    statement
+  }
+}
+    `;
+export type CreateViewMutationFn = Apollo.MutationFunction<CreateViewMutation, CreateViewMutationVariables>;
+
+/**
+ * __useCreateViewMutation__
+ *
+ * To run a mutation, you first call `useCreateViewMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateViewMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createViewMutation, { data, loading, error }] = useCreateViewMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useCreateViewMutation(baseOptions?: Apollo.MutationHookOptions<CreateViewMutation, CreateViewMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateViewMutation, CreateViewMutationVariables>(CreateViewDocument, options);
+      }
+export type CreateViewMutationHookResult = ReturnType<typeof useCreateViewMutation>;
+export type CreateViewMutationResult = Apollo.MutationResult<CreateViewMutation>;
+export type CreateViewMutationOptions = Apollo.BaseMutationOptions<CreateViewMutation, CreateViewMutationVariables>;
+export const DeleteViewDocument = gql`
+    mutation DeleteView($where: ViewWhereUniqueInput!) {
+  deleteView(where: $where)
+}
+    `;
+export type DeleteViewMutationFn = Apollo.MutationFunction<DeleteViewMutation, DeleteViewMutationVariables>;
+
+/**
+ * __useDeleteViewMutation__
+ *
+ * To run a mutation, you first call `useDeleteViewMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteViewMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteViewMutation, { data, loading, error }] = useDeleteViewMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function useDeleteViewMutation(baseOptions?: Apollo.MutationHookOptions<DeleteViewMutation, DeleteViewMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteViewMutation, DeleteViewMutationVariables>(DeleteViewDocument, options);
+      }
+export type DeleteViewMutationHookResult = ReturnType<typeof useDeleteViewMutation>;
+export type DeleteViewMutationResult = Apollo.MutationResult<DeleteViewMutation>;
+export type DeleteViewMutationOptions = Apollo.BaseMutationOptions<DeleteViewMutation, DeleteViewMutationVariables>;
+export const GetViewDocument = gql`
+    query GetView($where: ViewWhereUniqueInput!) {
+  view(where: $ViewWhereUniqueInput) {
+    id
+    name
+    statement
+  }
+}
+    `;
+
+/**
+ * __useGetViewQuery__
+ *
+ * To run a query within a React component, call `useGetViewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetViewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetViewQuery({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function useGetViewQuery(baseOptions: Apollo.QueryHookOptions<GetViewQuery, GetViewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetViewQuery, GetViewQueryVariables>(GetViewDocument, options);
+      }
+export function useGetViewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetViewQuery, GetViewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetViewQuery, GetViewQueryVariables>(GetViewDocument, options);
+        }
+export type GetViewQueryHookResult = ReturnType<typeof useGetViewQuery>;
+export type GetViewLazyQueryHookResult = ReturnType<typeof useGetViewLazyQuery>;
+export type GetViewQueryResult = Apollo.QueryResult<GetViewQuery, GetViewQueryVariables>;
+export const ListViewsDocument = gql`
+    query ListViews {
+  listViews {
+    id
+    name
+    statement
+  }
+}
+    `;
+
+/**
+ * __useListViewsQuery__
+ *
+ * To run a query within a React component, call `useListViewsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useListViewsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useListViewsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useListViewsQuery(baseOptions?: Apollo.QueryHookOptions<ListViewsQuery, ListViewsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ListViewsQuery, ListViewsQueryVariables>(ListViewsDocument, options);
+      }
+export function useListViewsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ListViewsQuery, ListViewsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ListViewsQuery, ListViewsQueryVariables>(ListViewsDocument, options);
+        }
+export type ListViewsQueryHookResult = ReturnType<typeof useListViewsQuery>;
+export type ListViewsLazyQueryHookResult = ReturnType<typeof useListViewsLazyQuery>;
+export type ListViewsQueryResult = Apollo.QueryResult<ListViewsQuery, ListViewsQueryVariables>;
+export const PreviewViewDataDocument = gql`
+    mutation PreviewViewData($where: ViewWhereUniqueInput!) {
+  previewViewData(where: $data)
+}
+    `;
+export type PreviewViewDataMutationFn = Apollo.MutationFunction<PreviewViewDataMutation, PreviewViewDataMutationVariables>;
+
+/**
+ * __usePreviewViewDataMutation__
+ *
+ * To run a mutation, you first call `usePreviewViewDataMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `usePreviewViewDataMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [previewViewDataMutation, { data, loading, error }] = usePreviewViewDataMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function usePreviewViewDataMutation(baseOptions?: Apollo.MutationHookOptions<PreviewViewDataMutation, PreviewViewDataMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<PreviewViewDataMutation, PreviewViewDataMutationVariables>(PreviewViewDataDocument, options);
+      }
+export type PreviewViewDataMutationHookResult = ReturnType<typeof usePreviewViewDataMutation>;
+export type PreviewViewDataMutationResult = Apollo.MutationResult<PreviewViewDataMutation>;
+export type PreviewViewDataMutationOptions = Apollo.BaseMutationOptions<PreviewViewDataMutation, PreviewViewDataMutationVariables>;
+export const ValidateViewDocument = gql`
+    mutation ValidateView($data: ValidateViewInput!) {
+  validateView(data: $data) {
+    valid
+    message
+  }
+}
+    `;
+export type ValidateViewMutationFn = Apollo.MutationFunction<ValidateViewMutation, ValidateViewMutationVariables>;
+
+/**
+ * __useValidateViewMutation__
+ *
+ * To run a mutation, you first call `useValidateViewMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useValidateViewMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [validateViewMutation, { data, loading, error }] = useValidateViewMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useValidateViewMutation(baseOptions?: Apollo.MutationHookOptions<ValidateViewMutation, ValidateViewMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ValidateViewMutation, ValidateViewMutationVariables>(ValidateViewDocument, options);
+      }
+export type ValidateViewMutationHookResult = ReturnType<typeof useValidateViewMutation>;
+export type ValidateViewMutationResult = Apollo.MutationResult<ValidateViewMutation>;
+export type ValidateViewMutationOptions = Apollo.BaseMutationOptions<ValidateViewMutation, ValidateViewMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/view.ts
+++ b/wren-ui/src/apollo/client/graphql/view.ts
@@ -1,0 +1,52 @@
+import { gql } from '@apollo/client';
+
+export const CREATE_VIEW = gql`
+  mutation CreateView($data: CreateViewInput!) {
+    createView(data: $data) {
+      id
+      name
+      statement
+    }
+  }
+`;
+
+export const DELETE_VIEW = gql`
+  mutation DeleteView($where: ViewWhereUniqueInput!) {
+    deleteView(where: $where)
+  }
+`;
+
+export const GET_VIEW = gql`
+  query GetView($where: ViewWhereUniqueInput!) {
+    view(where: $ViewWhereUniqueInput) {
+      id
+      name
+      statement
+    }
+  }
+`;
+
+export const LIST_VIEWS = gql`
+  query ListViews {
+    listViews {
+      id
+      name
+      statement
+    }
+  }
+`;
+
+export const PREVIEW_VIEW_DATA = gql`
+  mutation PreviewViewData($where: ViewWhereUniqueInput!) {
+    previewViewData(where: $data)
+  }
+`;
+
+export const VALIDATE_CREATE_VIEW = gql`
+  mutation ValidateView($data: ValidateViewInput!) {
+    validateView(data: $data) {
+      valid
+      message
+    }
+  }
+`;

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -1,6 +1,7 @@
-import { Skeleton, Typography } from 'antd';
+import { Button, Skeleton, Typography } from 'antd';
 import styled from 'styled-components';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
+import SaveOutlined from '@ant-design/icons/SaveOutlined';
 import StepContent from '@/components/pages/home/promptThread/StepContent';
 
 const { Title, Text } = Typography;
@@ -29,6 +30,7 @@ interface Props {
   }>;
   fullSql: string;
   threadResponseId: number;
+  onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
 }
 
 export default function AnswerResult(props: Props) {
@@ -39,6 +41,7 @@ export default function AnswerResult(props: Props) {
     answerResultSteps,
     fullSql,
     threadResponseId,
+    onOpenSaveAsViewModal,
   } = props;
 
   return (
@@ -64,6 +67,17 @@ export default function AnswerResult(props: Props) {
           />
         ))}
       </StyledAnswer>
+      <Button
+        className="mt-2 gray-6"
+        type="text"
+        size="small"
+        icon={<SaveOutlined />}
+        onClick={() =>
+          onOpenSaveAsViewModal({ sql: fullSql, responseId: threadResponseId })
+        }
+      >
+        Save as View
+      </Button>
     </Skeleton>
   );
 }

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -10,6 +10,7 @@ import {
 
 interface Props {
   data: DetailedThread;
+  onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
 }
 
 const StyledPromptThread = styled.div`
@@ -38,6 +39,7 @@ const AnswerResultTemplate = ({
   question,
   detail,
   error,
+  onOpenSaveAsViewModal,
 }) => {
   return (
     <div key={`${id}-${index}`}>
@@ -57,6 +59,7 @@ const AnswerResultTemplate = ({
           question={question}
           fullSql={detail?.sql}
           threadResponseId={id}
+          onOpenSaveAsViewModal={onOpenSaveAsViewModal}
         />
       )}
     </div>
@@ -66,7 +69,7 @@ const AnswerResultTemplate = ({
 const AnswerResultIterator = makeIterable(AnswerResultTemplate);
 
 export default function PromptThread(props: Props) {
-  const { data } = props;
+  const { data, onOpenSaveAsViewModal } = props;
   const divRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -88,7 +91,11 @@ export default function PromptThread(props: Props) {
 
   return (
     <StyledPromptThread className="mt-12" ref={divRef}>
-      <AnswerResultIterator data={data?.responses || []} sql={data?.sql} />
+      <AnswerResultIterator
+        data={data?.responses || []}
+        sql={data?.sql}
+        onOpenSaveAsViewModal={onOpenSaveAsViewModal}
+      />
     </StyledPromptThread>
   );
 }

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -23,7 +23,9 @@ const DiagramWrapper = styled.div`
 export function Modeling() {
   const diagramRef = useRef(null);
 
-  const { data } = useDiagramQuery();
+  const { data } = useDiagramQuery({
+    fetchPolicy: 'cache-and-network',
+  });
 
   const diagramData = useMemo(() => {
     if (!data) return null;

--- a/wren-ui/src/utils/error/dictionary.ts
+++ b/wren-ui/src/utils/error/dictionary.ts
@@ -40,4 +40,9 @@ export const ERROR_TEXTS = {
       REQUIRED: 'Please select at least one table.',
     },
   },
+  SAVE_AS_VIEW: {
+    NAME: {
+      REQUIRED: 'Please input view name.',
+    },
+  },
 };

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -77,6 +77,15 @@ class CreateThreadResponseErrorHandler extends ErrorHandler {
   }
 }
 
+class CreateViewErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to create view.';
+    }
+  }
+}
+
 errorHandlers.set('SaveTables', new SaveTablesErrorHandler());
 errorHandlers.set('SaveRelations', new SaveRelationsErrorHandler());
 errorHandlers.set('CreateAskingTask', new CreateAskingTaskErrorHandler());
@@ -87,6 +96,7 @@ errorHandlers.set(
   'CreateThreadResponse',
   new CreateThreadResponseErrorHandler(),
 );
+errorHandlers.set('CreateView', new CreateViewErrorHandler());
 
 const errorHandler = (error: ErrorResponse) => {
   const operationName = error?.operation?.operationName || '';


### PR DESCRIPTION
## UI integrating API - Save as view

  - Show view on modeling page
  - Save as View Modal

### Task
 - [x] Add Save as View Modal
 - [x] Connect API to create a View
    - validate name
    - save view
    - diagram API

### UI
![截圖 2024-04-15 下午2 20 51](https://github.com/Canner/WrenAI/assets/42527625/561f91f5-d5c3-42d8-abd0-3d411844d51d)
![截圖 2024-04-15 下午2 21 19](https://github.com/Canner/WrenAI/assets/42527625/0dbf8376-5210-469a-8f80-2a377b908e74)
![截圖 2024-04-15 下午2 21 23](https://github.com/Canner/WrenAI/assets/42527625/fcbdd42b-3d1a-4db4-a01b-83bd79f1c6c2)


![截圖 2024-04-15 下午3 38 14](https://github.com/Canner/WrenAI/assets/42527625/ecc40c2d-7710-4858-8fe3-606cddeb6c2f)
![截圖 2024-04-15 下午3 43 49](https://github.com/Canner/WrenAI/assets/42527625/7e92d536-e8b6-4a74-afb2-3ddd87e34f85)

