### PR TITLE
fix(wren-ui/api): fix engine throws 400 error if properties contains non-string value

### DIFF
--- a/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
+++ b/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, pick } from 'lodash';
 import {
   Model,
   ModelColumn,
@@ -104,10 +104,13 @@ export class MDLBuilder implements IMDLBuilder {
       return;
     }
     this.manifest.views = this.views.map((view: View) => {
+      // only pick displayName from properties
+      // if putting properties not string, it will throw error
+      const properties = pick(JSON.parse(view.properties), ['displayName']);
       return {
         name: view.name,
         statement: view.statement,
-        properties: JSON.parse(view.properties),
+        properties,
       };
     });
   }

--- a/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
+++ b/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
@@ -1,4 +1,4 @@
-import { isEmpty, pick } from 'lodash';
+import { isEmpty, pick, pickBy } from 'lodash';
 import {
   Model,
   ModelColumn,
@@ -6,7 +6,7 @@ import {
   RelationInfo,
   View,
 } from '../repositories';
-import { Manifest, ModelMDL } from './type';
+import { Manifest, ModelMDL, ViewMDL } from './type';
 import { getLogger } from '@server/utils';
 
 const logger = getLogger('MDLBuilder');
@@ -104,9 +104,12 @@ export class MDLBuilder implements IMDLBuilder {
       return;
     }
     this.manifest.views = this.views.map((view: View) => {
-      // only pick displayName from properties
       // if putting properties not string, it will throw error
-      const properties = pick(JSON.parse(view.properties), ['displayName']);
+      // filter out properties that have string value
+      const properties = pickBy<ViewMDL['properties']>(
+        JSON.parse(view.properties),
+        (value) => typeof value === 'string',
+      );
       return {
         name: view.name,
         statement: view.statement,

--- a/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
+++ b/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
@@ -1,4 +1,4 @@
-import { isEmpty, pick, pickBy } from 'lodash';
+import { isEmpty, pickBy } from 'lodash';
 import {
   Model,
   ModelColumn,

--- a/wren-ui/src/apollo/server/mdl/type.ts
+++ b/wren-ui/src/apollo/server/mdl/type.ts
@@ -56,7 +56,7 @@ export interface ViewMDL {
   name: string;
   statement: string;
   properties?: {
-    displayName: string;
+    displayName?: string;
     description?: string;
   };
 }


### PR DESCRIPTION
## description
Fix engine throws 400 error if properties contains non-string value