### PR TITLE
feat(wren-ui/e2e): add E2E basic check

### DIFF
--- a/wren-ui/e2e/commonTests/home.ts
+++ b/wren-ui/e2e/commonTests/home.ts
@@ -1,0 +1,87 @@
+import { Page, expect } from '@playwright/test';
+import {
+  AskingTask,
+  AskingTaskStatus,
+  ThreadResponse,
+} from '@/apollo/client/graphql/__types__';
+
+export const checkAskingProcess = async (page: Page, question: string) => {
+  // check process state
+  await expect(page.getByText('Searching data')).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(page.getByRole('button', { name: 'Stop' })).toBeVisible();
+  await expect(page.getByPlaceholder('Ask to explore your data')).toHaveValue(
+    question,
+  );
+  await expect(page.getByRole('button', { name: 'Ask' })).toBeDisabled();
+};
+
+export const waitingForAskingTask = async (page: Page, baseURL) => {
+  await page.waitForResponse(
+    async (response) => {
+      const responseBody = await response.json();
+      const responseData: AskingTask = responseBody?.data?.askingTask;
+      return (
+        response.url() === `${baseURL}/api/graphql` &&
+        response.status() === 200 &&
+        responseBody &&
+        [AskingTaskStatus.FAILED, AskingTaskStatus.FINISHED].includes(
+          responseData?.status,
+        )
+      );
+    },
+    { timeout: 100000 },
+  );
+};
+
+export const checkCandidatesResult = async (page: Page) => {
+  await expect(
+    page.locator('div').filter({ hasText: 'result(s) found' }).last(),
+  ).toBeVisible();
+  await expect(page.getByText('result(s) found')).toBeVisible();
+};
+
+export const getFirstCandidatesResultSummary = async (page: Page) => {
+  const candidatesResultHandle = await page.evaluateHandle(
+    (document) => {
+      const nodes: any = Array.from(
+        document.querySelectorAll('div[role="row"]'),
+      );
+      const node = nodes[nodes.length - 1];
+      const firstResult = node.firstElementChild.lastElementChild;
+
+      return firstResult.childNodes[1].innerText;
+    },
+    await page.evaluateHandle(() => document),
+  );
+
+  const firstResultSummary = await candidatesResultHandle.jsonValue();
+  await candidatesResultHandle.dispose();
+
+  return firstResultSummary;
+};
+
+export const checkSkeletonLoading = async (page: Page, isShow: boolean) => {
+  await expect(page.locator('.ant-skeleton-content')).toBeVisible({
+    visible: isShow,
+  });
+};
+
+export const waitingForThreadResponse = async (page: Page, baseURL: string) => {
+  await page.waitForResponse(
+    async (response) => {
+      const responseBody = await response.json();
+      const responseData: ThreadResponse = responseBody?.data?.threadResponse;
+      return (
+        response.url() === `${baseURL}/api/graphql` &&
+        response.status() === 200 &&
+        responseBody &&
+        [AskingTaskStatus.FAILED, AskingTaskStatus.FINISHED].includes(
+          responseData?.status,
+        )
+      );
+    },
+    { timeout: 100000 },
+  );
+};

--- a/wren-ui/e2e/commonTests/modeling.ts
+++ b/wren-ui/e2e/commonTests/modeling.ts
@@ -26,9 +26,11 @@ export const checkDeployUndeployedChanges = async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Deploy' })).toBeEnabled();
 };
 
-export const executeDeploy = async ({ page }) => {
-  await page.goto('/modeling');
-  await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+export const executeDeploy = async ({ page, baseURL }) => {
+  if (page.url() !== `${baseURL}/modeling`) {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+  }
 
   await page.getByRole('button', { name: 'Deploy' }).click();
   await expect(

--- a/wren-ui/e2e/commonTests/modeling.ts
+++ b/wren-ui/e2e/commonTests/modeling.ts
@@ -1,0 +1,20 @@
+import { expect } from '@playwright/test';
+
+export const checkDeploySynced = async ({ page }) => {
+  await page.goto('/modeling');
+  await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+  await expect(page.getByLabel('check-circle').locator('svg')).toBeVisible();
+  await expect(page.getByText('Synced')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Deploy' })).toBeDisabled();
+};
+
+export const checkDeployUndeployedChanges = async ({ page }) => {
+  await page.goto('/modeling');
+  await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+  await expect(page.getByLabel('warning').locator('svg')).toBeVisible();
+  await expect(page.getByText('Undeployed changes')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Deploy' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Deploy' })).toBeEnabled();
+};

--- a/wren-ui/e2e/commonTests/onboarding.ts
+++ b/wren-ui/e2e/commonTests/onboarding.ts
@@ -9,3 +9,10 @@ export const setupModels = async ({ page }) => {
   await page.getByRole('button', { name: 'Next' }).click();
   await expect(page).toHaveURL('/setup/relationships', { timeout: 60000 });
 };
+
+export const saveRecommendedRelationships = async ({ page }) => {
+  await page.goto('/setup/relationships');
+
+  await page.getByRole('button', { name: 'Finish' }).click();
+  await expect(page).toHaveURL('/home', { timeout: 60000 });
+};

--- a/wren-ui/e2e/specs/connectBigQuery.spec.ts
+++ b/wren-ui/e2e/specs/connectBigQuery.spec.ts
@@ -35,4 +35,9 @@ test.describe('Test BigQuery data source', async () => {
   });
 
   test('Setup all models', onboarding.setupModels);
+
+  test(
+    'Save recommended relationships',
+    onboarding.saveRecommendedRelationships,
+  );
 });

--- a/wren-ui/e2e/specs/connectDuckDB.spec.ts
+++ b/wren-ui/e2e/specs/connectDuckDB.spec.ts
@@ -28,4 +28,9 @@ test.describe('Test DuckDB data source', () => {
   });
 
   test('Setup all models', onboarding.setupModels);
+
+  test(
+    'Save recommended relationships',
+    onboarding.saveRecommendedRelationships,
+  );
 });

--- a/wren-ui/e2e/specs/connectPostgreSQL.spec.ts
+++ b/wren-ui/e2e/specs/connectPostgreSQL.spec.ts
@@ -38,4 +38,9 @@ test.describe('Test PostgreSQL data source', () => {
   });
 
   test('Setup all models', onboarding.setupModels);
+
+  test(
+    'Save recommended relationships',
+    onboarding.saveRecommendedRelationships,
+  );
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -92,8 +92,24 @@ test.describe('Test E-commerce sample dataset', () => {
     });
   });
 
