### PR TITLE
refine demo site for easier debugging

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -58,9 +58,9 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.7.4
     pull_policy: always
-    expose:
-      - 6333
-      - 6334
+    ports:
+      - 6333:6333
+      - 6334:6334
     networks:
       - wren
 

--- a/wren-ai-service/demo/Makefile
+++ b/wren-ai-service/demo/Makefile
@@ -1,13 +1,12 @@
 prepare:
 	cd ../../docker; docker compose --env-file .env.local -f docker-compose-dev.yaml up -d
-	cd ..; make run-qdrant
 
 stop:
 	cd ../../docker; docker compose --env-file .env.local -f docker-compose-dev.yaml down
-	cd ..; make stop-qdrant
 
 ui:
-	cd ../../wren-ui; export DB_TYPE=sqlite export SQLITE_FILE=db.sqlite3 && yarn install && yarn rollback --all && yarn migrate && yarn dev
+	cd ../../wren-ui; export DB_TYPE=sqlite export SQLITE_FILE=db.sqlite3 export WREN_AI_ENDPOINT=http://localhost:5556 && \
+	yarn install && yarn rollback --all && yarn migrate && yarn dev
 
 ai:
 	cd ..; make start


### PR DESCRIPTION
from now on, ui and wren-ai-service demo app use the same wren-ai-service and qdrant for local development

- expose qdrant ports in docker/docker-compose-dev.yaml
- remove run-qdrant and stop-qdrant in wren-ai-service/demo/Makefile
- rewrite make ui command in wren-ai-service/demo/Makefile