### PR TITLE
fix(wren-ui/api): fix update model metadata

### DIFF
--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -329,7 +329,9 @@ export class ModelResolver {
 
     // if description is not null, or undefined, update the description in properties
     if (!isNil(data.description)) {
-      const properties = JSON.parse(model.properties);
+      const properties = isNil(data.description)
+        ? {}
+        : JSON.parse(model.properties);
       properties.description = this.determineMetadataValue(data.description);
       modelMetadata.properties = JSON.stringify(properties);
     }


### PR DESCRIPTION
## Description
 - Fix update model metadata failed bug
 - Reported issue from: https://discord.com/channels/1227143286951514152/1240988826772570182


### Root cause
The original `model.properties` value is `null`, so putting the value into `JSON.parse()` will get `null`.
**properties** is null not an object, so cannot assign a description to it.

## Reproduce bug:
Step 1: onboarding
Step 2: update model description

### Reference 
#### Model data example:
```js
{
  id: 96,
  projectId: 4,
  displayName: 'public.film',
  sourceTableName: 'public.film',
  referenceName: 'public_film',
  refSql: 'select * from "public"."film"',
  cached: 0,
  refreshTime: null,
  properties: null,
  createdAt: '2024-05-17 09:31:43',
  updatedAt: '2024-05-17 09:31:43'
}
```
