### PR TITLE
Fix(wren-ui): fix previewSql mutation for doing dry run

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
@@ -143,8 +143,10 @@ export class IbisAdaptor implements IIbisAdaptor {
         `${this.ibisServerEndpoint}/v2/ibis/${dataSourceUrlMap[dataSource]}/query?dryRun=true`,
         body,
       );
+      logger.debug(`Ibis server Dry run success`);
       return true;
     } catch (err) {
+      logger.debug(`Got error when dry running ibis: ${err.response.data}`);
       throw Errors.create(Errors.GeneralErrorCodes.DRY_RUN_ERROR, {
         customMessage: err.response.data,
         originalError: err,

--- a/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
@@ -359,6 +359,7 @@ export class WrenEngineAdaptor implements IWrenEngineAdaptor {
         url: url.href,
         data: body,
       });
+      logger.debug(`Wren Engine Dry run success`);
       return res.data;
     } catch (err: any) {
       logger.debug(

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -674,7 +674,7 @@ export class ModelResolver {
       mdl,
       dryRun,
     });
-    return dryRun ? { dryRun: previewRes } : previewRes;
+    return dryRun ? { dryRun: 'success' } : previewRes;
   }
 
   public async getNativeSql(

--- a/wren-ui/src/apollo/server/utils/error.ts
+++ b/wren-ui/src/apollo/server/utils/error.ts
@@ -29,6 +29,9 @@ export enum GeneralErrorCodes {
 
   // when createing views
   INVALID_VIEW_CREATION = 'INVALID_VIEW_CREATION',
+
+  // dry run error
+  DRY_RUN_ERROR = 'DRY_RUN_ERROR',
 }
 
 export const errorMessages = {
@@ -66,6 +69,9 @@ export const errorMessages = {
 
   // when createing views
   [GeneralErrorCodes.INVALID_VIEW_CREATION]: 'Invalid view creation',
+
+  // dry run error
+  [GeneralErrorCodes.DRY_RUN_ERROR]: 'Dry run sql statement error',
 };
 
 export const shortMessages = {
@@ -82,6 +88,7 @@ export const shortMessages = {
   [GeneralErrorCodes.INVALID_EXPRESSION]: 'Invalid expression',
   [GeneralErrorCodes.INVALID_CALCULATED_FIELD]: 'Invalid calculated field',
   [GeneralErrorCodes.INVALID_VIEW_CREATION]: 'Invalid view creation',
+  [GeneralErrorCodes.DRY_RUN_ERROR]: 'Dry run sql statement error',
 };
 
 export const create = (


### PR DESCRIPTION
- Throw an GraphQL error  back to the client  instead of returning false
- The GraphQL error contains the error code DRY_RUN_ERROR and the error message from ibis/wren-engine back to the client

### Example GraphQL response when failed
```
{
    "errors": [
        {
            "locations": [
                {
                    "line": 1,
                    "column": 51
                }
            ],
            "path": [
                "previewSql"
            ],
            "message": "Exception: <class 'psycopg2.errors.UndefinedTable'>, message: relation \"public_order\" does not exist\nLINE 1: ...hic5g3ffz553y AS SELECT tmp.* FROM (SELECT * FROM public_ord...\n                                                             ^\n",
            "extensions": {
                "code": "DRY_RUN_ERROR",
                "message": "Exception: <class 'psycopg2.errors.UndefinedTable'>, message: relation \"public_order\" does not exist\nLINE 1: ...hic5g3ffz553y AS SELECT tmp.* FROM (SELECT * FROM public_ord...\n                                                             ^\n",
                "shortMessage": "Dry run sql statement error",
                "stacktrace": [
                    "GraphQLError: Exception: <class 'psycopg2.errors.UndefinedTable'>, message: relation \"public_order\" does not exist",
                    "LINE 1: ...hic5g3ffz553y AS SELECT tmp.* FROM (SELECT * FROM public_ord...",
                    "                                                             ^",
                    "",
                    "    at Module.create (webpack-internal:///(api)/./src/apollo/server/utils/error.ts:86:17)",
                    "    at IbisAdaptor.dryRun (webpack-internal:///(api)/./src/apollo/server/adaptors/ibisAdaptor.ts:77:68)",
                    "    at runMicrotasks (<anonymous>)",
                    "    at processTicksAndRejections (node:internal/process/task_queues:96:5)",
                    "    at async QueryService.preview (webpack-internal:///(api)/./src/apollo/server/services/queryService.ts:52:17)",
                    "    at async ModelResolver.previewSql (webpack-internal:///(api)/./src/apollo/server/resolvers/modelResolver.ts:541:28)"
                ]
            }
        }
    ],
    "data": null
}
```