### PR TITLE
feat(wren-ui): Support SSL property to Postgres connector

### DIFF
--- a/wren-ui/src/apollo/server/connectors/postgresConnector.ts
+++ b/wren-ui/src/apollo/server/connectors/postgresConnector.ts
@@ -15,6 +15,7 @@ export interface PostgresConnectionConfig {
   host: string;
   database: string;
   port: number;
+  ssl?: boolean;
 }
 
 export interface PostgresColumnResponse {

--- a/wren-ui/src/apollo/server/repositories/projectRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/projectRepository.ts
@@ -13,6 +13,7 @@ export interface Project {
   type: string; // Project datasource type. ex: bigquery, mysql, postgresql, mongodb, etc
   displayName: string; // Project display name
   credentials: string; // Database credentials. General purpose field for storing credentials
+  configurations: Record<string, any>; // Project connection configurations
 
   // bq
   projectId: string; // BigQuery project id
@@ -20,7 +21,6 @@ export interface Project {
 
   // duckdb
   initSql: string; // DuckDB init sql
-  configurations: Record<string, any>; // DuckDB configurations
   extensions: string[];
 
   // pg

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -375,6 +375,7 @@ export class ProjectResolver {
       properties.port = project.port;
       properties.database = project.database;
       properties.user = project.user;
+      properties.ssl = project.configurations?.ssl;
     }
 
     return properties;

--- a/wren-ui/src/apollo/server/types/dataSource.ts
+++ b/wren-ui/src/apollo/server/types/dataSource.ts
@@ -41,4 +41,5 @@ export interface PGDataSourceProperties {
   database: string;
   user: string;
   password: string;
+  ssl?: boolean;
 }

--- a/wren-ui/src/components/pages/setup/dataSources/PostgreSQLProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/PostgreSQLProperties.tsx
@@ -1,4 +1,4 @@
-import { Form, Input } from 'antd';
+import { Form, Input, Switch } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
 
@@ -87,6 +87,9 @@ export default function PostgreSQLProperties(props: Props) {
         ]}
       >
         <Input placeholder="PostgreSQL database name" disabled={isEditMode} />
+      </Form.Item>
+      <Form.Item label="Use SSL" name="ssl" valuePropName="checked">
+        <Switch />
       </Form.Item>
     </>
   );

--- a/wren-ui/src/components/settings/DataSourceSettings.tsx
+++ b/wren-ui/src/components/settings/DataSourceSettings.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import Image from 'next/image';
-import { useEffect } from 'react';
-import { Button, Form, Modal, message } from 'antd';
+import { useEffect, useMemo } from 'react';
+import { Button, Form, Modal, message, Alert } from 'antd';
 import { makeIterable } from '@/utils/iteration';
 import { DATA_SOURCES, FORM_MODE, Path } from '@/utils/enum';
 import { getDataSource, getTemplates } from '@/components/pages/setup/utils';
@@ -82,13 +82,15 @@ const DataSourcePanel = (props: Props) => {
   const current = getDataSource(type as unknown as DATA_SOURCES);
   const [form] = Form.useForm();
 
-  const [updateDataSource, { loading }] = useUpdateDataSourceMutation({
+  const [updateDataSource, { loading, error }] = useUpdateDataSourceMutation({
     onError: (error) => console.error(error),
     onCompleted: async () => {
       refetchSettings();
       message.success('Successfully update data source.');
     },
   });
+
+  const connectErrorMessage = useMemo(() => error?.message, [error]);
 
   useEffect(() => properties && reset(), [properties]);
 
@@ -127,6 +129,16 @@ const DataSourcePanel = (props: Props) => {
       </div>
       <Form form={form} layout="vertical" className="py-3 px-4">
         <current.component mode={FORM_MODE.EDIT} />
+
+        {connectErrorMessage && (
+          <Alert
+            message="Failed to connect"
+            description={connectErrorMessage || 'Cannot connect to data source'}
+            type="error"
+            showIcon
+            className="my-6"
+          />
+        )}
 
         <div className="py-2 text-right">
           <Button className="mr-2" style={{ width: 80 }} onClick={reset}>

--- a/wren-ui/src/hooks/useSetupConnection.tsx
+++ b/wren-ui/src/hooks/useSetupConnection.tsx
@@ -38,6 +38,7 @@ export const transformFormToProperties = (
         properties?.password === PASSWORD_PLACEHOLDER
           ? undefined
           : properties?.password,
+      ssl: properties?.ssl,
     };
   }
 


### PR DESCRIPTION
## Description
- Provide SSL property to PostgreSQL data source
- Replenish the Alert component in the update data source settings

## UI Screenshot
<img width="1086" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/346ccd9a-e0bf-411a-a108-9db7d95d8f07">

<img width="995" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/6b5baf55-c080-441b-8d6e-a5f7d31e3279">

## Related issue
close #180 