### PR TITLE
feat(wren-ui): Support share connection info

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -56,6 +56,15 @@ export type CompactTable = {
   properties?: Maybe<Scalars['JSON']>;
 };
 
+export type ConnectionInfo = {
+  __typename?: 'ConnectionInfo';
+  database: Scalars['String'];
+  password?: Maybe<Scalars['String']>;
+  port: Scalars['Int'];
+  schema: Scalars['String'];
+  username?: Maybe<Scalars['String']>;
+};
+
 export type CreateModelInput = {
   cached: Scalars['Boolean'];
   calculatedFields?: InputMaybe<Array<CalculatedFieldInput>>;
@@ -446,6 +455,7 @@ export type Query = {
   __typename?: 'Query';
   askingTask: AskingTask;
   autoGenerateRelation?: Maybe<Array<RecommandRelations>>;
+  connectionInfo: ConnectionInfo;
   diagram: Diagram;
   listDataSourceTables: Array<CompactTable>;
   listModels: Array<ModelInfo>;

--- a/wren-ui/src/apollo/client/graphql/deploy.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/deploy.generated.ts
@@ -13,6 +13,11 @@ export type DeployStatusQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 export type DeployStatusQuery = { __typename?: 'Query', modelSync: { __typename?: 'ModelSyncResponse', status: Types.SyncStatus } };
 
+export type ConnectionInfoQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type ConnectionInfoQuery = { __typename?: 'Query', connectionInfo: { __typename?: 'ConnectionInfo', database: string, schema: string, port: number, username?: string | null, password?: string | null } };
+
 
 export const DeployDocument = gql`
     mutation Deploy {
@@ -78,3 +83,41 @@ export function useDeployStatusLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type DeployStatusQueryHookResult = ReturnType<typeof useDeployStatusQuery>;
 export type DeployStatusLazyQueryHookResult = ReturnType<typeof useDeployStatusLazyQuery>;
 export type DeployStatusQueryResult = Apollo.QueryResult<DeployStatusQuery, DeployStatusQueryVariables>;
+export const ConnectionInfoDocument = gql`
+    query ConnectionInfo {
+  connectionInfo {
+    database
+    schema
+    port
+    username
+    password
+  }
+}
+    `;
+
+/**
+ * __useConnectionInfoQuery__
+ *
+ * To run a query within a React component, call `useConnectionInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useConnectionInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useConnectionInfoQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useConnectionInfoQuery(baseOptions?: Apollo.QueryHookOptions<ConnectionInfoQuery, ConnectionInfoQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ConnectionInfoQuery, ConnectionInfoQueryVariables>(ConnectionInfoDocument, options);
+      }
+export function useConnectionInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConnectionInfoQuery, ConnectionInfoQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ConnectionInfoQuery, ConnectionInfoQueryVariables>(ConnectionInfoDocument, options);
+        }
+export type ConnectionInfoQueryHookResult = ReturnType<typeof useConnectionInfoQuery>;
+export type ConnectionInfoLazyQueryHookResult = ReturnType<typeof useConnectionInfoLazyQuery>;
+export type ConnectionInfoQueryResult = Apollo.QueryResult<ConnectionInfoQuery, ConnectionInfoQueryVariables>;

--- a/wren-ui/src/apollo/client/graphql/deploy.ts
+++ b/wren-ui/src/apollo/client/graphql/deploy.ts
@@ -13,3 +13,15 @@ export const GET_DEPLOY_STATUS = gql`
     }
   }
 `;
+
+export const CONNECTION_INFO = gql`
+  query ConnectionInfo {
+    connectionInfo {
+      database
+      schema
+      port
+      username
+      password
+    }
+  }
+`;

--- a/wren-ui/src/components/HeaderBar.tsx
+++ b/wren-ui/src/components/HeaderBar.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import LogoBar from '@/components/LogoBar';
 import { Path } from '@/utils/enum';
 import Deploy from '@/components/deploy/Deploy';
+import SharePopover from '@/components/SharePopover';
 
 const { Header } = Layout;
 
@@ -66,7 +67,12 @@ export default function HeaderBar() {
             </Space>
           )}
         </Space>
-        {isModeling && <Deploy />}
+        {isModeling && (
+          <Space size={[16, 0]}>
+            <Deploy />
+            <SharePopover />
+          </Space>
+        )}
       </div>
     </StyledHeader>
   );

--- a/wren-ui/src/components/SharePopover.tsx
+++ b/wren-ui/src/components/SharePopover.tsx
@@ -1,0 +1,86 @@
+import { Button, Input, Popover, Space, Typography } from 'antd';
+import styled from 'styled-components';
+import { ShareIcon } from '@/utils/icons';
+import { useConnectionInfoQuery } from '@/apollo/client/graphql/deploy.generated';
+
+const { Title, Text } = Typography;
+
+const Content = styled.div`
+  width: 423px;
+  padding: 4px 0;
+  .adm-share-title {
+    font-size: 14px;
+    margin-bottom: 16px;
+  }
+  .adm-share-subtitle {
+    margin-bottom: 8px;
+  }
+`;
+
+const StyledInput = styled(Input)`
+  display: block;
+  color: var(--gray-10);
+  .ant-input {
+    background-color: var(--gray-4);
+  }
+
+  .ant-typography-copy {
+    color: var(--gray-8);
+  }
+
+  .ant-typography-copy-success:focus {
+    color: var(--green-6);
+  }
+`;
+
+export default function SharePopover() {
+  const { data } = useConnectionInfoQuery();
+  const connections = data?.connectionInfo;
+
+  const sources = [
+    { title: 'Database', type: 'text', value: connections?.database },
+    { title: 'Port', type: 'text', value: String(connections?.port || '') },
+    { title: 'Username', type: 'text', value: connections?.username },
+    { title: 'Password', type: 'password', value: connections?.password },
+  ];
+
+  const content = (
+    <Content>
+      <Title className="adm-share-title">
+        <Space>
+          <ShareIcon />
+          Share
+        </Space>
+      </Title>
+      <div style={{ marginBottom: 16 }}>
+        You can connect applications via our protocol.
+      </div>
+
+      <Space style={{ width: '100%' }} direction="vertical" size={[0, 16]}>
+        {sources.map(({ title, type, value }) => (
+          <div key={title}>
+            <div className="adm-share-subtitle">{title}</div>
+            <StyledInput
+              type={type}
+              readOnly
+              value={value}
+              addonAfter={
+                <Text
+                  copyable={{ text: value, tooltips: ['Copy', 'Copied!'] }}
+                />
+              }
+            />
+          </div>
+        ))}
+      </Space>
+    </Content>
+  );
+
+  return (
+    <Popover content={content} trigger="click" placement="bottomRight">
+      <Button size="small" type="primary" className="adm-modeling-header-btn">
+        Share
+      </Button>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Description
 - Support share connection info

## Tasks
- [x] Add the `Share` button, next to the **Deploy** button on the modeling header bar
- [x] Connect Query **connectionInfo** API
- [x] Share Popover
    -  Add share info description message
    -  Connection information (with a copy button on every property)

### UI

![header_bar_share_button](https://github.com/Canner/WrenAI/assets/42527625/f6ecbbb7-2ec9-4841-b1d9-052f5a0c6799)


![header_bar_share_connection_info](https://github.com/Canner/WrenAI/assets/42527625/499503f0-c7db-4b1a-b528-766f4c6f8096)