-  test('Trigger and check deploy MDL successfully', async ({ page }) => {
-    await modelingHelper.executeDeploy({ page });
+  test('Trigger and check deploy MDL successfully', async ({
+    page,
+    baseURL,
+  }) => {
+    await modelingHelper.executeDeploy({ page, baseURL });
     await modelingHelper.checkDeploySynced({ page });
+  });
+
+  test('Save as view successfully', async ({ page, baseURL }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    await homeHelper.saveAsView(
+      { page, baseURL },
+      {
+        question: suggestedQuestions[1],
+        viewName: 'avg review score by city',
+      },
+    );
   });
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
 import * as helper from '../helper';
+import * as homeHelper from '../commonTests/home';
+
+const suggestedQuestions = [
+  'What are the top 3 value for orders placed by customers in each city?',
+  'What is the average score of reviews submitted for orders placed by customers in each city?',
+  'What is the total value of payments made by customers from each state?',
+];
 
 test.describe('Test E-commerce sample dataset', () => {
   test.beforeAll(async () => {
@@ -10,20 +17,149 @@ test.describe('Test E-commerce sample dataset', () => {
     await page.goto('/setup/connection');
     await page.getByRole('button', { name: 'E-commerce' }).click();
     await expect(page).toHaveURL('/home', { timeout: 60000 });
+
+    for (const question of suggestedQuestions) {
+      await expect(page.getByText(question)).toBeVisible();
+    }
+  });
+
+  test('Use suggestion question', async ({ page, baseURL }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL('/home', { timeout: 60000 });
+
+    // select first suggested question
+    const suggestedQuestion = suggestedQuestions[0];
+    await page.getByText(suggestedQuestion).click();
+
+    // check asking process state and wait for asking task to finish
+    await homeHelper.checkAskingProcess(page, suggestedQuestions[0]);
+    await homeHelper.waitingForAskingTask(page, baseURL);
+    await homeHelper.checkCandidatesResult(page);
+
+    const firstResult = await homeHelper.getFirstCandidatesResultSummary(page);
+    await page.getByRole('cell', { name: firstResult }).first().click();
+
+    await homeHelper.checkSkeletonLoading(page, true);
+    await homeHelper.waitingForThreadResponse(page, baseURL);
+    await homeHelper.checkSkeletonLoading(page, false);
+
+    // check question block
     await expect(
-      page.getByText(
-        'What are the top 3 value for orders placed by customers in each city?',
-      ),
+      page.getByLabel('question-circle').locator('svg'),
+    ).toBeVisible();
+    await expect(page.getByText('Question:')).toBeVisible();
+    await expect(page.getByText(suggestedQuestion)).toBeVisible();
+
+    // check thread summary
+    await expect(
+      page.getByRole('heading', { name: firstResult }),
+    ).toBeVisible();
+
+    // check show preview data table as default open
+    await expect(page.locator('.ant-table')).toBeVisible();
+    await expect(page.getByText('Showing up to 500 rows')).toBeVisible();
+
+    // check up-circle icon with Collapse button
+    await expect(page.getByLabel('up-circle').locator('svg')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Collapse' })).toBeVisible();
+
+    // click View Full SQL button
+    await page.getByRole('button', { name: 'View Full SQL' }).click();
+    await expect(page.locator('.ace_editor')).toBeVisible();
+
+    // check collapse and copy button
+    await expect(page.getByLabel('up-circle').locator('svg')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Collapse' })).toBeVisible();
+    await expect(page.getByLabel('copy').locator('svg')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible();
+
+    // check save icon button
+    await expect(page.getByLabel('save').locator('svg')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Save as View' }),
+    ).toBeVisible();
+  });
+
+  test('Follow up question', async ({ page, baseURL }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL('/home', { timeout: 60000 });
+
+    // click existing thread
+    await page
+      .getByRole('tree')
+      .locator('div')
+      .filter({ hasText: /\W/ })
+      .nth(2)
+      .click();
+
+    const question =
+      'What are the total sales values for each quarter of each year?';
+
+    // ask follow up question
+    await page.getByPlaceholder('Ask to explore your data').fill(question);
+    await page.getByRole('button', { name: 'Ask' }).click();
+
+    // check asking process state and wait for asking task to finish
+    await homeHelper.checkAskingProcess(page, question);
+    await homeHelper.waitingForAskingTask(page, baseURL);
+    await homeHelper.checkCandidatesResult(page);
+
+    // click the View SQL
+    await page
+      .getByRole('cell', { name: 'Result 1 function View SQL' })
+      .getByRole('button')
+      .click();
+    await page.getByLabel('Close', { exact: true }).click();
+
+    const firstResult = await homeHelper.getFirstCandidatesResultSummary(page);
+    await page.getByRole('cell', { name: firstResult }).click();
+
+    await homeHelper.checkSkeletonLoading(page, true);
+    await homeHelper.waitingForThreadResponse(page, baseURL);
+    await homeHelper.checkSkeletonLoading(page, false);
+
+    // check question block
+    await expect(
+      page.getByLabel('question-circle').locator('svg').last(),
+    ).toBeVisible();
+    await expect(page.getByText('Question:').last()).toBeVisible();
+    await expect(page.getByText(question)).toBeVisible();
+
+    // check thread summary
+    await expect(
+      page.getByRole('heading', { name: firstResult }),
+    ).toBeVisible();
+
+    await expect(page.locator('.ant-table').last()).toBeVisible();
+    await expect(page.getByText('Showing up to 500 rows').last()).toBeVisible();
+
+    // check up-circle icon with Collapse button
+    await expect(
+      page.getByLabel('up-circle').locator('svg').last(),
     ).toBeVisible();
     await expect(
-      page.getByText(
-        'What are the top 3 value for orders placed by customers in each city?',
-      ),
+      page.getByRole('button', { name: 'Collapse' }).last(),
+    ).toBeVisible();
+
+    // click View Full SQL button
+    await page.getByRole('button', { name: 'View Full SQL' }).last().click();
+
+    await expect(page.locator('.ace_editor')).toBeVisible();
+
+    // check collapse and copy button
+    await expect(
+      page.getByLabel('up-circle').locator('svg').last(),
     ).toBeVisible();
     await expect(
-      page.getByText(
-        'What is the total value of payments made by customers from each state?',
-      ),
+      page.getByRole('button', { name: 'Collapse' }).last(),
+    ).toBeVisible();
+    await expect(page.getByLabel('copy').locator('svg')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible();
+
+    // check save icon button
+    await expect(page.getByLabel('save').locator('svg').last()).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Save as View' }).last(),
     ).toBeVisible();
   });
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -112,4 +112,17 @@ test.describe('Test E-commerce sample dataset', () => {
       },
     );
   });
+
+  test('Update view metadata successfully', async ({ page, baseURL }) => {
+    await modelingHelper.updateViewMetadata(
+      { page, baseURL },
+      {
+        viewDisplayName: 'avg review score by city',
+        viewDescription: '',
+        newViewDisplayName: 'avg review score per city',
+        newViewDescription:
+          'Average review score for orders placed by customers in each city.',
+      },
+    );
+  });
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -24,7 +24,10 @@ test.describe('Test E-commerce sample dataset', () => {
     }
   });
 
-  test('Check should be in Synced status', modelingHelper.checkDeploySynced);
+  test(
+    'Check deploy status should be in Synced status',
+    modelingHelper.checkDeploySynced,
+  );
 
   test('Use suggestion question', async ({ page, baseURL }) => {
     // select first suggested question
@@ -66,7 +69,7 @@ test.describe('Test E-commerce sample dataset', () => {
   });
 
   test(
-    'Check deploy is Undeployed changes',
+    'Check deploy status should be in Undeployed changes status',
     modelingHelper.checkDeployUndeployedChanges,
   );
 
@@ -78,5 +81,19 @@ test.describe('Test E-commerce sample dataset', () => {
       toFieldColumnDisplayName: 'CustomerId',
       relationshipType: 'One-to-many',
     });
+  });
+
+  test('Update model metadata successfully', async ({ page }) => {
+    await modelingHelper.updateModelMetadata(page, {
+      modelDisplayName: 'orders',
+      modelDescription: 'A model representing the orders data.',
+      newModelDisplayName: 'Orders',
+      newModelDescription: '',
+    });
+  });
+
+  test('Trigger and check deploy MDL successfully', async ({ page }) => {
+    await modelingHelper.executeDeploy({ page });
+    await modelingHelper.checkDeploySynced({ page });
   });
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -45,90 +45,10 @@ test.describe('Test E-commerce sample dataset', () => {
   });
 
   test('Model CRUD successfully', async ({ page }) => {
-    await page.goto('/modeling');
-    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
-
-    const modelDisplayName = 'customers';
-
-    // click sidebar customers model
-    await page.getByRole('complementary').getByText(modelDisplayName).click();
-
-    // delete model
-    await page
-      .locator('div')
-      .filter({ hasText: new RegExp(`^${modelDisplayName}$`) })
-      .getByRole('button')
-      .click();
-    await page.getByText('Delete', { exact: true }).click();
-    await expect(
-      page
-        .getByRole('dialog')
-        .locator('div')
-        .filter({ hasText: 'Are you sure you want to delete this model?' })
-        .nth(1),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await expect(page.getByText('Successfully deleted model.')).toBeVisible();
-
-    // check customers model is deleted
-    await expect(
-      page.getByRole('complementary').getByText(modelDisplayName),
-    ).toBeHidden();
-
-    // add model back
-    await page
-      .locator('div')
-      .filter({ hasText: /^Models\(\d\)$/ })
-      .locator('path')
-      .first()
-      .click();
-
-    // chkeck Model drawer open
-    await expect(page.locator('.ant-drawer-mask')).toBeVisible();
-    await expect(
-      page
-        .locator('div')
-        .filter({ hasText: /^Create a data model$/ })
-        .first(),
-    ).toBeVisible();
-
-    // select customers table and some columns
-    await page.getByLabel('Select a table').click();
-    await page.getByTitle(modelDisplayName).locator('div').click();
-    await page
-      .getByRole('row', { name: /^Id .*/ })
-      .getByLabel('')
-      .check();
-
-    await page.getByRole('button', { name: 'right' }).click();
-
-    // set Id as primary key
-    await page.getByLabel('Select primary key').click();
-    await page.locator('form').getByTitle('Id').locator('div').click();
-    await page.getByRole('button', { name: 'Submit' }).click();
-
-    await expect(page.getByText('Successfully created model.')).toBeVisible();
-
-    // check customers model is added
-    await expect(
-      page.getByRole('complementary').getByText(modelDisplayName),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId('diagram__model-node__customers'),
-    ).toBeVisible();
-
-    // update columns
-    await page
-      .locator('div')
-      .filter({ hasText: new RegExp(`^${modelDisplayName}$`) })
-      .getByRole('button')
-      .click();
-    await page.getByText('Update Columns').click();
-    await page.getByLabel('', { exact: true }).first().check();
-    await page.getByRole('button', { name: 'right' }).click();
-    await page.getByRole('button', { name: 'Submit' }).click();
-
-    await expect(page.getByText('Successfully updated model.')).toBeVisible();
+    await modelingHelper.executeModelCRUD(page, {
+      modelDisplayName: 'customers',
+      primaryKeyColumn: 'Id',
+    });
   });
 
   test('Add relationship successfully', async ({ page }) => {
@@ -136,60 +56,13 @@ test.describe('Test E-commerce sample dataset', () => {
     await expect(page).toHaveURL('/modeling', { timeout: 60000 });
 
     // Following the previous test, we assume the customers model is created, and it's have not any relationships
-    const modelDisplayName = 'customers';
-    const toFieldModelDisplayName = 'orders';
-
-    // add relationship
-    await page
-      .locator('div')
-      .filter({ hasText: /^Relationships$/ })
-      .getByRole('button')
-      .first()
-      .click();
-
-    // check relationship modal open
-    await expect(
-      page
-        .locator('div')
-        .filter({
-          hasText: 'Add relationship',
-        })
-        .nth(2),
-    ).toBeVisible();
-    await expect(page.getByText('Add relationship')).toBeVisible();
-
-    // from field
-    await page.getByTestId('common__fields-select').first().click();
-    await page
-      .getByTestId('common__fields__select-option')
-      .filter({ hasText: 'Id' })
-      .click();
-
-    // to field
-    await page.getByTestId('common__models-select').last().click();
-    await page
-      .getByTestId('common__models__select-option')
-      .filter({ hasText: 'orders' })
-      .click();
-    await page.getByTestId('common__fields-select').last().click();
-    await page
-      .getByTestId('common__fields__select-option')
-      .filter({ hasText: 'CustomerId' })
-      .click();
-
-    // type
-    await page.getByTestId('relationship-form__type-select').click();
-    await page.getByText('One-to-many').click();
-    await page.getByRole('button', { name: 'Submit' }).click();
-
-    await expect(
-      page.getByText('Successfully created relationship.'),
-    ).toBeVisible();
-    await expect(
-      page
-        .getByTestId(`diagram__model-node__${modelDisplayName}`)
-        .getByTitle(toFieldModelDisplayName),
-    ).toBeVisible();
+    await modelingHelper.addRelationship(page, {
+      fromFieldModelDisplayName: 'customers',
+      fromFieldColumnDisplayName: 'Id',
+      toFieldModelDisplayName: 'orders',
+      toFieldColumnDisplayName: 'CustomerId',
+      relationshipType: 'One-to-many',
+    });
   });
 
   test(
@@ -198,126 +71,12 @@ test.describe('Test E-commerce sample dataset', () => {
   );
 
   test('Relationship CRUD successfully', async ({ page }) => {
-    await page.goto('/modeling');
-    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
-
-    const modelDisplayName = 'customers';
-    const toFieldModelDisplayName = 'orders';
-
-    await page.getByRole('complementary').getByText(modelDisplayName).click();
-
-    // delete relationship
-    await page
-      .getByTestId(`diagram__model-node__${modelDisplayName}`)
-      .getByRole('button', { name: 'more' })
-      .nth(1)
-      .click();
-    await page.getByText('Delete', { exact: true }).click();
-
-    // check delete relationship modal open
-    await expect(
-      page
-        .getByRole('dialog')
-        .locator('div')
-        .filter({
-          hasText: 'Are you sure you want to delete this relationship?',
-        })
-        .nth(1),
-    ).toBeVisible();
-    await expect(
-      page.getByText('Are you sure you want to delete this relationship?'),
-    ).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
-
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await expect(
-      page.getByText('Successfully deleted relationship.'),
-    ).toBeVisible();
-
-    // check relationship is deleted
-    await expect(
-      page
-        .getByTestId(`diagram__model-node__${modelDisplayName}`)
-        .getByTitle(toFieldModelDisplayName),
-    ).toBeHidden();
-
-    // add relationship
-    await page
-      .locator('div')
-      .filter({ hasText: /^Relationships$/ })
-      .getByRole('button')
-      .first()
-      .click();
-
-    // check relationship modal open
-    await expect(
-      page
-        .locator('div')
-        .filter({
-          hasText: 'Add relationship',
-        })
-        .nth(2),
-    ).toBeVisible();
-    await expect(page.getByText('Add relationship')).toBeVisible();
-
-    // from field
-    await page.getByTestId('common__fields-select').first().click();
-    await page
-      .getByTestId('common__fields__select-option')
-      .filter({ hasText: 'Id' })
-      .click();
-
-    // to field
-    await page.getByTestId('common__models-select').last().click();
-    await page
-      .getByTestId('common__models__select-option')
-      .filter({ hasText: 'orders' })
-      .click();
-    await page.getByTestId('common__fields-select').last().click();
-    await page
-      .getByTestId('common__fields__select-option')
-      .filter({ hasText: 'CustomerId' })
-      .click();
-
-    // type
-    await page.getByTestId('relationship-form__type-select').click();
-    await page.getByText('One-to-one').click();
-    await page.getByRole('button', { name: 'Submit' }).click();
-
-    await expect(
-      page.getByText('Successfully created relationship.'),
-    ).toBeVisible();
-    await expect(
-      page
-        .getByTestId(`diagram__model-node__${modelDisplayName}`)
-        .getByTitle(toFieldModelDisplayName),
-    ).toBeVisible();
-
-    // update relationship
-    await page.getByRole('complementary').getByText(modelDisplayName).click();
-    await page
-      .getByTestId(`diagram__model-node__${modelDisplayName}`)
-      .getByRole('button', { name: 'more' })
-      .nth(1)
-      .click();
-
-    await page.getByText('Edit').click();
-    await expect(
-      page
-        .locator('div')
-        .filter({
-          hasText: 'Update relationship',
-        })
-        .nth(2),
-    ).toBeVisible();
-    await expect(page.getByText('Update relationship')).toBeVisible();
-
-    await page.getByTestId('relationship-form__type-select').click();
-    await page.getByTitle('One-to-many').locator('div').click();
-    await page.getByRole('button', { name: 'Submit' }).click();
-    await expect(
-      page.getByText('Successfully updated relationship.'),
-    ).toBeVisible();
+    await modelingHelper.executeRelationshipCRUD(page, {
+      fromFieldModelDisplayName: 'customers',
+      fromFieldColumnDisplayName: 'Id',
+      toFieldModelDisplayName: 'orders',
+      toFieldColumnDisplayName: 'CustomerId',
+      relationshipType: 'One-to-many',
+    });
   });
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -24,142 +24,20 @@ test.describe('Test E-commerce sample dataset', () => {
   });
 
   test('Use suggestion question', async ({ page, baseURL }) => {
-    await page.goto('/');
-    await expect(page).toHaveURL('/home', { timeout: 60000 });
-
     // select first suggested question
-    const suggestedQuestion = suggestedQuestions[0];
-    await page.getByText(suggestedQuestion).click();
-
-    // check asking process state and wait for asking task to finish
-    await homeHelper.checkAskingProcess(page, suggestedQuestions[0]);
-    await homeHelper.waitingForAskingTask(page, baseURL);
-    await homeHelper.checkCandidatesResult(page);
-
-    const firstResult = await homeHelper.getFirstCandidatesResultSummary(page);
-    await page.getByRole('cell', { name: firstResult }).first().click();
-
-    await homeHelper.checkSkeletonLoading(page, true);
-    await homeHelper.waitingForThreadResponse(page, baseURL);
-    await homeHelper.checkSkeletonLoading(page, false);
-
-    // check question block
-    await expect(
-      page.getByLabel('question-circle').locator('svg'),
-    ).toBeVisible();
-    await expect(page.getByText('Question:')).toBeVisible();
-    await expect(page.getByText(suggestedQuestion)).toBeVisible();
-
-    // check thread summary
-    await expect(
-      page.getByRole('heading', { name: firstResult }),
-    ).toBeVisible();
-
-    // check show preview data table as default open
-    await expect(page.locator('.ant-table')).toBeVisible();
-    await expect(page.getByText('Showing up to 500 rows')).toBeVisible();
-
-    // check up-circle icon with Collapse button
-    await expect(page.getByLabel('up-circle').locator('svg')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Collapse' })).toBeVisible();
-
-    // click View Full SQL button
-    await page.getByRole('button', { name: 'View Full SQL' }).click();
-    await expect(page.locator('.ace_editor')).toBeVisible();
-
-    // check collapse and copy button
-    await expect(page.getByLabel('up-circle').locator('svg')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Collapse' })).toBeVisible();
-    await expect(page.getByLabel('copy').locator('svg')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible();
-
-    // check save icon button
-    await expect(page.getByLabel('save').locator('svg')).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Save as View' }),
-    ).toBeVisible();
+    await homeHelper.askSuggestionQuestionTest({
+      page,
+      baseURL,
+      suggestedQuestion: suggestedQuestions[1],
+    });
   });
 
   test('Follow up question', async ({ page, baseURL }) => {
-    await page.goto('/');
-    await expect(page).toHaveURL('/home', { timeout: 60000 });
-
-    // click existing thread
-    await page
-      .getByRole('tree')
-      .locator('div')
-      .filter({ hasText: /\W/ })
-      .nth(2)
-      .click();
-
-    const question =
-      'What are the total sales values for each quarter of each year?';
-
-    // ask follow up question
-    await page.getByPlaceholder('Ask to explore your data').fill(question);
-    await page.getByRole('button', { name: 'Ask' }).click();
-
-    // check asking process state and wait for asking task to finish
-    await homeHelper.checkAskingProcess(page, question);
-    await homeHelper.waitingForAskingTask(page, baseURL);
-    await homeHelper.checkCandidatesResult(page);
-
-    // click the View SQL
-    await page
-      .getByRole('cell', { name: 'Result 1 function View SQL' })
-      .getByRole('button')
-      .click();
-    await page.getByLabel('Close', { exact: true }).click();
-
-    const firstResult = await homeHelper.getFirstCandidatesResultSummary(page);
-    await page.getByRole('cell', { name: firstResult }).click();
-
-    await homeHelper.checkSkeletonLoading(page, true);
-    await homeHelper.waitingForThreadResponse(page, baseURL);
-    await homeHelper.checkSkeletonLoading(page, false);
-
-    // check question block
-    await expect(
-      page.getByLabel('question-circle').locator('svg').last(),
-    ).toBeVisible();
-    await expect(page.getByText('Question:').last()).toBeVisible();
-    await expect(page.getByText(question)).toBeVisible();
-
-    // check thread summary
-    await expect(
-      page.getByRole('heading', { name: firstResult }),
-    ).toBeVisible();
-
-    await expect(page.locator('.ant-table').last()).toBeVisible();
-    await expect(page.getByText('Showing up to 500 rows').last()).toBeVisible();
-
-    // check up-circle icon with Collapse button
-    await expect(
-      page.getByLabel('up-circle').locator('svg').last(),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Collapse' }).last(),
-    ).toBeVisible();
-
-    // click View Full SQL button
-    await page.getByRole('button', { name: 'View Full SQL' }).last().click();
-
-    await expect(page.locator('.ace_editor')).toBeVisible();
-
-    // check collapse and copy button
-    await expect(
-      page.getByLabel('up-circle').locator('svg').last(),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Collapse' }).last(),
-    ).toBeVisible();
-    await expect(page.getByLabel('copy').locator('svg')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible();
-
-    // check save icon button
-    await expect(page.getByLabel('save').locator('svg').last()).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Save as View' }).last(),
-    ).toBeVisible();
+    await homeHelper.followUpQuestionTest({
+      page,
+      baseURL,
+      question:
+        'What are the total sales values for each quarter of each year?',
+    });
   });
 });

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import * as helper from '../helper';
 import * as homeHelper from '../commonTests/home';
+import * as modelingHelper from '../commonTests/modeling';
 
 const suggestedQuestions = [
   'What are the top 3 value for orders placed by customers in each city?',
@@ -23,6 +24,8 @@ test.describe('Test E-commerce sample dataset', () => {
     }
   });
 
+  test('Check should be in Synced status', modelingHelper.checkDeploySynced);
+
   test('Use suggestion question', async ({ page, baseURL }) => {
     // select first suggested question
     await homeHelper.askSuggestionQuestionTest({
@@ -39,5 +42,282 @@ test.describe('Test E-commerce sample dataset', () => {
       question:
         'What are the total sales values for each quarter of each year?',
     });
+  });
+
+  test('Model CRUD successfully', async ({ page }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    const modelDisplayName = 'customers';
+
+    // click sidebar customers model
+    await page.getByRole('complementary').getByText(modelDisplayName).click();
+
+    // delete model
+    await page
+      .locator('div')
+      .filter({ hasText: new RegExp(`^${modelDisplayName}$`) })
+      .getByRole('button')
+      .click();
+    await page.getByText('Delete', { exact: true }).click();
+    await expect(
+      page
+        .getByRole('dialog')
+        .locator('div')
+        .filter({ hasText: 'Are you sure you want to delete this model?' })
+        .nth(1),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByText('Successfully deleted model.')).toBeVisible();
+
+    // check customers model is deleted
+    await expect(
+      page.getByRole('complementary').getByText(modelDisplayName),
+    ).toBeHidden();
+
+    // add model back
+    await page
+      .locator('div')
+      .filter({ hasText: /^Models\(\d\)$/ })
+      .locator('path')
+      .first()
+      .click();
+
+    // chkeck Model drawer open
+    await expect(page.locator('.ant-drawer-mask')).toBeVisible();
+    await expect(
+      page
+        .locator('div')
+        .filter({ hasText: /^Create a data model$/ })
+        .first(),
+    ).toBeVisible();
+
+    // select customers table and some columns
+    await page.getByLabel('Select a table').click();
+    await page.getByTitle(modelDisplayName).locator('div').click();
+    await page
+      .getByRole('row', { name: /^Id .*/ })
+      .getByLabel('')
+      .check();
+
+    await page.getByRole('button', { name: 'right' }).click();
+
+    // set Id as primary key
+    await page.getByLabel('Select primary key').click();
+    await page.locator('form').getByTitle('Id').locator('div').click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page.getByText('Successfully created model.')).toBeVisible();
+
+    // check customers model is added
+    await expect(
+      page.getByRole('complementary').getByText(modelDisplayName),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('diagram__model-node__customers'),
+    ).toBeVisible();
+
+    // update columns
+    await page
+      .locator('div')
+      .filter({ hasText: new RegExp(`^${modelDisplayName}$`) })
+      .getByRole('button')
+      .click();
+    await page.getByText('Update Columns').click();
+    await page.getByLabel('', { exact: true }).first().check();
+    await page.getByRole('button', { name: 'right' }).click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page.getByText('Successfully updated model.')).toBeVisible();
+  });
+
+  test('Add relationship successfully', async ({ page }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    // Following the previous test, we assume the customers model is created, and it's have not any relationships
+    const modelDisplayName = 'customers';
+    const toFieldModelDisplayName = 'orders';
+
+    // add relationship
+    await page
+      .locator('div')
+      .filter({ hasText: /^Relationships$/ })
+      .getByRole('button')
+      .first()
+      .click();
+
+    // check relationship modal open
+    await expect(
+      page
+        .locator('div')
+        .filter({
+          hasText: 'Add relationship',
+        })
+        .nth(2),
+    ).toBeVisible();
+    await expect(page.getByText('Add relationship')).toBeVisible();
+
+    // from field
+    await page.getByTestId('common__fields-select').first().click();
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: 'Id' })
+      .click();
+
+    // to field
+    await page.getByTestId('common__models-select').last().click();
+    await page
+      .getByTestId('common__models__select-option')
+      .filter({ hasText: 'orders' })
+      .click();
+    await page.getByTestId('common__fields-select').last().click();
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: 'CustomerId' })
+      .click();
+
+    // type
+    await page.getByTestId('relationship-form__type-select').click();
+    await page.getByText('One-to-many').click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(
+      page.getByText('Successfully created relationship.'),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`diagram__model-node__${modelDisplayName}`)
+        .getByTitle(toFieldModelDisplayName),
+    ).toBeVisible();
+  });
+
+  test(
+    'Check deploy is Undeployed changes',
+    modelingHelper.checkDeployUndeployedChanges,
+  );
+
+  test('Relationship CRUD successfully', async ({ page }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    const modelDisplayName = 'customers';
+    const toFieldModelDisplayName = 'orders';
+
+    await page.getByRole('complementary').getByText(modelDisplayName).click();
+
+    // delete relationship
+    await page
+      .getByTestId(`diagram__model-node__${modelDisplayName}`)
+      .getByRole('button', { name: 'more' })
+      .nth(1)
+      .click();
+    await page.getByText('Delete', { exact: true }).click();
+
+    // check delete relationship modal open
+    await expect(
+      page
+        .getByRole('dialog')
+        .locator('div')
+        .filter({
+          hasText: 'Are you sure you want to delete this relationship?',
+        })
+        .nth(1),
+    ).toBeVisible();
+    await expect(
+      page.getByText('Are you sure you want to delete this relationship?'),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(
+      page.getByText('Successfully deleted relationship.'),
+    ).toBeVisible();
+
+    // check relationship is deleted
+    await expect(
+      page
+        .getByTestId(`diagram__model-node__${modelDisplayName}`)
+        .getByTitle(toFieldModelDisplayName),
+    ).toBeHidden();
+
+    // add relationship
+    await page
+      .locator('div')
+      .filter({ hasText: /^Relationships$/ })
+      .getByRole('button')
+      .first()
+      .click();
+
+    // check relationship modal open
+    await expect(
+      page
+        .locator('div')
+        .filter({
+          hasText: 'Add relationship',
+        })
+        .nth(2),
+    ).toBeVisible();
+    await expect(page.getByText('Add relationship')).toBeVisible();
+
+    // from field
+    await page.getByTestId('common__fields-select').first().click();
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: 'Id' })
+      .click();
+
+    // to field
+    await page.getByTestId('common__models-select').last().click();
+    await page
+      .getByTestId('common__models__select-option')
+      .filter({ hasText: 'orders' })
+      .click();
+    await page.getByTestId('common__fields-select').last().click();
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: 'CustomerId' })
+      .click();
+
+    // type
+    await page.getByTestId('relationship-form__type-select').click();
+    await page.getByText('One-to-one').click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(
+      page.getByText('Successfully created relationship.'),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId(`diagram__model-node__${modelDisplayName}`)
+        .getByTitle(toFieldModelDisplayName),
+    ).toBeVisible();
+
+    // update relationship
+    await page.getByRole('complementary').getByText(modelDisplayName).click();
+    await page
+      .getByTestId(`diagram__model-node__${modelDisplayName}`)
+      .getByRole('button', { name: 'more' })
+      .nth(1)
+      .click();
+
+    await page.getByText('Edit').click();
+    await expect(
+      page
+        .locator('div')
+        .filter({
+          hasText: 'Update relationship',
+        })
+        .nth(2),
+    ).toBeVisible();
+    await expect(page.getByText('Update relationship')).toBeVisible();
+
+    await page.getByTestId('relationship-form__type-select').click();
+    await page.getByTitle('One-to-many').locator('div').click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(
+      page.getByText('Successfully updated relationship.'),
+    ).toBeVisible();
   });
 });

--- a/wren-ui/e2e/specs/connectSampleNBA.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleNBA.spec.ts
@@ -113,4 +113,17 @@ test.describe('Test NBA sample dataset', () => {
       },
     );
   });
