### PR TITLE
fix(wren-ui): handle network error issues for asking a question

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -337,7 +337,17 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
     }
 
     // use custom error to transform error
-    const error = body?.error?.code ? Errors.create(body?.error?.code) : null;
+    const code = body?.error?.code;
+    const error = code
+      ? Errors.create(
+          code,
+          code === Errors.GeneralErrorCodes.AI_SERVICE_UNDEFINED_ERROR
+            ? {
+                customMessage: body?.error?.message,
+              }
+            : undefined,
+        )
+      : null;
 
     // format custom error into WrenAIError that is used in graphql
     const formattedError = error

--- a/wren-ui/src/apollo/server/utils/error.ts
+++ b/wren-ui/src/apollo/server/utils/error.ts
@@ -8,6 +8,9 @@ export enum GeneralErrorCodes {
   NO_RELEVANT_DATA = 'NO_RELEVANT_DATA',
   NO_RELEVANT_SQL = 'NO_RELEVANT_SQL',
 
+  // Exception error for AI service (e.g., network connection error)
+  AI_SERVICE_UNDEFINED_ERROR = 'OTHERS',
+
   // Connector errors
   // duckdb
   INIT_SQL_ERROR = 'INIT_SQL_ERROR',
@@ -77,7 +80,9 @@ export const create = (
       originalError,
       code,
       message,
-      shortMessage: shortMessages[code],
+      shortMessage:
+        shortMessages[code] ||
+        shortMessages[GeneralErrorCodes.INTERNAL_SERVER_ERROR],
     },
   });
 

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -250,6 +250,13 @@ errorHandlers.set('UpdateRelationship', new UpdateRelationshipErrorHandler());
 errorHandlers.set('DeleteRelationship', new DeleteRelationshipErrorHandler());
 
 const errorHandler = (error: ErrorResponse) => {
+  // networkError
+  if (error.networkError) {
+    message.error(
+      'No internet. Please check your network connection and try again.',
+    );
+  }
+
   const operationName = error?.operation?.operationName || '';
   if (error.graphQLErrors) {
     for (const err of error.graphQLErrors) {


### PR DESCRIPTION
## Description
 Handle network error issue for https://github.com/Canner/WrenAI/issues/175


## Issue ticket number
closes #175

## Solution
 - Based on the reference background context, considering the **OTHERS** error code does not directly mean network error, I think we can pass an error message from the AI service to the web and show it on the UI at this stage.

### Reference background context

 - When there is no network, after the web backend sends the API request to the AI ​​Service, the final return data will be:
```json
{
  "status": "failed",
  "response": null,
  "error": {
    "code": "OTHERS",
    "message": "Connection error."
  }
}
```

 - Snippet code for AI Service

We can see the below snippet code of handle exception error:

https://github.com/Canner/WrenAI/blob/d24cdc1090fc9bdaa8722a720b02b1b2281b9786/wren-ai-service/src/web/v1/services/ask_details.py#L106-L113

https://github.com/Canner/WrenAI/blob/e997bd0d5142e4c40dfc72cda07e2e243808d884/wren-ai-service/src/web/v1/services/ask.py#L271-L278

## Tasks
 - [x] Defaults to internal server error if not mapped to short message (**shortMessage**)
 - [x] Show default message for network error when calling an API

## UI screenshots

 - Step 1: Go to /home page
 - Step 2: Turn off Wi-Fi
 - Step 3: Ask a question
 

![截圖 2024-05-09 上午9 34 57](https://github.com/Canner/WrenAI/assets/42527625/61ccf0dd-668f-4ca6-aa70-83050dfc5f9d)
