### PR TITLE
feat(wren-ui): Offer view result for similar questions

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -98,15 +98,17 @@ export type CreateSimpleMetricInput = {
 };
 
 export type CreateThreadInput = {
-  question: Scalars['String'];
-  sql: Scalars['String'];
-  summary: Scalars['String'];
+  question?: InputMaybe<Scalars['String']>;
+  sql?: InputMaybe<Scalars['String']>;
+  summary?: InputMaybe<Scalars['String']>;
+  viewId?: InputMaybe<Scalars['Int']>;
 };
 
 export type CreateThreadResponseInput = {
-  question: Scalars['String'];
-  sql: Scalars['String'];
-  summary: Scalars['String'];
+  question?: InputMaybe<Scalars['String']>;
+  sql?: InputMaybe<Scalars['String']>;
+  summary?: InputMaybe<Scalars['String']>;
+  viewId?: InputMaybe<Scalars['Int']>;
 };
 
 export type CreateViewInput = {
@@ -658,7 +660,14 @@ export type ResultCandidate = {
   __typename?: 'ResultCandidate';
   sql: Scalars['String'];
   summary: Scalars['String'];
+  type: ResultCandidateType;
+  view?: Maybe<ViewInfo>;
 };
+
+export enum ResultCandidateType {
+  LLM = 'LLM',
+  VIEW = 'VIEW'
+}
 
 export type SampleDatasetInput = {
   name: SampleDatasetName;
@@ -737,6 +746,7 @@ export type ThreadResponseDetail = {
   description?: Maybe<Scalars['String']>;
   sql?: Maybe<Scalars['String']>;
   steps: Array<DetailStep>;
+  view?: Maybe<ViewInfo>;
 };
 
 export type ThreadUniqueWhereInput = {

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -5,7 +5,7 @@ import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type CommonErrorFragment = { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null };
 
-export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null };
+export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string } | null } | null };
 
 export type SuggestedQuestionsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -17,7 +17,7 @@ export type AskingTaskQueryVariables = Types.Exact<{
 }>;
 
 
-export type AskingTaskQuery = { __typename?: 'Query', askingTask: { __typename?: 'AskingTask', status: Types.AskingTaskStatus, candidates: Array<{ __typename?: 'ResultCandidate', sql: string, summary: string }>, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } };
+export type AskingTaskQuery = { __typename?: 'Query', askingTask: { __typename?: 'AskingTask', status: Types.AskingTaskStatus, candidates: Array<{ __typename?: 'ResultCandidate', sql: string, summary: string, type: Types.ResultCandidateType, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string } | null }>, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } };
 
 export type ThreadsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -29,14 +29,14 @@ export type ThreadQueryVariables = Types.Exact<{
 }>;
 
 
-export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, summary: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null }> } };
+export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, summary: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string } | null } | null }> } };
 
 export type ThreadResponseQueryVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
 }>;
 
 
-export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null } };
+export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string } | null } | null } };
 
 export type CreateAskingTaskMutationVariables = Types.Exact<{
   data: Types.AskingTaskInput;
@@ -65,7 +65,7 @@ export type CreateThreadResponseMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> } | null } };
+export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string } | null } | null } };
 
 export type UpdateThreadMutationVariables = Types.Exact<{
   where: Types.ThreadUniqueWhereInput;
@@ -118,6 +118,11 @@ export const CommonResponseFragmentDoc = gql`
       sql
       cteName
     }
+    view {
+      id
+      name
+      statement
+    }
   }
 }
     `;
@@ -165,6 +170,12 @@ export const AskingTaskDocument = gql`
     candidates {
       sql
       summary
+      type
+      view {
+        id
+        name
+        statement
+      }
     }
     error {
       ...CommonError

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -23,6 +23,11 @@ const COMMON_RESPONSE = gql`
         sql
         cteName
       }