+
+  test('Update view metadata successfully', async ({ page, baseURL }) => {
+    await modelingHelper.updateViewMetadata(
+      { page, baseURL },
+      {
+        viewDisplayName: 'teams with highest average points per game',
+        viewDescription: '',
+        newViewDisplayName: 'teams with the top average points per game',
+        newViewDescription:
+          'Describe the team with the highest average points scored per game',
+      },
+    );
+  });
 });

--- a/wren-ui/e2e/specs/connectSampleNBA.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleNBA.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import * as helper from '../helper';
 import * as homeHelper from '../commonTests/home';
+import * as modelingHelper from '../commonTests/modeling';
 
 const suggestedQuestions = [
   'How many three-pointers were made by each player in each game?',
@@ -23,6 +24,8 @@ test.describe('Test NBA sample dataset', () => {
     }
   });
 
+  test('Check should be in Synced status', modelingHelper.checkDeploySynced);
+
   test('Use suggestion question', async ({ page, baseURL }) => {
     // select first suggested question
     await homeHelper.askSuggestionQuestionTest({
@@ -37,6 +40,42 @@ test.describe('Test NBA sample dataset', () => {
       page,
       baseURL,
       question: 'Which player has made the most three-pointers?',
+    });
+  });
+
+  test('Model CRUD successfully', async ({ page }) => {
+    await modelingHelper.executeModelCRUD(page, {
+      modelDisplayName: 'player',
+      primaryKeyColumn: 'Id',
+    });
+  });
+
+  test('Add relationship successfully', async ({ page }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    // Following the previous test, we assume the customers model is created, and it's have not any relationships
+    await modelingHelper.addRelationship(page, {
+      fromFieldModelDisplayName: 'player',
+      fromFieldColumnDisplayName: 'TeamId',
+      toFieldModelDisplayName: 'team',
+      toFieldColumnDisplayName: 'Id',
+      relationshipType: 'One-to-one',
+    });
+  });
+
+  test(
+    'Check deploy is Undeployed changes',
+    modelingHelper.checkDeployUndeployedChanges,
+  );
+
+  test('Relationship CRUD successfully', async ({ page }) => {
+    await modelingHelper.executeRelationshipCRUD(page, {
+      fromFieldModelDisplayName: 'player',
+      fromFieldColumnDisplayName: 'TeamId',
+      toFieldModelDisplayName: 'team',
+      toFieldColumnDisplayName: 'Id',
+      relationshipType: 'One-to-one',
     });
   });
 });

