### PR TITLE
fix(wren-ui): Fix pg save data source missing await

### DIFF
--- a/wren-ui/src/apollo/server/factories/pgStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/pgStrategy.ts
@@ -22,9 +22,9 @@ export class PGStrategy implements IDataSourceStrategy {
   public async createDataSource(properties: PGDataSourceProperties) {
     const { displayName, host, port, database, user, password } = properties;
 
-    this.testConnection(properties);
+    await this.testConnection(properties);
 
-    this.patchConfigToWrenEngine(properties);
+    await this.patchConfigToWrenEngine(properties);
 
     // save DataSource to database
     const credentials = { password } as any;


### PR DESCRIPTION
## Description
The onboarding saves PG data source that won't return errors because of missing await the promise of connection testing