### PR TITLE
feat(wren-ui): Add model CRUD UI to diagram

### DIFF
--- a/wren-ui/src/components/ActionButton.tsx
+++ b/wren-ui/src/components/ActionButton.tsx
@@ -1,0 +1,31 @@
+import { Button } from 'antd';
+import PlusSquareOutlined from '@ant-design/icons/PlusSquareOutlined';
+import { MoreIcon } from '@/utils/icons';
+
+interface Props {
+  onClick?: (event: React.MouseEvent) => void;
+  className?: string;
+  marginLeft?: number;
+  marginRight?: number;
+}
+
+const makeActionButton = (icon: React.ReactNode) => (props: Props) => {
+  const { onClick, className, marginLeft, marginRight } = props;
+  const click = (event) => {
+    onClick && onClick(event);
+    event.stopPropagation();
+  };
+  return (
+    <Button
+      className={className}
+      style={{ marginLeft, marginRight }}
+      icon={icon}
+      onClick={click}
+      type="text"
+      size="small"
+    />
+  );
+};
+
+export const AddButton = makeActionButton(<PlusSquareOutlined />);
+export const MoreButton = makeActionButton(<MoreIcon />);

--- a/wren-ui/src/components/ActionButton.tsx
+++ b/wren-ui/src/components/ActionButton.tsx
@@ -4,15 +4,32 @@ import { MoreIcon } from '@/utils/icons';
 
 interface Props {
   onClick?: (event: React.MouseEvent) => void;
+  onMouseEnter?: (event: React.MouseEvent) => void;
+  onMouseLeave?: (event: React.MouseEvent) => void;
   className?: string;
   marginLeft?: number;
   marginRight?: number;
 }
 
 const makeActionButton = (icon: React.ReactNode) => (props: Props) => {
-  const { onClick, className, marginLeft, marginRight } = props;
+  const {
+    onClick,
+    onMouseEnter,
+    onMouseLeave,
+    className,
+    marginLeft,
+    marginRight,
+  } = props;
   const click = (event) => {
     onClick && onClick(event);
+    event.stopPropagation();
+  };
+  const mouseEnter = (event) => {
+    onMouseEnter && onMouseEnter(event);
+    event.stopPropagation();
+  };
+  const mouseLeave = (event) => {
+    onMouseLeave && onMouseLeave(event);
     event.stopPropagation();
   };
   return (
@@ -21,6 +38,8 @@ const makeActionButton = (icon: React.ReactNode) => (props: Props) => {
       style={{ marginLeft, marginRight }}
       icon={icon}
       onClick={click}
+      onMouseEnter={mouseEnter}
+      onMouseLeave={mouseLeave}
       type="text"
       size="small"
     />

--- a/wren-ui/src/components/diagram/Context.ts
+++ b/wren-ui/src/components/diagram/Context.ts
@@ -3,7 +3,6 @@ import { ComposeDiagram } from '@/utils/data';
 
 export interface ClickPayload {
   [key: string]: any;
-  title: string;
   data: ComposeDiagram;
 }
 

--- a/wren-ui/src/components/diagram/Context.ts
+++ b/wren-ui/src/components/diagram/Context.ts
@@ -10,9 +10,11 @@ export interface ClickPayload {
 type ContextProps = {
   onMoreClick: (data: ClickPayload) => void;
   onNodeClick: (data: ClickPayload) => void;
+  onAddClick: (data: ClickPayload) => void;
 } | null;
 
 export const DiagramContext = createContext<ContextProps>({
   onMoreClick: () => {},
   onNodeClick: () => {},
+  onAddClick: () => {},
 });

--- a/wren-ui/src/components/diagram/CustomDropdown.tsx
+++ b/wren-ui/src/components/diagram/CustomDropdown.tsx
@@ -1,8 +1,13 @@
 import { Dropdown, Menu } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
-import { MORE_ACTION } from '@/utils/enum';
+import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
 import EditOutlined from '@ant-design/icons/EditOutlined';
-import { DeleteViewModal } from '@/components/modals/DeleteModal';
+import {
+  DeleteCalculatedFieldModal,
+  DeleteRelationshipModal,
+  DeleteModelModal,
+  DeleteViewModal,
+} from '@/components/modals/DeleteModal';
 
 interface Props {
   [key: string]: any;
@@ -44,7 +49,7 @@ export const ModelDropdown = makeDropdown((props: Props) => {
     },
     {
       label: (
-        <DeleteViewModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
+        <DeleteModelModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
       ),
       className: 'red-5',
       key: MORE_ACTION.DELETE,
@@ -71,7 +76,13 @@ export const ViewDropdown = makeDropdown((props: Props) => {
 });
 
 export const ColumnDropdown = makeDropdown((props: Props) => {
-  const { onMoreClick } = props;
+  const { onMoreClick, nodeType } = props;
+
+  const DeleteColumnModal =
+    {
+      [NODE_TYPE.CALCULATED_FIELD]: DeleteCalculatedFieldModal,
+      [NODE_TYPE.RELATION]: DeleteRelationshipModal,
+    }[nodeType] || DeleteCalculatedFieldModal;
 
   const items: ItemType[] = [
     {
@@ -86,7 +97,7 @@ export const ColumnDropdown = makeDropdown((props: Props) => {
     },
     {
       label: (
-        <DeleteViewModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
+        <DeleteColumnModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
       ),
       className: 'red-5',
       key: MORE_ACTION.DELETE,

--- a/wren-ui/src/components/diagram/CustomDropdown.tsx
+++ b/wren-ui/src/components/diagram/CustomDropdown.tsx
@@ -1,35 +1,49 @@
 import { Dropdown, Menu } from 'antd';
-import { MORE_ACTION } from '@/utils/enum';
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
+import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
+import EditOutlined from '@ant-design/icons/EditOutlined';
 import { DeleteViewModal } from '@/components/modals/DeleteModal';
 
 interface Props {
+  nodeType: NODE_TYPE;
   onMoreClick: (type: MORE_ACTION) => void;
   children: React.ReactNode;
 }
 
 export default function CustomDropdown(props: Props) {
-  const { onMoreClick, children } = props;
+  const { nodeType, onMoreClick, children } = props;
+  const isModel = nodeType === NODE_TYPE.MODEL;
+
+  const items: ItemType[] = [
+    {
+      label: (
+        <DeleteViewModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
+      ),
+      className: 'red-5',
+      key: MORE_ACTION.DELETE,
+      onClick: ({ domEvent }) => domEvent.stopPropagation(),
+    },
+  ];
+
+  if (isModel) {
+    items.unshift({
+      label: (
+        <>
+          <EditOutlined className="gray-8 mr-2" />
+          Update Columns
+        </>
+      ),
+      key: MORE_ACTION.UPDATE_COLUMNS,
+      onClick: () => onMoreClick(MORE_ACTION.UPDATE_COLUMNS),
+    });
+  }
 
   return (
     <Dropdown
       trigger={['click']}
       overlayStyle={{ minWidth: 100, userSelect: 'none' }}
       overlay={
-        <Menu
-          onClick={(e) => e.domEvent.stopPropagation()}
-          items={[
-            {
-              label: (
-                <DeleteViewModal
-                  onConfirm={() => onMoreClick(MORE_ACTION.DELETE)}
-                />
-              ),
-              className: 'red-5',
-              key: MORE_ACTION.DELETE,
-              onClick: ({ domEvent }) => domEvent.stopPropagation(),
-            },
-          ]}
-        />
+        <Menu onClick={(e) => e.domEvent.stopPropagation()} items={items} />
       }
     >
       {children}

--- a/wren-ui/src/components/diagram/CustomDropdown.tsx
+++ b/wren-ui/src/components/diagram/CustomDropdown.tsx
@@ -1,20 +1,47 @@
 import { Dropdown, Menu } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
-import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
+import { MORE_ACTION } from '@/utils/enum';
 import EditOutlined from '@ant-design/icons/EditOutlined';
 import { DeleteViewModal } from '@/components/modals/DeleteModal';
 
 interface Props {
-  nodeType: NODE_TYPE;
+  [key: string]: any;
   onMoreClick: (type: MORE_ACTION) => void;
   children: React.ReactNode;
 }
 
-export default function CustomDropdown(props: Props) {
-  const { nodeType, onMoreClick, children } = props;
-  const isModel = nodeType === NODE_TYPE.MODEL;
+const makeDropdown =
+  (getItems: (props: Props) => ItemType[]) => (props: Props) => {
+    const { children } = props;
 
+    const items = getItems(props);
+
+    return (
+      <Dropdown
+        trigger={['click']}
+        overlayStyle={{ minWidth: 100, userSelect: 'none' }}
+        overlay={
+          <Menu onClick={(e) => e.domEvent.stopPropagation()} items={items} />
+        }
+      >
+        {children}
+      </Dropdown>
+    );
+  };
+
+export const ModelDropdown = makeDropdown((props: Props) => {
+  const { onMoreClick } = props;
   const items: ItemType[] = [
+    {
+      label: (
+        <>
+          <EditOutlined className="gray-8 mr-2" />
+          Update Columns
+        </>
+      ),
+      key: MORE_ACTION.UPDATE_COLUMNS,
+      onClick: () => onMoreClick(MORE_ACTION.UPDATE_COLUMNS),
+    },
     {
       label: (
         <DeleteViewModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
@@ -25,28 +52,47 @@ export default function CustomDropdown(props: Props) {
     },
   ];
 
-  if (isModel) {
-    items.unshift({
+  return items;
+});
+
+export const ViewDropdown = makeDropdown((props: Props) => {
+  const { onMoreClick } = props;
+  const items: ItemType[] = [
+    {
+      label: (
+        <DeleteViewModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
+      ),
+      className: 'red-5',
+      key: MORE_ACTION.DELETE,
+      onClick: ({ domEvent }) => domEvent.stopPropagation(),
+    },
+  ];
+  return items;
+});
+
+export const ColumnDropdown = makeDropdown((props: Props) => {
+  const { onMoreClick } = props;
+
+  const items: ItemType[] = [
+    {
       label: (
         <>
           <EditOutlined className="gray-8 mr-2" />
-          Update Columns
+          Edit
         </>
       ),
-      key: MORE_ACTION.UPDATE_COLUMNS,
-      onClick: () => onMoreClick(MORE_ACTION.UPDATE_COLUMNS),
-    });
-  }
+      key: MORE_ACTION.EDIT,
+      onClick: () => onMoreClick(MORE_ACTION.EDIT),
+    },
+    {
+      label: (
+        <DeleteViewModal onConfirm={() => onMoreClick(MORE_ACTION.DELETE)} />
+      ),
+      className: 'red-5',
+      key: MORE_ACTION.DELETE,
+      onClick: ({ domEvent }) => domEvent.stopPropagation(),
+    },
+  ];
 
-  return (
-    <Dropdown
-      trigger={['click']}
-      overlayStyle={{ minWidth: 100, userSelect: 'none' }}
-      overlay={
-        <Menu onClick={(e) => e.domEvent.stopPropagation()} items={items} />
-      }
-    >
-      {children}
-    </Dropdown>
-  );
-}
+  return items;
+});

--- a/wren-ui/src/components/diagram/CustomDropdown.tsx
+++ b/wren-ui/src/components/diagram/CustomDropdown.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Dropdown, Menu } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
@@ -12,12 +13,13 @@ import {
 interface Props {
   [key: string]: any;
   onMoreClick: (type: MORE_ACTION) => void;
+  onMenuEnter?: (event: React.MouseEvent) => void;
   children: React.ReactNode;
 }
 
 const makeDropdown =
   (getItems: (props: Props) => ItemType[]) => (props: Props) => {
-    const { children } = props;
+    const { children, onMenuEnter } = props;
 
     const items = getItems(props);
 
@@ -26,7 +28,11 @@ const makeDropdown =
         trigger={['click']}
         overlayStyle={{ minWidth: 100, userSelect: 'none' }}
         overlay={
-          <Menu onClick={(e) => e.domEvent.stopPropagation()} items={items} />
+          <Menu
+            onClick={(e) => e.domEvent.stopPropagation()}
+            items={items}
+            onMouseEnter={onMenuEnter}
+          />
         }
       >
         {children}
@@ -36,6 +42,7 @@ const makeDropdown =
 
 export const ModelDropdown = makeDropdown((props: Props) => {
   const { onMoreClick } = props;
+
   const items: ItemType[] = [
     {
       label: (
@@ -76,7 +83,8 @@ export const ViewDropdown = makeDropdown((props: Props) => {
 });
 
 export const ColumnDropdown = makeDropdown((props: Props) => {
-  const { onMoreClick, nodeType } = props;
+  const { onMoreClick, data } = props;
+  const { nodeType } = data;
 
   const DeleteColumnModal =
     {

--- a/wren-ui/src/components/diagram/customNode/Column.tsx
+++ b/wren-ui/src/components/diagram/customNode/Column.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ReactFlowInstance, useReactFlow } from 'reactflow';
 import styled from 'styled-components';
 import MarkerHandle from '@/components/diagram/customNode/MarkerHandle';
@@ -34,7 +35,10 @@ const NodeColumn = styled.div`
   }
 `;
 
-export const ColumnTitle = styled.div`
+const Title = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   color: var(--gray-8);
   padding: 4px 12px;
   cursor: default;
@@ -46,10 +50,17 @@ type ColumnProps = {
   displayName: string;
   style?: React.CSSProperties;
   icon: React.ReactNode;
-  append?: React.ReactNode;
+  extra?: React.ReactNode;
   onMouseEnter?: (reactflowInstance: ReactFlowInstance) => void;
   onMouseLeave?: (reactflowInstance: ReactFlowInstance) => void;
 };
+
+type ColumnTitleProps = {
+  show: boolean;
+  extra?: React.ReactNode;
+  children: React.ReactNode;
+};
+
 export default function Column(props: ColumnProps) {
   const {
     id,
@@ -59,7 +70,7 @@ export default function Column(props: ColumnProps) {
     displayName,
     style = {},
     icon,
-    append,
+    extra,
   } = props;
   const reactflowInstance = useReactFlow();
   const mouseEnter = onMouseEnter
@@ -79,7 +90,7 @@ export default function Column(props: ColumnProps) {
         <span title={type}>{icon}</span>
         <span title={displayName}>{displayName}</span>
       </div>
-      {append}
+      {extra}
       <MarkerHandle id={id.toString()} />
     </NodeColumn>
   );
@@ -87,6 +98,21 @@ export default function Column(props: ColumnProps) {
   return nodeColumn;
 }
 
-export const MoreColumnTip = (props: { count: number }) => {
+const MoreColumnTip = (props: { count: number }) => {
   return <div className="text-sm gray-7 px-3 py-1">and {props.count} more</div>;
 };
+
+const ColumnTitle = (props: ColumnTitleProps) => {
+  const { show, extra, children } = props;
+  if (!show) return null;
+
+  return (
+    <Title>
+      {children}
+      <span>{extra}</span>
+    </Title>
+  );
+};
+
+Column.Title = ColumnTitle;
+Column.MoreTip = MoreColumnTip;

--- a/wren-ui/src/components/diagram/customNode/Column.tsx
+++ b/wren-ui/src/components/diagram/customNode/Column.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ReactFlowInstance, useReactFlow } from 'reactflow';
 import styled from 'styled-components';
 import MarkerHandle from '@/components/diagram/customNode/MarkerHandle';
 
@@ -50,8 +49,8 @@ type ColumnProps = {
   style?: React.CSSProperties;
   icon: React.ReactNode;
   extra?: React.ReactNode;
-  onMouseEnter?: (reactflowInstance: ReactFlowInstance) => void;
-  onMouseLeave?: (reactflowInstance: ReactFlowInstance) => void;
+  onMouseEnter?: (event: React.MouseEvent) => void;
+  onMouseLeave?: (event: React.MouseEvent) => void;
 };
 
 type ColumnTitleProps = {
@@ -71,19 +70,12 @@ export default function Column(props: ColumnProps) {
     icon,
     extra,
   } = props;
-  const reactflowInstance = useReactFlow();
-  const mouseEnter = onMouseEnter
-    ? () => onMouseEnter(reactflowInstance)
-    : undefined;
-  const mouseLeave = onMouseLeave
-    ? () => onMouseLeave(reactflowInstance)
-    : undefined;
 
   const nodeColumn = (
     <NodeColumn
       style={style}
-      onMouseEnter={mouseEnter}
-      onMouseLeave={mouseLeave}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <div className="adm-column-title">
         <span title={type}>{icon}</span>

--- a/wren-ui/src/components/diagram/customNode/Column.tsx
+++ b/wren-ui/src/components/diagram/customNode/Column.tsx
@@ -16,7 +16,6 @@ const NodeColumn = styled.div`
   }
 
   svg {
-    cursor: auto;
     flex-shrink: 0;
   }
 

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -38,13 +38,11 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
   const onMoreClick = (type: MORE_ACTION) => {
     context?.onMoreClick({
       type,
-      title: data.originalData.displayName,
       data: data.originalData,
     });
   };
   const onNodeClick = () => {
     context?.onNodeClick({
-      title: data.originalData.displayName,
       data: data.originalData,
     });
   };

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -48,6 +48,12 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
       data: data.originalData,
     });
   };
+  const onAddClick = (targetNodeType: NODE_TYPE) => {
+    context?.onAddClick({
+      targetNodeType,
+      data: data.originalData,
+    });
+  };
 
   const hasRelationships = !!data.originalData.relationFields.length;
   const hasCalculatedFields = !!data.originalData.calculatedFields.length;
@@ -68,9 +74,9 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
         </span>
         <span>
           <CachedIcon originalData={data.originalData} />
-          <CustomDropdown nodeType={NODE_TYPE.MODEL} onMoreClick={onMoreClick}>
+          <ModelDropdown onMoreClick={onMoreClick}>
             <MoreButton className="gray-1" marginRight={-4} />
-          </CustomDropdown>
+          </ModelDropdown>
         </span>
 
         <MarkerHandle id={data.originalData.id.toString()} />
@@ -80,14 +86,26 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
         {renderColumns([...data.originalData.fields])}
         <Column.Title
           show={hasCalculatedFields}
-          extra={<AddButton className="gray-8" marginRight={-8} />}
+          extra={
+            <AddButton
+              className="gray-8"
+              marginRight={-8}
+              onClick={() => onAddClick(NODE_TYPE.CALCULATED_FIELD)}
+            />
+          }
         >
           Calculated Fields
         </Column.Title>
         {renderColumns(data.originalData.calculatedFields)}
         <Column.Title
           show={hasRelationships}
-          extra={<AddButton className="gray-8" marginRight={-8} />}
+          extra={
+            <AddButton
+              className="gray-8"
+              marginRight={-8}
+              onClick={() => onAddClick(NODE_TYPE.RELATION)}
+            />
+          }
         >
           Relationships
         </Column.Title>
@@ -104,6 +122,14 @@ const ColumnTemplate = (props) => {
   const isRelationship = nodeType === NODE_TYPE.RELATION;
   const isCalculatedField = nodeType === NODE_TYPE.CALCULATED_FIELD;
   const isMoreButtonShow = isCalculatedField || isRelationship;
+
+  const context = useContext(DiagramContext);
+  const onMoreClick = (type: MORE_ACTION) => {
+    context?.onMoreClick({
+      type,
+      data: props,
+    });
+  };
 
   const onMouseEnter = useCallback((reactflowInstance: any) => {
     if (!isRelationship) return;

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useContext } from 'react';
-import { Typography } from 'antd';
+import { Button, Typography } from 'antd';
 import {
   highlightEdges,
   highlightNodes,
@@ -18,7 +18,7 @@ import Column, {
   ColumnTitle,
   MoreColumnTip,
 } from '@/components/diagram/customNode/Column';
-import { PrimaryKeyIcon, ModelIcon } from '@/utils/icons';
+import { PrimaryKeyIcon, ModelIcon, MoreIcon } from '@/utils/icons';
 import {
   ComposeDiagram,
   ComposeDiagramField,
@@ -27,12 +27,20 @@ import {
 import { getColumnTypeIcon } from '@/utils/columnType';
 import { makeIterable } from '@/utils/iteration';
 import { Config } from '@/utils/diagram';
-import { NODE_TYPE } from '@/utils/enum';
+import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
+import CustomDropdown from '@/components/diagram/CustomDropdown';
 
 const { Text } = Typography;
 
 export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
   const context = useContext(DiagramContext);
+  const onMoreClick = (type: MORE_ACTION) => {
+    context?.onMoreClick({
+      type,
+      title: data.originalData.displayName,
+      data: data.originalData,
+    });
+  };
   const onNodeClick = () => {
     context?.onNodeClick({
       title: data.originalData.displayName,
@@ -58,6 +66,15 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
         </span>
         <span>
           <CachedIcon originalData={data.originalData} />
+          <CustomDropdown nodeType={NODE_TYPE.MODEL} onMoreClick={onMoreClick}>
+            <Button
+              className="gray-1"
+              icon={<MoreIcon />}
+              onClick={(event) => event.stopPropagation()}
+              type="text"
+              size="small"
+            />
+          </CustomDropdown>
         </span>
 
         <MarkerHandle id={data.originalData.id.toString()} />

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -138,7 +138,7 @@ const ColumnTemplate = (props) => {
         <>
           {isPrimaryKey && <PrimaryKeyIcon />}{' '}
           {isMoreButtonShow && (
-            <ColumnDropdown onMoreClick={onMoreClick}>
+            <ColumnDropdown nodeType={nodeType} onMoreClick={onMoreClick}>
               <MoreButton className="gray-8" marginRight={-4} />
             </ColumnDropdown>
           )}

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -25,7 +25,10 @@ import { getColumnTypeIcon } from '@/utils/columnType';
 import { makeIterable } from '@/utils/iteration';
 import { Config } from '@/utils/diagram';
 import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
-import CustomDropdown from '@/components/diagram/CustomDropdown';
+import {
+  ModelDropdown,
+  ColumnDropdown,
+} from '@/components/diagram/CustomDropdown';
 import { AddButton, MoreButton } from '@/components/ActionButton';
 
 const { Text } = Typography;
@@ -135,7 +138,9 @@ const ColumnTemplate = (props) => {
         <>
           {isPrimaryKey && <PrimaryKeyIcon />}{' '}
           {isMoreButtonShow && (
-            <MoreButton className="gray-8" marginRight={-4} />
+            <ColumnDropdown onMoreClick={onMoreClick}>
+              <MoreButton className="gray-8" marginRight={-4} />
+            </ColumnDropdown>
           )}
         </>
       }

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -24,13 +24,11 @@ export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
   const onMoreClick = (type: MORE_ACTION) => {
     context?.onMoreClick({
       type,
-      title: data.originalData.displayName,
       data: data.originalData,
     });
   };
   const onNodeClick = () => {
     context?.onNodeClick({
-      title: data.originalData.displayName,
       data: data.originalData,
     });
   };

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useContext } from 'react';
 import { Button, Typography } from 'antd';
 import { MoreIcon, ViewIcon } from '@/utils/icons';
-import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
+import { MORE_ACTION } from '@/utils/enum';
 import { ComposeDiagram, ComposeDiagramField, DiagramView } from '@/utils/data';
 import { getColumnTypeIcon } from '@/utils/columnType';
 import { Config } from '@/utils/diagram';
@@ -15,7 +15,7 @@ import {
 } from '@/components/diagram/customNode/utils';
 import MarkerHandle from '@/components/diagram/customNode/MarkerHandle';
 import Column from '@/components/diagram/customNode/Column';
-import CustomDropdown from '@/components/diagram/CustomDropdown';
+import { ViewDropdown } from '@/components/diagram/CustomDropdown';
 
 const { Text } = Typography;
 
@@ -51,7 +51,7 @@ export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
           </Text>
         </span>
         <span>
-          <CustomDropdown nodeType={NODE_TYPE.VIEW} onMoreClick={onMoreClick}>
+          <ViewDropdown onMoreClick={onMoreClick}>
             <Button
               className="gray-1"
               icon={<MoreIcon />}
@@ -59,7 +59,7 @@ export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
               type="text"
               size="small"
             />
-          </CustomDropdown>
+          </ViewDropdown>
         </span>
 
         <MarkerHandle id={data.originalData.id} />

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -1,16 +1,21 @@
 import { memo, useCallback, useContext } from 'react';
 import { Button, Typography } from 'antd';
 import { MoreIcon, ViewIcon } from '@/utils/icons';
-import { MORE_ACTION } from '@/utils/enum';
+import { MORE_ACTION, NODE_TYPE } from '@/utils/enum';
 import { ComposeDiagram, ComposeDiagramField, DiagramView } from '@/utils/data';
 import { getColumnTypeIcon } from '@/utils/columnType';
 import { Config } from '@/utils/diagram';
 import { makeIterable } from '@/utils/iteration';
-import { DiagramContext } from '../Context';
-import { CustomNodeProps, NodeBody, NodeHeader, StyledNode } from './utils';
-import MarkerHandle from './MarkerHandle';
-import Column, { MoreColumnTip } from './Column';
-import CustomDropdown from '../CustomDropdown';
+import { DiagramContext } from '@/components/diagram/Context';
+import {
+  CustomNodeProps,
+  NodeBody,
+  NodeHeader,
+  StyledNode,
+} from '@/components/diagram/customNode/utils';
+import MarkerHandle from '@/components/diagram/customNode/MarkerHandle';
+import Column, { MoreColumnTip } from '@/components/diagram/customNode/Column';
+import CustomDropdown from '@/components/diagram/CustomDropdown';
 
 const { Text } = Typography;
 
@@ -46,7 +51,7 @@ export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
           </Text>
         </span>
         <span>
-          <CustomDropdown onMoreClick={onMoreClick}>
+          <CustomDropdown nodeType={NODE_TYPE.VIEW} onMoreClick={onMoreClick}>
             <Button
               className="gray-1"
               icon={<MoreIcon />}

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -14,7 +14,7 @@ import {
   StyledNode,
 } from '@/components/diagram/customNode/utils';
 import MarkerHandle from '@/components/diagram/customNode/MarkerHandle';
-import Column, { MoreColumnTip } from '@/components/diagram/customNode/Column';
+import Column from '@/components/diagram/customNode/Column';
 import CustomDropdown from '@/components/diagram/CustomDropdown';
 
 const { Text } = Typography;
@@ -92,7 +92,7 @@ function getColumns(
   return (
     <>
       <ColumnIterator data={slicedColumns} highlight={data.highlight} />
-      {moreCount > 0 && <MoreColumnTip count={moreCount} />}
+      {moreCount > 0 && <Column.MoreTip count={moreCount} />}
     </>
   );
 }

--- a/wren-ui/src/components/diagram/customNode/utils.tsx
+++ b/wren-ui/src/components/diagram/customNode/utils.tsx
@@ -93,34 +93,6 @@ export const NodeBody = styled.div`
   padding-bottom: 4px;
 `;
 
-export const NodeColumn = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 4px 12px;
-  color: var(--gray-9);
-
-  svg {
-    cursor: auto;
-    flex-shrink: 0;
-  }
-
-  .adm-column-title {
-    display: flex;
-    align-items: center;
-    min-width: 1px;
-    svg {
-      margin-right: 6px;
-    }
-    > span {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
-`;
-
 export const CachedIcon = ({ originalData }: { originalData: CachedProps }) => {
   return originalData.cached ? (
     <Tooltip

--- a/wren-ui/src/components/diagram/index.tsx
+++ b/wren-ui/src/components/diagram/index.tsx
@@ -47,13 +47,14 @@ interface Props {
   data: DiagramData;
   onMoreClick: (data: ClickPayload) => void;
   onNodeClick: (data: ClickPayload) => void;
+  onAddClick: (data: ClickPayload) => void;
 }
 
 const ReactFlowDiagram = forwardRef(function ReactFlowDiagram(
   props: Props,
   ref,
 ) {
-  const { data, onMoreClick, onNodeClick } = props;
+  const { data, onMoreClick, onNodeClick, onAddClick } = props;
   const [forceRender, setForceRender] = useState(false);
   const reactFlowInstance = useReactFlow();
   useImperativeHandle(ref, () => reactFlowInstance, [reactFlowInstance]);
@@ -110,7 +111,7 @@ const ReactFlowDiagram = forwardRef(function ReactFlowDiagram(
 
   return (
     <>
-      <DiagramContext.Provider value={{ onMoreClick, onNodeClick }}>
+      <DiagramContext.Provider value={{ onMoreClick, onNodeClick, onAddClick }}>
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/wren-ui/src/components/modals/DeleteModal.tsx
+++ b/wren-ui/src/components/modals/DeleteModal.tsx
@@ -72,3 +72,24 @@ export const DeleteViewModal = makeDeleteModal(DefaultDeleteButton, {
   content:
     'This will be permanently deleted, please confirm you want to delete it.',
 });
+
+export const DeleteModelModal = makeDeleteModal(DefaultDeleteButton, {
+  icon: <DeleteOutlined className="mr-2" />,
+  itemName: 'model',
+  content:
+    'This will be permanently deleted, please confirm you want to delete it.',
+});
+
+export const DeleteCalculatedFieldModal = makeDeleteModal(DefaultDeleteButton, {
+  icon: <DeleteOutlined className="mr-2" />,
+  itemName: 'calculated field',
+  content:
+    'This will be permanently deleted, please confirm you want to delete it.',
+});
+
+export const DeleteRelationshipModal = makeDeleteModal(DefaultDeleteButton, {
+  icon: <DeleteOutlined className="mr-2" />,
+  itemName: 'relationship',
+  content:
+    'This will be permanently deleted, please confirm you want to delete it.',
+});

--- a/wren-ui/src/components/modals/DeleteModal.tsx
+++ b/wren-ui/src/components/modals/DeleteModal.tsx
@@ -18,7 +18,7 @@ type Config = {
 
 export const makeDeleteModal =
   (Component, config?: Config) => (props: DeleteModalProps) => {
-    const { content, modalProps = {}, onConfirm, ...restProps } = props;
+    const { title, content, modalProps = {}, onConfirm, ...restProps } = props;
 
     return (
       <Component

--- a/wren-ui/src/components/pages/modeling/metadata/ModelMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/ModelMetadata.tsx
@@ -36,7 +36,7 @@ export default function ModelMetadata(props: Props) {
 
       <div className="mb-6">
         <Typography.Text className="d-block gray-7 mb-2">
-          Fields ({fields.length})
+          Columns ({fields.length})
         </Typography.Text>
         <FieldTable dataSource={fields} />
       </div>

--- a/wren-ui/src/components/sidebar/Modeling.tsx
+++ b/wren-ui/src/components/sidebar/Modeling.tsx
@@ -28,15 +28,21 @@ export const StyledSidebarTree = styled(SidebarTree)`
 export interface Props {
   data: Diagram;
   onSelect: (selectKeys) => void;
+  onOpenModelDrawer: () => void;
 }
 
 export default function Modeling(props: Props) {
-  const { data, onSelect } = props;
+  const { data, onSelect, onOpenModelDrawer } = props;
   const { models = [], views = [] } = data || {};
 
   return (
     <>
-      <ModelTree models={models} onSelect={onSelect} selectedKeys={[]} />
+      <ModelTree
+        models={models}
+        onSelect={onSelect}
+        selectedKeys={[]}
+        onOpenModelDrawer={onOpenModelDrawer}
+      />
       <ViewTree views={views} onSelect={onSelect} selectedKeys={[]} />
     </>
   );

--- a/wren-ui/src/components/sidebar/modeling/ModelTree.tsx
+++ b/wren-ui/src/components/sidebar/modeling/ModelTree.tsx
@@ -4,18 +4,27 @@ import { DiagramModel } from '@/utils/data';
 import { getNodeTypeIcon } from '@/utils/nodeType';
 import { createTreeGroupNode, getColumnNode } from '@/components/sidebar/utils';
 import LabelTitle from '@/components/sidebar/LabelTitle';
+import PlusSquareOutlined from '@ant-design/icons/PlusSquareOutlined';
 import { StyledSidebarTree } from '@/components/sidebar/Modeling';
 
-export default function ModelTree(props: {
+interface Props {
   [key: string]: any;
   models: DiagramModel[];
-}) {
-  const { models } = props;
+  onOpenModelDrawer: () => void;
+}
+
+export default function ModelTree(props: Props) {
+  const { onOpenModelDrawer, models } = props;
 
   const getModelGroupNode = createTreeGroupNode({
     groupName: 'Models',
     groupKey: 'models',
-    icons: [],
+    icons: [
+      {
+        key: 'add-model',
+        icon: () => <PlusSquareOutlined onClick={() => onOpenModelDrawer()} />,
+      },
+    ],
   });
 
   const [tree, setTree] = useState<DataNode[]>(getModelGroupNode());

--- a/wren-ui/src/components/sidebar/modeling/ViewTree.tsx
+++ b/wren-ui/src/components/sidebar/modeling/ViewTree.tsx
@@ -10,6 +10,11 @@ import { createTreeGroupNode, getColumnNode } from '@/components/sidebar/utils';
 import LabelTitle from '@/components/sidebar/LabelTitle';
 import { StyledSidebarTree } from '@/components/sidebar/Modeling';
 
+interface Props {
+  [key: string]: any;
+  views: DiagramView[];
+}
+
 export const createViewInfoModalProps = {
   title: 'How to create a View?',
   content: (
@@ -31,10 +36,7 @@ export const createViewInfoModalProps = {
   } as any,
 };
 
-export default function ViewTree(props: {
-  [key: string]: any;
-  views: DiagramView[];
-}) {
+export default function ViewTree(props: Props) {
   const { views } = props;
 
   const getViewGroupNode = createTreeGroupNode({

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -107,6 +107,10 @@ export default function Modeling() {
         sidebar={{
           data: diagramData,
           onSelect,
+          onOpenModelDrawer: () => {
+            // TODO: open model drawer
+            console.log('open model drawer');
+          },
         }}
       >
         <DiagramWrapper>

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -77,14 +77,42 @@ export default function Modeling() {
 
   const onMoreClick = (payload) => {
     const { type, data } = payload;
+    const { nodeType } = data;
     const action = {
+      [MORE_ACTION.UPDATE_COLUMNS]: () => {
+        switch (nodeType) {
+          case NODE_TYPE.MODEL:
+            console.log('update columns');
+            break;
+          default:
+            console.log(data);
+            break;
+        }
+      },
       [MORE_ACTION.EDIT]: () => {
-        // TODO: handle edit action
+        switch (nodeType) {
+          case NODE_TYPE.CALCULATED_FIELD:
+            console.log('edit calculated field');
+            break;
+          case NODE_TYPE.RELATION:
+            console.log('edit relation');
+            break;
+          default:
+            console.log(data);
+            break;
+        }
       },
       [MORE_ACTION.DELETE]: async () => {
-        const { nodeType } = data;
-
         switch (nodeType) {
+          case NODE_TYPE.MODEL:
+            console.log('delete model');
+            break;
+          case NODE_TYPE.CALCULATED_FIELD:
+            console.log('delete calculated field');
+            break;
+          case NODE_TYPE.RELATION:
+            console.log('delete relation');
+            break;
           case NODE_TYPE.VIEW:
             await deleteViewMutation({
               variables: { where: { id: data.viewId } },
@@ -98,6 +126,21 @@ export default function Modeling() {
       },
     };
     action[type] && action[type]();
+  };
+
+  const onAddClick = (payload) => {
+    const { targetNodeType } = payload;
+    switch (targetNodeType) {
+      case NODE_TYPE.CALCULATED_FIELD:
+        console.log('add calculated field');
+        break;
+      case NODE_TYPE.RELATION:
+        console.log('add relation');
+        break;
+      default:
+        console.log('add', targetNodeType);
+        break;
+    }
   };
 
   return (
@@ -119,6 +162,7 @@ export default function Modeling() {
             data={diagramData}
             onMoreClick={onMoreClick}
             onNodeClick={onNodeClick}
+            onAddClick={onAddClick}
           />
         </DiagramWrapper>
         <MetadataDrawer

--- a/wren-ui/src/utils/enum/modeling.ts
+++ b/wren-ui/src/utils/enum/modeling.ts
@@ -6,4 +6,5 @@ export {
 export enum MORE_ACTION {
   EDIT = 'edit',
   DELETE = 'delete',
+  UPDATE_COLUMNS = 'update_columns',
 }


### PR DESCRIPTION
## Description

- Add more action in diagram
- Sidebar can only create model, others actions will be added in diagram.

## Tasks

- [x] Model diagram add calculated fields subtitle & create, edit, delete
    - [x]  columns.length > Config.columnsLimit (50)
- [x] Model diagram add relations subtitle & create, edit, delete
- [x] Model diagram more actions: Update columns
- [x] Adapt all actions to modeling page 
- [x] Unify `fields` naming to columns
