### PR TITLE
fix(wren-ui): show the connected data source when on the original SQL mode only

### DIFF
--- a/wren-ui/src/components/pages/home/promptThread/CollapseContent.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/CollapseContent.tsx
@@ -74,16 +74,20 @@ export default function CollapseContent(props: Props) {
           {showNativeSQL && (
             <StyledToolBar className="d-flex justify-space-between text-family-base">
               <div>
-                <Image
-                  className="mr-2"
-                  src={DATA_SOURCE_OPTIONS[dataSourceType].logo}
-                  alt={DATA_SOURCE_OPTIONS[dataSourceType].label}
-                  width="22"
-                  height="22"
-                />
-                <Text className="gray-8 text-medium text-sm">
-                  {DATA_SOURCE_OPTIONS[dataSourceType].label}
-                </Text>
+                {nativeSQLResult.nativeSQLMode && (
+                  <>
+                    <Image
+                      className="mr-2"
+                      src={DATA_SOURCE_OPTIONS[dataSourceType].logo}
+                      alt={DATA_SOURCE_OPTIONS[dataSourceType].label}
+                      width="22"
+                      height="22"
+                    />
+                    <Text className="gray-8 text-medium text-sm">
+                      {DATA_SOURCE_OPTIONS[dataSourceType].label}
+                    </Text>
+                  </>
+                )}
               </div>
               <div>
                 <Switch

--- a/wren-ui/src/hooks/useSetupRelations.tsx
+++ b/wren-ui/src/hooks/useSetupRelations.tsx
@@ -46,6 +46,12 @@ export default function useSetupRelations() {
       [],
     );
 
+    // redirect to the home page if there is no relationship data needs to be saved
+    if (relations.length === 0) {
+      onRedirectToHomePage();
+      return;
+    }
+
     await saveRelationsMutation({
       variables: { data: { relations } },
     });


### PR DESCRIPTION
## Description
 - Fix
   - show the connected data source when on the original SQL mode only
   - redirect to the home page if there is no relationship data needs to be saved

### UI
![截圖 2024-05-07 下午12 19 53](https://github.com/Canner/WrenAI/assets/42527625/8d78eca8-0e68-47f5-8533-948c7b3f3c42)

