### PR TITLE
fix(wren-ui): fix auto-generated relationships

### DIFF
--- a/wren-ui/src/apollo/server/factories/bqStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/bqStrategy.ts
@@ -1,4 +1,5 @@
 import { BigQueryOptions } from '@google-cloud/bigquery';
+import { capitalize } from 'lodash';
 import { IConnector } from '../connectors/connector';
 import { Model, ModelColumn, Project } from '../repositories';
 import {
@@ -228,10 +229,8 @@ export class BigQueryStrategy implements IDataSourceStrategy {
       const relation: AnalysisRelationInfo = {
         // upper case the first letter of the sourceTableName
         name:
-          fromModel.sourceTableName.charAt(0).toUpperCase() +
-          fromModel.sourceTableName.slice(1) +
-          toModel.sourceTableName.charAt(0).toUpperCase() +
-          toModel.sourceTableName.slice(1),
+          capitalize(fromModel.sourceTableName) +
+          capitalize(toModel.sourceTableName),
         fromModelId: fromModel.id,
         fromModelReferenceName: fromModel.referenceName,
         fromColumnId: fromColumn.id,

--- a/wren-ui/src/apollo/server/factories/postgresStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/postgresStrategy.ts
@@ -1,3 +1,4 @@
+import { capitalize } from 'lodash';
 import { IDataSourceStrategy } from './dataSourceStrategy';
 import {
   AnalysisRelationInfo,
@@ -219,10 +220,8 @@ export class PostgresStrategy implements IDataSourceStrategy {
       const relation: AnalysisRelationInfo = {
         // upper case the first letter of the sourceTableName
         name:
-          fromModel.sourceTableName.charAt(0).toUpperCase() +
-          fromModel.sourceTableName.slice(1) +
-          toModel.sourceTableName.charAt(0).toUpperCase() +
-          toModel.sourceTableName.slice(1),
+          capitalize(fromModel.sourceTableName) +
+          capitalize(toModel.sourceTableName),
         fromModelId: fromModel.id,
         fromModelReferenceName: fromModel.referenceName,
         fromColumnId: fromColumn.id,

--- a/wren-ui/src/apollo/server/services/modelService.ts
+++ b/wren-ui/src/apollo/server/services/modelService.ts
@@ -19,7 +19,7 @@ import {
 } from '../models';
 import { IMDLService } from './mdlService';
 import { IWrenEngineAdaptor } from '../adaptors/wrenEngineAdaptor';
-import { isEmpty } from 'lodash';
+import { isEmpty, capitalize } from 'lodash';
 import { replaceAllowableSyntax, validateDisplayName } from '../utils/regex';
 import * as Errors from '@server/utils/error';
 
@@ -511,14 +511,10 @@ export class ModelService implements IModelService {
     );
 
     return (
-      fromModel.sourceTableName.charAt(0).toUpperCase() +
-      fromModel.sourceTableName.slice(1) +
-      fromColumn.referenceName.charAt(0).toUpperCase() +
-      fromColumn.referenceName.slice(1) +
-      toModel.sourceTableName.charAt(0).toUpperCase() +
-      toModel.sourceTableName.slice(1) +
-      toColumn.referenceName.charAt(0).toUpperCase() +
-      toColumn.referenceName.slice(1)
+      capitalize(fromModel.sourceTableName) +
+      capitalize(fromColumn.referenceName) +
+      capitalize(toModel.sourceTableName) +
+      capitalize(toColumn.referenceName)
     );
   }
 

--- a/wren-ui/src/apollo/server/services/modelService.ts
+++ b/wren-ui/src/apollo/server/services/modelService.ts
@@ -498,11 +498,14 @@ export class ModelService implements IModelService {
     if (!fromModel || !toModel) {
       throw new Error('Model not found');
     }
+
     return (
       fromModel.sourceTableName.charAt(0).toUpperCase() +
       fromModel.sourceTableName.slice(1) +
+      relation.fromColumnId +
       toModel.sourceTableName.charAt(0).toUpperCase() +
-      toModel.sourceTableName.slice(1)
+      toModel.sourceTableName.slice(1) +
+      relation.toColumnId
     );
   }
 

--- a/wren-ui/src/apollo/server/services/modelService.ts
+++ b/wren-ui/src/apollo/server/services/modelService.ts
@@ -353,7 +353,7 @@ export class ModelService implements IModelService {
       if (!toColumn) {
         throw new Error(`Column not found, column Id  ${relation.toColumnId}`);
       }
-      const relationName = this.generateRelationName(relation, models);
+      const relationName = this.generateRelationName(relation, models, columns);
       return {
         projectId: project.id,
         name: relationName,
@@ -385,7 +385,7 @@ export class ModelService implements IModelService {
     if (!valid) {
       throw new Error(message);
     }
-    const relationName = this.generateRelationName(relation, models);
+    const relationName = this.generateRelationName(relation, models, columns);
     const savedRelation = await this.relationRepository.createOne({
       projectId: project.id,
       name: relationName,
@@ -492,20 +492,33 @@ export class ModelService implements IModelService {
     return replaceAllowableSyntax(displayName);
   }
 
-  private generateRelationName(relation: RelationData, models: Model[]) {
+  private generateRelationName(
+    relation: RelationData,
+    models: Model[],
+    columns: ModelColumn[],
+  ) {
     const fromModel = models.find((m) => m.id === relation.fromModelId);
     const toModel = models.find((m) => m.id === relation.toModelId);
     if (!fromModel || !toModel) {
       throw new Error('Model not found');
     }
 
+    const fromColumn = columns.find(
+      (column) => column.id === relation.fromColumnId,
+    );
+    const toColumn = columns.find(
+      (column) => column.id === relation.toColumnId,
+    );
+
     return (
       fromModel.sourceTableName.charAt(0).toUpperCase() +
       fromModel.sourceTableName.slice(1) +
-      relation.fromColumnId +
+      fromColumn.referenceName.charAt(0).toUpperCase() +
+      fromColumn.referenceName.slice(1) +
       toModel.sourceTableName.charAt(0).toUpperCase() +
       toModel.sourceTableName.slice(1) +
-      relation.toColumnId
+      toColumn.referenceName.charAt(0).toUpperCase() +
+      toColumn.referenceName.slice(1)
     );
   }
 

--- a/wren-ui/src/components/pages/setup/DefineRelations.tsx
+++ b/wren-ui/src/components/pages/setup/DefineRelations.tsx
@@ -136,7 +136,7 @@ function EditableRelationTable(props: EditableRelationTableProps) {
           </Button>
         )}
         rowKey={(record: RelationsDataType) =>
-          `${modelName}-${record.toField.modelName}-${index}`
+          `${modelName}-${record.fromField.fieldName}-${record.toField.modelName}-${record.toField.fieldName}-${index}`
         }
       />
     </div>


### PR DESCRIPTION
## Description
 fix auto-generated relationships

## Solution
 - Will not see the duplicate rowKey error message in the console.log
 - Successfully apply auto-generated table relationships

## UI Screenshot

![截圖 2024-05-16 下午3 38 32](https://github.com/Canner/WrenAI/assets/42527625/0f48255f-9c80-4d7b-87d7-3c64227c3c38)

## Issue ticket number
closes #193