+      view {
+        id
+        name
+        statement
+      }
     }
   }
 `;
@@ -45,6 +50,12 @@ export const ASKING_TASK = gql`
       candidates {
         sql
         summary
+        type
+        view {
+          id
+          name
+          statement
+        }
       }
       error {
         ...CommonError

--- a/wren-ui/src/components/EllipsisWrapper.tsx
+++ b/wren-ui/src/components/EllipsisWrapper.tsx
@@ -5,6 +5,7 @@ interface Props {
   text?: string;
   children?: ReactNode;
   multipleLine?: number;
+  minHeight?: number;
 }
 
 const Wrapper = styled.div<{ multipleLine?: number }>`
@@ -23,7 +24,7 @@ const Wrapper = styled.div<{ multipleLine?: number }>`
 `;
 
 export default function EllipsisWrapper(props: Props) {
-  const { text, multipleLine, children } = props;
+  const { text, multipleLine, minHeight, children } = props;
   const ref = useRef<HTMLDivElement | null>(null);
   const [width, setWidth] = useState(undefined);
   const hasWidth = width !== undefined;
@@ -49,7 +50,7 @@ export default function EllipsisWrapper(props: Props) {
       ref={ref}
       title={title}
       multipleLine={multipleLine}
-      style={{ width }}
+      style={{ width, minHeight }}
     >
       {hasWidth ? renderContent() : null}
     </Wrapper>

--- a/wren-ui/src/components/pages/home/prompt/Result.tsx
+++ b/wren-ui/src/components/pages/home/prompt/Result.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from 'react';
-import { Row, Col, Button } from 'antd';
+import Link from 'next/link';
+import { Row, Col, Button, Popover } from 'antd';
 import styled from 'styled-components';
-import { PROCESS_STATE } from '@/utils/enum';
+import { PROCESS_STATE, Path } from '@/utils/enum';
 import { makeIterable } from '@/utils/iteration';
 import CheckCircleOutlined from '@ant-design/icons/CheckCircleOutlined';
 import FunctionOutlined from '@ant-design/icons/FunctionOutlined';
@@ -10,6 +11,8 @@ import StopOutlined from '@ant-design/icons/StopFilled';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import WarningOutlined from '@ant-design/icons/WarningOutlined';
+import FileAddOutlined from '@ant-design/icons/FileAddOutlined';
+import { SparklesIcon } from '@/utils/icons';
 import ViewSQLModal from '@/components/pages/home/prompt/ViewSQLModal';
 import EllipsisWrapper from '@/components/EllipsisWrapper';
 import ErrorCollapse from '@/components/ErrorCollapse';
@@ -30,11 +33,18 @@ const StyledResult = styled.div`
 
 const ResultBlock = styled.div`
   user-select: none;
-  height: 129px;
+  overflow: hidden;
   &:hover {
     border-color: var(--geekblue-6) !important;
     transition: border-color ease 0.2s;
   }
+`;
+
+const MarkedResultBlock = styled.div`
+  height: 32px;
+  margin-left: -12px;
+  margin-right: -12px;
+  padding-top: 8px;
 `;
 
 interface Props {
@@ -46,11 +56,12 @@ interface Props {
   onStop: () => void;
 }
 
-const ResultTemplate = ({ index, summary, sql, onSelect, onShowSQL }) => {
+const ResultTemplate = ({ index, summary, sql, view, onSelect, onShowSQL }) => {
+  const isViewSaved = !!view;
   return (
     <Col span={8}>
       <ResultBlock
-        className="border border-gray-5 rounded px-3 pt-3 pb-4 cursor-pointer"
+        className="border border-gray-5 rounded px-3 pt-3 cursor-pointer"
         onClick={() => onSelect({ sql, summary })}
       >
         <div className="d-flex justify-space-between align-center text-sm mb-3">
@@ -66,7 +77,38 @@ const ResultTemplate = ({ index, summary, sql, onSelect, onShowSQL }) => {
             View SQL
           </Button>
         </div>
-        <EllipsisWrapper multipleLine={3} text={summary} />
+        <EllipsisWrapper multipleLine={3} minHeight={66} text={summary} />
+        <MarkedResultBlock onClickCapture={(event) => event.stopPropagation()}>
+          {isViewSaved && (
+            <Popover
+              trigger={['hover']}
+              placement="topLeft"
+              content={
+                <div className="d-flex" style={{ width: 300 }}>
+                  <SparklesIcon
+                    className="text-md geekblue-6 mr-2"
+                    style={{ marginTop: 2 }}
+                  />
+                  <div>
+                    This search result corresponds to a saved view:{' '}
+                    <Link
+                      href={`${Path.Modeling}?viewId=${view.id}&openMetadata=true`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      {view.name}
+                    </Link>
+                  </div>
+                </div>
+              }
+            >
+              <div className="d-flex align-center bg-geekblue-1 geekblue-6 text-xs px-3 py-1">
+                <FileAddOutlined className="text-sm mr-2" /> Result from a saved
+                view
+              </div>
+            </Popover>
+          )}
+        </MarkedResultBlock>
       </ResultBlock>
     </Col>
   );
@@ -172,7 +214,7 @@ const Finished = (props: Props) => {
           Close
         </Button>
       </div>
-      <Row gutter={12}>
+      <Row gutter={[12, 12]}>
         <ResultColumnIterator
           data={data}
           onShowSQL={showSQL}

--- a/wren-ui/src/components/pages/home/prompt/Result.tsx
+++ b/wren-ui/src/components/pages/home/prompt/Result.tsx
@@ -62,7 +62,7 @@ const ResultTemplate = ({ index, summary, sql, view, onSelect, onShowSQL }) => {
     <Col span={8}>
       <ResultBlock
         className="border border-gray-5 rounded px-3 pt-3 cursor-pointer"
-        onClick={() => onSelect({ sql, summary })}
+        onClick={() => onSelect({ sql, summary, viewId: view?.id })}
       >
         <div className="d-flex justify-space-between align-center text-sm mb-3">
           <div className="border border-gray-5 px-2 rounded-pill">

--- a/wren-ui/src/components/pages/home/prompt/index.tsx
+++ b/wren-ui/src/components/pages/home/prompt/index.tsx
@@ -20,9 +20,10 @@ import {
 
 interface Props {
   onSelect: (payload: {
-    sql: string;
-    summary: string;
-    question: string;
+    sql?: string;
+    summary?: string;
+    question?: string;
+    viewId?: number;
   }) => void;
   onStop: () => void;
   onSubmit: (value: string) => void;
@@ -96,7 +97,15 @@ export default forwardRef<Attributes, Props>(function Prompt(props, ref) {
   }, [error]);
 
   const selectResult = (payload) => {
-    onSelect && onSelect({ ...payload, question });
+    const isSavedViewCandidate = !!payload.viewId;
+    const data = isSavedViewCandidate
+      ? { viewId: payload.viewId }
+      : {
+          sql: payload.sql,
+          summary: payload.summary,
+          question,
+        };
+    onSelect && onSelect(data);
     closeResult();
   };
 

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
+import Link from 'next/link';
 import { Col, Button, Row, Skeleton, Typography } from 'antd';
 import styled from 'styled-components';
+import { Path } from '@/utils/enum';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
 import SaveOutlined from '@ant-design/icons/SaveOutlined';
+import FileDoneOutlined from '@ant-design/icons/FileDoneOutlined';
 import StepContent from '@/components/pages/home/promptThread/StepContent';
 
 const { Title, Text } = Typography;
@@ -50,6 +53,10 @@ interface Props {
   isLastThreadResponse: boolean;
   onTriggerScrollToBottom: () => void;
   summary: string;
+  view?: {
+    id: number;
+    name: string;
+  };
 }
 
 export default function AnswerResult(props: Props) {
@@ -64,7 +71,10 @@ export default function AnswerResult(props: Props) {
     onOpenSaveAsViewModal,
     onTriggerScrollToBottom,
     summary,
+    view,
   } = props;
+
+  const isViewSaved = !!view;
 
   const [ellipsis, setEllipsis] = useState(true);
 
@@ -104,17 +114,35 @@ export default function AnswerResult(props: Props) {
           />
         ))}
       </StyledAnswer>
-      <Button
-        className="mt-2 gray-6"
-        type="text"
-        size="small"
-        icon={<SaveOutlined />}
-        onClick={() =>
-          onOpenSaveAsViewModal({ sql: fullSql, responseId: threadResponseId })
-        }
-      >
-        Save as View
-      </Button>
+      {isViewSaved ? (
+        <div className="mt-2 gray-6 text-medium">
+          <FileDoneOutlined className="mr-2" />
+          Generated from saved view{' '}
+          <Link
+            className="gray-7"
+            href={`${Path.Modeling}?viewId=${view.id}&openMetadata=true`}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {view.name}
+          </Link>
+        </div>
+      ) : (
+        <Button
+          className="mt-2 gray-6"
+          type="text"
+          size="small"
+          icon={<SaveOutlined />}
+          onClick={() =>
+            onOpenSaveAsViewModal({
+              sql: fullSql,
+              responseId: threadResponseId,
+            })
+          }
+        >
+          Save as View
+        </Button>
+      )}
     </Skeleton>
   );
 }

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -64,6 +64,7 @@ const AnswerResultTemplate = ({
           loading={status !== AskingTaskStatus.FINISHED}
           question={question}
           summary={summary}
+          view={detail?.view}
           fullSql={detail?.sql}
           threadResponseId={id}
           onOpenSaveAsViewModal={onOpenSaveAsViewModal}

--- a/wren-ui/src/pages/modeling.tsx
+++ b/wren-ui/src/pages/modeling.tsx
@@ -1,4 +1,6 @@
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import { useSearchParams } from 'next/navigation';
 import { forwardRef, useEffect, useMemo, useRef } from 'react';
 import { message } from 'antd';
 import styled from 'styled-components';
@@ -55,6 +57,8 @@ const DiagramWrapper = styled.div`
 `;
 
 export default function Modeling() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const diagramRef = useRef(null);
 
   const { data } = useDiagramQuery({
@@ -198,6 +202,25 @@ export default function Modeling() {
   const editMetadataModal = useModalAction();
   const calculatedFieldModal = useModalAction();
   const relationshipModal = useRelationshipModal(diagramData);
+
+  const queryParams = {
+    viewId: searchParams.get('viewId'),
+    openMetadata: searchParams.get('openMetadata'),
+  };
+
+  // doing actions if the route has specific query params
+  useEffect(() => {
+    if (!diagramData) return;
+    // open view metadata drawer
+    if (queryParams.viewId && queryParams.openMetadata) {
+      const searchedView = diagramData.views.find(
+        (view) => view.viewId === Number(queryParams.viewId),
+      );
+      !!searchedView && metadataDrawer.openDrawer(searchedView);
+      // clear query params after opening the drawer
+      router.replace(router.pathname);
+    }
+  }, [queryParams, diagramData]);
 
   useEffect(() => {
     if (metadataDrawer.state.visible) {


### PR DESCRIPTION
## Description
For ask candidates
- Display a saved view mark in the search results, indicating to users that they have previously asked a similar question and saved the view.
For threads
- Display a saved view mark in thread details, informing users that the thread was created based on a saved view.
For modeling page
- Add a query parameter `?viewId=x&openMetadata=true` to automatically open the view metadata drawer upon navigation.

## UI Screeshot
<img width="770" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/86772059-5c5a-4c1b-a731-dc3e867ca094">

<img width="834" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/8f649bf2-36aa-411c-ae71-03b52d92387b">

