### PR TITLE
fix(wren-ui): Column may have multiple relationships with different models

### DIFF
--- a/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
@@ -54,17 +54,23 @@ export class DiagramResolver {
         (column) => column.modelId === model.id,
       );
       allColumns.forEach((column) => {
-        const relation = relations.find((relation) =>
-          [relation.fromColumnId, relation.toColumnId].includes(column.id),
-        );
+        const columnRelations = relations
+          .map((relation) =>
+            [relation.fromColumnId, relation.toColumnId].includes(column.id)
+              ? relation
+              : null,
+          )
+          .filter((relation) => !!relation);
 
-        if (relation) {
-          const transformedRelationField = this.transformModelRelationField({
-            relation,
-            currentModel: model,
-            models,
+        if (columnRelations.length > 0) {
+          columnRelations.forEach((relation) => {
+            const transformedRelationField = this.transformModelRelationField({
+              relation,
+              currentModel: model,
+              models,
+            });
+            transformedModel.relationFields.push(transformedRelationField);
           });
-          transformedModel.relationFields.push(transformedRelationField);
         }
 
         if (column.isCalculated) {

--- a/wren-ui/src/utils/diagram/transformer.ts
+++ b/wren-ui/src/utils/diagram/transformer.ts
@@ -172,8 +172,14 @@ export class Transformer {
       )!;
       const targetField = targetModel.relationFields.find(
         (field) =>
-          [field.fromColumnName, field.toColumnName].toString() ===
-          [relationField.fromColumnName, relationField.toColumnName].toString(),
+          [
+            `${field.fromModelName}.${field.fromColumnName}`,
+            `${field.toModelName}.${field.toColumnName}`,
+          ].toString() ===
+          [
+            `${relationField.fromModelName}.${relationField.fromColumnName}`,
+            `${relationField.toModelName}.${relationField.toColumnName}`,
+          ].toString(),
       );
 
       // check what source and target relation order


### PR DESCRIPTION
## Description
A column may have multiple relationships with different models, so it should use `map` to retrieve all relations of the column

In the image below, 
the `orders` model and `payments` model have a relationship but it couldn't be rendered correctly
The `orders.OrderId` only renders one relationship (`orders.OrderId = order_items.OrderId`)

But it actually has multiple relationships with different models:
- `orders.OrderId = order_items.OrderId `
- `payments.OrderId = orders.OrderId`
- `orders.OrderId = reviews.OrderId`

<img width="1145" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/5c907ddf-25fd-4f35-9b11-4a6e1f7e6edb">

### Expected behavior
Renders all relationships of `orders.OrderId`

<img width="1149" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/81e44d8e-05a3-4e70-b248-a7bf2e44ccfe">

