### PR TITLE
chore(wren-ui): Downgrade columns limit to 10 in diagram

### DIFF
--- a/wren-ui/src/utils/diagram/transformer.ts
+++ b/wren-ui/src/utils/diagram/transformer.ts
@@ -22,7 +22,7 @@ export const Config = {
   // the height of more tip
   moreTipHeight: 25,
   // the columns limit
-  columnsLimit: 50,
+  columnsLimit: 10,
   // the overflow of the model body
   bodyOverflow: 'auto',
   // the margin x between the model and the other models


### PR DESCRIPTION
## Description
Downgrade columns limit to 10

## UI Screenshot

<img width="1159" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/0b8a1d1f-1c5b-4cb0-a4e4-090bd1414042">

