### PR TITLE
feat(wren-ui): Integrate UI and CRUD API for relationship

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -233,13 +233,17 @@ export type DiagramModelRelationField = {
   __typename?: 'DiagramModelRelationField';
   description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
+  fromColumnId: Scalars['Int'];
   fromColumnName: Scalars['String'];
+  fromModelId: Scalars['Int'];
   fromModelName: Scalars['String'];
   id: Scalars['String'];
   nodeType: NodeType;
   referenceName: Scalars['String'];
   relationId: Scalars['Int'];
+  toColumnId: Scalars['Int'];
   toColumnName: Scalars['String'];
+  toModelId: Scalars['Int'];
   toModelName: Scalars['String'];
   type: RelationType;
 };

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -499,7 +499,7 @@ export type MutationUpdateModelMetadataArgs = {
 
 export type MutationUpdateRelationArgs = {
   data: UpdateRelationInput;
-  where?: InputMaybe<WhereIdInput>;
+  where: WhereIdInput;
 };
 
 

--- a/wren-ui/src/apollo/client/graphql/diagram.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/diagram.generated.ts
@@ -5,14 +5,14 @@ import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type ViewFieldFragment = { __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType };
 
-export type RelationFieldFragment = { __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelName: string, fromColumnName: string, toModelName: string, toColumnName: string, description?: string | null };
+export type RelationFieldFragment = { __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelId: number, fromModelName: string, fromColumnId: number, fromColumnName: string, toModelId: number, toModelName: string, toColumnId: number, toColumnName: string, description?: string | null };
 
 export type FieldFragment = { __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null };
 
 export type DiagramQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type DiagramQuery = { __typename?: 'Query', diagram: { __typename?: 'Diagram', models: Array<{ __typename?: 'DiagramModel', id: string, modelId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, sourceTableName: string, refSql: string, cached: boolean, refreshTime?: string | null, description?: string | null, fields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, calculatedFields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, relationFields: Array<{ __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelName: string, fromColumnName: string, toModelName: string, toColumnName: string, description?: string | null } | null> } | null>, views: Array<{ __typename?: 'DiagramView', id: string, viewId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, statement: string, fields: Array<{ __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType } | null> } | null> } };
+export type DiagramQuery = { __typename?: 'Query', diagram: { __typename?: 'Diagram', models: Array<{ __typename?: 'DiagramModel', id: string, modelId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, sourceTableName: string, refSql: string, cached: boolean, refreshTime?: string | null, description?: string | null, fields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, calculatedFields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, relationFields: Array<{ __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelId: number, fromModelName: string, fromColumnId: number, fromColumnName: string, toModelId: number, toModelName: string, toColumnId: number, toColumnName: string, description?: string | null } | null> } | null>, views: Array<{ __typename?: 'DiagramView', id: string, viewId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, statement: string, fields: Array<{ __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType } | null> } | null> } };
 
 export const ViewFieldFragmentDoc = gql`
     fragment ViewField on DiagramViewField {
@@ -31,9 +31,13 @@ export const RelationFieldFragmentDoc = gql`
   nodeType
   displayName
   referenceName
+  fromModelId
   fromModelName
+  fromColumnId
   fromColumnName
+  toModelId
   toModelName
+  toColumnId
   toColumnName
   description
 }

