### PR TITLE
fix(wren-ui): Fix Posthog related env in client

### DIFF
--- a/wren-ui/src/pages/_app.tsx
+++ b/wren-ui/src/pages/_app.tsx
@@ -16,8 +16,8 @@ Spin.setDefaultIndicator(defaultIndicator);
 const setupTelemetry = (userConfig) => {
   // Check that PostHog is client-side (used to handle Next.js SSR)
   if (userConfig.isTelemetryEnabled && typeof window !== 'undefined') {
-    posthog.init(env.posthogAPIKey, {
-      api_host: env.posthogHost,
+    posthog.init(userConfig.telemetryKey, {
+      api_host: userConfig.telemetryHost,
       autocapture: {
         dom_event_allowlist: ['click'],
         css_selector_allowlist: ['[data-ph-capture="true"]'],

--- a/wren-ui/src/pages/api/config.ts
+++ b/wren-ui/src/pages/api/config.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getConfig } from '@/apollo/server/config';
+
+export default function handler(_: NextApiRequest, res: NextApiResponse) {
+  const config = getConfig();
+  const encodedTelemetryKey = config.posthogApiKey
+    ? Buffer.from(config.posthogApiKey).toString('base64')
+    : '';
+
+  res.status(200).json({
+    isTelemetryEnabled: config.telemetryEnabled || false,
+    telemetryKey: encodedTelemetryKey,
+    telemetryHost: config.posthogHost || '',
+    userUUID: config.userUUID || '',
+  });
+}

--- a/wren-ui/src/utils/env.ts
+++ b/wren-ui/src/utils/env.ts
@@ -1,13 +1,19 @@
 const env = {
   isDevelopment: process.env.NODE_ENV === 'development',
   isProduction: process.env.NODE_ENV === 'production',
-  isTelemetryEnabled:
-    process.env.NEXT_PUBLIC_TELEMETRY_ENABLED &&
-    process.env.NEXT_PUBLIC_TELEMETRY_ENABLED.toLocaleLowerCase() === 'true',
-  userUUID: process.env.NEXT_PUBLIC_USER_UUID,
   posthogAPIKey: process.env.NEXT_PUBLIC_POSTHOG_API_KEY,
   posthogHost:
     process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
 };
 
 export default env;
+
+// Get the user configuration
+export const getUserConfig = async () => {
+  const config = await fetch('/api/config').then((res) => res.json());
+  const decodedTelemetryKey = Buffer.from(
+    config.telemetryKey,
+    'base64',
+  ).toString();
+  return { ...config, telemetryKey: decodedTelemetryKey };
+};

--- a/wren-ui/src/utils/env.ts
+++ b/wren-ui/src/utils/env.ts
@@ -1,9 +1,6 @@
 const env = {
   isDevelopment: process.env.NODE_ENV === 'development',
   isProduction: process.env.NODE_ENV === 'production',
-  posthogAPIKey: process.env.NEXT_PUBLIC_POSTHOG_API_KEY,
-  posthogHost:
-    process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
 };
 
 export default env;


### PR DESCRIPTION
## Description

By design, Nextjs client side cannot receive runtime env, the `NEXT_PUBLIC` env will be converted to frozen value, so we need to provide env at the build time.

> If you build and deploy a single Docker image to multiple environments, all NEXT_PUBLIC_ variables will be frozen with the value evaluated at build time, so these values need to be set appropriately when the project is built.

As an alternative, add an API to retrieve the user option from the backend such as telemetry enabling