### PR TITLE
feat(wren-ui): Update relationship rule

### DIFF
--- a/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
@@ -52,7 +52,6 @@ export interface IRelationRepository extends IBasicRepository<Relation> {
     },
     queryOptions?: IQueryOptions,
   ): Promise<RelationInfo[]>;
-  findExistedRelationBetweenModels(modelIds): Promise<RelationInfo[]>;
 }
 
 export class RelationRepository
@@ -185,27 +184,6 @@ export class RelationRepository
       'tmc.reference_name AS toColumnName',
       'tmc.display_name AS toColumnDisplayName',
     );
-    return result.map((r) => this.transformFromDBData(r)) as RelationInfo[];
-  }
-
-  public async findExistedRelationBetweenModels(modelIds) {
-    const query = this.knex(this.tableName)
-      .join(
-        'model_column AS fmc',
-        `${this.tableName}.from_column_id`,
-        '=',
-        'fmc.id',
-      )
-      .join(
-        'model_column AS tmc',
-        `${this.tableName}.to_column_id`,
-        '=',
-        'tmc.id',
-      )
-      .whereIn('fmc.model_id', modelIds)
-      .whereIn('tmc.model_id', modelIds)
-      .select(`${this.tableName}.*`);
-    const result = await query;
     return result.map((r) => this.transformFromDBData(r)) as RelationInfo[];
   }
 }

--- a/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
@@ -4,6 +4,7 @@ import {
   IBasicRepository,
   IQueryOptions,
 } from './baseRepository';
+import { RelationData } from '../types';
 
 export interface Relation {
   id: number; // ID
@@ -51,6 +52,9 @@ export interface IRelationRepository extends IBasicRepository<Relation> {
       modelIds?: number[];
     },
     queryOptions?: IQueryOptions,
+  ): Promise<RelationInfo[]>;
+  findExistedRelationBetweenModels(
+    relation: RelationData,
   ): Promise<RelationInfo[]>;
 }
 
@@ -184,6 +188,36 @@ export class RelationRepository
       'tmc.reference_name AS toColumnName',
       'tmc.display_name AS toColumnDisplayName',
     );
+    return result.map((r) => this.transformFromDBData(r)) as RelationInfo[];
+  }
+
+  public async findExistedRelationBetweenModels(relation: RelationData) {
+    const { fromModelId, fromColumnId, toModelId, toColumnId } = relation;
+    const query = this.knex(this.tableName)
+      .join(
+        'model_column AS fmc',
+        `${this.tableName}.from_column_id`,
+        '=',
+        'fmc.id',
+      )
+      .join(
+        'model_column AS tmc',
+        `${this.tableName}.to_column_id`,
+        '=',
+        'tmc.id',
+      )
+      // duplicate relationship check
+      .whereRaw(
+        `fmc.model_id = ? And ${this.tableName}.from_column_id = ? And tmc.model_id = ? And ${this.tableName}.to_column_id = ?`,
+        [fromModelId, fromColumnId, toModelId, toColumnId],
+      )
+      // reverse relationship check
+      .orWhereRaw(
+        `fmc.model_id = ? And ${this.tableName}.from_column_id = ? And tmc.model_id = ? And ${this.tableName}.to_column_id = ?`,
+        [toModelId, toColumnId, fromModelId, fromColumnId],
+      )
+      .select(`${this.tableName}.*`);
+    const result = await query;
     return result.map((r) => this.transformFromDBData(r)) as RelationInfo[];
   }
 }

--- a/wren-ui/src/apollo/server/services/modelService.ts
+++ b/wren-ui/src/apollo/server/services/modelService.ts
@@ -684,6 +684,16 @@ export class ModelService implements IModelService {
       };
     }
 
+    const existedRelations =
+      await this.relationRepository.findExistedRelationBetweenModels(relation);
+
+    if (existedRelations.length > 0) {
+      return {
+        valid: false,
+        message: 'This relationship already exists.',
+      };
+    }
+
     return { valid: true };
   }
 }

--- a/wren-ui/src/apollo/server/services/modelService.ts
+++ b/wren-ui/src/apollo/server/services/modelService.ts
@@ -684,18 +684,6 @@ export class ModelService implements IModelService {
       };
     }
 
-    // only one relation between two models
-    const existedRelations =
-      await this.relationRepository.findExistedRelationBetweenModels([
-        fromModelId,
-        toModelId,
-      ]);
-    if (existedRelations.length > 0) {
-      return {
-        valid: false,
-        message: 'Only one relation between two models',
-      };
-    }
     return { valid: true };
   }
 }

