### PR TITLE
WORKERS & wren-engine-svc

### DIFF
--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -23,7 +23,7 @@ data:
   TELEMETRY_ENABLED: "false"
   
   # service endpoints of AI service & engine service
-  WREN_ENGINE_ENDPOINT: "https://wren-ui.myhost.net"
+  WREN_ENGINE_ENDPOINT: "http://wren-engine-svc:8080"
   WREN_AI_ENDPOINT: "http://wren-ai-service:5555"
   #WREN_AI_ENDPOINT: "http://wren-ai-service.ai-system.svc.cluster.local:5555"
 

--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -24,8 +24,8 @@ data:
   
   # service endpoints of AI service & engine service
   WREN_ENGINE_ENDPOINT: "http://wren-engine-svc:8080"
-  WREN_AI_ENDPOINT: "http://wren-ai-service:5555"
-  #WREN_AI_ENDPOINT: "http://wren-ai-service.ai-system.svc.cluster.local:5555"
+  WREN_AI_ENDPOINT: "http://wren-ai-service-svc:5555"
+  #WREN_AI_ENDPOINT: "http://wren-ai-service-svc.ai-system.svc.cluster.local:5555"
 
   # "sqlite", or "pg" for postgres as UI application database
   DB_TYPE: pg

--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -26,7 +26,7 @@ data:
   WREN_ENGINE_ENDPOINT: "http://wren-engine-svc:8080"
   WREN_AI_ENDPOINT: "http://wren-ai-service-svc:5555"
   #WREN_AI_ENDPOINT: "http://wren-ai-service-svc.ai-system.svc.cluster.local:5555"
-  AI_SERVICE_WORKERS: "4"
+  AI_SERVICE_WORKERS: "1"
   # "sqlite", or "pg" for postgres as UI application database
   DB_TYPE: pg
 

--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -26,7 +26,7 @@ data:
   WREN_ENGINE_ENDPOINT: "http://wren-engine-svc:8080"
   WREN_AI_ENDPOINT: "http://wren-ai-service-svc:5555"
   #WREN_AI_ENDPOINT: "http://wren-ai-service-svc.ai-system.svc.cluster.local:5555"
-
+  AI_SERVICE_WORKERS: "4"
   # "sqlite", or "pg" for postgres as UI application database
   DB_TYPE: pg
 
@@ -35,4 +35,4 @@ data:
   #For bootstrap
   DATA_PATH: "/app/data"
 
-  ### if DB_TYPE = "postgres" you must provide PG_URL string in the *Secret* manifest file (deployment/kustomizations/examples/secret-wren_example.yaml) to connect to postgres  
+  ### if DB_TYPE = "postgres" you must provide PG_URL string in the *Secret* manifest file (deployment/kustomizations/examples/secret-wren_example.yaml) to connect to postgres

--- a/deployment/kustomizations/base/deploy-wren-ai-service.yaml
+++ b/deployment/kustomizations/base/deploy-wren-ai-service.yaml
@@ -21,6 +21,11 @@ spec:
               configMapKeyRef:
                 name: wren-config
                 key: WREN_AI_SERVICE_PORT
+          - name: WORKERS
+            valueFrom: 
+              configMapKeyRef:
+                name: wren-config
+                key: AI_SERVICE_WORKERS
           - name: OPENAI_API_KEY
             valueFrom: 
               secretKeyRef:

--- a/deployment/kustomizations/patches/cm.yaml
+++ b/deployment/kustomizations/patches/cm.yaml
@@ -22,7 +22,7 @@
     TELEMETRY_ENABLED: "false"
     
     # service endpoints of AI service & engine service
-    WREN_ENGINE_ENDPOINT: "https://wren-ui.myhost.net"
+    WREN_ENGINE_ENDPOINT: "http://wren-engine-svc:8080"
     #fix:
     WREN_AI_ENDPOINT: "http://wren-ai-service:5555"
 


### PR DESCRIPTION
WORKERS required for the deploy-wren-ai-service.yaml
wren-engine-svc is the correct dns name in k8s