### PR TITLE
fix(wren-ai-sevice): phony demo folder

### DIFF
--- a/wren-ai-service/Makefile
+++ b/wren-ai-service/Makefile
@@ -77,3 +77,5 @@ test:
 
 load-test:
 	poetry run python -m tests.locust.locust_script
+
+.PHONY: demo


### PR DESCRIPTION
I encountered an issue as follows when executing `make demo` command to start the demo-site streamlit app.
```zsh
✦2 ➜ make demo  
make: `demo' is up to date.
```

and the root cause is having a same-name folder over there. thus, need to declare the demo in the .PHONY

See also:
- https://stackoverflow.com/questions/3931741/why-does-make-think-the-target-is-up-to-date
- https://stackoverflow.com/questions/2145590/what-is-the-purpose-of-phony-in-a-makefile