### PR TITLE
feat(wren-ui): Detects schema change - table & column

### DIFF
--- a/wren-ui/migrations/20240610070534_create_schema_change_table.js
+++ b/wren-ui/migrations/20240610070534_create_schema_change_table.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable('schema_change', (table) => {
+    table.increments('id').comment('ID');
+    table.integer('project_id').comment('Reference to project.id');
+
+    // schema change info
+    table.jsonb('change').nullable();
+    table.jsonb('resolve').nullable();
+
+    // timestamps
+    table.timestamps(true, true);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable('schema_change');
+};

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -211,7 +211,7 @@ export default class DataSourceSchemaDetector
       JSON.stringify(lastSchemaChange?.change) !== JSON.stringify(diffSchema);
 
     if (isNewSchemaChange) {
-      this.ctx.schemaChangeRepository.createOne({
+      await this.ctx.schemaChangeRepository.createOne({
         projectId: this.projectId,
         change: diffSchema,
         // Set the resolve to false if there are any changes. It will set resolve to true once the schema has been synced.

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -1,0 +1,195 @@
+import { differenceWith, isEmpty, isEqual } from 'lodash';
+import { CompactTable } from '@server/connectors/connector';
+import { DataSourceStrategyFactory } from '@server/factories/onboardingFactory';
+import { IContext } from '@server/types';
+import { getLogger } from 'log4js';
+
+const logger = getLogger('DataSourceSchemaDetector');
+logger.level = 'debug';
+
+type DataSourceSchema = {
+  name: string;
+  columns: {
+    name: string;
+    type: string;
+  }[];
+};
+
+type DataSourceSchemaChange = {
+  [SchemaChangeType.DELETED_TABLES]: DataSourceSchema[];
+  [SchemaChangeType.DELETED_COLUMNS]: DataSourceSchema[];
+  [SchemaChangeType.MODIFIED_COLUMNS]: DataSourceSchema[];
+};
+
+enum SchemaChangeType {
+  // the tables has been deleted
+  DELETED_TABLES = 'deletedTables',
+  // the columns has been deleted
+  DELETED_COLUMNS = 'deletedColumns',
+  // the columns type has been changed
+  MODIFIED_COLUMNS = 'modifiedColumns',
+}
+
+interface IDataSourceSchemaDetector {
+  detectSchemaChange(): Promise<void>;
+}
+
+export default class DataSourceSchemaDetector
+  implements IDataSourceSchemaDetector
+{
+  public ctx: IContext;
+  public projectId: string;
+
+  constructor({ ctx }: { ctx: IContext }) {
+    this.ctx = ctx;
+  }
+
+  public async detectSchemaChange() {
+    const diffSchema = await this.getDiffSchema();
+    if (diffSchema) {
+      this.addSchemaChange(diffSchema);
+    }
+  }
+
+  private async getDiffSchema() {
+    logger.info('Start to detect Data Source Schema changes.');
+    const currentSchema = await this.getCurrentSchema();
+    const latestSchema = await this.getLatestSchema();
+
+    const diffSchema = currentSchema.reduce((result, currentTable) => {
+      const lastestTable = latestSchema.find(
+        (table) => table.name === currentTable.name,
+      );
+      // If the table is not found in the latest schema, it means the table has been deleted.
+      if (!lastestTable) {
+        result[SchemaChangeType.DELETED_TABLES] = [
+          ...(result[SchemaChangeType.DELETED_TABLES] || []),
+          currentTable,
+        ];
+        return result;
+      }
+
+      // If the table is found in the latest schema, we need to diff the columns.
+      const diffColumns = differenceWith(
+        currentTable.columns,
+        lastestTable.columns,
+        isEqual,
+      );
+      if (diffColumns.length > 0) {
+        for (const currentColumn of diffColumns) {
+          const latestColumn = lastestTable.columns.find(
+            (column) => column.name === currentColumn.name,
+          );
+          // If the column is not found in the latest schema, it means the column has been deleted.
+          if (!latestColumn) {
+            result[SchemaChangeType.DELETED_COLUMNS] = [
+              ...(result[SchemaChangeType.DELETED_COLUMNS] || []),
+              { name: currentTable.name, columns: [currentColumn] },
+            ];
+            continue;
+          }
+
+          // If the column is found in the latest schema, it means the column has been modified.
+          result[SchemaChangeType.MODIFIED_COLUMNS] = [
+            ...(result[SchemaChangeType.MODIFIED_COLUMNS] || []),
+            {
+              name: currentTable.name,
+              // show the latest column type
+              columns: [latestColumn],
+            },
+          ];
+        }
+      }
+
+      return result;
+    }, {});
+
+    if (!isEmpty(diffSchema)) {
+      logger.debug('Diff Schema:', JSON.stringify(diffSchema));
+      logger.info('Data Source Schema has changed.');
+      return diffSchema as DataSourceSchemaChange;
+    }
+
+    logger.info('No changes in Data Source Schema.');
+    return null;
+  }
+
+  private async addSchemaChange(diffSchema: DataSourceSchemaChange) {
+    const project = await this.ctx.projectService.getCurrentProject();
+
+    const getResolveState = (change) => (!!change ? false : null);
+
+    const schemaChange = JSON.stringify(diffSchema);
+    const lastSchemaChange =
+      await this.ctx.schemaChangeRepository.findLastSchemaChange(project.id);
+    // If the schema change is the same as the last one, we don't need to create a new one.
+    const isNewSchemaChange = lastSchemaChange?.change !== schemaChange;
+
+    if (isNewSchemaChange) {
+      this.ctx.schemaChangeRepository.createOne({
+        projectId: project.id,
+        change: schemaChange,
+        // Set the resolve to false if there are any changes. It will set resolve to true once the schema has been synced.
+        resolve: JSON.stringify({
+          [SchemaChangeType.DELETED_TABLES]: getResolveState(
+            diffSchema[SchemaChangeType.DELETED_TABLES],
+          ),
+          [SchemaChangeType.DELETED_COLUMNS]: getResolveState(
+            diffSchema[SchemaChangeType.DELETED_COLUMNS],
+          ),
+          [SchemaChangeType.MODIFIED_COLUMNS]: getResolveState(
+            diffSchema[SchemaChangeType.MODIFIED_COLUMNS],
+          ),
+        }),
+      });
+    }
+  }
+
+  private async getCurrentSchema(): Promise<DataSourceSchema[]> {
+    const project = await this.ctx.projectService.getCurrentProject();
+    const models = await this.ctx.modelRepository.findAllBy({
+      projectId: project.id,
+    });
+    const modelIds = models.map((model) => model.id);
+    const modelColumns =
+      await this.ctx.modelColumnRepository.findColumnsByModelIds(modelIds);
+    const result = models.map((model) => {
+      return {
+        name: model.sourceTableName,
+        columns: modelColumns
+          .filter(
+            (column) => column.modelId === model.id && !column.isCalculated,
+          )
+          .map((column) => ({
+            name: column.sourceColumnName,
+            type: column.type,
+          })),
+      };
+    });
+    return result;
+  }
+
+  private async getLatestSchema(): Promise<DataSourceSchema[]> {
+    const project = await this.ctx.projectService.getCurrentProject();
+    const dataSourceType = project.type;
+    const strategy = DataSourceStrategyFactory.create(dataSourceType, {
+      ctx: this.ctx,
+      project,
+    });
+    const latestDataSourceTables = (await strategy.listTable({
+      formatToCompactTable: true,
+    })) as CompactTable[];
+    const result = latestDataSourceTables.map((table) => {
+      return {
+        name: table.name,
+        columns: table.columns.map((column) => {
+          return {
+            name: column.name,
+            type: column.type,
+          };
+        }),
+      };
+    });
+    return result;
+  }
+}

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -35,7 +35,7 @@ export enum SchemaChangeType {
 }
 
 export interface IDataSourceSchemaDetector {
-  detectSchemaChange(): Promise<void>;
+  detectSchemaChange(): Promise<boolean>;
   resolveSchemaChange(type: string): Promise<void>;
 }
 
@@ -53,8 +53,9 @@ export default class DataSourceSchemaDetector
   public async detectSchemaChange() {
     const diffSchema = await this.getDiffSchema();
     if (diffSchema) {
-      this.addSchemaChange(diffSchema);
+      await this.addSchemaChange(diffSchema);
     }
+    return !!diffSchema;
   }
 
   public async resolveSchemaChange(type: string) {

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -1,6 +1,4 @@
 import { camelCase, differenceWith, isEmpty, isEqual } from 'lodash';
-import { CompactTable } from '@server/connectors/connector';
-import { DataSourceStrategyFactory } from '@server/factories/onboardingFactory';
 import { IContext } from '@server/types';
 import { getLogger } from 'log4js';
 
@@ -264,14 +262,8 @@ export default class DataSourceSchemaDetector
     const project = await this.ctx.projectRepository.findOneBy({
       id: this.projectId,
     });
-    const dataSourceType = project.type;
-    const strategy = DataSourceStrategyFactory.create(dataSourceType, {
-      ctx: this.ctx,
-      project,
-    });
-    const latestDataSourceTables = (await strategy.listTable({
-      formatToCompactTable: true,
-    })) as CompactTable[];
+    const latestDataSourceTables =
+      await this.ctx.projectService.getProjectDataSourceTables(project);
     const result = latestDataSourceTables.map((table) => {
       return {
         name: table.name,

--- a/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
@@ -36,6 +36,11 @@ export interface IModelColumnRepository extends IBasicRepository<ModelColumn> {
   ): Promise<void>;
   resetModelPrimaryKey(modelId: number): Promise<void>;
   setModelPrimaryKey(modelId: number, sourceColumnName: string): Promise<void>;
+  deleteAllBySourceColumnNames(
+    modelId: number,
+    sourceColumnNames: string[],
+    queryOptions?: IQueryOptions,
+  ): Promise<number>;
 }
 
 export class ModelColumnRepository
@@ -95,5 +100,18 @@ export class ModelColumnRepository
     await this.knex<ModelColumn>('model_column')
       .where(this.transformToDBData({ modelId, sourceColumnName }))
       .update(this.transformToDBData({ isPk: true }));
+  }
+
+  public async deleteAllBySourceColumnNames(
+    modelId: number,
+    sourceColumnNames: string[],
+    queryOptions?: IQueryOptions,
+  ): Promise<number> {
+    const executer = queryOptions?.tx ? queryOptions.tx : this.knex;
+    const builder = executer(this.tableName)
+      .where(this.transformToDBData({ modelId }))
+      .whereIn('source_column_name', sourceColumnNames)
+      .delete();
+    return await builder;
   }
 }

--- a/wren-ui/src/apollo/server/repositories/schemaChangeRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/schemaChangeRepository.ts
@@ -1,11 +1,22 @@
 import { Knex } from 'knex';
 import { BaseRepository, IBasicRepository } from './baseRepository';
+import {
+  camelCase,
+  isPlainObject,
+  mapKeys,
+  mapValues,
+  snakeCase,
+} from 'lodash';
+import {
+  DataSourceSchemaChange,
+  DataSourceSchemaResolve,
+} from '@server/managers/dataSourceSchemaDetector';
 
 export interface SchemaChange {
   id: number; // ID
   projectId: number; // Reference to project.id
-  change: string; // Schema change in JSON format
-  resolve: string; // Save resolve in JSON format, for example: { "deletedTables": true, "deletedColumns": true, "modifiedColumns": false  }
+  change: DataSourceSchemaChange; // Schema change
+  resolve: DataSourceSchemaResolve; // Save resolve
 }
 
 export interface ISchemaChangeRepository
@@ -30,4 +41,36 @@ export class SchemaChangeRepository
       .first();
     return (res && this.transformFromDBData(res)) || null;
   }
+
+  protected override transformToDBData = (data: any) => {
+    if (!isPlainObject(data)) {
+      throw new Error('Unexpected dbdata');
+    }
+    const transformedData = mapValues(data, (value, key) => {
+      if (['change', 'resolve'].includes(key)) {
+        return value ? JSON.stringify(value) : null;
+      }
+      return value;
+    });
+    return mapKeys(transformedData, (_value, key) => snakeCase(key));
+  };
+
+  protected override transformFromDBData = (data: any): SchemaChange => {
+    if (!isPlainObject(data)) {
+      throw new Error('Unexpected dbdata');
+    }
+    const camelCaseData = mapKeys(data, (_value, key) => camelCase(key));
+    const formattedData = mapValues(camelCaseData, (value, key) => {
+      if (['change', 'resolve'].includes(key)) {
+        // The value from Sqlite will be string type, while the value from PG is JSON object
+        if (typeof value === 'string') {
+          return value ? JSON.parse(value) : value;
+        } else {
+          return value;
+        }
+      }
+      return value;
+    }) as SchemaChange;
+    return formattedData;
+  };
 }

--- a/wren-ui/src/apollo/server/repositories/schemaChangeRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/schemaChangeRepository.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+import { BaseRepository, IBasicRepository } from './baseRepository';
+
+export interface SchemaChange {
+  id: number; // ID
+  projectId: number; // Reference to project.id
+  change: string; // Schema change in JSON format
+  resolve: string; // Save resolve in JSON format, for example: { "deletedTables": true, "deletedColumns": true, "modifiedColumns": false  }
+}
+
+export interface ISchemaChangeRepository
+  extends IBasicRepository<SchemaChange> {
+  findLastSchemaChange(projectId: number): Promise<SchemaChange | null>;
+}
+
+export class SchemaChangeRepository
+  extends BaseRepository<SchemaChange>
+  implements ISchemaChangeRepository
+{
+  constructor(knexPg: Knex) {
+    super({ knexPg, tableName: 'schema_change' });
+  }
+
+  public async findLastSchemaChange(projectId: number) {
+    const res = await this.knex
+      .select('*')
+      .from(this.tableName)
+      .where(this.transformToDBData({ projectId }))
+      .orderBy('created_at', 'desc')
+      .first();
+    return (res && this.transformFromDBData(res)) || null;
+  }
+}

--- a/wren-ui/src/apollo/server/repositories/schemaChangeRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/schemaChangeRepository.ts
@@ -17,6 +17,8 @@ export interface SchemaChange {
   projectId: number; // Reference to project.id
   change: DataSourceSchemaChange; // Schema change
   resolve: DataSourceSchemaResolve; // Save resolve
+  createdAt: string; // Created at
+  updateAt: string; // Updated at
 }
 
 export interface ISchemaChangeRepository

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -56,6 +56,7 @@ const resolvers = {
     previewModelData: modelResolver.previewModelData,
     updateModelMetadata: modelResolver.updateModelMetadata,
     triggerDataSourceDetection: projectResolver.triggerDataSourceDetection,
+    resolveSchemaChange: projectResolver.resolveSchemaChange,
 
     // calculated field
     createCalculatedField: modelResolver.createCalculatedField,

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -21,6 +21,7 @@ const resolvers = {
     onboardingStatus: projectResolver.getOnboardingStatus,
     modelSync: modelResolver.checkModelSync,
     diagram: diagramResolver.getDiagram,
+    schemaChange: projectResolver.getSchemaChange,
 
     // Ask
     askingTask: askingResolver.getAskingTask,

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -54,6 +54,7 @@ const resolvers = {
     deleteModel: modelResolver.deleteModel,
     previewModelData: modelResolver.previewModelData,
     updateModelMetadata: modelResolver.updateModelMetadata,
+    triggerDataSourceDetection: projectResolver.triggerDataSourceDetection,
 
     // calculated field
     createCalculatedField: modelResolver.createCalculatedField,

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -446,6 +446,7 @@ export class ProjectResolver {
         deletedTables: null,
         deletedColumns: null,
         modifiedColumns: null,
+        lastSchemaChangeTime: null,
       };
     }
 
@@ -497,7 +498,10 @@ export class ProjectResolver {
       return { ...result, [key]: affectedChanges };
     }, {});
 
-    return unresolvedChanges;
+    return {
+      ...unresolvedChanges,
+      lastSchemaChangeTime: lastSchemaChange.createdAt,
+    };
   }
 
   public async triggerDataSourceDetection(
@@ -510,8 +514,8 @@ export class ProjectResolver {
       ctx,
       projectId: project.id,
     });
-    await schemaDetector.detectSchemaChange();
-    return true;
+    const hasSchemaChange = await schemaDetector.detectSchemaChange();
+    return hasSchemaChange;
   }
 
   public async resolveSchemaChange(

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -84,6 +84,8 @@ export class ProjectResolver {
       return true;
     }
 
+    await ctx.schemaChangeRepository.deleteAllBy({ projectId: id });
+
     await ctx.deployService.deleteAllByProjectId(id);
     await ctx.askingService.deleteAllByProjectId(id);
     await ctx.modelService.deleteAllViewsByProjectId(id);

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -28,6 +28,7 @@ import { snakeCase } from 'lodash';
 import { CompactTable, ProjectData } from '../services';
 import { replaceAllowableSyntax } from '../utils/regex';
 import { DuckDBPrepareOptions } from '@server/adaptors/wrenEngineAdaptor';
+import DataSourceSchemaDetector from '@server/managers/dataSourceSchemaDetector';
 
 const logger = getLogger('DataSourceResolver');
 logger.level = 'debug';
@@ -51,6 +52,8 @@ export class ProjectResolver {
     this.saveRelations = this.saveRelations.bind(this);
     this.getOnboardingStatus = this.getOnboardingStatus.bind(this);
     this.startSampleDataset = this.startSampleDataset.bind(this);
+    this.triggerDataSourceDetection =
+      this.triggerDataSourceDetection.bind(this);
   }
 
   public async getSettings(_root: any, _arg: any, ctx: IContext) {
@@ -425,6 +428,16 @@ export class ProjectResolver {
     // async deploy
     this.deploy(ctx);
     return savedRelations;
+  }
+
+  public async triggerDataSourceDetection(
+    _root: any,
+    _arg: any,
+    ctx: IContext,
+  ) {
+    const schemaDetector = new DataSourceSchemaDetector({ ctx });
+    await schemaDetector.detectSchemaChange();
+    return true;
   }
 
   private async deploy(ctx: IContext) {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -625,6 +625,7 @@ export const typeDefs = gql`
     deletedTables: [DetailedChangeTable!]
     deletedColumns: [DetailedChangeTable!]
     modifiedColumns: [DetailedChangeTable!]
+    lastSchemaChangeTime: String
   }
 
   type DetailedChangeTable {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -42,6 +42,12 @@ export const typeDefs = gql`
     UNSYNCRONIZED
   }
 
+  enum SchemaChangeType {
+    DELETED_TABLES
+    DELETED_COLUMNS
+    MODIFIED_COLUMNS
+  }
+
   type DataSource {
     type: DataSourceName!
     properties: JSON!
@@ -621,6 +627,10 @@ export const typeDefs = gql`
     modifiedColumns: JSON
   }
 
+  input ResolveSchemaChangeWhereInput {
+    type: SchemaChangeType!
+  }
+
   # Query and Mutation
   type Query {
     # On Boarding Steps
@@ -669,6 +679,7 @@ export const typeDefs = gql`
     deleteModel(where: ModelWhereInput!): Boolean!
     previewModelData(where: WhereIdInput!): JSON!
     triggerDataSourceDetection: Boolean!
+    resolveSchemaChange(where: ResolveSchemaChangeWhereInput!): Boolean!
 
     # Metadata
     updateModelMetadata(

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -660,6 +660,7 @@ export const typeDefs = gql`
     updateModel(where: ModelWhereInput!, data: UpdateModelInput!): JSON!
     deleteModel(where: ModelWhereInput!): Boolean!
     previewModelData(where: WhereIdInput!): JSON!
+    triggerDataSourceDetection: Boolean!
 
     # Metadata
     updateModelMetadata(

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -622,9 +622,21 @@ export const typeDefs = gql`
 
   # Schema Change
   type SchemaChange {
-    deletedTables: JSON
-    deletedColumns: JSON
-    modifiedColumns: JSON
+    deletedTables: [DetailedChangeTable!]
+    deletedColumns: [DetailedChangeTable!]
+    modifiedColumns: [DetailedChangeTable!]
+  }
+
+  type DetailedChangeTable {
+    sourceTableName: String!
+    displayName: String!
+    columns: [DetailedChangeColumn!]!
+  }
+
+  type DetailedChangeColumn {
+    sourceColumnName: String!
+    displayName: String!
+    type: String!
   }
 
   input ResolveSchemaChangeWhereInput {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -614,6 +614,13 @@ export const typeDefs = gql`
     dryRun: Boolean
   }
 
+  # Schema Change
+  type SchemaChange {
+    deletedTables: JSON
+    deletedColumns: JSON
+    modifiedColumns: JSON
+  }
+
   # Query and Mutation
   type Query {
     # On Boarding Steps
@@ -626,6 +633,7 @@ export const typeDefs = gql`
     model(where: ModelWhereInput!): DetailedModel!
     modelSync: ModelSyncResponse!
     diagram: Diagram!
+    schemaChange: SchemaChange!
 
     # View
     listViews: [ViewInfo!]!

--- a/wren-ui/src/apollo/server/types/context.ts
+++ b/wren-ui/src/apollo/server/types/context.ts
@@ -8,6 +8,7 @@ import {
   IRelationRepository,
   IViewRepository,
 } from '../repositories';
+import { ISchemaChangeRepository } from '../repositories/schemaChangeRepository';
 import { IDeployLogRepository } from '../repositories/deployLogRepository';
 import {
   IQueryService,
@@ -42,4 +43,5 @@ export interface IContext {
   relationRepository: IRelationRepository;
   viewRepository: IViewRepository;
   deployRepository: IDeployLogRepository;
+  schemaChangeRepository: ISchemaChangeRepository;
 }

--- a/wren-ui/src/pages/api/graphql.ts
+++ b/wren-ui/src/pages/api/graphql.ts
@@ -25,6 +25,7 @@ import { WrenAIAdaptor } from '@/apollo/server/adaptors/wrenAIAdaptor';
 import { AskingService } from '@/apollo/server/services/askingService';
 import { ThreadRepository } from '@/apollo/server/repositories/threadRepository';
 import { ThreadResponseRepository } from '@/apollo/server/repositories/threadResponseRepository';
+import { SchemaChangeRepository } from '@/apollo/server/repositories/schemaChangeRepository';
 import { defaultApolloErrorHandler } from '@/apollo/server/utils/error';
 import { Telemetry } from '@/apollo/server/telemetry/telemetry';
 import { IbisAdaptor } from '@/apollo/server/adaptors/ibisAdaptor';
@@ -63,6 +64,7 @@ const bootstrapServer = async () => {
   const threadRepository = new ThreadRepository(knex);
   const threadResponseRepository = new ThreadResponseRepository(knex);
   const viewRepository = new ViewRepository(knex);
+  const schemaChangeRepository = new SchemaChangeRepository(knex);
 
   const wrenEngineAdaptor = new WrenEngineAdaptor({
     wrenEngineEndpoint: serverConfig.wrenEngineEndpoint,
@@ -176,6 +178,7 @@ const bootstrapServer = async () => {
       relationRepository,
       viewRepository,
       deployRepository: deployLogRepository,
+      schemaChangeRepository,
     }),
   });
   await apolloServer.start();


### PR DESCRIPTION
New PR from #339 (The old PR closed because it's base branch has been merged & deleted)

## Description
- [x] Get schema change API - Query
   ```graphql
   query SchemaChange {
       schemaChange {
         deletedTables
         deletedColumns
         modifiedColumns
      }
   }
   ```
- [x] Trigger schema change API - Mutation 
   ```graphql
    mutation Mutation {
       triggerDataSourceDetection
    }
   ```
- [x] Resolve schema change API - Mutation
   ```graphql
    # The modified columns is not support for resolving schema changes
    enum SchemaChangeType {
      DELETED_TABLES
      DELETED_COLUMNS
      MODIFIED_COLUMNS
    }

    input ResolveSchemaChangeWhereInput {
      type: SchemaChangeType!
    }

    mutation Mutation($where: ResolveSchemaChangeWhereInput!) {
      resolveSchemaChange(where: $where)
    }
   ```