### PR TITLE
fix(wren-ui): Exclude self-referential relationship in auto-generated relationship

### DIFF
--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -269,7 +269,12 @@ export class ProjectResolver {
       id,
       displayName,
       referenceName,
-      relations: relations.filter((relation) => relation.fromModelId === id),
+      relations: relations.filter(
+        (relation) =>
+          relation.fromModelId === id &&
+          // exclude self-referential relationship
+          relation.toModelId !== relation.fromModelId,
+      ),
     }));
   }
 

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -138,7 +138,11 @@ const ColumnTemplate = (props) => {
         (edge: any) =>
           trimId(edge.sourceHandle) === id || trimId(edge.targetHandle) === id,
       );
-      setEdges(highlightEdges([relatedEdge.id], true));
+
+      // skip to highlight & open relationship popup if no related edge
+      if (!relatedEdge) return;
+
+      setEdges(highlightEdges([relatedEdge?.id], true));
       setNodes(
         highlightNodes(
           [relatedEdge.source, relatedEdge.target],

--- a/wren-ui/src/utils/diagram/transformer.ts
+++ b/wren-ui/src/utils/diagram/transformer.ts
@@ -184,6 +184,10 @@ export class Transformer {
             model.referenceName,
           ),
       )!;
+
+      // skip the edge if model not found
+      if (!targetModel) continue;
+
       const targetField = targetModel.relationFields.find(
         (field) =>
           [


### PR DESCRIPTION
## Description 

Self-Referential Relationship: In a self-referential relationship, a column within a model refers back to the same model. For example, consider an `Employee` model where the `reportsTo` column holds the `ID` of another `Employee`, indicating who each employee reports to. This means that the `Employee` model is linked to itself through the `reportsTo` column. 

**Currently, WrenAI does not support creating such relationships where a column in a model references the same model**. 

## Fix
- Exclude self-referential relationship in auto-generated relationship
- Skip the edge in modeling diagram if model not existed