### PR TITLE
Feature(wren-ui): adjust display name validation logic of Calculated field & View 

### DIFF
--- a/wren-ui/src/apollo/server/models/model.ts
+++ b/wren-ui/src/apollo/server/models/model.ts
@@ -54,13 +54,19 @@ export enum ExpressionName {
 
 export interface CreateCalculatedFieldData {
   modelId: number;
-  name: string;
+  name: string; //displayName
   expression: ExpressionName;
   lineage: number[];
 }
 
 export interface UpdateCalculatedFieldData {
-  name: string;
+  name: string; //displayName
+  expression: ExpressionName;
+  lineage: number[];
+}
+
+export interface CheckCalculatedFieldCanQueryData {
+  referenceName: string;
   expression: ExpressionName;
   lineage: number[];
 }

--- a/wren-ui/src/apollo/server/utils/regex.ts
+++ b/wren-ui/src/apollo/server/utils/regex.ts
@@ -1,0 +1,33 @@
+export interface ValidationResult {
+  valid: boolean;
+  message: string | null;
+}
+
+export function validateDisplayName(displayName: string): ValidationResult {
+  let message = null;
+  let valid = true;
+
+  const allowableSyntaxRegex = /^[A-Za-z0-9 !@#$%^&*()_+{}[\],.'"-]*$/;
+  const syntaxValid = allowableSyntaxRegex.test(displayName);
+  if (!syntaxValid) {
+    valid = false;
+    message =
+      'Invalid displayName, Only space & [  a-z, A-Z, 0-9, _, -, !@#$%^&*()-+{}[]\'".,  ] are allowed.';
+  }
+  const startWithLetterRegex = /^[A-Za-z]/;
+  const startWithLetterValid = startWithLetterRegex.test(displayName);
+  if (!startWithLetterValid) {
+    valid = false;
+    message = 'Invalid displayName, Must start with a letter.';
+  }
+
+  return {
+    valid,
+    message,
+  };
+}
+
+export function replaceAllowableSyntax(str: string) {
+  const replacedStr = str.replace(/[!@#$%^&*()+{}[\]'",. -]/g, '_');
+  return replacedStr;
+}

--- a/wren-ui/src/apollo/server/utils/tests/regex.test.ts
+++ b/wren-ui/src/apollo/server/utils/tests/regex.test.ts
@@ -1,0 +1,62 @@
+import { validateDisplayName, replaceAllowableSyntax } from '../regex';
+
+describe('validateDisplayName', () => {
+  it('should return valid when displayName contains only allowable syntax and start with a letter', () => {
+    // Arrange
+    const displayName = 'Valid Display Name !@#$%^&*()_+{}[].,"\'';
+
+    // Act
+    const result = validateDisplayName(displayName);
+
+    // Assert
+    expect(result.valid).toBe(true);
+    expect(result.message).toBeNull();
+  });
+
+  it.each([['~'], ['<'], ['\\'], ['>'], ['?']])(
+    'should return invalid when displayName contains invalid syntax: %s',
+    ([invalidSyntax]) => {
+      // Arrange
+      const displayName = `Invalid Display Name ${invalidSyntax}`;
+
+      // Act
+      const result = validateDisplayName(displayName);
+
+      // Assert
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe(
+        'Invalid displayName, Only space & [  a-z, A-Z, 0-9, _, -, !@#$%^&*()-+{}[]\'".,  ] are allowed.',
+      );
+    },
+  );
+  it.each([['@'], ['1'], [' ']])(
+    'should return invalid when displayName does not start with a letter',
+    ([invalidSyntax]) => {
+      // Arrange
+      const displayName = `${invalidSyntax}Display Name`;
+
+      // Act
+      const result = validateDisplayName(displayName);
+
+      // Assert
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe(
+        'Invalid displayName, Must start with a letter.',
+      );
+    },
+  );
+});
+
+describe('replaceAllowableSyntax', () => {
+  it('should replace allowable syntax characters with underscores', () => {
+    // Arrange
+    const str = 'Replace   !@#$%^&*() -+{}[],\'".';
+
+    // Act
+    const result = replaceAllowableSyntax(str);
+
+    // Assert
+    expect(result).toBe('Replace________________________');
+    expect(result.length).toBe(str.length);
+  });
+});


### PR DESCRIPTION
Adjust logic:
 - use input displayName to generate referenceName
 - validation target is input displayName


### Example
created view 
<img width="1010" alt="image" src="https://github.com/Canner/WrenAI/assets/38731840/5f832e8a-330b-4c07-b20e-d42c3c4587e7">

created calculated field
<img width="988" alt="image" src="https://github.com/Canner/WrenAI/assets/38731840/04458af0-3be1-4f5c-bee2-b188fc441b46">
