### PR TITLE
feat(wren-ui): Convert column original name by following the reference name rule

### DIFF
--- a/wren-ui/src/apollo/server/factories/bqStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/bqStrategy.ts
@@ -15,7 +15,11 @@ import {
 } from '../connectors/bqConnector';
 import { Encryptor, toBase64 } from '../utils';
 import { IDataSourceStrategy } from './dataSourceStrategy';
-import { findColumnsToUpdate, updateModelPrimaryKey } from './util';
+import {
+  findColumnsToUpdate,
+  updateModelPrimaryKey,
+  adaptColumnNameToReferenceName,
+} from './util';
 
 export class BigQueryStrategy implements IDataSourceStrategy {
   connector: IConnector<any, any>;
@@ -367,7 +371,7 @@ export class BigQueryStrategy implements IDataSourceStrategy {
         isCalculated: false,
         displayName: columnName,
         sourceColumnName: columnName,
-        referenceName: columnName,
+        referenceName: adaptColumnNameToReferenceName(columnName),
         type: tableColumn?.data_type || 'string',
         notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
         isPk: primaryKey === columnName,
@@ -406,7 +410,7 @@ export class BigQueryStrategy implements IDataSourceStrategy {
           isCalculated: false,
           displayName: columnName,
           sourceColumnName: columnName,
-          referenceName: columnName,
+          referenceName: adaptColumnNameToReferenceName(columnName),
           type: tableColumn?.data_type || 'string',
           notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
           isPk: false,

--- a/wren-ui/src/apollo/server/factories/bqStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/bqStrategy.ts
@@ -18,7 +18,7 @@ import { IDataSourceStrategy } from './dataSourceStrategy';
 import {
   findColumnsToUpdate,
   updateModelPrimaryKey,
-  adaptColumnNameToReferenceName,
+  transformInvalidColumnName,
 } from './util';
 
 export class BigQueryStrategy implements IDataSourceStrategy {
@@ -371,7 +371,7 @@ export class BigQueryStrategy implements IDataSourceStrategy {
         isCalculated: false,
         displayName: columnName,
         sourceColumnName: columnName,
-        referenceName: adaptColumnNameToReferenceName(columnName),
+        referenceName: transformInvalidColumnName(columnName),
         type: tableColumn?.data_type || 'string',
         notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
         isPk: primaryKey === columnName,
@@ -410,7 +410,7 @@ export class BigQueryStrategy implements IDataSourceStrategy {
           isCalculated: false,
           displayName: columnName,
           sourceColumnName: columnName,
-          referenceName: adaptColumnNameToReferenceName(columnName),
+          referenceName: transformInvalidColumnName(columnName),
           type: tableColumn?.data_type || 'string',
           notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
           isPk: false,

--- a/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
@@ -11,7 +11,7 @@ import { IDataSourceStrategy } from './dataSourceStrategy';
 import {
   findColumnsToUpdate,
   updateModelPrimaryKey,
-  adaptColumnNameToReferenceName,
+  transformInvalidColumnName,
 } from './util';
 
 export class DuckDBStrategy implements IDataSourceStrategy {
@@ -271,7 +271,7 @@ export class DuckDBStrategy implements IDataSourceStrategy {
         isCalculated: false,
         displayName: columnName,
         sourceColumnName: columnName,
-        referenceName: adaptColumnNameToReferenceName(columnName),
+        referenceName: transformInvalidColumnName(columnName),
         type: compactColumn.type || 'string',
         notNull: compactColumn.notNull,
         isPk: primaryKey === columnName,
@@ -307,7 +307,7 @@ export class DuckDBStrategy implements IDataSourceStrategy {
           isCalculated: false,
           displayName: columnName,
           sourceColumnName: columnName,
-          referenceName: adaptColumnNameToReferenceName(columnName),
+          referenceName: transformInvalidColumnName(columnName),
           type: compactColumn.type || 'string',
           notNull: compactColumn.notNull,
           isPk: false,

--- a/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
@@ -8,7 +8,11 @@ import {
 } from '../connectors/duckdbConnector';
 import { trim } from '../utils';
 import { IDataSourceStrategy } from './dataSourceStrategy';
-import { findColumnsToUpdate, updateModelPrimaryKey } from './util';
+import {
+  findColumnsToUpdate,
+  updateModelPrimaryKey,
+  adaptColumnNameToReferenceName,
+} from './util';
 
 export class DuckDBStrategy implements IDataSourceStrategy {
   connector: IConnector<any, any>;
@@ -267,7 +271,7 @@ export class DuckDBStrategy implements IDataSourceStrategy {
         isCalculated: false,
         displayName: columnName,
         sourceColumnName: columnName,
-        referenceName: columnName,
+        referenceName: adaptColumnNameToReferenceName(columnName),
         type: compactColumn.type || 'string',
         notNull: compactColumn.notNull,
         isPk: primaryKey === columnName,
@@ -303,7 +307,7 @@ export class DuckDBStrategy implements IDataSourceStrategy {
           isCalculated: false,
           displayName: columnName,
           sourceColumnName: columnName,
-          referenceName: columnName,
+          referenceName: adaptColumnNameToReferenceName(columnName),
           type: compactColumn.type || 'string',
           notNull: compactColumn.notNull,
           isPk: false,

--- a/wren-ui/src/apollo/server/factories/postgresStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/postgresStrategy.ts
@@ -12,7 +12,11 @@ import {
   PostgresConnector,
 } from '../connectors/postgresConnector';
 import { Encryptor } from '../utils';
-import { findColumnsToUpdate, updateModelPrimaryKey } from './util';
+import {
+  findColumnsToUpdate,
+  updateModelPrimaryKey,
+  adaptColumnNameToReferenceName,
+} from './util';
 
 export class PostgresStrategy implements IDataSourceStrategy {
   private project?: Project;
@@ -327,7 +331,7 @@ export class PostgresStrategy implements IDataSourceStrategy {
         isCalculated: false,
         displayName: columnName,
         sourceColumnName: columnName,
-        referenceName: columnName,
+        referenceName: adaptColumnNameToReferenceName(columnName),
         type: tableColumn?.data_type || 'string',
         notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
         isPk: primaryKey === columnName,
@@ -378,7 +382,7 @@ export class PostgresStrategy implements IDataSourceStrategy {
           isCalculated: false,
           displayName: columnName,
           sourceColumnName: columnName,
-          referenceName: columnName,
+          referenceName: adaptColumnNameToReferenceName(columnName),
           type: tableColumn?.data_type || 'string',
           notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
           isPk: false,

--- a/wren-ui/src/apollo/server/factories/postgresStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/postgresStrategy.ts
@@ -15,7 +15,7 @@ import { Encryptor } from '../utils';
 import {
   findColumnsToUpdate,
   updateModelPrimaryKey,
-  adaptColumnNameToReferenceName,
+  transformInvalidColumnName,
 } from './util';
 
 export class PostgresStrategy implements IDataSourceStrategy {
@@ -331,7 +331,7 @@ export class PostgresStrategy implements IDataSourceStrategy {
         isCalculated: false,
         displayName: columnName,
         sourceColumnName: columnName,
-        referenceName: adaptColumnNameToReferenceName(columnName),
+        referenceName: transformInvalidColumnName(columnName),
         type: tableColumn?.data_type || 'string',
         notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
         isPk: primaryKey === columnName,
@@ -382,7 +382,7 @@ export class PostgresStrategy implements IDataSourceStrategy {
           isCalculated: false,
           displayName: columnName,
           sourceColumnName: columnName,
-          referenceName: adaptColumnNameToReferenceName(columnName),
+          referenceName: transformInvalidColumnName(columnName),
           type: tableColumn?.data_type || 'string',
           notNull: tableColumn.is_nullable.toLocaleLowerCase() !== 'yes',
           isPk: false,

--- a/wren-ui/src/apollo/server/factories/util.ts
+++ b/wren-ui/src/apollo/server/factories/util.ts
@@ -1,4 +1,5 @@
 import { IModelColumnRepository, ModelColumn } from '../repositories';
+import { replaceAllowableSyntax } from '@server/utils/regex';
 
 export function findColumnsToUpdate(
   columns: string[],
@@ -34,4 +35,14 @@ export async function updateModelPrimaryKey(
   if (primaryKey) {
     await repository.setModelPrimaryKey(modelId, primaryKey);
   }
+}
+
+export function adaptColumnNameToReferenceName(columnName: string) {
+  let referenceName = replaceAllowableSyntax(columnName);
+  // If the reference name does not start with a letter, add a prefix
+  const startWithLetterRegex = /^[A-Za-z]/;
+  if (!startWithLetterRegex.test(referenceName)) {
+    referenceName = `r_${referenceName}`;
+  }
+  return referenceName;
 }

--- a/wren-ui/src/apollo/server/factories/util.ts
+++ b/wren-ui/src/apollo/server/factories/util.ts
@@ -37,12 +37,12 @@ export async function updateModelPrimaryKey(
   }
 }
 
-export function adaptColumnNameToReferenceName(columnName: string) {
+export function transformInvalidColumnName(columnName: string) {
   let referenceName = replaceAllowableSyntax(columnName);
   // If the reference name does not start with a letter, add a prefix
   const startWithLetterRegex = /^[A-Za-z]/;
   if (!startWithLetterRegex.test(referenceName)) {
-    referenceName = `r_${referenceName}`;
+    referenceName = `col_${referenceName}`;
   }
   return referenceName;
 }

--- a/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
+++ b/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
@@ -325,6 +325,10 @@ export class MDLBuilder implements IMDLBuilder {
     currentModel?: ModelMDL,
   ): string {
     if (!column.isCalculated) {
+      // Provide original column name in expression to MDL if referenceName has converted.
+      if (column.sourceColumnName !== column.referenceName) {
+        return `"${column.sourceColumnName}"`;
+      }
       return '';
     }
     // calculated field


### PR DESCRIPTION
## Description
- Add a converted function to replace the original name which does not follow the reference name rule.
- Passing the original column name in MDL's  column expression property to WrenEngine
   For example:
   ```Json
   {
       "name": "_3pointplay",
       "expression": "\"3pointplay\""
   }
   ```
 

## Ticket
close #179 