### PR TITLE
feat(wren-ui): Support schema change phase 2

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -147,6 +147,19 @@ export type DetailStep = {
   summary: Scalars['String'];
 };
 
+export type DetailedAffectedCalculatedFields = {
+  __typename?: 'DetailedAffectedCalculatedFields';
+  displayName: Scalars['String'];
+  referenceName: Scalars['String'];
+  type: Scalars['String'];
+};
+
+export type DetailedAffectedRelationships = {
+  __typename?: 'DetailedAffectedRelationships';
+  displayName: Scalars['String'];
+  referenceName: Scalars['String'];
+};
+
 export type DetailedChangeColumn = {
   __typename?: 'DetailedChangeColumn';
   displayName: Scalars['String'];
@@ -156,8 +169,10 @@ export type DetailedChangeColumn = {
 
 export type DetailedChangeTable = {
   __typename?: 'DetailedChangeTable';
+  calculatedFields: Array<DetailedAffectedCalculatedFields>;
   columns: Array<DetailedChangeColumn>;
   displayName: Scalars['String'];
+  relationships: Array<DetailedAffectedRelationships>;
   sourceTableName: Scalars['String'];
 };
 
@@ -341,10 +356,6 @@ export type FieldInfo = {
   type?: Maybe<Scalars['String']>;
 };
 
-export type GetMdlInput = {
-  hash: Scalars['String'];
-};
-
 export type GetMdlResult = {
   __typename?: 'GetMDLResult';
   hash: Scalars['String'];
@@ -397,7 +408,6 @@ export type Mutation = {
   deleteThread: Scalars['Boolean'];
   deleteView: Scalars['Boolean'];
   deploy: Scalars['JSON'];
-  getMDL: GetMdlResult;
   previewData: Scalars['JSON'];
   previewModelData: Scalars['JSON'];
   previewSql: Scalars['JSON'];
@@ -484,11 +494,6 @@ export type MutationDeleteThreadArgs = {
 
 export type MutationDeleteViewArgs = {
   where: ViewWhereUniqueInput;
-};
-
-
-export type MutationGetMdlArgs = {
-  data?: InputMaybe<GetMdlInput>;
 };
 
 
@@ -632,6 +637,7 @@ export type Query = {
   autoGenerateRelation: Array<RecommendRelations>;
   connectionInfo: ConnectionInfo;
   diagram: Diagram;
+  getMDL: GetMdlResult;
   listDataSourceTables: Array<CompactTable>;
   listModels: Array<ModelInfo>;
   listViews: Array<ViewInfo>;
@@ -651,6 +657,11 @@ export type Query = {
 
 export type QueryAskingTaskArgs = {
   taskId: Scalars['String'];
+};
+
+
+export type QueryGetMdlArgs = {
+  hash: Scalars['String'];
 };
 
 

--- a/wren-ui/src/apollo/client/graphql/dataSource.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/dataSource.generated.ts
@@ -51,7 +51,7 @@ export type SaveRelationsMutation = { __typename?: 'Mutation', saveRelations: an
 export type SchemaChangeQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type SchemaChangeQuery = { __typename?: 'Query', schemaChange: { __typename?: 'SchemaChange', lastSchemaChangeTime?: string | null, deletedTables?: Array<{ __typename?: 'DetailedChangeTable', sourceTableName: string, displayName: string, columns: Array<{ __typename?: 'DetailedChangeColumn', sourceColumnName: string, displayName: string, type: string }> }> | null, deletedColumns?: Array<{ __typename?: 'DetailedChangeTable', sourceTableName: string, displayName: string, columns: Array<{ __typename?: 'DetailedChangeColumn', sourceColumnName: string, displayName: string, type: string }> }> | null, modifiedColumns?: Array<{ __typename?: 'DetailedChangeTable', sourceTableName: string, displayName: string, columns: Array<{ __typename?: 'DetailedChangeColumn', sourceColumnName: string, displayName: string, type: string }> }> | null } };
+export type SchemaChangeQuery = { __typename?: 'Query', schemaChange: { __typename?: 'SchemaChange', lastSchemaChangeTime?: string | null, deletedTables?: Array<{ __typename?: 'DetailedChangeTable', sourceTableName: string, displayName: string, columns: Array<{ __typename?: 'DetailedChangeColumn', sourceColumnName: string, displayName: string, type: string }>, relationships: Array<{ __typename?: 'DetailedAffectedRelationships', displayName: string, referenceName: string }>, calculatedFields: Array<{ __typename?: 'DetailedAffectedCalculatedFields', displayName: string, referenceName: string, type: string }> }> | null, deletedColumns?: Array<{ __typename?: 'DetailedChangeTable', sourceTableName: string, displayName: string, columns: Array<{ __typename?: 'DetailedChangeColumn', sourceColumnName: string, displayName: string, type: string }>, relationships: Array<{ __typename?: 'DetailedAffectedRelationships', displayName: string, referenceName: string }>, calculatedFields: Array<{ __typename?: 'DetailedAffectedCalculatedFields', displayName: string, referenceName: string, type: string }> }> | null, modifiedColumns?: Array<{ __typename?: 'DetailedChangeTable', sourceTableName: string, displayName: string, columns: Array<{ __typename?: 'DetailedChangeColumn', sourceColumnName: string, displayName: string, type: string }>, relationships: Array<{ __typename?: 'DetailedAffectedRelationships', displayName: string, referenceName: string }>, calculatedFields: Array<{ __typename?: 'DetailedAffectedCalculatedFields', displayName: string, referenceName: string, type: string }> }> | null } };
 
 export type TriggerDataSourceDetectionMutationVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -324,6 +324,15 @@ export const SchemaChangeDocument = gql`
         displayName
         type
       }
+      relationships {
+        displayName
+        referenceName
+      }
+      calculatedFields {
+        displayName
+        referenceName
+        type
+      }
     }
     deletedColumns {
       sourceTableName
@@ -333,6 +342,15 @@ export const SchemaChangeDocument = gql`
         displayName
         type
       }
+      relationships {
+        displayName
+        referenceName
+      }
+      calculatedFields {
+        displayName
+        referenceName
+        type
+      }
     }
     modifiedColumns {
       sourceTableName
@@ -340,6 +358,15 @@ export const SchemaChangeDocument = gql`
       columns {
         sourceColumnName
         displayName
+        type
+      }
+      relationships {
+        displayName
+        referenceName
+      }
+      calculatedFields {
+        displayName
+        referenceName
         type
       }
     }

--- a/wren-ui/src/apollo/client/graphql/dataSource.ts
+++ b/wren-ui/src/apollo/client/graphql/dataSource.ts
@@ -81,6 +81,15 @@ export const GET_SCHEMA_CHANGE = gql`
           displayName
           type
         }
+        relationships {
+          displayName
+          referenceName
+        }
+        calculatedFields {
+          displayName
+          referenceName
+          type
+        }
       }
       deletedColumns {
         sourceTableName
@@ -90,6 +99,15 @@ export const GET_SCHEMA_CHANGE = gql`
           displayName
           type
         }
+        relationships {
+          displayName
+          referenceName
+        }
+        calculatedFields {
+          displayName
+          referenceName
+          type
+        }
       }
       modifiedColumns {
         sourceTableName
@@ -97,6 +115,15 @@ export const GET_SCHEMA_CHANGE = gql`
         columns {
           sourceColumnName
           displayName
+          type
+        }
+        relationships {
+          displayName
+          referenceName
+        }
+        calculatedFields {
+          displayName
+          referenceName
           type
         }
       }

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -105,17 +105,20 @@ export default class DataSourceSchemaDetector
       projectId: this.projectId,
     });
 
+    const modelColumns =
+      await this.ctx.modelColumnRepository.findColumnsByModelIds(
+        models.map((model) => model.id),
+      );
+
     const affectedModels = models.filter(
       (model) =>
         changes.findIndex((table) => table.name === model.sourceTableName) !==
         -1,
     );
-    const allCalculatedFields =
-      await this.ctx.modelColumnRepository.findAllCalculatedFields();
 
-    const modelIds = affectedModels.map((model) => model.id);
-    const modelColumns =
-      await this.ctx.modelColumnRepository.findColumnsByModelIds(modelIds);
+    const allCalculatedFields = modelColumns.filter(
+      (column) => column.isCalculated,
+    );
 
     const modelRelationships =
       await this.ctx.relationRepository.findRelationInfoBy({

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -137,16 +137,15 @@ export default class DataSourceSchemaDetector
           );
 
           // Get affected calculated fields and affected relationships
-          const affectedMaterials =
-            await this.getAffectedCalculatedFieldsAndRelationships(
-              model,
-              selfModelColumns,
-              {
-                models,
-                allCalculatedFields,
-                modelRelationships,
-              },
-            );
+          const affectedMaterials = await this.getAffectedResources(
+            model,
+            selfModelColumns,
+            {
+              models,
+              allCalculatedFields,
+              modelRelationships,
+            },
+          );
 
           // delete columns and calculated fields
           const affectedColumns = uniqBy(
@@ -219,16 +218,15 @@ export default class DataSourceSchemaDetector
             [],
           );
 
-          const affectedMaterials =
-            await this.getAffectedCalculatedFieldsAndRelationships(
-              model,
-              columns,
-              {
-                models,
-                allCalculatedFields,
-                modelRelationships,
-              },
-            );
+          const affectedMaterials = await this.getAffectedResources(
+            model,
+            columns,
+            {
+              models,
+              allCalculatedFields,
+              modelRelationships,
+            },
+          );
 
           // delete calculated fields
           const affectedCalculatedFields = uniqBy(
@@ -442,7 +440,7 @@ export default class DataSourceSchemaDetector
     logger.info(`Schema change "${schemaChangeTypes}" resolved successfully.`);
   }
 
-  private async getAffectedCalculatedFieldsAndRelationships(
+  private async getAffectedResources(
     model: Model,
     columns: ModelColumn[],
     {

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -474,7 +474,10 @@ export default class DataSourceSchemaDetector
           const affectedCalculatedFieldsByRelationshipId =
             allCalculatedFields.filter((calculatedField) => {
               const lineage = JSON.parse(calculatedField.lineage);
-              return lineage && lineage[lineage.length - 1] === relationship.id;
+
+              // pop the column ID from the lineage
+              lineage.pop();
+              return lineage && lineage.includes(relationship.id);
             });
 
           result.calculatedFields.push(

--- a/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
+++ b/wren-ui/src/apollo/server/managers/dataSourceSchemaDetector.ts
@@ -147,37 +147,21 @@ export default class DataSourceSchemaDetector
             },
           );
 
-          // delete columns and calculated fields
+          // delete calculated fields
           const affectedColumns = uniqBy(
-            [
-              ...selfModelColumnsWithCalculatedFields,
-              ...affectedMaterials.calculatedFields,
-            ],
+            affectedMaterials.calculatedFields,
             'id',
           );
 
           logger.debug(
-            `Start to remove columns and calculated fields. ${affectedColumns.map(
+            `Start to remove all affected calculated fields "${affectedColumns.map(
               (column) => `${column.displayName} (${column.referenceName})`,
-            )}.`,
+            )}".`,
           );
 
           const columnIds = affectedColumns.map((column) => column.id);
-          await this.ctx.modelColumnRepository.deleteAllByColumnIds(columnIds);
-
-          // delete relationships
-          logger.debug(
-            `Start to remove relationships "${affectedMaterials.relationships.map(
-              (relationship) =>
-                `${relationship.displayName} (${relationship.referenceName})`,
-            )}" from model "${model.referenceName}".`,
-          );
-
-          const relationshipIds = affectedMaterials.relationships.map(
-            (relationship) => relationship.id,
-          );
-          return await this.ctx.relationRepository.deleteAllByRelationshipIds(
-            relationshipIds,
+          return await this.ctx.modelColumnRepository.deleteAllByColumnIds(
+            columnIds,
           );
         }),
       );
@@ -242,22 +226,6 @@ export default class DataSourceSchemaDetector
 
           const columnIds = affectedCalculatedFields.map((column) => column.id);
           await this.ctx.modelColumnRepository.deleteAllByColumnIds(columnIds);
-
-          // delete relationships
-          logger.debug(
-            `Start to remove relationships "${affectedMaterials.relationships.map(
-              (relationship) =>
-                `${relationship.displayName} (${relationship.referenceName})`,
-            )}" from model "${model.referenceName}".`,
-          );
-
-          const relationshipIds = affectedMaterials.relationships.map(
-            (relationship) => relationship.id,
-          );
-
-          await this.ctx.relationRepository.deleteAllByRelationshipIds(
-            relationshipIds,
-          );
 
           // delete columns
           const affectedColumnNames = affectedColumns.map(

--- a/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
@@ -41,7 +41,6 @@ export interface IModelColumnRepository extends IBasicRepository<ModelColumn> {
     sourceColumnNames: string[],
     queryOptions?: IQueryOptions,
   ): Promise<number>;
-  findAllCalculatedFields(queryOptions?: IQueryOptions): Promise<ModelColumn[]>;
   deleteAllByColumnIds(
     columnIds: number[],
     queryOptions?: IQueryOptions,
@@ -118,16 +117,6 @@ export class ModelColumnRepository
       .whereIn('source_column_name', sourceColumnNames)
       .delete();
     return await builder;
-  }
-
-  public async findAllCalculatedFields(
-    queryOptions?: IQueryOptions,
-  ): Promise<ModelColumn[]> {
-    const executer = queryOptions?.tx ? queryOptions.tx : this.knex;
-    const result = await executer<ModelColumn>('model_column')
-      .where('is_calculated', true)
-      .select('*');
-    return result.map((r) => this.transformFromDBData(r));
   }
 
   public async deleteAllByColumnIds(

--- a/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
@@ -41,6 +41,7 @@ export interface IModelColumnRepository extends IBasicRepository<ModelColumn> {
     sourceColumnNames: string[],
     queryOptions?: IQueryOptions,
   ): Promise<number>;
+  findAllCalculatedFields(): Promise<ModelColumn[]>;
 }
 
 export class ModelColumnRepository
@@ -113,5 +114,12 @@ export class ModelColumnRepository
       .whereIn('source_column_name', sourceColumnNames)
       .delete();
     return await builder;
+  }
+
+  public async findAllCalculatedFields(): Promise<ModelColumn[]> {
+    const result = await this.knex<ModelColumn>('model_column')
+      .where('is_calculated', true)
+      .select('*');
+    return result.map((r) => this.transformFromDBData(r));
   }
 }

--- a/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/modelColumnRepository.ts
@@ -123,15 +123,8 @@ export class ModelColumnRepository
   public async findAllCalculatedFields(
     queryOptions?: IQueryOptions,
   ): Promise<ModelColumn[]> {
-    if (queryOptions && queryOptions.tx) {
-      const { tx } = queryOptions;
-      const result = await tx(this.tableName)
-        .where('is_calculated', true)
-        .select('*');
-      return result.map((r) => this.transformFromDBData(r));
-    }
-
-    const result = await this.knex<ModelColumn>('model_column')
+    const executer = queryOptions?.tx ? queryOptions.tx : this.knex;
+    const result = await executer<ModelColumn>('model_column')
       .where('is_calculated', true)
       .select('*');
     return result.map((r) => this.transformFromDBData(r));
@@ -141,13 +134,8 @@ export class ModelColumnRepository
     columnIds: number[],
     queryOptions?: IQueryOptions,
   ): Promise<void> {
-    if (queryOptions && queryOptions.tx) {
-      const { tx } = queryOptions;
-      await tx(this.tableName).whereIn('id', columnIds).delete();
-      return;
-    }
-
-    await this.knex<ModelColumn>(this.tableName)
+    const executer = queryOptions?.tx ? queryOptions.tx : this.knex;
+    await executer<ModelColumn>(this.tableName)
       .whereIn('id', columnIds)
       .delete();
   }

--- a/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
@@ -56,6 +56,10 @@ export interface IRelationRepository extends IBasicRepository<Relation> {
   findExistedRelationBetweenModels(
     relation: RelationData,
   ): Promise<RelationInfo[]>;
+  deleteAllByRelationshipIds(
+    relationshipIds: number[],
+    queryOptions?: IQueryOptions,
+  ): Promise<void>;
 }
 
 export class RelationRepository
@@ -219,5 +223,18 @@ export class RelationRepository
       .select(`${this.tableName}.*`);
     const result = await query;
     return result.map((r) => this.transformFromDBData(r)) as RelationInfo[];
+  }
+
+  public async deleteAllByRelationshipIds(
+    relationshipIds: number[],
+    queryOptions?: IQueryOptions,
+  ) {
+    if (queryOptions && queryOptions.tx) {
+      const { tx } = queryOptions;
+      await tx(this.tableName).whereIn('id', relationshipIds).delete();
+      return;
+    }
+
+    await this.knex(this.tableName).whereIn('id', relationshipIds).delete();
   }
 }

