### PR TITLE
feat(wren-ui): Improve thread response UI

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -177,6 +177,7 @@ export type DetailedThread = {
   __typename?: 'DetailedThread';
   id: Scalars['Int'];
   responses: Array<ThreadResponse>;
+  /** @deprecated Doesn't seem to be reasonable to put a sql in a thread */
   sql: Scalars['String'];
   summary: Scalars['String'];
 };
@@ -602,6 +603,7 @@ export type Task = {
 export type Thread = {
   __typename?: 'Thread';
   id: Scalars['Int'];
+  /** @deprecated Doesn't seem to be reasonable to put a sql in a thread */
   sql: Scalars['String'];
   summary: Scalars['String'];
 };
@@ -613,6 +615,7 @@ export type ThreadResponse = {
   id: Scalars['Int'];
   question: Scalars['String'];
   status: AskingTaskStatus;
+  summary: Scalars['String'];
 };
 
 export type ThreadResponseDetail = {

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -5,7 +5,7 @@ import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type CommonErrorFragment = { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null };
 
-export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null };
+export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null };
 
 export type SuggestedQuestionsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -22,21 +22,21 @@ export type AskingTaskQuery = { __typename?: 'Query', askingTask: { __typename?:
 export type ThreadsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ThreadsQuery = { __typename?: 'Query', threads: Array<{ __typename?: 'Thread', id: number, sql: string, summary: string }> };
+export type ThreadsQuery = { __typename?: 'Query', threads: Array<{ __typename?: 'Thread', id: number, summary: string }> };
 
 export type ThreadQueryVariables = Types.Exact<{
   threadId: Types.Scalars['Int'];
 }>;
 
 
-export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, summary: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null }> } };
+export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, summary: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null }> } };
 
 export type ThreadResponseQueryVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
 }>;
 
 