--- a/wren-ui/src/components/modals/RelationModal.tsx
+++ b/wren-ui/src/components/modals/RelationModal.tsx
@@ -7,8 +7,8 @@ import CombineFieldSelector from '@/components/selectors/CombineFieldSelector';
 import { JOIN_TYPE, FORM_MODE, convertIdentifierToObject } from '@/utils/enum';
 import { getJoinTypeText } from '@/utils/data';
 import {
-  relationshipFromFieldValidator,
-  relationshipToFieldValidator,
+  createRelationshipFromFieldValidator,
+  createRelationshipToFieldValidator,
 } from '@/utils/validator';
 import useCombineFieldOptions, {
   convertDefaultValueToIdentifier,
@@ -25,7 +25,7 @@ export const FormFieldKey = {
 export interface RelationFormValues {
   fromField: { model: string; field: string };
   toField: { model: string; field: string };
-  type: string;
+  type?: string;
 }
 
 export type RelationFieldValue = Pick<
@@ -112,7 +112,7 @@ export default function RelationModal(props: Props) {
           required
           rules={[
             ({ getFieldValue }) => ({
-              validator: relationshipFromFieldValidator(
+              validator: createRelationshipFromFieldValidator(
                 isUpdateMode,
                 relations,
                 getFieldValue,
@@ -135,7 +135,7 @@ export default function RelationModal(props: Props) {
           required
           rules={[
             ({ getFieldValue }) => ({
-              validator: relationshipToFieldValidator(
+              validator: createRelationshipToFieldValidator(
                 isUpdateMode,
                 relations,
                 getFieldValue,

--- a/wren-ui/src/components/modals/RelationModal.tsx
+++ b/wren-ui/src/components/modals/RelationModal.tsx
@@ -8,9 +8,16 @@ import { JOIN_TYPE, FORM_MODE, convertIdentifierToObject } from '@/utils/enum';
 import { getJoinTypeText } from '@/utils/data';
 import useCombineFieldOptions, {
   convertDefaultValueToIdentifier,
+  convertFormValuesToIdentifier,
 } from '@/hooks/useCombineFieldOptions';
 import { RelationsDataType } from '@/components/table/ModelRelationSelectionTable';
 import { SelectedRecommendRelations } from '@/components/pages/setup/DefineRelations';
+
+const FormFieldKey = {
+  FROM_FIELD: 'fromField',
+  TO_FIELD: 'toField',
+  TYPE: 'type',
+};
 
 export interface RelationFormValues {
   fromField: { model: string; field: string };
@@ -27,6 +34,37 @@ type Props = ModalAction<RelationFieldValue, RelationFormValues> & {
   model: string;
   loading?: boolean;
   relations: SelectedRecommendRelations;
+};
+
+/**
+ * Check if the relationship already exists
+ *
+ * Consider: Assume we have an existing relationship: Customers.orderId -> Orders.orderId, One-to-Many
+ * There are two cases to check:
+ * 1. Same as from and to of existing relationship
+ *    (E.g., add new relationship: Customers.orderId -> Orders.orderId)
+ * 2. Reverse of from and to of existing relationship
+ *    (E.g., add new relationship: Orders.orderId -> Customers.orderId)
+ *
+ * @param existingRelationships
+ * @param formValues
+ * @returns boolean
+ */
+const isExistRelationship = (
+  existingRelationships: RelationsDataType[],
+  formValues: RelationsDataType,
+) => {
+  return existingRelationships.find(
+    (relationship) =>
+      (relationship.fromField.modelId === formValues.fromField.modelId &&
+        relationship.fromField.fieldId === formValues.fromField.fieldId &&
+        relationship.toField.modelId === formValues.toField.modelId &&
+        relationship.toField.fieldId === formValues.toField.fieldId) ||
+      (relationship.fromField.modelId === formValues.toField.modelId &&
+        relationship.fromField.fieldId === formValues.toField.fieldId &&
+        relationship.toField.modelId === formValues.fromField.modelId &&
+        relationship.toField.fieldId === formValues.fromField.fieldId),
+  );
 };
 
 export default function RelationModal(props: Props) {
@@ -71,50 +109,6 @@ export default function RelationModal(props: Props) {
     value: JOIN_TYPE[key],
   }));
 
-  // check that only 1 set of relationships can be set up between models
-  const toCombineModelOptions = toCombineField.modelOptions.map(
-    (modelOption) => {
-      const modelList = Object.entries(relations).reduce(
-        (acc, [modelName, modelRelations]) => {
-          if (modelName === model) {
-            const toFieldModelList = modelRelations.map(
-              (relation) => relation.toField.modelName,
-            );
-
-            acc = [
-              ...acc,
-              ...(isEmpty(defaultValue)
-                ? toFieldModelList
-                : toFieldModelList.filter(
-                    (toFieldModel) =>
-                      toFieldModel !== defaultValue.toField.modelName,
-                  )),
-            ];
-          } else {
-            const toFieldModelList = modelRelations.map(
-              (relation) => relation.toField.modelName,
-            );
-            if (toFieldModelList.includes(model)) {
-              acc = [...acc, modelName];
-            }
-          }
-
-          return acc;
-        },
-        [],
-      );
-
-      const modelValue: { id: string; referenceName: string } =
-        convertIdentifierToObject(modelOption.value);
-      const disabled = modelList.includes(modelValue.referenceName);
-
-      return {
-        ...modelOption,
-        disabled,
-      };
-    },
-  );
-
   const submit = () => {
     form
       .validateFields()
@@ -142,13 +136,40 @@ export default function RelationModal(props: Props) {
       <Form form={form} preserve={false} layout="vertical">
         <Form.Item
           label="From"
-          name="fromField"
+          name={FormFieldKey.FROM_FIELD}
           required
           rules={[
-            {
-              required: true,
-              message: ERROR_TEXTS.ADD_RELATION.FROM_FIELD.REQUIRED,
-            },
+            ({ getFieldValue }) => ({
+              validator(_, value) {
+                if (!value || !value.field) {
+                  return Promise.reject(
+                    ERROR_TEXTS.ADD_RELATION.FROM_FIELD.REQUIRED,
+                  );
+                }
+
+                if (!isUpdateMode) {
+                  const toField = getFieldValue(FormFieldKey.TO_FIELD);
+                  if (toField && toField.model && toField.field) {
+                    if (
+                      isExistRelationship(
+                        relations[model],
+                        convertFormValuesToIdentifier({
+                          fromField: value,
+                          toField,
+                          type: '',
+                        }),
+                      )
+                    ) {
+                      return Promise.reject(
+                        ERROR_TEXTS.ADD_RELATION.RELATIONSHIP.EXIST,
+                      );
+                    }
+                  }
+                }
+
+                return Promise.resolve();
+              },
+            }),
           ]}
         >
           <CombineFieldSelector
@@ -162,15 +183,35 @@ export default function RelationModal(props: Props) {
         </Form.Item>
         <Form.Item
           label="To"
-          name="toField"
+          name={FormFieldKey.TO_FIELD}
           required
           rules={[
-            () => ({
+            ({ getFieldValue }) => ({
               validator(_, value) {
                 if (!value || !value.field) {
                   return Promise.reject(
                     ERROR_TEXTS.ADD_RELATION.TO_FIELD.REQUIRED,
                   );
+                }
+
+                if (!isUpdateMode) {
+                  const fromField = getFieldValue(FormFieldKey.FROM_FIELD);
+                  if (fromField && fromField.model && fromField.field) {
+                    if (
+                      isExistRelationship(
+                        relations[model],
+                        convertFormValuesToIdentifier({
+                          fromField,
+                          toField: value,
+                          type: '',
+                        }),
+                      )
+                    ) {
+                      return Promise.reject(
+                        ERROR_TEXTS.ADD_RELATION.RELATIONSHIP.EXIST,
+                      );
+                    }
+                  }
                 }
 
                 return Promise.resolve();
@@ -180,7 +221,7 @@ export default function RelationModal(props: Props) {
         >
           <CombineFieldSelector
             onModelChange={toCombineField.onModelChange}
-            modelOptions={toCombineModelOptions}
+            modelOptions={toCombineField.modelOptions}
             fieldOptions={toCombineField.fieldOptions}
             modelDisabled={isUpdateMode}
             fieldDisabled={isUpdateMode}
@@ -188,7 +229,7 @@ export default function RelationModal(props: Props) {
         </Form.Item>
         <Form.Item
           label="Type"
-          name="type"
+          name={FormFieldKey.TYPE}
           required
           rules={[
             {

--- a/wren-ui/src/components/selectors/CombineFieldSelector.tsx
+++ b/wren-ui/src/components/selectors/CombineFieldSelector.tsx
@@ -68,6 +68,8 @@ export default function CombineFieldSelector(props: Props) {
         placeholder="Model"
         value={value?.model || modelValue}
         disabled={modelDisabled}
+        showSearch
+        optionFilterProp="label"
       />
       <Select
         className="flex-grow-1"
@@ -76,6 +78,8 @@ export default function CombineFieldSelector(props: Props) {
         placeholder="Field"
         value={value?.field || fieldValue}
         disabled={fieldDisabled}
+        showSearch
+        optionFilterProp="label"
       />
     </Input.Group>
   );

--- a/wren-ui/src/utils/error/dictionary.ts
+++ b/wren-ui/src/utils/error/dictionary.ts
@@ -49,6 +49,9 @@ export const ERROR_TEXTS = {
     RELATION_TYPE: {
       REQUIRED: 'Please select a relationship type.',
     },
+    RELATIONSHIP: {
+      EXIST: 'This relationship already exists.',
+    },
   },
   SETUP_MODEL: {
     TABLE: {

--- a/wren-ui/src/utils/validator/index.ts
+++ b/wren-ui/src/utils/validator/index.ts
@@ -1,2 +1,3 @@
 export * from './calculatedFieldValidator';
 export * from './viewValidator';
+export * from './relationshipValidator';

--- a/wren-ui/src/utils/validator/relationshipValidator.ts
+++ b/wren-ui/src/utils/validator/relationshipValidator.ts
@@ -25,30 +25,34 @@ const isExistRelationship = (
 ) => {
   const relationshipsByFromFieldModel =
     relationships[formValues.fromField.modelName];
-  const isDuplicate = relationshipsByFromFieldModel.find(
-    (relationship) =>
-      relationship.fromField.modelId === formValues.fromField.modelId &&
-      relationship.fromField.fieldId === formValues.fromField.fieldId &&
-      relationship.toField.modelId === formValues.toField.modelId &&
-      relationship.toField.fieldId === formValues.toField.fieldId,
+  const isDuplicate = Boolean(
+    relationshipsByFromFieldModel.find(
+      (relationship) =>
+        relationship.fromField.modelId === formValues.fromField.modelId &&
+        relationship.fromField.fieldId === formValues.fromField.fieldId &&
+        relationship.toField.modelId === formValues.toField.modelId &&
+        relationship.toField.fieldId === formValues.toField.fieldId,
+    ),
   );
 
-  if (Boolean(isDuplicate)) return true;
+  if (isDuplicate) return true;
 
   const relationshipsbyToFieldModel =
     relationships[formValues.toField.modelName];
-  const isReverseDuplicate = relationshipsbyToFieldModel.find(
-    (relationship) =>
-      relationship.fromField.modelId === formValues.toField.modelId &&
-      relationship.fromField.fieldId === formValues.toField.fieldId &&
-      relationship.toField.modelId === formValues.fromField.modelId &&
-      relationship.toField.fieldId === formValues.fromField.fieldId,
+  const isReverseDuplicate = Boolean(
+    relationshipsbyToFieldModel.find(
+      (relationship) =>
+        relationship.fromField.modelId === formValues.toField.modelId &&
+        relationship.fromField.fieldId === formValues.toField.fieldId &&
+        relationship.toField.modelId === formValues.fromField.modelId &&
+        relationship.toField.fieldId === formValues.fromField.fieldId,
+    ),
   );
 
-  return Boolean(isReverseDuplicate);
+  return isReverseDuplicate;
 };
 
-export const relationshipFromFieldValidator =
+export const createRelationshipFromFieldValidator =
   (
     skip = false,
     relationships: SelectedRecommendRelations,
@@ -68,7 +72,6 @@ export const relationshipFromFieldValidator =
             convertFormValuesToIdentifier({
               fromField: value,
               toField,
-              type: '',
             }),
           )
         ) {
@@ -80,7 +83,7 @@ export const relationshipFromFieldValidator =
     return Promise.resolve();
   };
 
-export const relationshipToFieldValidator =
+export const createRelationshipToFieldValidator =
   (
     skip = false,
     relationships: SelectedRecommendRelations,
@@ -100,7 +103,6 @@ export const relationshipToFieldValidator =
             convertFormValuesToIdentifier({
               fromField,
               toField: value,
-              type: '',
             }),
           )
         ) {

--- a/wren-ui/src/utils/validator/relationshipValidator.ts
+++ b/wren-ui/src/utils/validator/relationshipValidator.ts
@@ -1,0 +1,113 @@
+import { FormInstance } from 'antd';
+import { ERROR_TEXTS } from '@/utils/error';
+import { RelationsDataType } from '@/components/table/ModelRelationSelectionTable';
+import { SelectedRecommendRelations } from '@/components/pages/setup/DefineRelations';
+import { convertFormValuesToIdentifier } from '@/hooks/useCombineFieldOptions';
+import { FormFieldKey } from '@/components/modals/RelationModal';
+
+/**
+ * Check if the relationship already exists
+ *
+ * Consider: Assume we have an existing relationship: Customers.orderId -> Orders.orderId, One-to-Many
+ * There are two cases to check:
+ * 1. Same as from and to of existing relationship
+ *    (E.g., add new relationship: Customers.orderId -> Orders.orderId)
+ * 2. Reverse of from and to of existing relationship
+ *    (E.g., add new relationship: Orders.orderId -> Customers.orderId)
+ *
+ * @param existingRelationships
+ * @param formValues
+ * @returns boolean
+ */
+const isExistRelationship = (
+  relationships: SelectedRecommendRelations,
+  formValues: RelationsDataType,
+) => {
+  const relationshipsByFromFieldModel =
+    relationships[formValues.fromField.modelName];
+  const isDuplicate = relationshipsByFromFieldModel.find(
+    (relationship) =>
+      relationship.fromField.modelId === formValues.fromField.modelId &&
+      relationship.fromField.fieldId === formValues.fromField.fieldId &&
+      relationship.toField.modelId === formValues.toField.modelId &&
+      relationship.toField.fieldId === formValues.toField.fieldId,
+  );
+
+  if (Boolean(isDuplicate)) return true;
+
+  const relationshipsbyToFieldModel =
+    relationships[formValues.toField.modelName];
+  const isReverseDuplicate = relationshipsbyToFieldModel.find(
+    (relationship) =>
+      relationship.fromField.modelId === formValues.toField.modelId &&
+      relationship.fromField.fieldId === formValues.toField.fieldId &&
+      relationship.toField.modelId === formValues.fromField.modelId &&
+      relationship.toField.fieldId === formValues.fromField.fieldId,
+  );
+
+  return Boolean(isReverseDuplicate);
+};
+
+export const relationshipFromFieldValidator =
+  (
+    skip = false,
+    relationships: SelectedRecommendRelations,
+    getFieldValue: FormInstance['getFieldValue'],
+  ) =>
+  async (_, value: any) => {
+    if (!value || !value.field) {
+      return Promise.reject(ERROR_TEXTS.ADD_RELATION.FROM_FIELD.REQUIRED);
+    }
+
+    if (!skip) {
+      const toField = getFieldValue(FormFieldKey.TO_FIELD);
+      if (toField && toField.model && toField.field) {
+        if (
+          isExistRelationship(
+            relationships,
+            convertFormValuesToIdentifier({
+              fromField: value,
+              toField,
+              type: '',
+            }),
+          )
+        ) {
+          return Promise.reject(ERROR_TEXTS.ADD_RELATION.RELATIONSHIP.EXIST);
+        }
+      }
+    }
+
+    return Promise.resolve();
+  };
+
+export const relationshipToFieldValidator =
+  (
+    skip = false,
+    relationships: SelectedRecommendRelations,
+    getFieldValue: FormInstance['getFieldValue'],
+  ) =>
+  async (_, value: any) => {
+    if (!value || !value.field) {
+      return Promise.reject(ERROR_TEXTS.ADD_RELATION.TO_FIELD.REQUIRED);
+    }
+
+    if (!skip) {
+      const fromField = getFieldValue(FormFieldKey.FROM_FIELD);
+      if (fromField && fromField.model && fromField.field) {
+        if (
+          isExistRelationship(
+            relationships,
+            convertFormValuesToIdentifier({
+              fromField,
+              toField: value,
+              type: '',
+            }),
+          )
+        ) {
+          return Promise.reject(ERROR_TEXTS.ADD_RELATION.RELATIONSHIP.EXIST);
+        }
+      }
+    }
+
+    return Promise.resolve();
+  };


### PR DESCRIPTION
## Description
 Based on the [issue #193](https://github.com/Canner/WrenAI/issues/193), Considering that there will be multiple relationships between two models in most usage scenarios, we decided to allow multiple relationships at this stage.

## Tasks
 - [x] [API] Update logic for findExistedRelationBetweenModels function
 - [x] [Relationship Modal UI] update relationship modal UI
   - Rules that do not allow the creation of new relationships:
      - Same as from and to of existing relationship
      - Reverse of from and to of existing relationship