### PR TITLE
Feature: support dry run in preview API

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -5,7 +5,11 @@ PLATFORM=linux/amd64
 WREN_ENGINE_PORT=8080
 WREN_ENGINE_SQL_PORT=7432
 WREN_AI_SERVICE_PORT=5555
+WREN_UI_PORT=3000
 IBIS_SERVER_PORT=8000
+
+# service endpoint (for docker-compose-dev.yaml file)
+WREN_UI_ENDPOINT=http://docker.for.mac.localhost:3000
 
 # version
 # CHANGE THIS TO THE LATEST VERSION

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -46,7 +46,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_GENERATION_MODEL: ${OPENAI_GENERATION_MODEL}
       QDRANT_HOST: qdrant
-      WREN_ENGINE_ENDPOINT: http://wren-engine:${WREN_ENGINE_PORT}
+      WREN_UI_ENDPOINT: ${WREN_UI_ENDPOINT}
       REDIS_HOST: ${AI_SERVICE_REDIS_HOST}
       REDIS_PORT: ${AI_SERVICE_REDIS_PORT}
       ENABLE_TIMER: ${AI_SERVICE_ENABLE_TIMER}
@@ -72,6 +72,7 @@ services:
       - ${IBIS_SERVER_PORT}:8000
     environment:
       WREN_ENGINE_ENDPOINT: http://wren-engine:${WREN_ENGINE_PORT}
+      LOG_LEVEL: DEBUG
     networks:
       - wren
 

--- a/wren-ui/src/apollo/server/models/model.ts
+++ b/wren-ui/src/apollo/server/models/model.ts
@@ -84,6 +84,7 @@ export interface CheckCalculatedFieldCanQueryData {
 
 export interface PreviewSQLData {
   sql: string;
-  projectId: number;
+  projectId?: number;
   limit?: number;
+  dryRun?: boolean;
 }

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -609,8 +609,9 @@ export const typeDefs = gql`
 
   input PreviewSQLDataInput {
     sql: String!
-    projectId: Int!
+    projectId: Int
     limit: Int
+    dryRun: Boolean
   }
 
   # Query and Mutation

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -471,11 +471,11 @@ export class AskingService implements IAskingService {
     const mdl = deployment.manifest;
     const steps = response.detail.steps;
     const sql = format(constructCteSql(steps, stepIndex));
-    const data = await this.queryService.preview(sql, {
+    const data = (await this.queryService.preview(sql, {
       project,
       mdl,
       limit,
-    });
+    })) as PreviewDataResponse;
 
     this.telemetry.send_event('preview_data', { sql });
     return data;


### PR DESCRIPTION
support dry run in preview API

## Example
### Request
```
mutation PreviewSql($data: PreviewSQLDataInput) { 
    previewSql(data: $data) 
}

{
  "data": {
    "dryRun": true,
    "limit": 1,
    "sql": "select * from public.orders"
  }
}

```

### Response
```
{
    "data": {
        "previewSql": {
            "dryRun": true
        }
    }
}
```