-export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null } };
+export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null } };
 
 export type CreateAskingTaskMutationVariables = Types.Exact<{
   data: Types.AskingTaskInput;
@@ -65,7 +65,7 @@ export type CreateThreadResponseMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null } };
+export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null } };
 
 export type UpdateThreadMutationVariables = Types.Exact<{
   where: Types.ThreadUniqueWhereInput;
@@ -101,6 +101,7 @@ export const CommonResponseFragmentDoc = gql`
     fragment CommonResponse on ThreadResponse {
   id
   question
+  summary
   status
   detail {
     sql
@@ -196,7 +197,6 @@ export const ThreadsDocument = gql`
     query Threads {
   threads {
     id
-    sql
     summary
   }
 }

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -13,6 +13,7 @@ const COMMON_RESPONSE = gql`
   fragment CommonResponse on ThreadResponse {
     id
     question
+    summary
     status
     detail {
       sql
@@ -57,7 +58,6 @@ export const THREADS = gql`
   query Threads {
     threads {
       id
-      sql
       summary
     }
   }

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -1,6 +1,8 @@
-import { Button, Skeleton, Typography } from 'antd';
+import { useState } from 'react';
+import { Col, Button, Row, Skeleton, Typography } from 'antd';
 import styled from 'styled-components';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
+import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
 import SaveOutlined from '@ant-design/icons/SaveOutlined';
 import StepContent from '@/components/pages/home/promptThread/StepContent';
 
@@ -20,6 +22,20 @@ const StyledAnswer = styled(Typography)`
   }
 `;
 
+const StyledQuestion = styled(Row)`
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: var(--gray-6);
+  background-color: var(--gray-3);
+  margin-bottom: 8px;
+  font-size: 14px;
+
+  &:hover {
+    background-color: var(--gray-4) !important;
+    cursor: pointer;
+  }
+`;
+
 interface Props {
   loading: boolean;
   question: string;
@@ -33,6 +49,7 @@ interface Props {
   onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
   isLastThreadResponse: boolean;
   onTriggerScrollToBottom: () => void;
+  summary: string;
 }
 
 export default function AnswerResult(props: Props) {
@@ -46,12 +63,26 @@ export default function AnswerResult(props: Props) {
     isLastThreadResponse,
     onOpenSaveAsViewModal,
     onTriggerScrollToBottom,
+    summary,
   } = props;
+
+  const [ellipsis, setEllipsis] = useState(true);
 
   return (
     <Skeleton active loading={loading}>
+      <StyledQuestion wrap={false} onClick={() => setEllipsis(!ellipsis)}>
+        <Col className="text-center" flex="96px">
+          <QuestionCircleOutlined className="mr-2 gray-6" />
+          <Text className="gray-6 text-base text-medium">Question:</Text>
+        </Col>
+        <Col flex="auto">
+          <Text className="gray-6" ellipsis={ellipsis}>
+            {question}
+          </Text>
+        </Col>
+      </StyledQuestion>
       <Title className="mb-6 text-bold gray-10" level={3}>
-        {question}
+        {summary}
       </Title>
       <StyledAnswer className="text-md gray-10 p-3 pr-10 pt-6">
         <Text className="adm-answer-title px-2">

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -31,6 +31,8 @@ interface Props {
   fullSql: string;
   threadResponseId: number;
   onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
+  isLastThreadResponse: boolean;
+  onTriggerScrollToBottom: () => void;
 }
 
 export default function AnswerResult(props: Props) {
@@ -41,7 +43,9 @@ export default function AnswerResult(props: Props) {
     answerResultSteps,
     fullSql,
     threadResponseId,
+    isLastThreadResponse,
     onOpenSaveAsViewModal,
+    onTriggerScrollToBottom,
   } = props;
 
   return (
@@ -64,6 +68,8 @@ export default function AnswerResult(props: Props) {
             stepIndex={index}
             summary={step.summary}
             threadResponseId={threadResponseId}
+            onTriggerScrollToBottom={onTriggerScrollToBottom}
+            isLastThreadResponse={isLastThreadResponse}
           />
         ))}
       </StyledAnswer>

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -52,7 +52,7 @@ export default function AnswerResult(props: Props) {
       <StyledAnswer className="text-md gray-10 p-3 pr-10 pt-6">
         <Text className="adm-answer-title px-2">
           <CheckCircleFilled className="mr-2 green-6" />
-          Answer
+          Summary
         </Text>
         <div className="pl-7 pb-5">{description}</div>
         {(answerResultSteps || []).map((step, index) => (

--- a/wren-ui/src/components/pages/home/promptThread/StepContent.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/StepContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Button, ButtonProps, Col, Row, Typography } from 'antd';
 import FunctionOutlined from '@ant-design/icons/FunctionOutlined';
 import { BinocularsIcon } from '@/utils/icons';
@@ -5,12 +6,15 @@ import CollapseContent, {
   Props as CollapseContentProps,
 } from '@/components/pages/home/promptThread/CollapseContent';
 import useAnswerStepContent from '@/hooks/useAnswerStepContent';
+import { nextTick } from '@/utils/time';
 
 const { Text, Paragraph } = Typography;
 
 interface Props {
   fullSql: string;
   isLastStep: boolean;
+  isLastThreadResponse: boolean;
+  onTriggerScrollToBottom: () => void;
   sql: string;
   stepIndex: number;
   summary: string;
@@ -18,8 +22,16 @@ interface Props {
 }
 
 export default function StepContent(props: Props) {
-  const { fullSql, isLastStep, sql, stepIndex, summary, threadResponseId } =
-    props;
+  const {
+    fullSql,
+    isLastStep,
+    isLastThreadResponse,
+    onTriggerScrollToBottom,
+    sql,
+    stepIndex,
+    summary,
+    threadResponseId,
+  } = props;
 
   const {
     collapseContentProps,
@@ -35,6 +47,20 @@ export default function StepContent(props: Props) {
   });
 
   const stepNumber = stepIndex + 1;
+
+  const autoTriggerPreviewDataButton = async () => {
+    await nextTick();
+    previewDataButtonProps.onClick();
+    await nextTick(1500);
+    onTriggerScrollToBottom();
+  };
+
+  // when is the last step of the last thread response, auto trigger preview data button
+  useEffect(() => {
+    if (isLastStep && isLastThreadResponse) {
+      autoTriggerPreviewDataButton();
+    }
+  }, [isLastStep, isLastThreadResponse]);
 
   return (
     <Row

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -40,7 +40,12 @@ const AnswerResultTemplate = ({
   detail,
   error,
   onOpenSaveAsViewModal,
+  onTriggerScrollToBottom,
+  data,
 }) => {
+  const lastResponseId = data[data.length - 1].id;
+  const isLastThreadResponse = id === lastResponseId;
+
   return (
     <div key={`${id}-${index}`}>
       {index > 0 && <Divider />}
@@ -60,6 +65,8 @@ const AnswerResultTemplate = ({
           fullSql={detail?.sql}
           threadResponseId={id}
           onOpenSaveAsViewModal={onOpenSaveAsViewModal}
+          onTriggerScrollToBottom={onTriggerScrollToBottom}
+          isLastThreadResponse={isLastThreadResponse}
         />
       )}
     </div>
@@ -72,20 +79,25 @@ export default function PromptThread(props: Props) {
   const { data, onOpenSaveAsViewModal } = props;
   const divRef = useRef<HTMLDivElement>(null);
 
+  const triggerScrollToBottom = () => {
+    const contentLayout = divRef.current.parentElement;
+    const lastChild = divRef.current.lastElementChild as HTMLElement;
+    const lastChildElement = lastChild.lastElementChild as HTMLElement;
+
+    if (
+      contentLayout.clientHeight <
+      lastChild.offsetTop + lastChild.clientHeight
+    ) {
+      contentLayout.scrollTo({
+        top: lastChildElement.offsetTop,
+        behavior: 'smooth',
+      });
+    }
+  };
+
   useEffect(() => {
     if (divRef.current && data?.responses.length > 0) {
-      const contentLayout = divRef.current.parentElement;
-      const lastChild = divRef.current.lastElementChild as HTMLElement;
-      const lastChildDivider = lastChild.firstElementChild as HTMLElement;
-      if (
-        contentLayout.clientHeight <
-        lastChild.offsetTop + lastChild.clientHeight
-      ) {
-        contentLayout.scrollTo({
-          top: lastChildDivider.offsetTop,
-          behavior: 'smooth',
-        });
-      }
+      triggerScrollToBottom();
     }
   }, [divRef, data]);
 
@@ -95,6 +107,7 @@ export default function PromptThread(props: Props) {
         data={data?.responses || []}
         sql={data?.sql}
         onOpenSaveAsViewModal={onOpenSaveAsViewModal}
+        onTriggerScrollToBottom={triggerScrollToBottom}
       />
     </StyledPromptThread>
   );

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -42,6 +42,7 @@ const AnswerResultTemplate = ({
   onOpenSaveAsViewModal,
   onTriggerScrollToBottom,
   data,
+  summary,
 }) => {
   const lastResponseId = data[data.length - 1].id;
   const isLastThreadResponse = id === lastResponseId;
@@ -62,6 +63,7 @@ const AnswerResultTemplate = ({
           description={detail?.description}
           loading={status !== AskingTaskStatus.FINISHED}
           question={question}
+          summary={summary}
           fullSql={detail?.sql}
           threadResponseId={id}
           onOpenSaveAsViewModal={onOpenSaveAsViewModal}
@@ -105,7 +107,6 @@ export default function PromptThread(props: Props) {
     <StyledPromptThread className="mt-12" ref={divRef}>
       <AnswerResultIterator
         data={data?.responses || []}
-        sql={data?.sql}
         onOpenSaveAsViewModal={onOpenSaveAsViewModal}
         onTriggerScrollToBottom={triggerScrollToBottom}
       />

--- a/wren-ui/src/components/sidebar/Home.tsx
+++ b/wren-ui/src/components/sidebar/Home.tsx
@@ -58,7 +58,6 @@ export default function Home(props: Props) {
     params?.id && setTreeSelectedKeys([params.id] as string[]);
   }, [params?.id]);
 
-  // initial workspace
   useEffect(() => {
     setTree(
       data.map((thread) => {


### PR DESCRIPTION
## Description
 - Improve thread response UX
   - Click a question block to expand or cancel expand it.
   - Default open preview data for the last step of the last thread.

## Tasks
 - [x] Use **Summary** instead of  **Answer**
    - [x] Update API
 - [x] Default open preview data for the last step of the last thread
 - [x] Support show thread question and summary

### UI (reference, not real data)
![q_2_1](https://github.com/Canner/WrenAI/assets/42527625/069a4040-d688-4089-89bf-20b5f5605b54)

![q_2_2](https://github.com/Canner/WrenAI/assets/42527625/f681ad3e-61f5-45a7-a49c-e930f10355aa)
![q_2_3](https://github.com/Canner/WrenAI/assets/42527625/2ce7ec48-e7d7-408c-bc6e-17e9ab65a2bd)
