### PR TITLE
feat(wren-ui): UI integration API of View for the modeling page

### DIFF
--- a/wren-ui/src/apollo/client/graphql/view.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/view.generated.ts
@@ -185,7 +185,7 @@ export type ListViewsLazyQueryHookResult = ReturnType<typeof useListViewsLazyQue
 export type ListViewsQueryResult = Apollo.QueryResult<ListViewsQuery, ListViewsQueryVariables>;
 export const PreviewViewDataDocument = gql`
     mutation PreviewViewData($where: ViewWhereUniqueInput!) {
-  previewViewData(where: $data)
+  previewViewData(where: $where)
 }
     `;
 export type PreviewViewDataMutationFn = Apollo.MutationFunction<PreviewViewDataMutation, PreviewViewDataMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/view.ts
+++ b/wren-ui/src/apollo/client/graphql/view.ts
@@ -38,7 +38,7 @@ export const LIST_VIEWS = gql`
 
 export const PREVIEW_VIEW_DATA = gql`
   mutation PreviewViewData($where: ViewWhereUniqueInput!) {
-    previewViewData(where: $data)
+    previewViewData(where: $where)
   }
 `;
 

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -20,6 +20,8 @@ export enum SyncStatusEnum {
   UNSYNCRONIZED = 'UNSYNCRONIZED',
 }
 
+const PREVIEW_MAX_OUTPUT_ROW = 100;
+
 export class ModelResolver {
   constructor() {
     this.listModels = this.listModels.bind(this);
@@ -315,7 +317,10 @@ export class ModelResolver {
       throw new Error('View not found');
     }
 
-    const data = await ctx.wrenEngineAdaptor.previewData(view.statement);
+    const data = await ctx.wrenEngineAdaptor.previewData(
+      view.statement,
+      PREVIEW_MAX_OUTPUT_ROW,
+    );
     return data;
   }
 

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -18,13 +18,17 @@ import Column, {
   MoreColumnTip,
 } from '@/components/diagram/customNode/Column';
 import { PrimaryKeyIcon, ModelIcon } from '@/utils/icons';
-import { ComposeDiagram, ComposeDiagramField } from '@/utils/data';
+import {
+  ComposeDiagram,
+  ComposeDiagramField,
+  DiagramModel,
+} from '@/utils/data';
 import { getColumnTypeIcon } from '@/utils/columnType';
 import { makeIterable } from '@/utils/iteration';
 import { Config } from '@/utils/diagram';
 import { NODE_TYPE } from '@/utils/enum';
 
-export const ModelNode = ({ data }: CustomNodeProps<ComposeDiagram>) => {
+export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
   const context = useContext(DiagramContext);
   const onNodeClick = () => {
     context?.onNodeClick({

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useContext } from 'react';
+import { Typography } from 'antd';
 import {
   highlightEdges,
   highlightNodes,
@@ -28,6 +29,8 @@ import { makeIterable } from '@/utils/iteration';
 import { Config } from '@/utils/diagram';
 import { NODE_TYPE } from '@/utils/enum';
 
+const { Text } = Typography;
+
 export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
   const context = useContext(DiagramContext);
   const onNodeClick = () => {
@@ -49,7 +52,9 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
       <NodeHeader className="dragHandle">
         <span className="adm-model-header">
           <ModelIcon />
-          {data.originalData.displayName}
+          <Text ellipsis title={data.originalData.displayName}>
+            {data.originalData.displayName}
+          </Text>
         </span>
         <span>
           <CachedIcon originalData={data.originalData} />

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useContext } from 'react';
 import { Button } from 'antd';
 import { MoreIcon, ViewIcon } from '@/utils/icons';
 import { MORE_ACTION } from '@/utils/enum';
-import { ComposeDiagram, ComposeDiagramField } from '@/utils/data';
+import { ComposeDiagramField, DiagramView } from '@/utils/data';
 import { getColumnTypeIcon } from '@/utils/columnType';
 import { DiagramContext } from '../Context';
 import { CustomNodeProps, NodeBody, NodeHeader, StyledNode } from './utils';
@@ -10,7 +10,7 @@ import MarkerHandle from './MarkerHandle';
 import Column from './Column';
 import CustomDropdown from '../CustomDropdown';
 
-export const ViewNode = ({ data }: CustomNodeProps<ComposeDiagram>) => {
+export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
   const context = useContext(DiagramContext);
   const onMoreClick = (type: MORE_ACTION) => {
     context?.onMoreClick({

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useContext } from 'react';
-import { Button } from 'antd';
+import { Button, Typography } from 'antd';
 import { MoreIcon, ViewIcon } from '@/utils/icons';
 import { MORE_ACTION } from '@/utils/enum';
 import { ComposeDiagramField, DiagramView } from '@/utils/data';
@@ -9,6 +9,8 @@ import { CustomNodeProps, NodeBody, NodeHeader, StyledNode } from './utils';
 import MarkerHandle from './MarkerHandle';
 import Column from './Column';
 import CustomDropdown from '../CustomDropdown';
+
+const { Text } = Typography;
 
 export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
   const context = useContext(DiagramContext);
@@ -33,12 +35,14 @@ export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
       <NodeHeader className="dragHandle" color="var(--green-6)">
         <span className="adm-model-header">
           <ViewIcon />
-          {data.originalData.displayName}
+          <Text ellipsis title={data.originalData.displayName}>
+            {data.originalData.displayName}
+          </Text>
         </span>
         <span>
           <CustomDropdown onMoreClick={onMoreClick}>
             <Button
-              className="gray-1 ml-1"
+              className="gray-1"
               icon={<MoreIcon />}
               onClick={(event) => event.stopPropagation()}
               type="text"

--- a/wren-ui/src/components/diagram/customNode/utils.tsx
+++ b/wren-ui/src/components/diagram/customNode/utils.tsx
@@ -1,4 +1,4 @@
-import { ComposeDiagram } from '@/utils/data';
+import { CachedProps } from '@/utils/data';
 import { LightningIcon } from '@/utils/icons';
 import { Tooltip } from 'antd';
 import { NodeProps } from 'reactflow';
@@ -116,11 +116,7 @@ export const NodeColumn = styled.div`
   }
 `;
 
-export const CachedIcon = ({
-  originalData,
-}: {
-  originalData: ComposeDiagram;
-}) => {
+export const CachedIcon = ({ originalData }: { originalData: CachedProps }) => {
   return originalData.cached ? (
     <Tooltip
       title={

--- a/wren-ui/src/components/diagram/customNode/utils.tsx
+++ b/wren-ui/src/components/diagram/customNode/utils.tsx
@@ -80,6 +80,11 @@ export const NodeHeader = styled.div`
     + svg {
       cursor: pointer;
     }
