### PR TITLE
feat(wren-ui): Show metadata of model & provide expandable rows to table

### DIFF
--- a/wren-ui/src/components/pages/modeling/metadata/ModelMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/ModelMetadata.tsx
@@ -9,17 +9,29 @@ export interface Props {
   fields: any[];
   calculatedFields: any[];
   relationFields: any[];
+  description: string;
   properties: Record<string, any>;
 }
 
 export default function ModelMetadata(props: Props) {
-  const { referenceName, fields = [], relationFields = [] } = props || {};
+  const {
+    referenceName,
+    fields = [],
+    relationFields = [],
+    description,
+  } = props || {};
 
   return (
     <>
       <div className="mb-6">
         <Typography.Text className="d-block gray-7 mb-2">Name</Typography.Text>
         <div>{referenceName || '-'}</div>
+      </div>
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Description
+        </Typography.Text>
+        <div>{description || '-'}</div>
       </div>
 
       <div className="mb-6">

--- a/wren-ui/src/components/table/BaseTable.tsx
+++ b/wren-ui/src/components/table/BaseTable.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
-import { Table, TableProps } from 'antd';
+import { Table, TableProps, Row, Col } from 'antd';
 import EllipsisWrapper from '@/components/EllipsisWrapper';
 import CodeBlock from '@/components/editor/CodeBlock';
 import { getColumnTypeIcon } from '@/utils/columnType';
 import { ComposeDiagramField, getJoinTypeText } from '@/utils/data';
+import { makeIterable } from '@/utils/iteration';
 
 export const COLUMN = {
   DISPLAY_NAME: {
@@ -110,5 +111,29 @@ export default function BaseTable(props: Props) {
         size: 'small',
       }}
     />
+  );
+}
+
+const ExpandableRowIterator = makeIterable((props) => {
+  const { title, value, index } = props;
+  return (
+    <>
+      {index > 0 && <div className="border-b border-gray-5" />}
+      <Row wrap={false} className="py-1 px-4">
+        <Col span={6} className="gray-6">
+          {title}
+        </Col>
+        <Col>{value}</Col>
+      </Row>
+    </>
+  );
+});
+
+export function ExpandableRows(props) {
+  const { data } = props;
+  return (
+    <div className="pl-12 text-sm gray-8 -my-1">
+      <ExpandableRowIterator data={data} />
+    </div>
   );
 }

--- a/wren-ui/src/components/table/FieldTable.tsx
+++ b/wren-ui/src/components/table/FieldTable.tsx
@@ -1,11 +1,28 @@
-import BaseTable, { Props, COLUMN } from '@/components/table/BaseTable';
+import BaseTable, {
+  Props,
+  COLUMN,
+  ExpandableRows,
+} from '@/components/table/BaseTable';
 
 export default function FieldTable(props: Props) {
   const { columns } = props;
   return (
     <BaseTable
       {...props}
-      columns={columns || [COLUMN.REFERENCE_NAME, COLUMN.TYPE]}
+      columns={
+        columns || [
+          COLUMN.REFERENCE_NAME,
+          COLUMN.TYPE,
+          { ...COLUMN.DESCRIPTION, width: 280 },
+        ]
+      }
+      expandable={{
+        expandedRowRender: (record) => (
+          <ExpandableRows
+            data={[{ title: 'Description', value: record.description || '-' }]}
+          />
+        ),
+      }}
     />
   );
 }

--- a/wren-ui/src/components/table/RelationTable.tsx
+++ b/wren-ui/src/components/table/RelationTable.tsx
@@ -1,4 +1,8 @@
-import BaseTable, { Props, COLUMN } from '@/components/table/BaseTable';
+import BaseTable, {
+  Props,
+  COLUMN,
+  ExpandableRows,
+} from '@/components/table/BaseTable';
 
 export default function RelationTable(props: Props) {
   const { columns } = props;
@@ -11,9 +15,16 @@ export default function RelationTable(props: Props) {
           COLUMN.RELATION_FROM,
           COLUMN.RELATION_TO,
           COLUMN.RELATION,
-          COLUMN.DESCRIPTION,
+          { ...COLUMN.DESCRIPTION, width: 150 },
         ]
       }
+      expandable={{
+        expandedRowRender: (record) => (
+          <ExpandableRows
+            data={[{ title: 'Description', value: record.description || '-' }]}
+          />
+        ),
+      }}
     />
   );
 }

--- a/wren-ui/src/styles/components/table.less
+++ b/wren-ui/src/styles/components/table.less
@@ -15,6 +15,12 @@
       border-bottom: none;
     }
   }
+
+  .ant-table-expanded-row {
+    .ant-table-cell {
+      background-color: @gray-3;
+    }
+  }
 }
 
 .ant-table-wrapper:not(.ant-table-has-header) {

--- a/wren-ui/src/utils/data/type/modeling.ts
+++ b/wren-ui/src/utils/data/type/modeling.ts
@@ -20,6 +20,7 @@ export type ComposeDiagramField = (
   | DiagramModelRelationField
   | DiagramViewField
 ) &
+  Partial<Pick<DiagramModel, 'description'>> &
   Partial<Pick<DiagramModelField, 'isPrimaryKey' | 'columnId'>> &
   Partial<
     Pick<


### PR DESCRIPTION
## Description
- Show metadata in metadata drawer
- Provide expandable table for full description showing

## UI Screenshot
<img width="1866" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/16eca797-b066-42d9-bad1-dcaa79173908">