--- a/wren-ui/e2e/specs/connectSampleNBA.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleNBA.spec.ts
@@ -24,7 +24,10 @@ test.describe('Test NBA sample dataset', () => {
     }
   });
 
-  test('Check should be in Synced status', modelingHelper.checkDeploySynced);
+  test(
+    'Check deploy status should be in Synced status',
+    modelingHelper.checkDeploySynced,
+  );
 
   test('Use suggestion question', async ({ page, baseURL }) => {
     // select first suggested question
@@ -65,7 +68,7 @@ test.describe('Test NBA sample dataset', () => {
   });
 
   test(
-    'Check deploy is Undeployed changes',
+    'Check deploy status should be in Undeployed changes status',
     modelingHelper.checkDeployUndeployedChanges,
   );
 
@@ -77,5 +80,21 @@ test.describe('Test NBA sample dataset', () => {
       toFieldColumnDisplayName: 'Id',
       relationshipType: 'One-to-one',
     });
+  });
+
+  test('Update model metadata successfully', async ({ page }) => {
+    await modelingHelper.updateModelMetadata(page, {
+      modelDisplayName: 'team',
+      modelDescription:
+        'This table describes NBA teams by their ID, team name, team abbreviation, and founding date.',
+      newModelDisplayName: 'Team',
+      newModelDescription:
+        'The team data table describes NBA teams by their ID, team name, team abbreviation, and founding date.',
+    });
+  });
+
+  test('Trigger and check deploy MDL successfully', async ({ page }) => {
+    await modelingHelper.executeDeploy({ page });
+    await modelingHelper.checkDeploySynced({ page });
   });
 });