+
+    .ant-typography {
+      width: 140px;
+      color: white;
+    }
   }
 `;
 

--- a/wren-ui/src/components/pages/modeling/metadata/ViewMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/ViewMetadata.tsx
@@ -1,16 +1,24 @@
 import { Button, Typography } from 'antd';
 import CodeBlock from '@/components/editor/CodeBlock';
 import PreviewData from '@/components/dataPreview/PreviewData';
+import { DiagramView } from '@/utils/data';
+import { usePreviewViewDataMutation } from '@/apollo/client/graphql/view.generated';
 
-export interface Props {
-  referenceName: string;
-  refSql: string;
-}
+export type Props = DiagramView;
 
 export default function ViewMetadata(props: Props) {
-  const { refSql, referenceName } = props || {};
+  const { referenceName, statement, viewId } = props || {};
 
-  // TODO: connect real preview view data API
+  const [previewViewDataMutation, previewViewDataResult] =
+    usePreviewViewDataMutation({
+      onError: (error) => console.error(error),
+    });
+
+  const onPreviewData = () => {
+    previewViewDataMutation({
+      variables: { where: { id: viewId } },
+    });
+  };
 
   return (
     <>
@@ -23,16 +31,24 @@ export default function ViewMetadata(props: Props) {
         <Typography.Text className="d-block gray-7 mb-2">
           SQL statement
         </Typography.Text>
-        <CodeBlock code={refSql} showLineNumbers maxHeight="300" />
+        <CodeBlock code={statement} showLineNumbers maxHeight="300" />
       </div>
 
       <div className="mb-6">
         <Typography.Text className="d-block gray-7 mb-2">
           Data preview (100 rows)
         </Typography.Text>
-        <Button>Preview data</Button>
+        <Button onClick={onPreviewData} loading={previewViewDataResult.loading}>
+          Preview data
+        </Button>
         <div className="my-3">
-          <PreviewData loading={false} />
+          <PreviewData
+            {...{
+              error: previewViewDataResult.error,
+              loading: previewViewDataResult.loading,
+              previewData: previewViewDataResult?.data?.previewViewData,
+            }}
+          />
         </div>
       </div>
     </>

--- a/wren-ui/src/components/sidebar/modeling/ModelTree.tsx
+++ b/wren-ui/src/components/sidebar/modeling/ModelTree.tsx
@@ -20,7 +20,6 @@ export default function ModelTree(props: {
 
   const [tree, setTree] = useState<DataNode[]>(getModelGroupNode());
 
-  // initial workspace
   useEffect(() => {
     setTree((_tree) =>
       getModelGroupNode({

--- a/wren-ui/src/components/sidebar/modeling/ViewTree.tsx
+++ b/wren-ui/src/components/sidebar/modeling/ViewTree.tsx
@@ -4,6 +4,7 @@ import { Modal } from 'antd';
 import { DataNode } from 'antd/es/tree';
 import PlusSquareOutlined from '@ant-design/icons/PlusSquareOutlined';
 import { Path } from '@/utils/enum';
+import { DiagramView } from '@/utils/data';
 import { getNodeTypeIcon } from '@/utils/nodeType';
 import { createTreeGroupNode, getColumnNode } from '@/components/sidebar/utils';
 import LabelTitle from '@/components/sidebar/LabelTitle';
@@ -19,8 +20,10 @@ export const createViewInfoModalProps = {
   ),
 };
 
-// TODO: update TS for props
-export default function ViewTree(props) {
+export default function ViewTree(props: {
+  [key: string]: any;
+  views: DiagramView[];
+}) {
   const { views } = props;
 
   const getViewGroupNode = createTreeGroupNode({
@@ -40,7 +43,6 @@ export default function ViewTree(props) {
 
   const [tree, setTree] = useState<DataNode[]>(getViewGroupNode());
 
-  // initial workspace
   useEffect(() => {
     setTree((_tree) =>
       getViewGroupNode({

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -3,7 +3,6 @@ import { forwardRef, useMemo, useRef } from 'react';
 import { message } from 'antd';
 import styled from 'styled-components';
 import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
-import { Diagram as DiagramData } from '@/utils/data';
 import SiderLayout from '@/components/layouts/SiderLayout';
 import MetadataDrawer from '@/components/pages/modeling/MetadataDrawer';
 import useDrawerAction from '@/hooks/useDrawerAction';
@@ -25,7 +24,7 @@ const DiagramWrapper = styled.div`
   height: 100%;
 `;
 
-export function Modeling() {
+export default function Modeling() {
   const diagramRef = useRef(null);
 
   const { data } = useDiagramQuery({
@@ -51,7 +50,7 @@ export function Modeling() {
 
   const diagramData = useMemo(() => {
     if (!data) return null;
-    return data?.diagram as DiagramData;
+    return data?.diagram;
   }, [data]);
 
   const metadataDrawer = useDrawerAction();
@@ -123,5 +122,3 @@ export function Modeling() {
     </DeployStatusContext.Provider>
   );
 }
-
-export default Modeling;

--- a/wren-ui/src/utils/data/type/modeling.ts
+++ b/wren-ui/src/utils/data/type/modeling.ts
@@ -1,24 +1,24 @@
 import {
-  Diagram as DiagramType,
   DiagramModel,
   DiagramModelField,
   DiagramModelRelationField,
+  DiagramView,
+  DiagramViewField,
 } from '@/apollo/client/graphql/__types__';
 export type {
+  Diagram,
   DiagramModel,
   DiagramModelField,
   DiagramModelRelationField,
+  DiagramView,
 } from '@/apollo/client/graphql/__types__';
 
-// TODO: remove this when the backend implemented
-export type Diagram = DiagramType & {
-  views: any[];
-};
+export type ComposeDiagram = DiagramModel | DiagramView;
 
-export type ComposeDiagram = DiagramModel;
 export type ComposeDiagramField = (
   | DiagramModelField
   | DiagramModelRelationField
+  | DiagramViewField
 ) &
   Partial<Pick<DiagramModelField, 'isPrimaryKey' | 'columnId'>> &
   Partial<
@@ -31,3 +31,8 @@ export type ComposeDiagramField = (
       | 'relationId'
     >
   >;
+
+export type CachedProps = {
+  cached: boolean;
+  refreshTime?: string;
+};

--- a/wren-ui/src/utils/diagram/transformer.ts
+++ b/wren-ui/src/utils/diagram/transformer.ts
@@ -5,6 +5,7 @@ import {
   Diagram,
   DiagramModel,
   DiagramModelRelationField,
+  DiagramView,
 } from '@/utils/data';
 
 export const Config = {
@@ -62,8 +63,7 @@ export class Transformer {
   private readonly config: typeof Config = Config;
   private models: DiagramModel[];
   public nodes: NodeWithData[] = [];
-  // TODO: update TS type
-  private views: any[];
+  private views: DiagramView[];
   public edges: Edge[] = [];
   private start: StartPoint = {
     x: 0,
@@ -133,7 +133,7 @@ export class Transformer {
     // check nodeType and add edge
     switch (nodeType) {
       case NODE_TYPE.MODEL:
-        this.addModelEdge(data);
+        this.addModelEdge(data as DiagramModel);
         break;
       default:
         break;


### PR DESCRIPTION
## Description

- Integrating delete to view diagram
- View Metadata drawer
    - Connect Diagram API to show view metadata data
    - Connect preview view data API to preview view data
- Note: For save as view and delete view (supported by the product at this stage), users need to return to the modeling page and click the Deploy button to trigger the Deploy button

## APIs

- deleteViewAPI
- diagram API
- previewViewData API

## Tasks

- [x]  Update GraphQL API schema
- [x]  Allow delete view
- [x]  Update TS for diagram API
- [x]  Show view metadata info
- [x]  Allow preview view data
- [x]  Specify 100 limit for previewViewData API 
- [x]  Show ellipsis when text overflows for diagram node header

### UI

#### Delete View

![截圖 2024-04-16 下午4 43 44](https://github.com/Canner/WrenAI/assets/42527625/886d1d1a-fb57-4ad7-8868-4b100ad1df2f)

![截圖 2024-04-16 下午4 43 49](https://github.com/Canner/WrenAI/assets/42527625/c54bd65f-e61c-4a96-b6ec-05ce1df1f15b)


![截圖 2024-04-16 下午4 44 24](https://github.com/Canner/WrenAI/assets/42527625/d8c036ba-4064-42c3-aca7-8e94b9d5ce3b)


#### View metadata info
![截圖 2024-04-16 下午4 44 48](https://github.com/Canner/WrenAI/assets/42527625/122ed35f-bd7f-47d0-b5fc-e37d4660781f)

#### Preview view data

![截圖 2024-04-16 下午4 44 53](https://github.com/Canner/WrenAI/assets/42527625/20827cc8-79ff-4b5a-a375-41952400776f)

#### Show ellipsis when text overflows for diagram node header
![截圖 2024-04-16 下午4 47 52](https://github.com/Canner/WrenAI/assets/42527625/e2673512-a782-4c39-b83a-f63acd293148)


