### PR TITLE
chore(wren-ai-service): move the development purpose API to the development router

### DIFF
--- a/wren-ai-service/src/__main__.py
+++ b/wren-ai-service/src/__main__.py
@@ -1,7 +1,5 @@
-import asyncio
 import logging
 import os
-import time
 from contextlib import asynccontextmanager
 
 import uvicorn
@@ -74,20 +72,6 @@ def root():
 @app.get("/health")
 def health():
     return {"status": "ok"}
-
-
-@app.get("/dummy")
-async def dummy(sleep: int = 4, is_async: bool = True, should_sleep: bool = True):
-    """
-    Dummy endpoint to test async behavior by sleeping for several seconds
-    """
-    if should_sleep:
-        if is_async:
-            await asyncio.sleep(sleep)
-        else:
-            time.sleep(sleep)
-
-    return {"status": "dummy"}
 
 
 if __name__ == "__main__":

--- a/wren-ai-service/src/__main__.py
+++ b/wren-ai-service/src/__main__.py
@@ -36,7 +36,6 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan, redoc_url=None)
 
-app.include_router(routers.router, prefix="/v1")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -44,6 +43,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.include_router(routers.router, prefix="/v1")
+if os.getenv("ENV") == "dev":
+    from src.web import development
+
+    app.include_router(development.router, prefix="/dev")
 
 
 @app.exception_handler(Exception)

--- a/wren-ai-service/src/web/development.py
+++ b/wren-ai-service/src/web/development.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/dummy")
+async def hello():
+    return {"message": "Hello World"}

--- a/wren-ai-service/src/web/development.py
+++ b/wren-ai-service/src/web/development.py
@@ -1,8 +1,20 @@
+import asyncio
+import time
+
 from fastapi import APIRouter
 
 router = APIRouter()
 
 
 @router.get("/dummy")
-async def hello():
-    return {"message": "Hello World"}
+async def dummy(sleep: int = 4, is_async: bool = True, should_sleep: bool = True):
+    """
+    Dummy endpoint to test async behavior by sleeping for several seconds
+    """
+    if should_sleep:
+        if is_async:
+            await asyncio.sleep(sleep)
+        else:
+            time.sleep(sleep)
+
+    return {"status": "dummy"}

--- a/wren-ai-service/tests/locust/locustfile.py
+++ b/wren-ai-service/tests/locust/locustfile.py
@@ -230,4 +230,4 @@ class AskDetailsUser(FastHttpUser):
 class DummyUser(FastHttpUser):
     @task
     def dummy(self):
-        self.client.get(url="/dummy")
+        self.client.get(url="/dev/dummy")


### PR DESCRIPTION
This PR aims to move the development-related Web API to a separate router, which can be enabled via an environment variable. When the environment is set to `dev`, FastAPI will display these APIs.

## Screenshots
- when env is dev

<img width="1515" alt="image" src="https://github.com/Canner/WrenAI/assets/52045032/68aacf7f-c774-4dcb-8085-21f11571ac55">

- when env is not dev

<img width="1515" alt="image" src="https://github.com/Canner/WrenAI/assets/52045032/dea5f2be-b0cd-44e3-b468-42254edd72c7">
