### PR TITLE
Chore/ai service/auto deploy at init

### DIFF
--- a/wren-ai-service/src/__main__.py
+++ b/wren-ai-service/src/__main__.py
@@ -25,11 +25,7 @@ setup_custom_logger(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # startup events
-    engine = container.init_globals()
-    # we automatically deploy the mdl model here
-    # in case the model is also not deployed in wren-ui, the error wil be thrown(but it doesn't matter)
-    if engine.name == "wren-ui":
-        await engine.force_deploy()
+    await container.init_globals()
 
     yield
 

--- a/wren-ai-service/src/__main__.py
+++ b/wren-ai-service/src/__main__.py
@@ -25,7 +25,11 @@ setup_custom_logger(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # startup events
-    container.init_globals()
+    engine = container.init_globals()
+    # we automatically deploy the mdl model here
+    # in case the model is also not deployed in wren-ui, the error wil be thrown(but it doesn't matter)
+    if engine.name == "wren-ui":
+        await engine.force_deploy()
 
     yield
 

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -33,7 +33,7 @@ ASK_SERVICE = None
 ASK_DETAILS_SERVICE = None
 
 
-def init_globals():
+async def init_globals():
     global SEMANTIC_SERVICE, ASK_SERVICE, ASK_DETAILS_SERVICE
 
     llm_provider, document_store_provider, engine = init_providers()
@@ -44,6 +44,10 @@ def init_globals():
     document_store_provider.get_store(
         dataset_name="view_questions", recreate_index=True
     )
+    # we automatically deploy the mdl model here
+    # in case the model is also not deployed in wren-ui, the error wil be thrown(but it doesn't matter)
+    if engine.name == "wren-ui":
+        await engine.force_deploy()
 
     SEMANTIC_SERVICE = SemanticsService(
         pipelines={
@@ -94,5 +98,3 @@ def init_globals():
             ),
         },
     )
-
-    return engine

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -44,10 +44,6 @@ def init_globals():
     document_store_provider.get_store(
         dataset_name="view_questions", recreate_index=True
     )
-    # we automatically deploy the mdl model here
-    # in case the model is also not deployed in wren-ui, the error wil be thrown(but it doesn't matter)
-    if engine.name == "wren-ui":
-        engine.force_deploy()
 
     SEMANTIC_SERVICE = SemanticsService(
         pipelines={
@@ -98,3 +94,5 @@ def init_globals():
             ),
         },
     )
+
+    return engine

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -44,6 +44,10 @@ def init_globals():
     document_store_provider.get_store(
         dataset_name="view_questions", recreate_index=True
     )
+    # we automatically deploy the mdl model here
+    # in case the model is also not deployed in wren-ui, the error wil be thrown(but it doesn't matter)
+    if engine.name == "wren-ui":
+        engine.force_deploy()
 
     SEMANTIC_SERVICE = SemanticsService(
         pipelines={

--- a/wren-ai-service/src/providers/engine/wren.py
+++ b/wren-ai-service/src/providers/engine/wren.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
 import orjson
-import requests
 
 from src.core.engine import Engine, add_quotes, remove_limit_statement
 from src.providers.loader import provider
@@ -42,17 +41,17 @@ class WrenUI(Engine):
                 return True, None
             return False, res.get("errors", [{}])[0].get("message", "Unknown error")
 
-    def force_deploy(self):
-        response = requests.post(
-            f"{self._endpoint}/api/graphql",
-            json={
-                "query": "mutation Deploy($force: Boolean) { deploy(force: $force) }",
-                "variables": {
-                    "force": True,
+    async def force_deploy(self):
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self._endpoint}/api/graphql",
+                json={
+                    "query": "mutation Deploy($force: Boolean) { deploy(force: $force) }",
+                    "variables": {"force": True},
                 },
-            },
-        )
-        logger.info(f"Forcing deployment: {response.json()}")
+            ) as response:
+                res = await response.json()
+                logger.info(f"Forcing deployment: {res}")
 
 
 @provider("wren-ibis")


### PR DESCRIPTION
Now when wren-ai-service is started, the document store is being cleaned, and users need to manually deploy the model. It's cumbersome, and this PR aims to solve the issue by trying to auto-redeploying the mdl model. In case there is no mdl model defined in wren-ui, the error will be thrown and we just ignore it. This PR is based on Andy's work by allowing deploying the mdl model by force.