--- a/wren-ui/e2e/specs/connectSampleNBA.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleNBA.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
 import * as helper from '../helper';
+import * as homeHelper from '../commonTests/home';
+
+const suggestedQuestions = [
+  'How many three-pointers were made by each player in each game?',
+  'What is the differences in turnover rates between teams with high and low average scores?',
+  'Which teams had the highest average points scored per game throughout the season?',
+];
 
 test.describe('Test NBA sample dataset', () => {
   test.beforeAll(async () => {
@@ -10,20 +17,26 @@ test.describe('Test NBA sample dataset', () => {
     await page.goto('/setup/connection');
     await page.getByRole('button', { name: 'NBA' }).click();
     await expect(page).toHaveURL('/home', { timeout: 60000 });
-    await expect(
-      page.getByText(
-        'How many three-pointers were made by each player in each game?',
-      ),
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        'What is the differences in turnover rates between teams with high and low average scores?',
-      ),
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        'Which teams had the highest average points scored per game throughout the season?',
-      ),
-    ).toBeVisible();
+
+    for (const question of suggestedQuestions) {
+      await expect(page.getByText(question)).toBeVisible();
+    }
+  });
+
+  test('Use suggestion question', async ({ page, baseURL }) => {
+    // select first suggested question
+    await homeHelper.askSuggestionQuestionTest({
+      page,
+      baseURL,
+      suggestedQuestion: suggestedQuestions[0],
+    });
+  });
+
+  test('Follow up question', async ({ page, baseURL }) => {
+    await homeHelper.followUpQuestionTest({
+      page,
+      baseURL,
+      question: 'Which player has made the most three-pointers?',
+    });
   });
 });

