### PR TITLE
Chore: refactor database schema to reflect how we use them.

### DIFF
--- a/wren-ui/migrations/20240327030000_create_ask_table.js
+++ b/wren-ui/migrations/20240327030000_create_ask_table.js
@@ -37,5 +37,5 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-  return knex.schema.dropTable('thread').dropTable('thread_response');
+  return knex.schema.dropTable('thread_response').dropTable('thread');
 };

--- a/wren-ui/migrations/20240418000000_update_project_table_pg.js
+++ b/wren-ui/migrations/20240418000000_update_project_table_pg.js
@@ -31,6 +31,6 @@ exports.up = function (knex) {
  */
 exports.down = function (knex) {
   return knex.schema.alterTable('project', (table) => {
-    table.dropColumns('host', 'port', 'database', 'username', 'password');
+    table.dropColumns('host', 'port', 'database', 'user');
   });
 };

--- a/wren-ui/migrations/20240530062133_update_project_table.js
+++ b/wren-ui/migrations/20240530062133_update_project_table.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+
+// create connectionInfo column in project table
+exports.up = function (knex) {
+  return knex.schema.table('project', (table) => {
+    table
+      .jsonb('connection_info')
+      .nullable()
+      .comment('Connection information for the project');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table('project', (table) => {
+    table.dropColumn('connection_info');
+  });
+};

--- a/wren-ui/migrations/20240530062809_transfer_project_table_data.js
+++ b/wren-ui/migrations/20240530062809_transfer_project_table_data.js
@@ -78,5 +78,5 @@ exports.up = async function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = async function (knex) {
-  await knex('project').update({ connectionInfo: null });
+  await knex('project').update({ connection_info: null });
 };

--- a/wren-ui/migrations/20240530062809_transfer_project_table_data.js
+++ b/wren-ui/migrations/20240530062809_transfer_project_table_data.js
@@ -1,0 +1,82 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const projects = await knex('project').select('*');
+
+  // bigquery data
+  const bigqueryConnectionInfo = projects
+    .filter((project) => project.type === 'BIG_QUERY')
+    .map((project) => {
+      return {
+        id: project.id,
+        connectionInfo: {
+          projectId: project.project_id,
+          datasetId: project.dataset_id,
+          credentials: project.credentials,
+        },
+      };
+    });
+
+  // duckdb data
+  const duckdbConnectionInfo = projects
+    .filter((project) => project.type === 'DUCKDB')
+    .map((project) => {
+      return {
+        id: project.id,
+        connectionInfo: {
+          initSql: project.init_sql || '',
+          configurations: project.configurations || {},
+          extensions: project.extensions || [],
+        },
+      };
+    });
+
+  // postgres data
+  const postgresConnectionInfo = projects
+    .filter((project) => project.type === 'POSTGRES')
+    .map((project) => {
+      const ssl =
+        project.configurations && project.configurations.ssl ? true : false;
+      return {
+        id: project.id,
+        connectionInfo: {
+          host: project.host,
+          port: project.port,
+          database: project.database,
+          user: project.user,
+          password: project.credentials,
+          ssl,
+        },
+      };
+    });
+
+  // update project table
+  for (const project of [
+    ...bigqueryConnectionInfo,
+    ...duckdbConnectionInfo,
+    ...postgresConnectionInfo,
+  ]) {
+    const { id, connectionInfo } = project;
+    if (process.env.DB_TYPE === 'pg') {
+      // postgres
+      await knex('project')
+        .where({ id })
+        .update({ connection_info: connectionInfo });
+    } else {
+      // sqlite
+      await knex('project')
+        .where({ id })
+        .update({ connection_info: JSON.stringify(connectionInfo) });
+    }
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex('project').update({ connectionInfo: null });
+};

--- a/wren-ui/migrations/20240530105955_drop_project_table_columns.js
+++ b/wren-ui/migrations/20240530105955_drop_project_table_columns.js
@@ -1,0 +1,65 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table('project', (table) => {
+    table.dropColumn('configurations');
+    table.dropColumn('credentials');
+    table.dropColumn('project_id');
+    table.dropColumn('dataset_id');
+    table.dropColumn('init_sql');
+    table.dropColumn('extensions');
+    table.dropColumn('host');
+    table.dropColumn('port');
+    table.dropColumn('database');
+    table.dropColumn('user');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table('project', (table) => {
+    table
+      .jsonb('configurations')
+      .nullable()
+      .comment(
+        'duckdb configurations that can be set in session, eg: { "key1": "value1", "key2": "value2" }',
+      );
+    table
+      .text('credentials')
+      .nullable()
+      .comment('database connection credentials');
+    table
+      .string('project_id')
+      .nullable()
+      .comment('gcp project id, big query specific');
+    table.string('dataset_id').nullable().comment('big query datasetId');
+    table.text('init_sql');
+    table
+      .jsonb('extensions')
+      .nullable()
+      .comment(
+        'duckdb extensions, will be a array-like string like, eg: ["extension1", "extension2"]',
+      );
+    table
+      .string('host')
+      .nullable()
+      .comment('postgresql host, postgresql specific');
+    table
+      .integer('port')
+      .nullable()
+      .comment('postgresql port, postgresql specific');
+    table
+      .string('database')
+      .nullable()
+      .comment('postgresql database, postgresql specific');
+    table
+      .string('user')
+      .nullable()
+      .comment('postgresql user, postgresql specific');
+  });
+};

--- a/wren-ui/migrations/20240531085916_transfer_model_properties.js
+++ b/wren-ui/migrations/20240531085916_transfer_model_properties.js
@@ -1,0 +1,63 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const projects = await knex('project').select('*');
+  const models = await knex('model').select('*');
+  console.log(`model len:${models.length}`);
+  for (const model of models) {
+    const project = projects.find((p) => p.id === model.project_id);
+    const dataSourceType = project.type;
+    // get schema & catalog if its available
+    let schema = null;
+    let catalog = null;
+    let table = null;
+    switch (dataSourceType) {
+      case 'BIG_QUERY': {
+        const connectionInfo =
+          typeof project.connection_info === 'string'
+            ? JSON.parse(project.connection_info)
+            : project.connection_info;
+        const datasetId = connectionInfo.datasetId;
+        if (!datasetId) continue;
+        const splitDataSetId = datasetId.split('.');
+        schema = splitDataSetId[1];
+        catalog = splitDataSetId[0];
+        table = model.source_table_name;
+        break;
+      }
+      case 'POSTGRES': {
+        const connectionInfo =
+          typeof project.connection_info === 'string'
+            ? JSON.parse(project.connection_info)
+            : project.connection_info;
+        catalog = connectionInfo.database;
+        schema = model.source_table_name.split('.')[0];
+        table = model.source_table_name.split('.')[1];
+        break;
+      }
+      case 'DUCKDB': {
+        // already have schema & catalog in properties
+        table = model.source_table_name;
+        break;
+      }
+    }
+    const oldProperties = model.properties ? JSON.parse(model.properties) : {};
+    const newProperties = {
+      schema,
+      catalog,
+      table,
+      ...oldProperties,
+    };
+    await knex('model')
+      .where({ id: model.id })
+      .update({ properties: JSON.stringify(newProperties) });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function () {};

--- a/wren-ui/migrations/20240531085916_transfer_model_properties.js
+++ b/wren-ui/migrations/20240531085916_transfer_model_properties.js
@@ -60,4 +60,6 @@ exports.up = async function (knex) {
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.down = function () {};
+exports.down = function () {
+  return Promise.resolve();
+};

--- a/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
@@ -18,6 +18,7 @@ export interface POSTGRESConnectionInfo {
   database: string;
   user: string;
   password: string;
+  ssl: boolean;
 }
 
 export interface BIGQUERYConnectionInfo {

--- a/wren-ui/src/apollo/server/connectors/bqConnector.ts
+++ b/wren-ui/src/apollo/server/connectors/bqConnector.ts
@@ -151,6 +151,10 @@ export class BQConnector
           name: row.table_name,
           description: row.table_description,
           columns: [],
+          properties: {
+            schema: row.table_schema,
+            catalog: row.table_catalog,
+          },
         };
         acc.push(table);
       }

--- a/wren-ui/src/apollo/server/factories/bqStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/bqStrategy.ts
@@ -339,8 +339,18 @@ export class BigQueryStrategy implements IDataSourceStrategy {
         return acc;
       }, {});
     const modelValues = tables.map((tableName) => {
+      const dataSourceColumn = dataSourceColumns.find(
+        (col) => col.table_name === tableName,
+      );
+      const { table_schema, table_catalog } = dataSourceColumn;
       const description = tableDescriptionMap[tableName];
-      const properties = description ? JSON.stringify({ description }) : null;
+      const properties = JSON.stringify({
+        description,
+        schema: table_schema,
+        catalog: table_catalog,
+        table: tableName,
+      });
+
       const model = {
         projectId,
         displayName: tableName, //use table name as displayName, referenceName and tableName

--- a/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
@@ -242,9 +242,9 @@ export class DuckDBStrategy implements IDataSourceStrategy {
       const compactTable = compactTables.find(
         (table) => table.name === tableName,
       );
-      const properties = compactTable.properties
-        ? JSON.stringify(compactTable.properties)
-        : null;
+
+      // compactTable contain schema and catalog, these information are for building tableReference in mdl
+      const properties = { ...compactTable.properties, table: tableName };
       const model = {
         projectId,
         displayName: tableName, //use table name as displayName, referenceName and tableName
@@ -253,7 +253,7 @@ export class DuckDBStrategy implements IDataSourceStrategy {
         refSql: `select * from ${compactTable.properties.schema}.${tableName}`,
         cached: false,
         refreshTime: null,
-        properties,
+        properties: properties ? JSON.stringify(properties) : null,
       } as Partial<Model>;
       return model;
     });

--- a/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
+++ b/wren-ui/src/apollo/server/factories/duckdbStrategy.ts
@@ -1,5 +1,10 @@
 import { IConnector, CompactTable } from '../connectors/connector';
-import { Model, ModelColumn, Project } from '../repositories';
+import {
+  DUCKDB_CONNECTION_INFO,
+  Model,
+  ModelColumn,
+  Project,
+} from '../repositories';
 import { DataSourceName, DuckDBDataSourceProperties, IContext } from '../types';
 import {
   DuckDBConnector,
@@ -40,6 +45,11 @@ export class DuckDBStrategy implements IDataSourceStrategy {
     });
 
     await this.patchConfigToWrenEngine();
+    const connectionInfo = {
+      initSql: trim(initSql),
+      extensions,
+      configurations,
+    } as DUCKDB_CONNECTION_INFO;
 
     // save DataSource to database
     const project = await this.ctx.projectRepository.createOne({
@@ -47,9 +57,7 @@ export class DuckDBStrategy implements IDataSourceStrategy {
       schema: 'public',
       catalog: 'wrenai',
       type: DataSourceName.DUCKDB,
-      initSql: trim(initSql),
-      configurations,
-      extensions,
+      connectionInfo,
     });
     return project;
   }
@@ -67,13 +75,16 @@ export class DuckDBStrategy implements IDataSourceStrategy {
 
     await this.patchConfigToWrenEngine();
 
+    const connectionInfo = {
+      initSql: trim(initSql),
+      extensions,
+      configurations,
+    } as DUCKDB_CONNECTION_INFO;
     const project = await this.ctx.projectRepository.updateOne(
       this.project.id,
       {
         displayName,
-        initSql: trim(initSql),
-        configurations,
-        extensions,
+        connectionInfo,
       },
     );
     return project;

--- a/wren-ui/src/apollo/server/mdl/test/mdlBuilder.test.ts
+++ b/wren-ui/src/apollo/server/mdl/test/mdlBuilder.test.ts
@@ -4,6 +4,7 @@ import {
   ModelColumn,
   RelationInfo,
   View,
+  BIG_QUERY_CONNECTION_INFO,
 } from '../../repositories';
 import { MDLBuilder, MDLBuilderBuildFromOptions } from '../mdlBuilder';
 import { ModelMDL, RelationMDL, ViewMDL } from '../type';
@@ -34,9 +35,11 @@ describe('MDLBuilder', () => {
         id: 1,
         type: 'bigquery',
         displayName: 'my project',
-        projectId: 'bq-project-id',
-        datasetId: 'my-dataset',
-        credentials: 'my-credential',
+        connectionInfo: {
+          projectId: 'bq-project-id',
+          datasetId: 'my-dataset',
+          credentials: 'my-credential',
+        } as BIG_QUERY_CONNECTION_INFO,
         catalog: 'wrenai',
         schema: 'public',
         sampleDataset: null,
@@ -209,9 +212,11 @@ describe('MDLBuilder', () => {
       id: 1,
       type: 'bigquery',
       displayName: 'my project',
-      projectId: 'bq-project-id',
-      datasetId: 'my-dataset',
-      credentials: 'my-credential',
+      connectionInfo: {
+        projectId: 'bq-project-id',
+        datasetId: 'my-dataset',
+        credentials: 'my-credential',
+      } as BIG_QUERY_CONNECTION_INFO,
       catalog: 'wrenai',
       schema: 'public',
       sampleDataset: null,

--- a/wren-ui/src/apollo/server/mdl/test/mdlBuilder.test.ts
+++ b/wren-ui/src/apollo/server/mdl/test/mdlBuilder.test.ts
@@ -37,7 +37,7 @@ describe('MDLBuilder', () => {
         displayName: 'my project',
         connectionInfo: {
           projectId: 'bq-project-id',
-          datasetId: 'my-dataset',
+          datasetId: 'bq-project-id.my-dataset',
           credentials: 'my-credential',
         } as BIG_QUERY_CONNECTION_INFO,
         catalog: 'wrenai',
@@ -54,7 +54,12 @@ describe('MDLBuilder', () => {
           refSql: 'SELECT * FROM order',
           cached: false,
           refreshTime: null,
-          properties: JSON.stringify({ description: 'foo table' }),
+          properties: JSON.stringify({
+            description: 'foo table',
+            schema: 'my-dataset',
+            catalog: 'bq-project-id',
+            table: 'order',
+          }),
         },
         {
           id: 2,
@@ -65,7 +70,11 @@ describe('MDLBuilder', () => {
           refSql: 'SELECT * FROM customer',
           cached: false,
           refreshTime: null,
-          properties: null,
+          properties: JSON.stringify({
+            schema: null,
+            catalog: null,
+            table: 'customer',
+          }),
         },
       ] as Model[];
       const columns = [
@@ -137,7 +146,12 @@ describe('MDLBuilder', () => {
       const expectedModels = [
         {
           name: 'order',
-          refSql: 'SELECT * FROM order',
+          tableReference: {
+            schema: 'my-dataset',
+            catalog: 'bq-project-id',
+            table: 'order',
+          },
+          refSql: null,
           columns: [
             {
               name: 'orderKey',
@@ -159,11 +173,19 @@ describe('MDLBuilder', () => {
           cached: false,
           refreshTime: null,
           primaryKey: 'orderKey',
-          properties: { description: 'foo table', displayName: 'order' },
+          properties: {
+            description: 'foo table',
+            displayName: 'order',
+          },
         },
         {
           name: 'customer',
-          refSql: 'SELECT * FROM customer',
+          tableReference: {
+            schema: null,
+            catalog: null,
+            table: 'customer',
+          },
+          refSql: null,
           columns: [
             {
               name: 'orderKey',
@@ -185,7 +207,9 @@ describe('MDLBuilder', () => {
           primaryKey: '',
           cached: false,
           refreshTime: null,
-          properties: { displayName: 'customer' },
+          properties: {
+            displayName: 'customer',
+          },
         },
       ] as ModelMDL[];
 
@@ -231,7 +255,12 @@ describe('MDLBuilder', () => {
         refSql: 'SELECT * FROM order',
         cached: false,
         refreshTime: null,
-        properties: JSON.stringify({ description: 'foo table' }),
+        properties: JSON.stringify({
+          description: 'foo table',
+          catalog: 'bq-project-id',
+          schema: 'my-dataset',
+          table: 'order',
+        }),
       },
       {
         id: 2,
@@ -242,7 +271,11 @@ describe('MDLBuilder', () => {
         refSql: 'SELECT * FROM customer',
         cached: false,
         refreshTime: null,
-        properties: null,
+        properties: JSON.stringify({
+          catalog: 'bq-project-id',
+          schema: 'my-dataset',
+          table: 'customer',
+        }),
       },
     ] as Model[];
     const columns = [
@@ -329,7 +362,12 @@ describe('MDLBuilder', () => {
     const expectedModels = [
       {
         name: 'order',
-        refSql: 'SELECT * FROM order',
+        refSql: null,
+        tableReference: {
+          schema: 'my-dataset',
+          catalog: 'bq-project-id',
+          table: 'order',
+        },
         columns: [
           {
             name: 'orderKey',
@@ -355,7 +393,12 @@ describe('MDLBuilder', () => {
       },
       {
         name: 'customer',
-        refSql: 'SELECT * FROM customer',
+        refSql: null,
+        tableReference: {
+          schema: 'my-dataset',
+          catalog: 'bq-project-id',
+          table: 'customer',
+        },
         columns: [
           {
             name: 'orderKey',

--- a/wren-ui/src/apollo/server/mdl/type.ts
+++ b/wren-ui/src/apollo/server/mdl/type.ts
@@ -14,6 +14,7 @@ export interface ColumnMDL {
 export interface ModelMDL {
   name: string; // eg: "OrdersModel", "LineitemModel"
   refSql?: string; // eg: "select * from orders", "select * from lineitem"
+  tableReference?: TableReference;
   columns?: ColumnMDL[];
   primaryKey?: string; // eg: "orderkey", "custkey"
   cached: boolean; // eg true, false
@@ -73,4 +74,10 @@ export interface Manifest {
   relationships?: RelationMDL[];
   enumDefinitions?: EnumDefinition[];
   views?: ViewMDL[];
+}
+
+export interface TableReference {
+  schema?: string;
+  catalog?: string;
+  table: string;
 }

--- a/wren-ui/src/apollo/server/repositories/projectRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/projectRepository.ts
@@ -9,30 +9,37 @@ import {
   isEmpty,
 } from 'lodash';
 
+export interface BIG_QUERY_CONNECTION_INFO {
+  projectId: string;
+  datasetId: string;
+  credentials: string;
+}
+export interface POSTGRES_CONNECTION_INFO {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+  ssl: boolean;
+}
+
+export interface DUCKDB_CONNECTION_INFO {
+  initSql: string;
+  extensions: Array<string>;
+  configurations: Record<string, any>;
+}
+
 export interface Project {
   id: number; // ID
   type: string; // Project datasource type. ex: bigquery, mysql, postgresql, mongodb, etc
   displayName: string; // Project display name
-  credentials: string; // Database credentials. General purpose field for storing credentials
-  configurations: Record<string, any>; // Project connection configurations
-
-  // bq
-  projectId: string; // BigQuery project id
-  datasetId: string; // BigQuery datasetId
-
-  // duckdb
-  initSql: string; // DuckDB init sql
-  extensions: string[];
-
-  // pg
-  host: string; // Host
-  port: number; // Port
-  database: string; // Database
-  user: string; // User
-
   catalog: string; // Catalog name
   schema: string; // Schema name
   sampleDataset: string; // Sample dataset name
+  connectionInfo:
+    | BIG_QUERY_CONNECTION_INFO
+    | POSTGRES_CONNECTION_INFO
+    | DUCKDB_CONNECTION_INFO;
 }
 
 export interface IProjectRepository extends IBasicRepository<Project> {
@@ -60,16 +67,13 @@ export class ProjectRepository
 
   public override transformFromDBData: (data: any) => Project = (data: any) => {
     if (!isPlainObject(data)) {
-      throw new Error('Unexpected dbdata');
+      throw new Error('Unexpected db data');
     }
     const camelCaseData = mapKeys(data, (_value, key) => camelCase(key));
     const formattedData = mapValues(camelCaseData, (value, key) => {
-      if (key === 'configurations') {
+      if (key === 'connectionInfo' && typeof value === 'string') {
         // should return {} if value is null / {}, use value ? {} : JSON.parse(value) will throw error when value is null
         return isEmpty(value) ? {} : JSON.parse(value);
-      }
-      if (key === 'extensions') {
-        return isEmpty(value) ? [] : JSON.parse(value);
       }
       return value;
     });
@@ -80,11 +84,11 @@ export class ProjectRepository
     data: Project,
   ) => {
     if (!isPlainObject(data)) {
-      throw new Error('Unexpected dbdata');
+      throw new Error('Unexpected db data');
     }
     const snakeCaseData = mapKeys(data, (_value, key) => snakeCase(key));
     const formattedData = mapValues(snakeCaseData, (value, key) => {
-      if (['configurations', 'extensions'].includes(key)) {
+      if (key === 'connectionInfo') {
         return JSON.stringify(value);
       }
       return value;

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -138,13 +138,13 @@ export class ModelResolver {
   }
 
   public async checkModelSync(_root: any, _args: any, ctx: IContext) {
-    const project = await ctx.projectService.getCurrentProject();
+    const { id } = await ctx.projectService.getCurrentProject();
     const { manifest } = await ctx.mdlService.makeCurrentModelMDL();
-    const currentHash = ctx.deployService.createMDLHash(manifest, project.id);
-    const lastDeploy = await ctx.deployService.getLastDeployment(project.id);
+    const currentHash = ctx.deployService.createMDLHash(manifest, id);
+    const lastDeploy = await ctx.deployService.getLastDeployment(id);
     const lastDeployHash = lastDeploy.hash;
     const inProgressDeployment =
-      await ctx.deployService.getInProgressDeployment(project.id);
+      await ctx.deployService.getInProgressDeployment(id);
     if (inProgressDeployment) {
       return { status: SyncStatusEnum.IN_PROGRESS };
     }
@@ -158,9 +158,9 @@ export class ModelResolver {
     _args: any,
     ctx: IContext,
   ): Promise<DeployResponse> {
-    const project = await ctx.projectService.getCurrentProject();
+    const { id } = await ctx.projectService.getCurrentProject();
     const { manifest } = await ctx.mdlService.makeCurrentModelMDL();
-    return await ctx.deployService.deploy(manifest, project.id);
+    return await ctx.deployService.deploy(manifest, id);
   }
 
   public async getMDL(_root: any, _args: any, ctx: IContext) {
@@ -173,8 +173,7 @@ export class ModelResolver {
   }
 
   public async listModels(_root: any, _args: any, ctx: IContext) {
-    const project = await ctx.projectService.getCurrentProject();
-    const projectId = project.id;
+    const { id: projectId } = await ctx.projectService.getCurrentProject();
     const models = await ctx.modelRepository.findAllBy({ projectId });
     const modelIds = models.map((m) => m.id);
     const modelColumnList =
@@ -445,8 +444,8 @@ export class ModelResolver {
 
   // list views
   public async listViews(_root: any, _args: any, ctx: IContext) {
-    const project = await ctx.projectService.getCurrentProject();
-    const views = await ctx.viewRepository.findAllBy({ projectId: project.id });
+    const { id } = await ctx.projectService.getCurrentProject();
+    const views = await ctx.viewRepository.findAllBy({ projectId: id });
     return views;
   }
 
@@ -627,8 +626,7 @@ export class ModelResolver {
     const { responseId } = args;
 
     // If using a sample dataset, native SQL is not supported
-    const project = await ctx.projectService.getCurrentProject();
-    const sampleDataset = project.sampleDataset;
+    const { sampleDataset } = await ctx.projectService.getCurrentProject();
     if (sampleDataset) {
       throw new Error(`Doesn't support Native SQL`);
     }
@@ -730,8 +728,8 @@ export class ModelResolver {
     }
     const referenceName = replaceAllowableSyntax(viewDisplayName);
     // check if view name is duplicated
-    const project = await ctx.projectService.getCurrentProject();
-    const views = await ctx.viewRepository.findAllBy({ projectId: project.id });
+    const { id } = await ctx.projectService.getCurrentProject();
+    const views = await ctx.viewRepository.findAllBy({ projectId: id });
     if (views.find((v) => v.name === referenceName && v.id !== selfView)) {
       return {
         valid: false,

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -346,9 +346,9 @@ export class AskingService implements IAskingService {
     });
 
     // 2. create a thread and the first thread response
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
     const thread = await this.threadRepository.createOne({
-      projectId: project.id,
+      projectId: id,
       sql: input.sql,
       summary: input.summary,
     });
@@ -370,8 +370,8 @@ export class AskingService implements IAskingService {
   }
 
   public async listThreads(): Promise<Thread[]> {
-    const project = await this.projectService.getCurrentProject();
-    return await this.threadRepository.listAllTimeDescOrder(project.id);
+    const { id } = await this.projectService.getCurrentProject();
+    return await this.threadRepository.listAllTimeDescOrder(id);
   }
 
   public async updateThread(
@@ -488,8 +488,8 @@ export class AskingService implements IAskingService {
   }
 
   private async getDeployId() {
-    const project = await this.projectService.getCurrentProject();
-    const lastDeploy = await this.deployService.getLastDeployment(project.id);
+    const { id } = await this.projectService.getCurrentProject();
+    const lastDeploy = await this.deployService.getLastDeployment(id);
     return lastDeploy.hash;
   }
 
@@ -521,9 +521,9 @@ export class AskingService implements IAskingService {
     }
 
     const properties = JSON.parse(view.properties) || {};
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
     const thread = await this.threadRepository.createOne({
-      projectId: project.id,
+      projectId: id,
       sql: view.statement,
       summary: properties.summary,
     });

--- a/wren-ui/src/apollo/server/services/modelService.ts
+++ b/wren-ui/src/apollo/server/services/modelService.ts
@@ -224,9 +224,9 @@ export class ModelService implements IModelService {
 
   public async updatePrimaryKeys(tables: SampleDatasetTable[]) {
     logger.debug('start update primary keys');
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
     const models = await this.modelRepository.findAllBy({
-      projectId: project.id,
+      projectId: id,
     });
     const tableToUpdate = tables.filter((t) => t.primaryKey);
     for (const table of tableToUpdate) {
@@ -243,9 +243,9 @@ export class ModelService implements IModelService {
 
   public async batchUpdateModelProperties(tables: SampleDatasetTable[]) {
     logger.debug('start batch update model description');
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
     const models = await this.modelRepository.findAllBy({
-      projectId: project.id,
+      projectId: id,
     });
 
     await Promise.all([
@@ -267,9 +267,9 @@ export class ModelService implements IModelService {
 
   public async batchUpdateColumnProperties(tables: SampleDatasetTable[]) {
     logger.debug('start batch update column description');
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
     const models = await this.modelRepository.findAllBy({
-      projectId: project.id,
+      projectId: id,
     });
     const sourceColumns =
       (await this.modelColumnRepository.findColumnsByModelIds(
@@ -329,10 +329,10 @@ export class ModelService implements IModelService {
     if (isEmpty(relations)) {
       return [];
     }
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
 
     const models = await this.modelRepository.findAllBy({
-      projectId: project.id,
+      projectId: id,
     });
 
     const columnIds = relations
@@ -355,7 +355,7 @@ export class ModelService implements IModelService {
       }
       const relationName = this.generateRelationName(relation, models, columns);
       return {
-        projectId: project.id,
+        projectId: id,
         name: relationName,
         fromColumnId: relation.fromColumnId,
         toColumnId: relation.toColumnId,
@@ -370,7 +370,7 @@ export class ModelService implements IModelService {
   }
 
   public async createRelation(relation: RelationData): Promise<Relation> {
-    const project = await this.projectService.getCurrentProject();
+    const { id } = await this.projectService.getCurrentProject();
     const modelIds = [relation.fromModelId, relation.toModelId];
     const models = await this.modelRepository.findAllByIds(modelIds);
     const columnIds = [relation.fromColumnId, relation.toColumnId];
@@ -387,7 +387,7 @@ export class ModelService implements IModelService {
     }
     const relationName = this.generateRelationName(relation, models, columns);
     const savedRelation = await this.relationRepository.createOne({
-      projectId: project.id,
+      projectId: id,
       name: relationName,
       fromColumnId: relation.fromColumnId,
       toColumnId: relation.toColumnId,

--- a/wren-ui/src/apollo/server/services/projectService.ts
+++ b/wren-ui/src/apollo/server/services/projectService.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import * as fs from 'fs';
 import path from 'path';
 import { Encryptor, getLogger } from '@server/utils';
-import { IProjectRepository } from '../repositories';
+import { BIG_QUERY_CONNECTION_INFO, IProjectRepository } from '../repositories';
 import { Project } from '../repositories';
 import { getConfig } from '../config';
 
@@ -41,7 +41,8 @@ export class ProjectService implements IProjectService {
     if (!project) {
       project = await this.getCurrentProject();
     }
-    const { credentials: encryptedCredentials } = project;
+    const connectionInfo = project.connectionInfo as BIG_QUERY_CONNECTION_INFO;
+    const encryptedCredentials = connectionInfo.credentials;
     const encryptor = new Encryptor(config);
     const credentials = encryptor.decrypt(encryptedCredentials);
     const filePath = this.writeCredentialFile(

--- a/wren-ui/src/apollo/server/services/queryService.ts
+++ b/wren-ui/src/apollo/server/services/queryService.ts
@@ -9,7 +9,7 @@ import {
   BIGQUERYConnectionInfo,
 } from '../adaptors/ibisAdaptor';
 import { Encryptor, getLogger } from '@server/utils';
-import { Project } from '../repositories';
+import { BIG_QUERY_CONNECTION_INFO, Project } from '../repositories';
 import { getConfig } from '../config';
 
 const logger = getLogger('QueryService');
@@ -129,29 +129,31 @@ export class QueryService implements IQueryService {
     const { type } = project;
     switch (type) {
       case DataSourceName.POSTGRES: {
+        const connectionInfo = project.connectionInfo as POSTGRESConnectionInfo;
         const encryptor = new Encryptor(config);
-        const decryptedCredentials = encryptor.decrypt(project.credentials);
+        const decryptedCredentials = encryptor.decrypt(connectionInfo.password);
         const { password } = JSON.parse(decryptedCredentials);
         return {
           datasource: DataSourceName.POSTGRES,
           connectionInfo: {
-            host: project.host,
-            port: project.port,
-            database: project.database,
-            user: project.user,
+            ...connectionInfo,
             password,
           } as POSTGRESConnectionInfo,
         };
       }
       case DataSourceName.BIG_QUERY: {
+        const connectionInfo =
+          project.connectionInfo as BIG_QUERY_CONNECTION_INFO;
         const encryptor = new Encryptor(config);
-        const decryptedCredentials = encryptor.decrypt(project.credentials);
+        const decryptedCredentials = encryptor.decrypt(
+          connectionInfo.credentials,
+        );
         const credential = Buffer.from(decryptedCredentials).toString('base64');
         return {
           datasource: DataSourceName.BIG_QUERY,
           connectionInfo: {
-            project_id: project.projectId,
-            dataset_id: project.datasetId,
+            project_id: connectionInfo.projectId,
+            dataset_id: connectionInfo.datasetId,
             credentials: credential,
           } as BIGQUERYConnectionInfo,
         };


### PR DESCRIPTION
- wrap data source connection related columns(host, port, ...) with a new column "connection_info"
- use `tableReference` in MDL manifest instead of refSql (ref: Wren Engine [PR](https://github.com/Canner/wren-engine/pull/491)). This will benefit performance for small queries and no longer have to deal with SQL format.
 