### PR TITLE
feat(wren-ui): Support edit view metadata mode

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -254,6 +254,7 @@ export type DiagramModelRelationField = {
 
 export type DiagramView = {
   __typename?: 'DiagramView';
+  description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   fields: Array<Maybe<DiagramViewField>>;
   id: Scalars['String'];
@@ -265,6 +266,7 @@ export type DiagramView = {
 
 export type DiagramViewField = {
   __typename?: 'DiagramViewField';
+  description?: Maybe<Scalars['String']>;
   displayName: Scalars['String'];
   id: Scalars['String'];
   nodeType: NodeType;
@@ -369,6 +371,7 @@ export type Mutation = {
   deleteView: Scalars['Boolean'];
   deploy: Scalars['JSON'];
   previewData: Scalars['JSON'];
+  previewModelData: Scalars['JSON'];
   previewViewData: Scalars['JSON'];
   resetCurrentProject: Scalars['Boolean'];
   saveDataSource: DataSource;
@@ -381,6 +384,7 @@ export type Mutation = {
   updateModelMetadata: Scalars['Boolean'];
   updateRelation: Scalars['JSON'];
   updateThread: Thread;
+  updateViewMetadata: Scalars['Boolean'];
   validateCalculatedField: CalculatedFieldValidationResponse;
   validateView: ViewValidationResponse;
 };
@@ -457,6 +461,11 @@ export type MutationPreviewDataArgs = {
 };
 
 
+export type MutationPreviewModelDataArgs = {
+  where: WhereIdInput;
+};
+
+
 export type MutationPreviewViewDataArgs = {
   where: ViewWhereUniqueInput;
 };
@@ -514,6 +523,12 @@ export type MutationUpdateRelationArgs = {
 export type MutationUpdateThreadArgs = {
   data: UpdateThreadInput;
   where: ThreadUniqueWhereInput;
+};
+
+
+export type MutationUpdateViewMetadataArgs = {
+  data: UpdateViewMetadataInput;
+  where: ViewWhereUniqueInput;
 };
 
 
@@ -782,6 +797,17 @@ export type UpdateRelationshipMetadataInput = {
 
 export type UpdateThreadInput = {
   summary?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateViewColumnMetadataInput = {
+  description?: InputMaybe<Scalars['String']>;
+  referenceName: Scalars['String'];
+};
+
+export type UpdateViewMetadataInput = {
+  columns?: InputMaybe<Array<UpdateViewColumnMetadataInput>>;
+  description?: InputMaybe<Scalars['String']>;
+  displayName?: InputMaybe<Scalars['String']>;
 };
 
 export type ValidateCalculatedFieldInput = {

--- a/wren-ui/src/apollo/client/graphql/diagram.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/diagram.generated.ts
@@ -3,7 +3,7 @@ import * as Types from './__types__';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type ViewFieldFragment = { __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType };
+export type ViewFieldFragment = { __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType, description?: string | null };
 
 export type RelationFieldFragment = { __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelId: number, fromModelName: string, fromModelDisplayName: string, fromColumnId: number, fromColumnName: string, fromColumnDisplayName: string, toModelId: number, toModelName: string, toModelDisplayName: string, toColumnId: number, toColumnName: string, toColumnDisplayName: string, description?: string | null };
 
@@ -12,7 +12,7 @@ export type FieldFragment = { __typename?: 'DiagramModelField', id: string, colu
 export type DiagramQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type DiagramQuery = { __typename?: 'Query', diagram: { __typename?: 'Diagram', models: Array<{ __typename?: 'DiagramModel', id: string, modelId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, sourceTableName: string, refSql: string, cached: boolean, refreshTime?: string | null, description?: string | null, fields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, calculatedFields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, relationFields: Array<{ __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelId: number, fromModelName: string, fromModelDisplayName: string, fromColumnId: number, fromColumnName: string, fromColumnDisplayName: string, toModelId: number, toModelName: string, toModelDisplayName: string, toColumnId: number, toColumnName: string, toColumnDisplayName: string, description?: string | null } | null> } | null>, views: Array<{ __typename?: 'DiagramView', id: string, viewId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, statement: string, fields: Array<{ __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType } | null> } | null> } };
+export type DiagramQuery = { __typename?: 'Query', diagram: { __typename?: 'Diagram', models: Array<{ __typename?: 'DiagramModel', id: string, modelId: number, nodeType: Types.NodeType, displayName: string, referenceName: string, sourceTableName: string, refSql: string, cached: boolean, refreshTime?: string | null, description?: string | null, fields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, calculatedFields: Array<{ __typename?: 'DiagramModelField', id: string, columnId: number, type: string, nodeType: Types.NodeType, displayName: string, referenceName: string, description?: string | null, isPrimaryKey: boolean, expression?: string | null, aggregation?: string | null, lineage?: Array<number> | null } | null>, relationFields: Array<{ __typename?: 'DiagramModelRelationField', id: string, relationId: number, type: Types.RelationType, nodeType: Types.NodeType, displayName: string, referenceName: string, fromModelId: number, fromModelName: string, fromModelDisplayName: string, fromColumnId: number, fromColumnName: string, fromColumnDisplayName: string, toModelId: number, toModelName: string, toModelDisplayName: string, toColumnId: number, toColumnName: string, toColumnDisplayName: string, description?: string | null } | null> } | null>, views: Array<{ __typename?: 'DiagramView', id: string, viewId: number, nodeType: Types.NodeType, displayName: string, description?: string | null, referenceName: string, statement: string, fields: Array<{ __typename?: 'DiagramViewField', id: string, displayName: string, referenceName: string, type: string, nodeType: Types.NodeType, description?: string | null } | null> } | null> } };
 
 export const ViewFieldFragmentDoc = gql`
     fragment ViewField on DiagramViewField {
@@ -21,6 +21,7 @@ export const ViewFieldFragmentDoc = gql`
   referenceName
   type
   nodeType
+  description
 }
     `;
 export const RelationFieldFragmentDoc = gql`
@@ -90,6 +91,7 @@ export const DiagramDocument = gql`
       viewId
       nodeType
       displayName
+      description
       referenceName
       statement
       fields {

--- a/wren-ui/src/apollo/client/graphql/diagram.ts
+++ b/wren-ui/src/apollo/client/graphql/diagram.ts
@@ -7,6 +7,7 @@ const VIEW_FIELD = gql`
     referenceName
     type
     nodeType
+    description
   }
 `;
 
@@ -79,6 +80,7 @@ export const DIAGRAM = gql`
         viewId
         nodeType
         displayName
+        description
         referenceName
         statement
         fields {

--- a/wren-ui/src/apollo/client/graphql/metadata.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/metadata.generated.ts
@@ -11,6 +11,14 @@ export type UpdateModelMetadataMutationVariables = Types.Exact<{
 
 export type UpdateModelMetadataMutation = { __typename?: 'Mutation', updateModelMetadata: boolean };
 
+export type UpdateViewMetadataMutationVariables = Types.Exact<{
+  where: Types.ViewWhereUniqueInput;
+  data: Types.UpdateViewMetadataInput;
+}>;
+
+
+export type UpdateViewMetadataMutation = { __typename?: 'Mutation', updateViewMetadata: boolean };
+
 
 export const UpdateModelMetadataDocument = gql`
     mutation UpdateModelMetadata($where: ModelWhereInput!, $data: UpdateModelMetadataInput!) {
@@ -44,3 +52,35 @@ export function useUpdateModelMetadataMutation(baseOptions?: Apollo.MutationHook
 export type UpdateModelMetadataMutationHookResult = ReturnType<typeof useUpdateModelMetadataMutation>;
 export type UpdateModelMetadataMutationResult = Apollo.MutationResult<UpdateModelMetadataMutation>;
 export type UpdateModelMetadataMutationOptions = Apollo.BaseMutationOptions<UpdateModelMetadataMutation, UpdateModelMetadataMutationVariables>;
+export const UpdateViewMetadataDocument = gql`
+    mutation UpdateViewMetadata($where: ViewWhereUniqueInput!, $data: UpdateViewMetadataInput!) {
+  updateViewMetadata(where: $where, data: $data)
+}
+    `;
+export type UpdateViewMetadataMutationFn = Apollo.MutationFunction<UpdateViewMetadataMutation, UpdateViewMetadataMutationVariables>;
+
+/**
+ * __useUpdateViewMetadataMutation__
+ *
+ * To run a mutation, you first call `useUpdateViewMetadataMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateViewMetadataMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateViewMetadataMutation, { data, loading, error }] = useUpdateViewMetadataMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateViewMetadataMutation(baseOptions?: Apollo.MutationHookOptions<UpdateViewMetadataMutation, UpdateViewMetadataMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateViewMetadataMutation, UpdateViewMetadataMutationVariables>(UpdateViewMetadataDocument, options);
+      }
+export type UpdateViewMetadataMutationHookResult = ReturnType<typeof useUpdateViewMetadataMutation>;
+export type UpdateViewMetadataMutationResult = Apollo.MutationResult<UpdateViewMetadataMutation>;
+export type UpdateViewMetadataMutationOptions = Apollo.BaseMutationOptions<UpdateViewMetadataMutation, UpdateViewMetadataMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/metadata.ts
+++ b/wren-ui/src/apollo/client/graphql/metadata.ts
@@ -8,3 +8,12 @@ export const UPDATE_MODEL_METADATA = gql`
     updateModelMetadata(where: $where, data: $data)
   }
 `;
+
+export const UPDATE_VIEW_METADATA = gql`
+  mutation UpdateViewMetadata(
+    $where: ViewWhereUniqueInput!
+    $data: UpdateViewMetadataInput!
+  ) {
+    updateViewMetadata(where: $where, data: $data)
+  }
+`;

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -232,7 +232,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
       } else {
         return {
           status: WrenAIDeployStatusEnum.FAILED,
-          error: `WrenAI: Deploy wren AI failed or timeout, hash: ${hash}`,
+          error: `WrenAI: Deploy wren AI failed or timeout, hash: ${hash}, `,
         };
       }
     } catch (err: any) {
@@ -281,6 +281,9 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
       const res = await axios.get(
         `${this.wrenAIBaseEndpoint}/v1/semantics-preparations/${deployId}/status`,
       );
+      if (res.data.error) {
+        logger.debug(`deploy error: ${res.data.error}`);
+      }
       return res.data?.status.toUpperCase() as WrenAISystemStatus;
     } catch (err: any) {
       logger.debug(

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -232,7 +232,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
       } else {
         return {
           status: WrenAIDeployStatusEnum.FAILED,
-          error: `WrenAI: Deploy wren AI failed or timeout, hash: ${hash}, `,
+          error: `WrenAI: Deploy wren AI failed or timeout, hash: ${hash}`,
         };
       }
     } catch (err: any) {

--- a/wren-ui/src/apollo/server/models/model.ts
+++ b/wren-ui/src/apollo/server/models/model.ts
@@ -25,12 +25,23 @@ export interface RelationshipMetadataInput {
   description: string;
 }
 
+export interface ViewColumnMetadataInput {
+  referenceName: string;
+  description: string;
+}
+
 export interface UpdateModelMetadataInput {
   displayName: string;
   description: string;
   columns: Array<ColumnMetadataInput>;
   calculatedFields: Array<CalculatedFieldMetadataInput>;
   relationships: Array<RelationshipMetadataInput>;
+}
+
+export interface UpdateViewMetadataInput {
+  displayName: string;
+  description: string;
+  columns: Array<ViewColumnMetadataInput>;
 }
 
 export enum ExpressionName {

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -81,6 +81,7 @@ const resolvers = {
     deleteView: modelResolver.deleteView,
     previewViewData: modelResolver.previewViewData,
     validateView: modelResolver.validateView,
+    updateViewMetadata: modelResolver.updateViewMetadata,
 
     // Settings
     resetCurrentProject: projectResolver.resetCurrentProject,

--- a/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/diagramResolver.ts
@@ -222,6 +222,7 @@ export class DiagramResolver {
       type: column.type,
       displayName: column.name,
       referenceName: column.name,
+      description: column?.properties?.description,
     }));
 
     return {
@@ -232,6 +233,7 @@ export class DiagramResolver {
       referenceName: view.name,
       displayName: properties?.displayName || view.name,
       fields,
+      description: properties?.description,
     };
   }
 }

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -4,6 +4,7 @@ import {
   UpdateModelMetadataInput,
   CreateCalculatedFieldData,
   UpdateCalculatedFieldData,
+  UpdateViewMetadataInput,
 } from '../models';
 import { IContext, RelationData, UpdateRelationData } from '../types';
 import { getLogger } from '@server/utils';
@@ -44,6 +45,7 @@ export class ModelResolver {
     this.validateView = this.validateView.bind(this);
     this.createView = this.createView.bind(this);
     this.deleteView = this.deleteView.bind(this);
+    this.updateViewMetadata = this.updateViewMetadata.bind(this);
 
     // preview
     this.previewModelData = this.previewModelData.bind(this);
@@ -570,6 +572,59 @@ export class ModelResolver {
     const sql = format(constructCteSql(steps));
 
     return await ctx.wrenEngineAdaptor.getNativeSQL(sql);
+  }
+
+  public async updateViewMetadata(
+    _root: any,
+    args: { where: { id: number }; data: UpdateViewMetadataInput },
+    ctx: IContext,
+  ): Promise<boolean> {
+    const viewId = args.where.id;
+    const data = args.data;
+
+    // check if view exists
+    const view = await ctx.viewRepository.findOneBy({ id: viewId });
+    if (!view) {
+      throw new Error('View not found');
+    }
+
+    // update view metadata
+    const properties = JSON.parse(view.properties);
+
+    // if displayName is not null, or undefined, update the displayName
+    if (!isNil(data.displayName)) {
+      properties.displayName = this.determineMetadataValue(data.displayName);
+    }
+
+    // if description is not null, or undefined, update the description in properties
+    if (!isNil(data.description)) {
+      properties.description = this.determineMetadataValue(data.description);
+    }
+
+    // view column metadata
+    if (!isEmpty(data.columns)) {
+      const viewColumns = properties.columns;
+      for (const col of viewColumns) {
+        const requestedMetadata = data.columns.find(
+          (c) => c.referenceName === col.name,
+        );
+
+        if (!isNil(requestedMetadata.description)) {
+          col.properties = col.properties || {};
+          col.properties.description = this.determineMetadataValue(
+            requestedMetadata.description,
+          );
+        }
+      }
+
+      properties.columns = viewColumns;
+    }
+
+    await ctx.viewRepository.updateOne(viewId, {
+      properties: JSON.stringify(properties),
+    });
+
+    return true;
   }
 
   private determineMetadataValue(value: string) {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -213,12 +213,23 @@ export const typeDefs = gql`
     description: String
   }
 
+  input UpdateViewColumnMetadataInput {
+    referenceName: String!
+    description: String
+  }
+
   input UpdateModelMetadataInput {
     displayName: String # Model display name, i,e, the alias of the model
     description: String # Model description
     columns: [UpdateColumnMetadataInput!] # Update column metadata
     calculatedFields: [UpdateCalculatedFieldMetadataInput!] # Update calculated field metadata
     relationships: [UpdateRelationshipMetadataInput!] # Update relationship metadata
+  }
+
+  input UpdateViewMetadataInput {
+    displayName: String # View display name, i,e, the alias of the view
+    description: String # View description
+    columns: [UpdateViewColumnMetadataInput!]
   }
 
   type FieldInfo {
@@ -330,6 +341,7 @@ export const typeDefs = gql`
     displayName: String!
     referenceName: String!
     fields: [DiagramViewField]!
+    description: String
   }
 
   type DiagramViewField {
@@ -338,6 +350,7 @@ export const typeDefs = gql`
     referenceName: String!
     type: String!
     nodeType: NodeType!
+    description: String
   }
 
   type DiagramModel {
@@ -613,6 +626,10 @@ export const typeDefs = gql`
     updateModelMetadata(
       where: ModelWhereInput!
       data: UpdateModelMetadataInput!
+    ): Boolean!
+    updateViewMetadata(
+      where: ViewWhereUniqueInput!
+      data: UpdateViewMetadataInput!
     ): Boolean!
 
     # Relation

--- a/wren-ui/src/apollo/server/types/diagram.ts
+++ b/wren-ui/src/apollo/server/types/diagram.ts
@@ -21,6 +21,7 @@ export interface DiagramView {
   displayName: string;
   referenceName: string;
   fields: DiagramViewField[];
+  description: string;
 }
 
 export interface DiagramViewField {
@@ -29,6 +30,7 @@ export interface DiagramViewField {
   referenceName: string;
   type: string;
   nodeType: NodeType;
+  description: string;
 }
 
 export interface DiagramModel {

--- a/wren-ui/src/components/EditableWrapper.tsx
+++ b/wren-ui/src/components/EditableWrapper.tsx
@@ -8,6 +8,7 @@ interface Props {
   children: React.ReactNode;
   dataIndex: string;
   record: any;
+  rules?: any[];
   handleSave: (id: string, value: { [key: string]: string }) => void;
 }
 
@@ -36,7 +37,7 @@ const EditableStyle = styled.div`
 export const EditableContext = createContext<FormInstance<any> | null>(null);
 
 export default function EditableWrapper(props: Props) {
-  const { children, dataIndex, record, handleSave } = props;
+  const { children, dataIndex, record, rules, handleSave } = props;
 
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<InputRef>(null);
@@ -67,7 +68,7 @@ export default function EditableWrapper(props: Props) {
   };
 
   const childNode = editing ? (
-    <Form.Item style={{ margin: 0 }} name={dataIndexKey}>
+    <Form.Item style={{ margin: 0 }} name={dataIndexKey} rules={rules}>
       <Input size="small" ref={inputRef} onPressEnter={save} onBlur={save} />
     </Form.Item>
   ) : (

--- a/wren-ui/src/components/modals/SaveAsViewModal.tsx
+++ b/wren-ui/src/components/modals/SaveAsViewModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Form, Input, Modal, Typography } from 'antd';
 import InfoCircleOutlined from '@ant-design/icons/InfoCircleOutlined';
 import { ModalAction } from '@/hooks/useModalAction';
-import { ERROR_TEXTS } from '@/utils/error';
+import { createViewNameValidator } from '@/utils/validator';
 import CodeBlock from '@/components/editor/CodeBlock';
 import { useValidateViewMutation } from '@/apollo/client/graphql/view.generated';
 
@@ -11,25 +11,6 @@ type Props = ModalAction<{ sql: string }> & {
   loading?: boolean;
   defaultValue: { sql: string; responseId: number };
 };
-
-const createViewTitleValidator =
-  (validateViewMutation: any) => async (_rule: any, value: string) => {
-    if (!value) {
-      return Promise.reject(ERROR_TEXTS.SAVE_AS_VIEW.NAME.REQUIRED);
-    }
-
-    const validateViewResult = await validateViewMutation({
-      variables: { data: { name: value } },
-    });
-
-    const { valid, message } = validateViewResult?.data?.validateView;
-
-    if (!valid) {
-      return Promise.reject(message);
-    }
-
-    return Promise.resolve();
-  };
 
 export default function SaveAsViewModal(props: Props) {
   const { visible, loading, onSubmit, onClose, defaultValue } = props;
@@ -90,7 +71,7 @@ export default function SaveAsViewModal(props: Props) {
           rules={[
             {
               required: true,
-              validator: createViewTitleValidator(validateViewMutation),
+              validator: createViewNameValidator(validateViewMutation),
             },
           ]}
         >

--- a/wren-ui/src/components/pages/modeling/EditMetadataModal.tsx
+++ b/wren-ui/src/components/pages/modeling/EditMetadataModal.tsx
@@ -26,9 +26,15 @@ export default function EditMetadataModal(props: Props) {
   const [form] = Form.useForm();
 
   const submit = async () => {
-    const values = form.getFieldValue(formNamespace);
-    await onSubmit({ data: values, nodeType });
-    onClose();
+    form
+      .validateFields()
+      .then(async () => {
+        // Get the saved metadata values to submit if there is no editing failed
+        const values = form.getFieldValue(formNamespace);
+        await onSubmit({ data: values, nodeType });
+        onClose();
+      })
+      .catch(console.error);
   };
 
   return (

--- a/wren-ui/src/components/pages/modeling/EditMetadataModal.tsx
+++ b/wren-ui/src/components/pages/modeling/EditMetadataModal.tsx
@@ -1,13 +1,15 @@
 import { Modal, Form } from 'antd';
 import { ModalAction } from '@/hooks/useModalAction';
 import { NODE_TYPE } from '@/utils/enum';
+import { EditableContext } from '@/components/EditableWrapper';
 import EditModelMetadata, {
   Props as EditModelProps,
 } from '@/components/pages/modeling/metadata/EditModelMetadata';
-import { EditableContext } from '@/components/EditableWrapper';
+import EditViewMetadata, {
+  Props as EditViewProps,
+} from '@/components/pages/modeling/metadata/EditViewMetadata';
 
-type DefaultValue = EditModelProps & {
-  modelId: number;
+type DefaultValue = (EditModelProps | EditViewProps) & {
   nodeType: NODE_TYPE;
 };
 
@@ -25,7 +27,7 @@ export default function EditMetadataModal(props: Props) {
 
   const submit = async () => {
     const values = form.getFieldValue(formNamespace);
-    await onSubmit({ data: values, id: defaultValue?.modelId });
+    await onSubmit({ data: values, nodeType });
     onClose();
   };
 
@@ -48,7 +50,14 @@ export default function EditMetadataModal(props: Props) {
           {nodeType === NODE_TYPE.MODEL && (
             <EditModelMetadata
               formNamespace={formNamespace}
-              {...defaultValue}
+              {...(defaultValue as EditModelProps)}
+            />
+          )}
+
+          {nodeType === NODE_TYPE.VIEW && (
+            <EditViewMetadata
+              formNamespace={formNamespace}
+              {...(defaultValue as EditViewProps)}
             />
           )}
         </Form>

--- a/wren-ui/src/components/pages/modeling/MetadataDrawer.tsx
+++ b/wren-ui/src/components/pages/modeling/MetadataDrawer.tsx
@@ -31,14 +31,12 @@ export default function MetadataDrawer(props: Props) {
       destroyOnClose
       onClose={onClose}
       extra={
-        isModel && (
-          <Button
-            icon={<EditOutlined />}
-            onClick={() => onEditClick(defaultValue)}
-          >
-            Edit
-          </Button>
-        )
+        <Button
+          icon={<EditOutlined />}
+          onClick={() => onEditClick(defaultValue)}
+        >
+          Edit
+        </Button>
       }
     >
       {isModel && <ModelMetadata {...defaultValue} />}

--- a/wren-ui/src/components/pages/modeling/metadata/EditBasicMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/EditBasicMetadata.tsx
@@ -4,8 +4,15 @@ import { cloneDeep, set } from 'lodash';
 import { NODE_TYPE } from '@/utils/enum';
 import EditableWrapper from '@/components/EditableWrapper';
 
-export default function EditBasicMetadata(props) {
-  const { dataSource, onChange, nodeType } = props;
+interface Props {
+  dataSource: any;
+  onChange?: (value: any) => void;
+  nodeType: NODE_TYPE;
+  rules?: Record<string, any[]>;
+}
+
+export default function EditBasicMetadata(props: Props) {
+  const { dataSource, onChange, nodeType, rules } = props;
   const [data, setData] = useState(dataSource);
 
   const isModel = nodeType === NODE_TYPE.MODEL;
@@ -66,6 +73,7 @@ export default function EditBasicMetadata(props) {
             record={data}
             dataIndex="displayName"
             handleSave={handleSave}
+            rules={rules?.displayName}
           >
             {data.displayName || '-'}
           </EditableWrapper>

--- a/wren-ui/src/components/pages/modeling/metadata/EditBasicMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/EditBasicMetadata.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from 'react';
 import { Typography, Row, Col } from 'antd';
 import { cloneDeep, set } from 'lodash';
+import { NODE_TYPE } from '@/utils/enum';
 import EditableWrapper from '@/components/EditableWrapper';
 
 export default function EditBasicMetadata(props) {
-  const { dataSource, onChange } = props;
+  const { dataSource, onChange, nodeType } = props;
   const [data, setData] = useState(dataSource);
+
+  const isModel = nodeType === NODE_TYPE.MODEL;
+  const isView = nodeType === NODE_TYPE.VIEW;
 
   useEffect(() => {
     // bind changeable metadata values
@@ -26,30 +30,48 @@ export default function EditBasicMetadata(props) {
 
   return (
     <>
-      <Row>
-        <Col span={12}>
-          <div className="mb-6">
-            <Typography.Text className="d-block gray-7 mb-2">
-              Name
-            </Typography.Text>
-            <div>{data.referenceName}</div>
-          </div>
-        </Col>
-        <Col span={12}>
-          <div className="mb-6">
-            <Typography.Text className="d-block gray-7 mb-2">
-              Alias
-            </Typography.Text>
-            <EditableWrapper
-              record={data}
-              dataIndex="displayName"
-              handleSave={handleSave}
-            >
-              {data.displayName || '-'}
-            </EditableWrapper>
-          </div>
-        </Col>
-      </Row>
+      {isModel && (
+        <Row>
+          <Col span={12}>
+            <div className="mb-6">
+              <Typography.Text className="d-block gray-7 mb-2">
+                Name
+              </Typography.Text>
+              <div>{data.referenceName}</div>
+            </div>
+          </Col>
+          <Col span={12}>
+            <div className="mb-6">
+              <Typography.Text className="d-block gray-7 mb-2">
+                Alias
+              </Typography.Text>
+              <EditableWrapper
+                record={data}
+                dataIndex="displayName"
+                handleSave={handleSave}
+              >
+                {data.displayName || '-'}
+              </EditableWrapper>
+            </div>
+          </Col>
+        </Row>
+      )}
+
+      {isView && (
+        <div className="mb-6">
+          <Typography.Text className="d-block gray-7 mb-2">
+            Name
+          </Typography.Text>
+          <EditableWrapper
+            record={data}
+            dataIndex="displayName"
+            handleSave={handleSave}
+          >
+            {data.displayName || '-'}
+          </EditableWrapper>
+        </div>
+      )}
+
       <div className="mb-6">
         <Typography.Text className="d-block gray-7 mb-2">
           Description

--- a/wren-ui/src/components/pages/modeling/metadata/EditModelMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/EditModelMetadata.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 import { Typography } from 'antd';
+import { NODE_TYPE } from '@/utils/enum';
 import FieldTable from '@/components/table/FieldTable';
 import CalculatedFieldTable from '@/components/table/CalculatedFieldTable';
 import RelationTable from '@/components/table/RelationTable';
@@ -17,6 +18,8 @@ export interface Props {
   relationFields: any[];
   description: string;
   properties: Record<string, any>;
+  nodeType: NODE_TYPE;
+  modelId: number;
 }
 
 const FIELDS_NAME = {
@@ -39,6 +42,8 @@ export default function EditModelMetadata(props: Props) {
     calculatedFields = [],
     relationFields = [],
     description,
+    nodeType,
+    modelId,
   } = props || {};
 
   const form = useContext(EditableContext);
@@ -48,6 +53,7 @@ export default function EditModelMetadata(props: Props) {
       [formNamespace]: {
         ...(form.getFieldValue(formNamespace) || {}),
         ...value,
+        modelId,
       },
     });
   };
@@ -71,6 +77,7 @@ export default function EditModelMetadata(props: Props) {
       <EditBasicMetadata
         dataSource={{ displayName, referenceName, description }}
         onChange={onChange}
+        nodeType={nodeType}
       />
 
       <div className="mb-6">

--- a/wren-ui/src/components/pages/modeling/metadata/EditViewMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/EditViewMetadata.tsx
@@ -1,0 +1,83 @@
+import { useContext } from 'react';
+import { Typography } from 'antd';
+import { NODE_TYPE } from '@/utils/enum';
+import FieldTable from '@/components/table/FieldTable';
+import { makeEditableBaseTable } from '@/components/table/EditableBaseTable';
+import { COLUMN } from '@/components/table/BaseTable';
+import { EditableContext } from '@/components/EditableWrapper';
+import EditBasicMetadata from './EditBasicMetadata';
+
+export interface Props {
+  formNamespace: string;
+  displayName: string;
+  fields: any[];
+  description: string;
+  properties: Record<string, any>;
+  nodeType: NODE_TYPE;
+  viewId: number;
+}
+
+const FIELDS_NAME = {
+  FIELDS: 'columns',
+};
+
+const FieldEditableTable = makeEditableBaseTable(FieldTable);
+
+export default function EditViewMetadata(props: Props) {
+  const {
+    formNamespace,
+    displayName,
+    fields = [],
+    description,
+    nodeType,
+    viewId,
+  } = props || {};
+
+  const form = useContext(EditableContext);
+
+  const onChange = (value) => {
+    form.setFieldsValue({
+      [formNamespace]: {
+        ...(form.getFieldValue(formNamespace) || {}),
+        ...value,
+        viewId,
+      },
+    });
+  };
+
+  const handleMetadataChange = (fieldsName: string) => (value: any[]) => {
+    // bind changeable metadata values
+    // The view's columns don't have their own column IDs, so we use the referenceName
+    onChange({
+      [fieldsName]: value.map((item) => ({
+        referenceName: item.referenceName,
+        description: item.description,
+      })),
+    });
+  };
+
+  return (
+    <>
+      <EditBasicMetadata
+        dataSource={{ displayName, description }}
+        onChange={onChange}
+        nodeType={nodeType}
+      />
+
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Columns ({fields.length})
+        </Typography.Text>
+        <FieldEditableTable
+          dataSource={fields}
+          columns={[
+            COLUMN.NAME,
+            { ...COLUMN.TYPE },
+            { ...COLUMN.DESCRIPTION, width: 280 },
+          ]}
+          onChange={handleMetadataChange(FIELDS_NAME.FIELDS)}
+        />
+      </div>
+    </>
+  );
+}

--- a/wren-ui/src/components/pages/modeling/metadata/EditViewMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/EditViewMetadata.tsx
@@ -3,9 +3,11 @@ import { Typography } from 'antd';
 import { NODE_TYPE } from '@/utils/enum';
 import FieldTable from '@/components/table/FieldTable';
 import { makeEditableBaseTable } from '@/components/table/EditableBaseTable';
+import { createViewNameValidator } from '@/utils/validator';
 import { COLUMN } from '@/components/table/BaseTable';
 import { EditableContext } from '@/components/EditableWrapper';
 import EditBasicMetadata from './EditBasicMetadata';
+import { useValidateViewMutation } from '@/apollo/client/graphql/view.generated';
 
 export interface Props {
   formNamespace: string;
@@ -35,6 +37,10 @@ export default function EditViewMetadata(props: Props) {
 
   const form = useContext(EditableContext);
 
+  const [validateViewMutation] = useValidateViewMutation({
+    fetchPolicy: 'no-cache',
+  });
+
   const onChange = (value) => {
     form.setFieldsValue({
       [formNamespace]: {
@@ -62,6 +68,16 @@ export default function EditViewMetadata(props: Props) {
         dataSource={{ displayName, description }}
         onChange={onChange}
         nodeType={nodeType}
+        rules={{
+          // View display name changing will trigger re-generate reference name
+          // So we need to validate the display name
+          displayName: [
+            {
+              required: true,
+              validator: createViewNameValidator(validateViewMutation),
+            },
+          ],
+        }}
       />
 
       <div className="mb-6">

--- a/wren-ui/src/components/pages/modeling/metadata/ViewMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/ViewMetadata.tsx
@@ -1,13 +1,21 @@
 import { Button, Typography } from 'antd';
 import CodeBlock from '@/components/editor/CodeBlock';
 import PreviewData from '@/components/dataPreview/PreviewData';
+import { COLUMN } from '@/components/table/BaseTable';
+import FieldTable from '@/components/table/FieldTable';
 import { DiagramView } from '@/utils/data';
 import { usePreviewViewDataMutation } from '@/apollo/client/graphql/view.generated';
 
 export type Props = DiagramView;
 
 export default function ViewMetadata(props: Props) {
-  const { displayName, statement, viewId } = props || {};
+  const {
+    displayName,
+    description,
+    fields = [],
+    statement,
+    viewId,
+  } = props || {};
 
   const [previewViewDataMutation, previewViewDataResult] =
     usePreviewViewDataMutation({
@@ -26,6 +34,24 @@ export default function ViewMetadata(props: Props) {
       <div className="mb-6">
         <Typography.Text className="d-block gray-7 mb-2">Name</Typography.Text>
         <div>{displayName || '-'}</div>
+      </div>
+
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Description
+        </Typography.Text>
+        <div>{description || '-'}</div>
+      </div>
+
+      <div className="mb-6">
+        <Typography.Text className="d-block gray-7 mb-2">
+          Columns ({fields.length})
+        </Typography.Text>
+        <FieldTable
+          columns={[COLUMN.NAME, COLUMN.TYPE, COLUMN.DESCRIPTION]}
+          dataSource={fields}
+          showExpandable
+        />
       </div>
 
       <div className="mb-6">

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -325,8 +325,26 @@ export default function Modeling() {
         <EditMetadataModal
           {...editMetadataModal.state}
           onClose={editMetadataModal.closeModal}
-          onSubmit={async ({ id, data }) => {
-            await updateModelMetadata({ variables: { where: { id }, data } });
+          onSubmit={async ({ nodeType, data }) => {
+            const { modelId, viewId, ...metadata } = data;
+            switch (nodeType) {
+              case NODE_TYPE.MODEL: {
+                await updateModelMetadata({
+                  variables: { where: { id: modelId }, data: metadata },
+                });
+                break;
+              }
+
+              case NODE_TYPE.VIEW: {
+                // TODO: connect to update view metadata
+                console.log('onSubmit VIEW', viewId, metadata);
+                break;
+              }
+
+              default:
+                console.log('onSubmit', nodeType, data);
+                break;
+            }
           }}
         />
         <ModelDrawer

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -157,7 +157,7 @@ class DeleteModelErrorHandler extends ErrorHandler {
   }
 }
 
-class UpdateModelMetdataErrorHandler extends ErrorHandler {
+class UpdateModelMetadataErrorHandler extends ErrorHandler {
   public getErrorMessage(error: GraphQLError) {
     switch (error.extensions?.code) {
       default:
@@ -220,6 +220,15 @@ class DeleteRelationshipErrorHandler extends ErrorHandler {
   }
 }
 
+class UpdateViewMetadataErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to update view metadata.';
+    }
+  }
+}
+
 errorHandlers.set('SaveTables', new SaveTablesErrorHandler());
 errorHandlers.set('SaveRelations', new SaveRelationsErrorHandler());
 errorHandlers.set('CreateAskingTask', new CreateAskingTaskErrorHandler());
@@ -235,7 +244,8 @@ errorHandlers.set('UpdateDataSource', new UpdateDataSourceErrorHandler());
 errorHandlers.set('CreateModel', new CreateModelErrorHandler());
 errorHandlers.set('UpdateModel', new UpdateModelErrorHandler());
 errorHandlers.set('DeleteModel', new DeleteModelErrorHandler());
-errorHandlers.set('UpdateModelMetadata', new UpdateModelMetdataErrorHandler());
+errorHandlers.set('UpdateModelMetadata', new UpdateModelMetadataErrorHandler());
+errorHandlers.set('UpdateViewMetadata', new UpdateViewMetadataErrorHandler());
 errorHandlers.set(
   'CreateCalculatedField',
   new CreateCalculatedFieldErrorHandler(),

--- a/wren-ui/src/utils/validator/index.ts
+++ b/wren-ui/src/utils/validator/index.ts
@@ -1,1 +1,2 @@
 export * from './calculatedFieldValidator';
+export * from './viewValidator';

--- a/wren-ui/src/utils/validator/viewValidator.ts
+++ b/wren-ui/src/utils/validator/viewValidator.ts
@@ -1,0 +1,20 @@
+import { ERROR_TEXTS } from '@/utils/error';
+
+export const createViewNameValidator =
+  (validateViewMutation: any) => async (_rule: any, value: string) => {
+    if (!value) {
+      return Promise.reject(ERROR_TEXTS.SAVE_AS_VIEW.NAME.REQUIRED);
+    }
+
+    const validateViewResult = await validateViewMutation({
+      variables: { data: { name: value } },
+    });
+
+    const { valid, message } = validateViewResult?.data?.validateView;
+
+    if (!valid) {
+      return Promise.reject(message);
+    }
+
+    return Promise.resolve();
+  };


### PR DESCRIPTION
## Description
 - Support edit view metadata mode

## Tasks
- [x] Metadata drawer
    - display name as drawer title (model & view)
    - show view’s display name on the **Name** field
    - show view’s description
    - list all columns
        - column name - **Name**
        - column type - **Type**
        - column description - **Description**
- [x] Those allowed to update metadata are:
    - view (alias) name
    - view description
    - column description
- [x] API
   - update `diagram` API
   - add `updateViewMetadata` API
- [x] Support update view metadata & error handler

## UI screenshots

![截圖 2024-05-09 下午5 56 08](https://github.com/Canner/WrenAI/assets/42527625/9cd1e7ea-c581-478e-9aa5-c6562ecc03f1)



![截圖 2024-05-09 下午5 56 12](https://github.com/Canner/WrenAI/assets/42527625/83c92409-ef75-474d-be0c-7d5a18cf2e3d)

![截圖 2024-05-09 下午6 00 23](https://github.com/Canner/WrenAI/assets/42527625/093a698a-86d5-4fcb-b375-5dc8f02b6952)


![截圖 2024-05-09 下午6 00 26](https://github.com/Canner/WrenAI/assets/42527625/d59c83f1-4ed1-4cf6-80c1-48ae032969c0)