--- a/wren-ui/e2e/specs/connectSampleNBA.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleNBA.spec.ts
@@ -93,8 +93,24 @@ test.describe('Test NBA sample dataset', () => {
     });
   });
 
-  test('Trigger and check deploy MDL successfully', async ({ page }) => {
-    await modelingHelper.executeDeploy({ page });
+  test('Trigger and check deploy MDL successfully', async ({
+    page,
+    baseURL,
+  }) => {
+    await modelingHelper.executeDeploy({ page, baseURL });
     await modelingHelper.checkDeploySynced({ page });
+  });
+
+  test('Save as view successfully', async ({ page, baseURL }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    await homeHelper.saveAsView(
+      { page, baseURL },
+      {
+        question: suggestedQuestions[2],
+        viewName: 'teams with highest average points per game',
+      },
+    );
   });
 });

--- a/wren-ui/e2e/specs/connectSampleNBA.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleNBA.spec.ts
@@ -126,4 +126,172 @@ test.describe('Test NBA sample dataset', () => {
       },
     );
   });
+
+  test('Calculated Fields CRUD successfully', async ({ page }) => {
+    await page.goto('/modeling');
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+
+    const modelDisplayName = 'game';
+    const cfName = 'count of games';
+    const expression = 'Sum';
+    const toFieldModelDisplayName = 'line_score';
+    const toFieldColumnDisplayName = 'GameId';
+    const newToFieldModelDisplayName = 'player_games';
+    const newToFieldColumnDisplayName = 'GameID';
+
+    await page
+      .getByRole('complementary')
+      .getByText(modelDisplayName, { exact: true })
+      .click();
+
+    // add calculated field
+    await page
+      .getByTestId(`diagram__model-node__${modelDisplayName}`)
+      .locator('div')
+      .filter({ hasText: /^Calculated Fields$/ })
+      .getByRole('button')
+      .first()
+      .click();
+
+    await expect(page.locator('.ant-modal-mask')).toBeVisible();
+    await expect(page.locator('div.ant-modal')).toBeVisible();
+    await expect(
+      page
+        .locator('div.ant-modal-title')
+        .filter({ hasText: 'Add calculated field' }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByLabel('Add calculated field')
+        .getByLabel('Close', { exact: true }),
+    ).toBeVisible();
+
+    await page.getByLabel('Name').click();
+    await page.getByLabel('Name').fill(cfName);
+
+    await page.getByTestId('common__descriptive-select').click();
+    await page.getByTitle(expression).locator('div').click();
+
+    await expect(page.getByTestId('common__lineage')).toBeVisible();
+
+    await expect(
+      page
+        .getByTestId('common__lineage-field-block')
+        .getByText(modelDisplayName, { exact: true }),
+    ).toBeVisible();
+
+    await page.getByTestId('common__lineage-fields-select').click();
+
+    // for skip disabled item
+    await page.getByTestId('common__lineage-fields-select').press('ArrowDown');
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: toFieldModelDisplayName })
+      .scrollIntoViewIfNeeded();
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: toFieldModelDisplayName })
+      .click();
+
+    await expect(
+      page
+        .getByTestId('common__lineage-field-block')
+        .getByText(toFieldModelDisplayName, { exact: true }),
+    ).toHaveCount(2);
+
+    await expect(page.getByText('Please select a field.')).toBeVisible();
+    await page.getByTestId('common__lineage-fields-select').last().click();
+
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: toFieldColumnDisplayName })
+      .scrollIntoViewIfNeeded();
+
+    await page
+      .getByTestId('common__fields__select-option')
+      .filter({ hasText: toFieldColumnDisplayName })
+      .click();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(
+      page.getByText('Successfully created calculated field.'),
+    ).toBeVisible();
+
+    // update calculated field
+    await page
+      .getByTestId(`diagram__model-node__${modelDisplayName}`)
+      .getByRole('button', { name: 'more' })
+      .nth(1)
+      .click();
+
+    await page.getByText('Edit').click();
+
+    await page
+      .getByTestId('common__lineage-field-block')
+      .filter({ hasText: toFieldModelDisplayName })
+      .getByText(toFieldColumnDisplayName, { exact: true })
+      .click();
+
+    await page
+      .getByTestId('common__lineage-fields-select')
+      .last()
+      .press('ArrowUp');
+    await page
+      .getByTestId('common__lineage-fields-select')
+      .last()
+      .press('ArrowUp');
+
+    await page
+      .getByTestId('common__fields__select-option')
+      .getByText(newToFieldModelDisplayName, { exact: true })
+      .scrollIntoViewIfNeeded();
+
+    await page
+      .getByTestId('common__fields__select-option')
+      .getByText(newToFieldModelDisplayName, { exact: true })
+      .click();
+    await expect(
+      page
+        .getByTestId('common__lineage-field-block')
+        .getByText(newToFieldModelDisplayName, { exact: true })
+        .last(),
+    ).toBeVisible();
+
+    await page.getByTestId('common__lineage-fields-select').last().click();
+    await page
+      .getByTestId('common__lineage-fields-select')
+      .last()
+      .press('ArrowDown');
+
+    await page
+      .getByTestId('common__fields__select-option')
+      .getByText(newToFieldColumnDisplayName, { exact: true })
+      .scrollIntoViewIfNeeded();
+
+    await page
+      .getByTestId('common__fields__select-option')
+      .getByText(newToFieldColumnDisplayName, { exact: true })
+      .click();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(
+      page.getByText('Successfully updated calculated field.'),
+    ).toBeVisible();
+
+    // delete calculated field
+    await page
+      .getByRole('complementary')
+      .getByText(modelDisplayName, { exact: true })
+      .click();
+    await page
+      .getByTestId(`diagram__model-node__${modelDisplayName}`)
+      .getByRole('button', { name: 'more' })
+      .nth(1)
+      .click();
+    await page.getByText('Delete', { exact: true }).click();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(
+      page.getByText('Successfully deleted calculated field.'),
+    ).toBeVisible();
+  });
 });