--- a/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
@@ -56,10 +56,6 @@ export interface IRelationRepository extends IBasicRepository<Relation> {
   findExistedRelationBetweenModels(
     relation: RelationData,
   ): Promise<RelationInfo[]>;
-  deleteAllByRelationshipIds(
-    relationshipIds: number[],
-    queryOptions?: IQueryOptions,
-  ): Promise<void>;
 }
 
 export class RelationRepository
@@ -223,13 +219,5 @@ export class RelationRepository
       .select(`${this.tableName}.*`);
     const result = await query;
     return result.map((r) => this.transformFromDBData(r)) as RelationInfo[];
-  }
-
-  public async deleteAllByRelationshipIds(
-    relationshipIds: number[],
-    queryOptions?: IQueryOptions,
-  ) {
-    const executer = queryOptions?.tx ? queryOptions.tx : this.knex;
-    await executer(this.tableName).whereIn('id', relationshipIds).delete();
   }
 }

--- a/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/relationshipRepository.ts
@@ -229,12 +229,7 @@ export class RelationRepository
     relationshipIds: number[],
     queryOptions?: IQueryOptions,
   ) {
-    if (queryOptions && queryOptions.tx) {
-      const { tx } = queryOptions;
-      await tx(this.tableName).whereIn('id', relationshipIds).delete();
-      return;
-    }
-
-    await this.knex(this.tableName).whereIn('id', relationshipIds).delete();
+    const executer = queryOptions?.tx ? queryOptions.tx : this.knex;
+    await executer(this.tableName).whereIn('id', relationshipIds).delete();
   }
 }

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -307,6 +307,7 @@ export class ModelResolver {
     const model = await ctx.modelRepository.findOneBy({ id: args.where.id });
     const existingColumns = await ctx.modelColumnRepository.findAllBy({
       modelId: model.id,
+      isCalculated: false,
     });
     const { sourceTableName } = model;
     this.validateTableExist(sourceTableName, dataSourceTables);

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -371,13 +371,8 @@ export class ModelResolver {
     if (!model) {
       throw new Error('Model not found');
     }
-    const modelColumns = await ctx.modelColumnRepository.findColumnsByModelIds([
-      model.id,
-    ]);
-    logger.debug('find columns');
-    const columnIds = modelColumns.map((c) => c.id);
-    await ctx.relationRepository.deleteRelationsByColumnIds(columnIds);
-    await ctx.modelColumnRepository.deleteMany(columnIds);
+
+    // related columns and relationships will be deleted in cascade
     await ctx.modelRepository.deleteOne(modelId);
     return true;
   }

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -472,26 +472,30 @@ export class ProjectResolver {
         const affectedModel = models.find(
           (model) => model.sourceTableName === change.name,
         );
-        return affectedModel
-          ? {
-              sourceTableName: change.name,
-              displayName: affectedModel.displayName,
-              columns: flatMap(change.columns, (column) => {
-                const affectedColumn = modelColumns.find(
-                  (modelColumn) =>
-                    modelColumn.sourceColumnName === column.name &&
-                    modelColumn.modelId === affectedModel.id,
-                );
-                return affectedColumn
-                  ? {
-                      sourceColumnName: column.name,
-                      displayName: affectedColumn?.displayName,
-                      type: column.type,
-                    }
-                  : [];
-              }),
-            }
-          : [];
+
+        if (!affectedModel) return [];
+
+        const columns = flatMap(change.columns, (column) => {
+          const affectedColumn = modelColumns.find(
+            (modelColumn) =>
+              modelColumn.sourceColumnName === column.name &&
+              modelColumn.modelId === affectedModel.id,
+          );
+
+          if (!affectedColumn) return [];
+
+          return {
+            sourceColumnName: column.name,
+            displayName: affectedColumn.displayName,
+            type: column.type,
+          };
+        });
+
+        return {
+          sourceTableName: change.name,
+          displayName: affectedModel.displayName,
+          columns,
+        };
       });
       return affecteds.length ? affecteds : null;
     };

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -481,10 +481,8 @@ export class ProjectResolver {
      *  - columns (called "affected column")
      *  - relationships (called "affected relationship")
      *  - calculated fields:
-     *    - calculated fields of a model
-     *    - calculated fields affected by relationships
-     *    - calculated fields affected by used columns
-     *
+     *    - calculated fields which were affected by affected columns
+     *    - calculated fields which were affected by affected relationships
      */
     const mappingAffectedToSchemaChange = (changes: DataSourceSchema[]) => {
       const affecteds = flatMap(changes, (change) => {

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -467,7 +467,7 @@ export class ProjectResolver {
       await ctx.modelColumnRepository.findColumnsByModelIds(modelIds);
 
     const modelRelationships = await ctx.relationRepository.findRelationInfoBy({
-      columnIds: modelColumns.map((column) => column.id),
+      modelIds,
     });
 
     const allCalculatedFields = modelColumns.filter(

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -470,8 +470,9 @@ export class ProjectResolver {
       columnIds: modelColumns.map((column) => column.id),
     });
 
-    const allCalculatedFields =
-      await ctx.modelColumnRepository.findAllCalculatedFields();
+    const allCalculatedFields = modelColumns.filter(
+      (column) => column.isCalculated,
+    );
 
     // Not only Mapping with affected models and columns data,
     // But also finding out affected relationships and affected calculated fields into schema change
@@ -640,7 +641,6 @@ export class ProjectResolver {
       ctx,
       projectId: project.id,
     });
-    await schemaDetector.detectSchemaChange();
     await schemaDetector.resolveSchemaChange(type);
     return true;
   }

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -474,6 +474,7 @@ export class ProjectResolver {
       (column) => column.isCalculated,
     );
 
+    // TODO: the same logic with getAffectedResources
     /**
      * According to affected models and column data, we also need to find affected resources, including calculated fields and relationships.
      *

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -629,12 +629,25 @@ export const typeDefs = gql`
     sourceTableName: String!
     displayName: String!
     columns: [DetailedChangeColumn!]!
+    calculatedFields: [DetailedAffectedCalculatedFields!]!
+    relationships: [DetailedAffectedRelationships!]!
   }
 
   type DetailedChangeColumn {
     sourceColumnName: String!
     displayName: String!
     type: String!
+  }
+
+  type DetailedAffectedCalculatedFields {
+    displayName: String!
+    referenceName: String!
+    type: String!
+  }
+
+  type DetailedAffectedRelationships {
+    displayName: String!
+    referenceName: String!
   }
 
   input ResolveSchemaChangeWhereInput {

--- a/wren-ui/src/apollo/server/utils/model.ts
+++ b/wren-ui/src/apollo/server/utils/model.ts
@@ -1,6 +1,6 @@
 import { IModelColumnRepository, ModelColumn } from '@server/repositories';
 import { replaceAllowableSyntax } from './regex';
-import { CompactTable } from '@server/services/metadataService';
+import { CompactColumn } from '@server/services/metadataService';
 
 export function transformInvalidColumnName(columnName: string) {
   let referenceName = replaceAllowableSyntax(columnName);
@@ -20,7 +20,7 @@ export function replaceInvalidReferenceName(referenceName: string) {
 export function findColumnsToUpdate(
   columns: string[],
   existingColumns: ModelColumn[],
-  sourceTableColumns: CompactTable[],
+  sourceTableColumns: CompactColumn[],
 ): {
   toDeleteColumnIds: number[];
   toCreateColumns: string[];

--- a/wren-ui/src/apollo/server/utils/model.ts
+++ b/wren-ui/src/apollo/server/utils/model.ts
@@ -1,5 +1,6 @@
 import { IModelColumnRepository, ModelColumn } from '@server/repositories';
 import { replaceAllowableSyntax } from './regex';
+import { CompactTable } from '@server/services/metadataService';
 
 export function transformInvalidColumnName(columnName: string) {
   let referenceName = replaceAllowableSyntax(columnName);
@@ -19,9 +20,14 @@ export function replaceInvalidReferenceName(referenceName: string) {
 export function findColumnsToUpdate(
   columns: string[],
   existingColumns: ModelColumn[],
+  sourceTableColumns: CompactTable[],
 ): {
   toDeleteColumnIds: number[];
   toCreateColumns: string[];
+  toUpdateColumns: Array<{
+    id: number;
+    type: string;
+  }>;
 } {
   const toDeleteColumnIds = existingColumns
     .map(({ id, sourceColumnName }) => {
@@ -35,9 +41,31 @@ export function findColumnsToUpdate(
   const toCreateColumns = columns.filter(
     (columnName) => !existColumnNames.includes(columnName),
   );
+
+  const toUpdateColumns = sourceTableColumns.reduce((acc, sourceColumn) => {
+    const existingColumn = existingColumns.find(
+      (col) => col.sourceColumnName === sourceColumn.name,
+    );
+    if (!existingColumn) return acc;
+
+    const columnName = columns.find((col) => col === sourceColumn.name);
+    if (!columnName) return acc;
+
+    if (sourceColumn.type === existingColumn.type) return acc;
+
+    return [
+      ...acc,
+      {
+        id: existingColumn.id,
+        type: sourceColumn.type || 'string',
+      },
+    ];
+  }, []);
+
   return {
     toDeleteColumnIds,
     toCreateColumns,
+    toUpdateColumns,
   };
 }
 

--- a/wren-ui/src/components/modals/SchemaChangeModal.tsx
+++ b/wren-ui/src/components/modals/SchemaChangeModal.tsx
@@ -325,7 +325,7 @@ export default function SchemaChangeModal(props: Props) {
                 expandedRowRender: (record: ExpandedRowsProps['record']) => (
                   <ExpandedRows
                     record={record}
-                    tipMessage="Following table shows resources affected by this model and will be deleted when resolving."
+                    tipMessage="The following table shows resources affected by this model and will be deleted when resolving."
                   />
                 ),
               }}
@@ -361,7 +361,7 @@ export default function SchemaChangeModal(props: Props) {
                 expandedRowRender: (record: ExpandedRowsProps['record']) => (
                   <ExpandedRows
                     record={record}
-                    tipMessage="Following table shows resources affected by this column of the model and will be deleted when resolving."
+                    tipMessage="The following table shows resources affected by this column of the model and will be deleted when resolving."
                   />
                 ),
               }}
@@ -393,7 +393,7 @@ export default function SchemaChangeModal(props: Props) {
                 expandedRowRender: (record: ExpandedRowsProps['record']) => (
                   <ExpandedRows
                     record={record}
-                    tipMessage="Following table shows the resources utilized by this column of the model. Please review each resource. Please manually update the relevant resources accordingly, if any changes are required."
+                    tipMessage="The following table shows the resources utilized by this column of the model. Please review each resource and manually update the relevant ones if any changes are required."
                   />
                 ),
               }}

--- a/wren-ui/src/components/modals/SchemaChangeModal.tsx
+++ b/wren-ui/src/components/modals/SchemaChangeModal.tsx
@@ -20,6 +20,7 @@ import {
   DetailedChangeTable,
   DetailedAffectedCalculatedFields,
   DetailedAffectedRelationships,
+  NodeType,
   SchemaChange,
   SchemaChangeType,
 } from '@/apollo/client/graphql/__types__';
@@ -68,29 +69,18 @@ type Props = ModalAction<SchemaChange> & {
   };
 };
 
-enum ResourceTypes {
-  CALCULATED_FIELD = 'Calculated Field',
-  RELATIONSHIP = 'Relationship',
-}
-
 const nestedColumns = [
   {
     title: 'Affected Resource',
     dataIndex: 'resourceType',
     width: 200,
-    render: (resourceType: ResourceTypes) => {
-      if (resourceType === ResourceTypes.CALCULATED_FIELD) {
-        return (
-          <Tag className="ant-tag--geekblue">
-            {ResourceTypes.CALCULATED_FIELD}
-          </Tag>
-        );
+    render: (resourceType: NodeType) => {
+      if (resourceType === NodeType.CALCULATED_FIELD) {
+        return <Tag className="ant-tag--geekblue">Calculated Field</Tag>;
       }
 
-      if (resourceType === ResourceTypes.RELATIONSHIP) {
-        return (
-          <Tag className="ant-tag--citrus">{ResourceTypes.RELATIONSHIP}</Tag>
-        );
+      if (resourceType === NodeType.RELATION) {
+        return <Tag className="ant-tag--citrus">Relationship</Tag>;
       }
 
       return null;
@@ -212,14 +202,14 @@ export default function SchemaChangeModal(props: Props) {
             index: number,
           ) => ({
             ...calculatedField,
-            resourceType: ResourceTypes.CALCULATED_FIELD,
+            resourceType: NodeType.CALCULATED_FIELD,
             rowKey: `${tables.sourceTableName}-${calculatedField.referenceName}-${index}`,
           }),
         ),
         ...tables.relationships.map(
           (relationship: DetailedAffectedRelationships, index: number) => ({
             ...relationship,
-            resourceType: ResourceTypes.RELATIONSHIP,
+            resourceType: NodeType.RELATION,
             rowKey: `${tables.sourceTableName}-${relationship.referenceName}-${index}`,
           }),
         ),

--- a/wren-ui/src/components/pages/modeling/form/ModelForm.tsx
+++ b/wren-ui/src/components/pages/modeling/form/ModelForm.tsx
@@ -79,39 +79,6 @@ export default function ModelForm(props: Props) {
     }
   }, [sourceTableFieldValue]);
 
-  useEffect(() => {
-    if (defaultValue) {
-      const fields: string[] = defaultValue.fields.map(
-        (field: DiagramModelField) => field.referenceName,
-      );
-
-      const primaryKeyField = defaultValue.fields.find(
-        (field: DiagramModelField) => field.isPrimaryKey,
-      );
-
-      form.setFieldsValue({
-        [FormFieldKey.COLUMNS]: fields,
-        [FormFieldKey.PRIMARY_KEY]: primaryKeyField?.referenceName,
-      });
-
-      setSourceTableName(defaultValue.sourceTableName);
-      setSelectedColumns(fields);
-    }
-  }, [defaultValue, form]);
-
-  const tableOptions: JSX.Element[] = dataSourceTables.map(
-    (table: CompactTable) => {
-      const disabled = inUsedModelList.includes(table.name);
-      const option = {
-        disabled,
-        children: table.name,
-        value: table.name,
-      };
-
-      return <Option {...option} key={option.value} />;
-    },
-  );
-
   const columns: Array<{
     key: string;
     name: string;
@@ -129,6 +96,39 @@ export default function ModelForm(props: Props) {
       key: column.name,
     }));
   }, [dataSourceTables, sourceTableName]);
+
+  useEffect(() => {
+    if (defaultValue) {
+      const fields: string[] = defaultValue.fields
+        .map((field: DiagramModelField) => field.referenceName)
+        .filter((col) => columns.find((c) => c.name === col));
+
+      const primaryKeyField = defaultValue.fields.find(
+        (field: DiagramModelField) => field.isPrimaryKey,
+      );
+
+      form.setFieldsValue({
+        [FormFieldKey.COLUMNS]: fields,
+        [FormFieldKey.PRIMARY_KEY]: primaryKeyField?.referenceName,
+      });
+
+      setSourceTableName(defaultValue.sourceTableName);
+      setSelectedColumns(fields);
+    }
+  }, [defaultValue, form, columns]);
+
+  const tableOptions: JSX.Element[] = dataSourceTables.map(
+    (table: CompactTable) => {
+      const disabled = inUsedModelList.includes(table.name);
+      const option = {
+        disabled,
+        children: table.name,
+        value: table.name,
+      };
+
+      return <Option {...option} key={option.value} />;
+    },
+  );
 
   const onChangeColumns = (newKeys: string[]) => setSelectedColumns(newKeys);
 

--- a/wren-ui/src/components/sidebar/modeling/ModelTree.tsx
+++ b/wren-ui/src/components/sidebar/modeling/ModelTree.tsx
@@ -24,6 +24,7 @@ import {
   useTriggerDataSourceDetectionMutation,
 } from '@/apollo/client/graphql/dataSource.generated';
 import { DIAGRAM } from '@/apollo/client/graphql/diagram';
+import { LIST_MODELS } from '@/apollo/client/graphql/model';
 
 dayJs.extend(utc);
 dayJs.extend(relativeTime);
@@ -75,7 +76,7 @@ export default function ModelTree(props: Props) {
           schemaChangeModal.closeModal();
         }
       },
-      refetchQueries: [{ query: DIAGRAM }],
+      refetchQueries: [{ query: DIAGRAM }, { query: LIST_MODELS }],
     });
   const { data: schemaChangeData, refetch: refetchSchemaChange } =
     useSchemaChangeQuery({

--- a/wren-ui/src/styles/components/alert.less
+++ b/wren-ui/src/styles/components/alert.less
@@ -1,6 +1,6 @@
 .ant-alert {
   align-items: flex-start;
-  .anticon-exclamation-circle {
+  .anticon-exclamation-circle, .anticon-warning {
     margin-top: 4px;
   }
   .ant-alert-message {

--- a/wren-ui/src/styles/components/table.less
+++ b/wren-ui/src/styles/components/table.less
@@ -28,12 +28,12 @@
       border-radius: 0;
 
       .ant-table-thead > tr > th {
-        background: #fafafa;
+        background: @gray-2;
       }
 
       .ant-table-tbody > tr.ant-table-row:hover > td,
       .ant-table-tbody > tr > td.ant-table-cell-row-hover {
-        background: #fafafa;
+        background: @gray-2;
       }
     }
   }

--- a/wren-ui/src/styles/components/table.less
+++ b/wren-ui/src/styles/components/table.less
@@ -21,6 +21,22 @@
       background-color: @gray-3;
     }
   }
+
+  .adm-nested-table {
+    .ant-table {
+      border: none;
+      border-radius: 0;
+
+      .ant-table-thead > tr > th {
+        background: #fafafa;
+      }
+
+      .ant-table-tbody > tr.ant-table-row:hover > td,
+      .ant-table-tbody > tr > td.ant-table-cell-row-hover {
+        background: #fafafa;
+      }
+    }
+  }
 }
 
 .ant-table-wrapper:not(.ant-table-has-header) {

--- a/wren-ui/src/styles/components/tag.less
+++ b/wren-ui/src/styles/components/tag.less
@@ -4,4 +4,9 @@
     background: @geekblue-1;
     border-color: @geekblue-6;
   }
+  &--citrus {
+    color: @citrus-6;
+    background: @citrus-1;
+    border-color: @citrus-6;
+  }
 }


### PR DESCRIPTION
## Description
- List affected calculated fields & Relationships
- Update resolveSchemaChange function

## Solution idea

The change column of the database is used to save data that is different from the source. The basic three changes of schema change can be known by comparing the change column data with the Model and Model columns data.

As we know, both Calculated fields and Relationships are created by selecting the column of the Model, and are related to the Column. Therefore, the phase 2 we want to support will be affected or have calculated fields and relationships that use the changed Column listed.


## Tasks
- List affected calculated fields & Relationships
- Delete all affected columns, calculated fields, and relationships to resolve schema change
- Fix update model columns related issues
- No expand icon if there are no affected calculated fields and relationships

## UI

![截圖 2024-06-26 下午2 15 57](https://github.com/Canner/WrenAI/assets/42527625/76799eeb-decd-4670-a050-e7376122d995)
![截圖 2024-06-26 下午2 23 59](https://github.com/Canner/WrenAI/assets/42527625/9c0d9ea2-b1e2-402c-8a27-2c62ac51b675)

#### Source Table Delete
![截圖 2024-06-26 下午2 28 03](https://github.com/Canner/WrenAI/assets/42527625/d7257516-4682-4796-a5d9-0de243d33190)


#### Source Column Delete
![截圖 2024-06-26 下午2 28 25](https://github.com/Canner/WrenAI/assets/42527625/55f48507-6462-4319-bc4d-3713f829cb68)



#### Column Type Change

![截圖 2024-06-26 下午2 32 19](https://github.com/Canner/WrenAI/assets/42527625/da7c8c93-d272-4b8d-8383-14189ea83238)

![截圖 2024-06-26 下午2 32 42](https://github.com/Canner/WrenAI/assets/42527625/ab38ee56-d6b4-4008-ad83-47932719015f)