--- a/wren-ui/src/apollo/client/graphql/diagram.ts
+++ b/wren-ui/src/apollo/client/graphql/diagram.ts
@@ -18,9 +18,13 @@ const RELATION_FIELD = gql`
     nodeType
     displayName
     referenceName
+    fromModelId
     fromModelName
+    fromColumnId
     fromColumnName
+    toModelId
     toModelName
+    toColumnId
     toColumnName
     description
   }

--- a/wren-ui/src/apollo/client/graphql/relationship.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/relationship.generated.ts
@@ -1,0 +1,122 @@
+import * as Types from './__types__';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions = {} as const;
+export type CreateRelationshipMutationVariables = Types.Exact<{
+  data: Types.RelationInput;
+}>;
+
+
+export type CreateRelationshipMutation = { __typename?: 'Mutation', createRelation: any };
+
+export type UpdateRelationshipMutationVariables = Types.Exact<{
+  where: Types.WhereIdInput;
+  data: Types.UpdateRelationInput;
+}>;
+
+
+export type UpdateRelationshipMutation = { __typename?: 'Mutation', updateRelation: any };
+
+export type DeleteRelationshipMutationVariables = Types.Exact<{
+  where: Types.WhereIdInput;
+}>;
+
+
+export type DeleteRelationshipMutation = { __typename?: 'Mutation', deleteRelation: boolean };
+
+
+export const CreateRelationshipDocument = gql`
+    mutation CreateRelationship($data: RelationInput!) {
+  createRelation(data: $data)
+}
+    `;
+export type CreateRelationshipMutationFn = Apollo.MutationFunction<CreateRelationshipMutation, CreateRelationshipMutationVariables>;
+
+/**
+ * __useCreateRelationshipMutation__
+ *
+ * To run a mutation, you first call `useCreateRelationshipMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateRelationshipMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createRelationshipMutation, { data, loading, error }] = useCreateRelationshipMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useCreateRelationshipMutation(baseOptions?: Apollo.MutationHookOptions<CreateRelationshipMutation, CreateRelationshipMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateRelationshipMutation, CreateRelationshipMutationVariables>(CreateRelationshipDocument, options);
+      }
+export type CreateRelationshipMutationHookResult = ReturnType<typeof useCreateRelationshipMutation>;
+export type CreateRelationshipMutationResult = Apollo.MutationResult<CreateRelationshipMutation>;
+export type CreateRelationshipMutationOptions = Apollo.BaseMutationOptions<CreateRelationshipMutation, CreateRelationshipMutationVariables>;
+export const UpdateRelationshipDocument = gql`
+    mutation UpdateRelationship($where: WhereIdInput!, $data: UpdateRelationInput!) {
+  updateRelation(where: $where, data: $data)
+}
+    `;
+export type UpdateRelationshipMutationFn = Apollo.MutationFunction<UpdateRelationshipMutation, UpdateRelationshipMutationVariables>;
+
+/**
+ * __useUpdateRelationshipMutation__
+ *
+ * To run a mutation, you first call `useUpdateRelationshipMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateRelationshipMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateRelationshipMutation, { data, loading, error }] = useUpdateRelationshipMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateRelationshipMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRelationshipMutation, UpdateRelationshipMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateRelationshipMutation, UpdateRelationshipMutationVariables>(UpdateRelationshipDocument, options);
+      }
+export type UpdateRelationshipMutationHookResult = ReturnType<typeof useUpdateRelationshipMutation>;
+export type UpdateRelationshipMutationResult = Apollo.MutationResult<UpdateRelationshipMutation>;
+export type UpdateRelationshipMutationOptions = Apollo.BaseMutationOptions<UpdateRelationshipMutation, UpdateRelationshipMutationVariables>;
+export const DeleteRelationshipDocument = gql`
+    mutation DeleteRelationship($where: WhereIdInput!) {
+  deleteRelation(where: $where)
+}
+    `;
+export type DeleteRelationshipMutationFn = Apollo.MutationFunction<DeleteRelationshipMutation, DeleteRelationshipMutationVariables>;
+
+/**
+ * __useDeleteRelationshipMutation__
+ *
+ * To run a mutation, you first call `useDeleteRelationshipMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteRelationshipMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteRelationshipMutation, { data, loading, error }] = useDeleteRelationshipMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function useDeleteRelationshipMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRelationshipMutation, DeleteRelationshipMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteRelationshipMutation, DeleteRelationshipMutationVariables>(DeleteRelationshipDocument, options);
+      }
+export type DeleteRelationshipMutationHookResult = ReturnType<typeof useDeleteRelationshipMutation>;
+export type DeleteRelationshipMutationResult = Apollo.MutationResult<DeleteRelationshipMutation>;
+export type DeleteRelationshipMutationOptions = Apollo.BaseMutationOptions<DeleteRelationshipMutation, DeleteRelationshipMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/relationship.ts
+++ b/wren-ui/src/apollo/client/graphql/relationship.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+
+export const CREATE_RELATIONSHIP = gql`
+  mutation CreateRelationship($data: RelationInput!) {
+    createRelation(data: $data)
+  }
+`;
+
+export const UPDATE_RELATIONSHIP = gql`
+  mutation UpdateRelationship(
+    $where: WhereIdInput!
+    $data: UpdateRelationInput!
+  ) {
+    updateRelation(where: $where, data: $data)
+  }
+`;
+
+export const DELETE_RELATIONSHIP = gql`
+  mutation DeleteRelationship($where: WhereIdInput!) {
+    deleteRelation(where: $where)
+  }
+`;

--- a/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
@@ -198,9 +198,13 @@ export class DiagramResolver {
       displayName,
       referenceName,
       type: relation.joinType as RelationType,
+      fromModelId: relation.fromModelId,
       fromModelName: relation.fromModelName,
+      fromColumnId: relation.fromColumnId,
       fromColumnName: relation.fromColumnName,
+      toModelId: relation.toModelId,
       toModelName: relation.toModelName,
+      toColumnId: relation.toColumnId,
       toColumnName: relation.toColumnName,
       description: properties?.description,
     };

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -246,7 +246,7 @@ export class ModelResolver {
       fields,
       primaryKey,
     );
-    logger.info(`Model created: ${model}`);
+    logger.info(`Model created: ${JSON.stringify(model)}`);
 
     return model;
   }
@@ -277,7 +277,7 @@ export class ModelResolver {
     this.validateColumnsExist(sourceTableName, fields, dataSourceTables);
 
     await strategy.updateModel(model, fields, primaryKey);
-    logger.info(`Model created: ${model}`);
+    logger.info(`Model created: ${JSON.stringify(model)}`);
 
     return model;
   }

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -378,9 +378,13 @@ export const typeDefs = gql`
     displayName: String!
     referenceName: String!
     description: String
+    fromModelId: Int!
     fromModelName: String!
+    fromColumnId: Int!
     fromColumnName: String!
+    toModelId: Int!
     toModelName: String!
+    toColumnId: Int!
     toColumnName: String!
   }
 

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -608,7 +608,7 @@ export const typeDefs = gql`
 
     # Relation
     createRelation(data: RelationInput!): JSON!
-    updateRelation(data: UpdateRelationInput!, where: WhereIdInput): JSON!
+    updateRelation(data: UpdateRelationInput!, where: WhereIdInput!): JSON!
     deleteRelation(where: WhereIdInput!): Boolean!
 
     # Calculated field

--- a/wren-ui/src/apollo/server/types/diagram.ts
+++ b/wren-ui/src/apollo/server/types/diagram.ts
@@ -68,9 +68,13 @@ export interface DiagramModelRelationField {
   nodeType: NodeType;
   displayName: string;
   referenceName: string;
+  fromModelId: number;
   fromModelName: string;
+  fromColumnId: number;
   fromColumnName: string;
+  toModelId: number;
   toModelName: string;
+  toColumnId: number;
   toColumnName: string;
   description: string;
 }

--- a/wren-ui/src/components/modals/RelationModal.tsx
+++ b/wren-ui/src/components/modals/RelationModal.tsx
@@ -4,7 +4,7 @@ import { Modal, Form, Select } from 'antd';
 import { ModalAction } from '@/hooks/useModalAction';
 import { ERROR_TEXTS } from '@/utils/error';
 import CombineFieldSelector from '@/components/selectors/CombineFieldSelector';
-import { JOIN_TYPE } from '@/utils/enum';
+import { JOIN_TYPE, FORM_MODE } from '@/utils/enum';
 import { getJoinTypeText } from '@/utils/data';
 import useCombineFieldOptions, {
   convertDefaultValueToIdentifier,
@@ -38,8 +38,12 @@ export default function RelationModal(props: Props) {
     onSubmit,
     relations,
     visible,
+    formMode,
   } = props;
   const [form] = Form.useForm();
+
+  // only suitable use for modeling page
+  const isUpdateMode = formMode === FORM_MODE.EDIT;
 
   const fromCombineField = useCombineFieldOptions({ model });
   const modelValue = fromCombineField.modelOptions.find(
@@ -150,6 +154,7 @@ export default function RelationModal(props: Props) {
           <CombineFieldSelector
             modelValue={modelValue}
             modelDisabled={true}
+            fieldDisabled={isUpdateMode}
             onModelChange={fromCombineField.onModelChange}
             modelOptions={fromCombineField.modelOptions}
             fieldOptions={fromCombineField.fieldOptions}
@@ -177,6 +182,8 @@ export default function RelationModal(props: Props) {
             onModelChange={toCombineField.onModelChange}
             modelOptions={toCombineModelOptions}
             fieldOptions={toCombineField.fieldOptions}
+            modelDisabled={isUpdateMode}
+            fieldDisabled={isUpdateMode}
           />
         </Form.Item>
         <Form.Item

--- a/wren-ui/src/hooks/useCombineFieldOptions.tsx
+++ b/wren-ui/src/hooks/useCombineFieldOptions.tsx
@@ -110,23 +110,31 @@ export default function useCombineFieldOptions(props: Props) {
       allModels.filter(
         (item) => !(excludeModels && excludeModels.includes(item.name)),
       ),
-    [excludeModels, baseModel],
+    [excludeModels, baseModel, data],
   );
 
-  const modelOptions = useMemo(() => {
-    return filteredModels.map((model) => ({
-      label: model.name,
-      value: convertObjectToIdentifier(model, modelKeys),
-    }));
-  }, [filteredModels]);
+  const modelOptions = useMemo(
+    () =>
+      filteredModels.map((model) => ({
+        label: model.name,
+        value: convertObjectToIdentifier(model, modelKeys),
+      })),
+    [filteredModels],
+  );
 
-  const fieldOptions = useMemo(() => {
-    const model = filteredModels.find((item) => item.name === baseModel);
-    return (model?.fields || []).map((field) => ({
-      label: field.referenceName,
-      value: convertObjectToIdentifier(field, fieldKeys),
-    }));
-  }, [modelOptions, baseModel]);
+  const filteredModel = useMemo(
+    () => filteredModels.find((item) => item.name === baseModel),
+    [modelOptions, baseModel],
+  );
+
+  const fieldOptions = useMemo(
+    () =>
+      (filteredModel?.fields || []).map((field) => ({
+        label: field.referenceName,
+        value: convertObjectToIdentifier(field, fieldKeys),
+      })),
+    [filteredModel],
+  );
 
   return { modelOptions, fieldOptions, onModelChange: setBaseModel };
 }

--- a/wren-ui/src/hooks/useRelationshipModal.tsx
+++ b/wren-ui/src/hooks/useRelationshipModal.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from 'react';
+import { NODE_TYPE } from '@/utils/enum';
+import { Diagram } from '@/utils/data';
+import useModalAction from '@/hooks/useModalAction';
+
+export default function useRelationshipModal(diagramData: Diagram | null) {
+  const relationshipModal = useModalAction();
+
+  const [selectedModelReferenceName, setSelectedModelReferenceName] =
+    useState<string>(null);
+
+  // Parse out the relationships data under all models
+  const relationships = useMemo(
+    () =>
+      (diagramData?.models || []).reduce((acc, currentValue) => {
+        const { referenceName, relationFields } = currentValue;
+        const newRelationship = relationFields.map((relationship) => {
+          return {
+            id: relationship.relationId,
+            fromField: {
+              modelId: String(relationship.fromModelId),
+              modelName: relationship.fromModelName,
+              fieldId: String(relationship.fromColumnId),
+              fieldName: relationship.fromColumnName,
+            },
+            toField: {
+              modelId: String(relationship.toModelId),
+              modelName: relationship.toModelName,
+              fieldId: String(relationship.toColumnId),
+              fieldName: relationship.toColumnName,
+            },
+            type: relationship.type,
+          };
+        });
+
+        acc[referenceName] = newRelationship;
+        return acc;
+      }, {}),
+    [diagramData],
+  );
+
+  const onClose = () => {
+    setSelectedModelReferenceName(null);
+    relationshipModal.closeModal();
+  };
+
+  const openModal = (data) => {
+    // update mode
+    if (data.nodeType === NODE_TYPE.RELATION) {
+      setSelectedModelReferenceName(data.fromModelName);
+      relationshipModal.openModal({
+        relationId: data.relationId,
+        fromField: {
+          modelId: String(data.fromModelId),
+          modelName: data.fromModelName,
+          fieldId: String(data.fromColumnId),
+          fieldName: data.fromColumnName,
+        },
+        toField: {
+          modelId: String(data.toModelId),
+          modelName: data.toModelName,
+          fieldId: String(data.toColumnId),
+          fieldName: data.toColumnName,
+        },
+        type: data.type,
+      });
+      return;
+    }
+
+    // create mode
+    setSelectedModelReferenceName(data.referenceName);
+    relationshipModal.openModal();
+  };
+
+  return {
+    onClose,
+    openModal,
+    state: {
+      ...relationshipModal.state,
+      model: selectedModelReferenceName,
+      relations: relationships,
+    },
+  };
+}

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -188,6 +188,33 @@ class DeleteCalculatedFieldErrorHandler extends ErrorHandler {
   }
 }
 
+class CreateRelationshipErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to create relationship.';
+    }
+  }
+}
+
+class UpdateRelationshipErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to update relationship.';
+    }
+  }
+}
+
+class DeleteRelationshipErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to delete relationship.';
+    }
+  }
+}
+
 errorHandlers.set('SaveTables', new SaveTablesErrorHandler());
 errorHandlers.set('SaveRelations', new SaveRelationsErrorHandler());
 errorHandlers.set('CreateAskingTask', new CreateAskingTaskErrorHandler());
@@ -216,6 +243,11 @@ errorHandlers.set(
   'DeleteCalculatedField',
   new DeleteCalculatedFieldErrorHandler(),
 );
+
+// Relationship
+errorHandlers.set('CreateRelationship', new CreateRelationshipErrorHandler());
+errorHandlers.set('UpdateRelationship', new UpdateRelationshipErrorHandler());
+errorHandlers.set('DeleteRelationship', new DeleteRelationshipErrorHandler());
 
 const errorHandler = (error: ErrorResponse) => {
   const operationName = error?.operation?.operationName || '';


### PR DESCRIPTION
## Description
 - Integrate UI and CRUD API for relationship

## Tasks
- [x]  Add relationship GraphQL APIs
- [x]  [API] Update transformModelRelationField for diagram API
- [x]  UI integrating API to relationship CRUD
- [x]  In the relationship update mode, only the relationship type can be editable
- [x]  [API] update logger info model payload

Note: Currently using **reference name**.