--- a/wren-ui/playwright.config.ts
+++ b/wren-ui/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   forbidOnly: false,
 
   // Retry on CI only.
-  retries: 2,
+  retries: 0,
 
   // Opt out of parallel tests on CI.
   workers: 1,

--- a/wren-ui/src/components/diagram/customNode/ModelNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ModelNode.tsx
@@ -61,7 +61,10 @@ export const ModelNode = ({ data }: CustomNodeProps<DiagramModel>) => {
   );
 
   return (
-    <StyledNode onClick={onNodeClick}>
+    <StyledNode
+      onClick={onNodeClick}
+      data-testid={`diagram__model-node__${data.originalData.displayName}`}
+    >
       <NodeHeader className="dragHandle">
         <span className="adm-model-header">
           <ModelIcon />

--- a/wren-ui/src/components/diagram/customNode/ViewNode.tsx
+++ b/wren-ui/src/components/diagram/customNode/ViewNode.tsx
@@ -40,7 +40,10 @@ export const ViewNode = ({ data }: CustomNodeProps<DiagramView>) => {
   );
 
   return (
-    <StyledNode onClick={onNodeClick}>
+    <StyledNode
+      onClick={onNodeClick}
+      data-testid={`diagram__view-node__${data.originalData.displayName}`}
+    >
       <NodeHeader className="dragHandle" color="var(--green-6)">
         <span className="adm-model-header">
           <ViewIcon />

--- a/wren-ui/src/components/modals/RelationModal.tsx
+++ b/wren-ui/src/components/modals/RelationModal.tsx
@@ -163,6 +163,7 @@ export default function RelationModal(props: Props) {
           ]}
         >
           <Select
+            data-testid="relationship-form__type-select"
             options={relationTypeOptions}
             placeholder="Select a relationship type"
           />

--- a/wren-ui/src/components/pages/home/prompt/Result.tsx
+++ b/wren-ui/src/components/pages/home/prompt/Result.tsx
@@ -89,7 +89,7 @@ const ResultTemplate = ({ index, summary, sql, view, onSelect, onShowSQL }) => {
                     className="text-md geekblue-6 mr-2"
                     style={{ marginTop: 2 }}
                   />
-                  <div>
+                  <div style={{ width: '90%', wordBreak: 'break-all' }}>
                     This search result corresponds to a saved view:{' '}
                     <Link
                       href={`${Path.Modeling}?viewId=${view.id}&openMetadata=true`}

--- a/wren-ui/src/components/pages/modeling/metadata/EditBasicMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/EditBasicMetadata.tsx
@@ -40,15 +40,15 @@ export default function EditBasicMetadata(props: Props) {
       {isModel && (
         <Row>
           <Col span={12}>
-            <div className="mb-6">
+            <div className="mb-6" data-testid="edit-metadata__name">
               <Typography.Text className="d-block gray-7 mb-2">
                 Name
               </Typography.Text>
               <div>{data.referenceName}</div>
             </div>
           </Col>
-          <Col span={12}>
-            <div className="mb-6">
+          <Col span={12} data-testid="edit-metadata__alias">
+            <div className="mb-6" data-testid="metadata__name">
               <Typography.Text className="d-block gray-7 mb-2">
                 Alias
               </Typography.Text>
@@ -65,7 +65,7 @@ export default function EditBasicMetadata(props: Props) {
       )}
 
       {isView && (
-        <div className="mb-6">
+        <div className="mb-6" data-testid="edit-metadata__name">
           <Typography.Text className="d-block gray-7 mb-2">
             Name
           </Typography.Text>
@@ -80,7 +80,7 @@ export default function EditBasicMetadata(props: Props) {
         </div>
       )}
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="edit-metadata__description">
         <Typography.Text className="d-block gray-7 mb-2">
           Description
         </Typography.Text>

--- a/wren-ui/src/components/pages/modeling/metadata/ModelMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/ModelMetadata.tsx
@@ -44,27 +44,27 @@ export default function ModelMetadata(props: Props) {
   return (
     <>
       <Row className="mb-6">
-        <Col span={12}>
+        <Col span={12} data-testid="metadata__name">
           <Typography.Text className="d-block gray-7 mb-2">
             Name
           </Typography.Text>
           <div>{referenceName || '-'}</div>
         </Col>
-        <Col span={12}>
+        <Col span={12} data-testid="metadata__alias">
           <Typography.Text className="d-block gray-7 mb-2">
             Alias
           </Typography.Text>
           <div>{displayName || '-'}</div>
         </Col>
       </Row>
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__description">
         <Typography.Text className="d-block gray-7 mb-2">
           Description
         </Typography.Text>
         <div>{description || '-'}</div>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__columns">
         <Typography.Text className="d-block gray-7 mb-2">
           Columns ({fields.length})
         </Typography.Text>
@@ -72,7 +72,7 @@ export default function ModelMetadata(props: Props) {
       </div>
 
       {!!calculatedFields.length && (
-        <div className="mb-6">
+        <div className="mb-6" data-testid="metadata__calculated-fields">
           <Typography.Text className="d-block gray-7 mb-2">
             Calculated fields ({calculatedFields.length})
           </Typography.Text>
@@ -81,7 +81,7 @@ export default function ModelMetadata(props: Props) {
       )}
 
       {!!relationFields.length && (
-        <div className="mb-6">
+        <div className="mb-6" data-testid="metadata__relationships">
           <Typography.Text className="d-block gray-7 mb-2">
             Relationships ({relationFields.length})
           </Typography.Text>
@@ -89,7 +89,7 @@ export default function ModelMetadata(props: Props) {
         </div>
       )}
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__preview-data">
         <Typography.Text className="d-block gray-7 mb-2">
           Data preview (100 rows)
         </Typography.Text>

--- a/wren-ui/src/components/pages/modeling/metadata/ViewMetadata.tsx
+++ b/wren-ui/src/components/pages/modeling/metadata/ViewMetadata.tsx
@@ -28,19 +28,19 @@ export default function ViewMetadata(props: Props) {
   // View only can input Name (alias), so it should show alias as Name in metadata.
   return (
     <>
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__name">
         <Typography.Text className="d-block gray-7 mb-2">Name</Typography.Text>
         <div>{displayName || '-'}</div>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__description">
         <Typography.Text className="d-block gray-7 mb-2">
           Description
         </Typography.Text>
         <div>{description || '-'}</div>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__columns">
         <Typography.Text className="d-block gray-7 mb-2">
           Columns ({fields.length})
         </Typography.Text>
@@ -51,14 +51,14 @@ export default function ViewMetadata(props: Props) {
         />
       </div>
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__sql-statement">
         <Typography.Text className="d-block gray-7 mb-2">
           SQL statement
         </Typography.Text>
         <CodeBlock code={statement} showLineNumbers maxHeight="300" />
       </div>
 
-      <div className="mb-6">
+      <div className="mb-6" data-testid="metadata__preview-data">
         <Typography.Text className="d-block gray-7 mb-2">
           Data preview (100 rows)
         </Typography.Text>

--- a/wren-ui/src/components/selectors/CombineFieldSelector.tsx
+++ b/wren-ui/src/components/selectors/CombineFieldSelector.tsx
@@ -70,6 +70,7 @@ export default function CombineFieldSelector(props: Props) {
         disabled={modelDisabled}
         showSearch
         optionFilterProp="label"
+        data-testid="common__models-select"
       />
       <Select
         className="flex-grow-1"
@@ -80,6 +81,7 @@ export default function CombineFieldSelector(props: Props) {
         disabled={fieldDisabled}
         showSearch
         optionFilterProp="label"
+        data-testid="common__fields-select"
       />
     </Input.Group>
   );

--- a/wren-ui/src/components/selectors/DescriptiveSelector.tsx
+++ b/wren-ui/src/components/selectors/DescriptiveSelector.tsx
@@ -131,6 +131,7 @@ export default function DescriptiveSelector(props: Props) {
       listHeight={maxHeight}
       placeholder={placeholder}
       dropdownMatchSelectWidth={dropdownMatchSelectWidth}
+      data-testid="common__descriptive-select"
     />
   );
 }

--- a/wren-ui/src/components/selectors/Selector.tsx
+++ b/wren-ui/src/components/selectors/Selector.tsx
@@ -18,6 +18,7 @@ const getOption = (item) => {
   return {
     ...item,
     value,
+    'data-testid': 'common__fields__select-option',
   };
 };
 

--- a/wren-ui/src/components/selectors/lineageSelector/FieldSelect.tsx
+++ b/wren-ui/src/components/selectors/lineageSelector/FieldSelect.tsx
@@ -115,7 +115,10 @@ export default function FieldSelect(props: IterableComponent<Props>) {
   };
 
   return isModelOrRelationshipNode ? (
-    <FieldBox className="adm-fieldBox flex-shrink-0">
+    <FieldBox
+      className="adm-fieldBox flex-shrink-0"
+      data-testid="common__lineage-field-block"
+    >
       <FieldHeader className="py-1 px-3">
         <ModelIcon className="mr-1 flex-shrink-0" />
         <div
@@ -142,6 +145,7 @@ export default function FieldSelect(props: IterableComponent<Props>) {
         onSelect={(value) => {
           onChange && onChange(value, index);
         }}
+        data-testid="common__lineage-fields-select"
       />
     </FieldBox>
   ) : null;

--- a/wren-ui/src/components/selectors/lineageSelector/index.tsx
+++ b/wren-ui/src/components/selectors/lineageSelector/index.tsx
@@ -82,6 +82,7 @@ export default function LineageSelector(props: Props) {
       className={`d-flex align-center bg-gray-3 px-8 py-12${
         status ? ` adm-${status}` : ''
       }`}
+      data-testid="common__lineage"
     >
       <SelectResult
         data={data}

--- a/wren-ui/src/hooks/useCombineFieldOptions.tsx
+++ b/wren-ui/src/hooks/useCombineFieldOptions.tsx
@@ -121,6 +121,7 @@ export default function useCombineFieldOptions(props: Props) {
       filteredModels.map((model) => ({
         label: model.displayName,
         value: convertObjectToIdentifier(model, modelKeys),
+        'data-testid': 'common__models__select-option',
       })),
     [filteredModels],
   );
@@ -135,6 +136,7 @@ export default function useCombineFieldOptions(props: Props) {
       (selectedModel?.fields || []).map((field) => ({
         label: field.displayName,
         value: convertObjectToIdentifier(field, fieldKeys),
+        'data-testid': 'common__fields__select-option',
       })),
     [selectedModel],
   );


### PR DESCRIPTION
## Description
 - add some basic checks for the sample datasets
 - add save recommended relationships test

## Tasks
 - Adjust UI style and add **data-testid**
 - For data source
   - add save recommended relationships test
 - For sample datasets
   - model CRUD test
   - relationship CRUD tests
   - update model metadata test
   - save as view test (include check offer view result)
   - update view metadata test
   - check deploy status tests (Synced & Undeployed changes)
   - execute deploy MDL test
 - Add calculated field CRUD test for NBA sample dataset

### UI screenshots
![截圖 2024-05-31 下午3 11 17](https://github.com/Canner/WrenAI/assets/42527625/b1683ae2-19e5-4999-878f-4a1dc50b6caf)


 ## Test Result
```bash
➜   yarn test:e2e
yarn run v1.22.19
warning ../../../../package.json: No license field

warning ../../../../package.json: No license field
[WebServer]  ⚠ Invalid next.config.js options detected:
[WebServer]  ⚠     Unrecognized key(s) in object: 'lessVarsFilePath', 'lessVarsFilePathAppendToEndOfContent'
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
[WebServer]  ⚠ "next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.


Running 42 tests using 1 worker
[setup db] › global.setup.ts:4:6 › create new database
creating new database...
created successfully.
[cleanup db] › global.teardown.ts:4:6 › delete database
deleting test database...
deleted successfully.
  Slow test file: [chromium] › specs/connectSampleNBA.spec.ts (2.0m)
  Slow test file: [chromium] › specs/connectSampleECommerce.spec.ts (1.8m)
  Consider splitting slow test files to speed up parallel execution
  6 skipped
  36 passed (4.2m)

To open last HTML report run:

  yarn playwright show-report

✨  Done in 254.22s.
```
![BQ_and_DuckDB](https://github.com/Canner/WrenAI/assets/42527625/bacb4e9f-f4a5-4cb7-a615-39191e0531a4)
![PG](https://github.com/Canner/WrenAI/assets/42527625/12f60132-1361-4948-a906-07c10705bbbf)
![ECommerce](https://github.com/Canner/WrenAI/assets/42527625/bb3217f6-5084-4f3c-9fd5-ca55d2286c7b)
<img width="1440" alt="截圖 2024-06-04 上午7 38 25" src="https://github.com/Canner/WrenAI/assets/42527625/bf7e11d3-3301-4d8b-b36c-64f1c78cc20c">
