### PR TITLE
feat(wren-ui): Add Pending Feedbacks UI

### DIFF
--- a/wren-ui/src/components/pages/home/thread/feedback/AdjustmentSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/AdjustmentSideFloat.tsx
@@ -1,0 +1,63 @@
+import clsx from 'clsx';
+import { useMemo } from 'react';
+import styled from 'styled-components';
+import { Button, Popconfirm } from 'antd';
+import { FileTextOutlined } from '@ant-design/icons';
+
+const StyledAdjustmentSideFloat = styled.div`
+  position: relative;
+  width: 325px;
+
+  .adjustmentSideFloat-title {
+    position: absolute;
+    top: -14px;
+    padding: 0 4px;
+  }
+`;
+
+interface Props {
+  className?: string;
+  references: any[];
+  onOpenReviewDrawer: () => void;
+  onResetAllChanges: () => void;
+}
+
+export default function AdjustmentSideFloat(props: Props) {
+  const { className, references, onOpenReviewDrawer, onResetAllChanges } =
+    props;
+
+  const changedReferences = useMemo(() => {
+    return (references || []).filter((item) => !!item.correctionPrompt);
+  }, [references]);
+
+  if (changedReferences.length === 0) return null;
+  return (
+    <StyledAdjustmentSideFloat
+      className={clsx('border border-gray-4 rounded p-4', className)}
+    >
+      <div className="adjustmentSideFloat-title text-md text-medium bg-gray-1 citrus-6 -ml-2">
+        <FileTextOutlined /> Pending adjustments
+      </div>
+      <div className="d-flex mt-2">
+        <Button
+          className="text-sm"
+          type="primary"
+          size="small"
+          onClick={onOpenReviewDrawer}
+        >
+          Review changes ({changedReferences.length})
+        </Button>
+        <Popconfirm
+          title="Are you sure?"
+          okText="Confirm"
+          okButtonProps={{ danger: true }}
+          onConfirm={onResetAllChanges}
+        >
+          <Button className="text-sm gray-6 ml-2" type="text" size="small">
+            Reset all
+          </Button>
+        </Popconfirm>
+      </div>
+    </StyledAdjustmentSideFloat>
+  );
+}

--- a/wren-ui/src/components/pages/home/thread/feedback/AdjustmentSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/AdjustmentSideFloat.tsx
@@ -36,7 +36,7 @@ export default function AdjustmentSideFloat(props: Props) {
       className={clsx('border border-gray-4 rounded p-4', className)}
     >
       <div className="adjustmentSideFloat-title text-md text-medium bg-gray-1 citrus-6 -ml-2">
-        <FileTextOutlined /> Pending adjustments
+        <FileTextOutlined /> Pending feedbacks
       </div>
       <div className="d-flex mt-2">
         <Button
@@ -45,7 +45,7 @@ export default function AdjustmentSideFloat(props: Props) {
           size="small"
           onClick={onOpenReviewDrawer}
         >
-          Review changes ({changedReferences.length})
+          Review feedbacks ({changedReferences.length})
         </Button>
         <Popconfirm
           title="Are you sure?"

--- a/wren-ui/src/components/pages/home/thread/feedback/FeedbackSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/FeedbackSideFloat.tsx
@@ -4,11 +4,11 @@ import styled from 'styled-components';
 import { Button, Popconfirm } from 'antd';
 import { FileTextOutlined } from '@ant-design/icons';
 
-const StyledAdjustmentSideFloat = styled.div`
+const StyledFeedbackSideFloat = styled.div`
   position: relative;
   width: 325px;
 
-  .adjustmentSideFloat-title {
+  .feedbackSideFloat-title {
     position: absolute;
     top: -14px;
     padding: 0 4px;
@@ -22,7 +22,7 @@ interface Props {
   onResetAllChanges: () => void;
 }
 
-export default function AdjustmentSideFloat(props: Props) {
+export default function FeedbackSideFloat(props: Props) {
   const { className, references, onOpenReviewDrawer, onResetAllChanges } =
     props;
 
@@ -32,10 +32,10 @@ export default function AdjustmentSideFloat(props: Props) {
 
   if (changedReferences.length === 0) return null;
   return (
-    <StyledAdjustmentSideFloat
+    <StyledFeedbackSideFloat
       className={clsx('border border-gray-4 rounded p-4', className)}
     >
-      <div className="adjustmentSideFloat-title text-md text-medium bg-gray-1 citrus-6 -ml-2">
+      <div className="feedbackSideFloat-title text-md text-medium bg-gray-1 citrus-6 -ml-2">
         <FileTextOutlined /> Pending feedbacks
       </div>
       <div className="d-flex mt-2">
@@ -58,6 +58,6 @@ export default function AdjustmentSideFloat(props: Props) {
           </Button>
         </Popconfirm>
       </div>
-    </StyledAdjustmentSideFloat>
+    </StyledFeedbackSideFloat>
   );
 }

--- a/wren-ui/src/components/pages/home/thread/feedback/ReferenceSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReferenceSideFloat.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
 import clsx from 'clsx';
+import { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { Tag, Typography, Button, Input } from 'antd';
 import { EditOutlined } from '@ant-design/icons';
@@ -9,7 +9,7 @@ import { ReferenceTypes, getReferenceIcon } from './utils';
 
 const StyledReferenceSideFloat = styled.div`
   position: relative;
-  width: 325px;
+  width: 330px;
 
   .referenceSideFloat-title {
     position: absolute;
@@ -20,20 +20,27 @@ const StyledReferenceSideFloat = styled.div`
 
 interface Props {
   references: any[];
-  saveCorrectionPrompt?: (id: string, value: string) => void;
+  onSaveCorrectionPrompt?: (id: string, value: string) => void;
 }
 
 const COLLAPSE_LIMIT = 3;
 
-const ReferenceSummaryTemplate = ({ title, type, referenceNum }) => {
+const ReferenceSummaryTemplate = ({
+  title,
+  type,
+  referenceNum,
+  correctionPrompt,
+}) => {
+  const isRevise = !!correctionPrompt;
   return (
     <div className="d-flex align-center my-1">
-      <Tag className="ant-tag__reference">
+      <Tag className={clsx('ant-tag__reference', { isRevise })}>
         <span className="mr-1 lh-xs">{getReferenceIcon(type)}</span>
         {referenceNum}
       </Tag>
       <Typography.Text className="gray-8" ellipsis>
         {title}
+        {isRevise && <span className="gray-6 ml-2">(revised)</span>}
       </Typography.Text>
     </div>
   );
@@ -80,6 +87,7 @@ const ReferenceTemplate = ({
   const handleEdit = () => {
     saveCorrectionPrompt(id, value);
     setIsEdit(false);
+    setValue('');
   };
 
   return (
@@ -110,6 +118,7 @@ const ReferenceTemplate = ({
                 placeholder="Add a prompt for adjustment..."
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
+                onPressEnter={handleEdit}
               />
               <Button
                 className="text-sm"
@@ -132,7 +141,7 @@ const GroupReferenceIterator = makeIterable(GroupReferenceTemplate);
 const ReferenceIterator = makeIterable(ReferenceTemplate);
 
 const References = (props: Props) => {
-  const { references, saveCorrectionPrompt } = props;
+  const { references, onSaveCorrectionPrompt } = props;
 
   const fieldReferences = references.filter(
     (ref) => ref.type === ReferenceTypes.FIELD,
@@ -167,10 +176,15 @@ const References = (props: Props) => {
   ];
 
   return (
-    <GroupReferenceIterator
-      data={resources}
-      saveCorrectionPrompt={saveCorrectionPrompt}
-    />
+    <div
+      className="pr-4 -mr-2"
+      style={{ maxHeight: 'calc(100vh - 240px)', overflowY: 'auto' }}
+    >
+      <GroupReferenceIterator
+        data={resources}
+        saveCorrectionPrompt={onSaveCorrectionPrompt}
+      />
+    </div>
   );
 };
 
@@ -190,7 +204,7 @@ export default function ReferenceSideFloat(props: Props) {
   if (references.length === 0) return null;
   return (
     <StyledReferenceSideFloat className="border border-gray-4 rounded p-4">
-      <div className="referenceSideFloat-title text-md text-medium bg-gray-1">
+      <div className="referenceSideFloat-title text-md text-medium bg-gray-1 -ml-2">
         <QuoteIcon /> References
       </div>
       {collapse ? (

--- a/wren-ui/src/components/pages/home/thread/feedback/ReferenceSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReferenceSideFloat.tsx
@@ -40,7 +40,6 @@ const ReferenceSummaryTemplate = ({
       </Tag>
       <Typography.Text className="gray-8" ellipsis>
         {title}
-        {isRevise && <span className="gray-6 ml-2">(revised)</span>}
       </Typography.Text>
     </div>
   );
@@ -103,7 +102,7 @@ const ReferenceTemplate = ({
           {title}
           <span className="gray-6 ml-2">
             {isRevise ? (
-              '(revised)'
+              '(feedback suggested)'
             ) : (
               <EditOutlined className="gray-6 " onClick={openEdit} />
             )}
@@ -115,7 +114,7 @@ const ReferenceTemplate = ({
               <Input
                 className="text-sm"
                 size="small"
-                placeholder="Add a prompt for adjustment..."
+                placeholder="Add a prompt for feedback..."
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
                 onPressEnter={handleEdit}

--- a/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
@@ -67,7 +67,7 @@ const ReviewTemplate = ({
       >
         <span className="gray-6 text-semi-bold flex-shrink-0 mr-1">
           <FileTextOutlined className="mr-1" />
-          Original:
+          Reference:
         </span>
         <Typography.Text className="gray-6" ellipsis={!isCollapse}>
           {title}
@@ -142,7 +142,7 @@ export default function ReviewDrawer(props: Props) {
   return (
     <Drawer
       visible={visible}
-      title={`Review changes (${changedReferences.length})`}
+      title={`Review feedbacks (${changedReferences.length})`}
       width={520}
       closable
       destroyOnClose

--- a/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
@@ -1,0 +1,167 @@
+import clsx from 'clsx';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Drawer,
+  Space,
+  Typography,
+  Tag,
+  Input,
+  Popconfirm,
+} from 'antd';
+import styled from 'styled-components';
+import {
+  EditOutlined,
+  DeleteOutlined,
+  FileTextOutlined,
+} from '@ant-design/icons';
+import { DrawerAction } from '@/hooks/useDrawerAction';
+import { makeIterable } from '@/utils/iteration';
+import { getReferenceIcon } from './utils';
+
+type Props = DrawerAction & {
+  references: any[];
+  onSaveCorrectionPrompt?: (id: string, value: string) => void;
+  onRemoveCorrectionPrompt?: (id: string) => void;
+};
+
+const StyledOriginal = styled.div`
+  cursor: pointer;
+  background-color: var(--gray-3);
+  &:hover {
+    background-color: var(--gray-4);
+  }
+`;
+
+const ReviewTemplate = ({
+  id,
+  title,
+  type,
+  referenceNum,
+  correctionPrompt,
+  saveCorrectionPrompt,
+  removeCorrectionPrompt,
+}) => {
+  const [isEdit, setIsEdit] = useState(false);
+  const [isCollapse, setIsCollapse] = useState(false);
+  const isRevise = !!correctionPrompt;
+
+  const openEdit = async () => {
+    setIsEdit(!isEdit);
+  };
+
+  const openDelete = () => {
+    removeCorrectionPrompt(id);
+  };
+
+  const handleEdit = (event) => {
+    saveCorrectionPrompt(id, event.target.value);
+    setIsEdit(false);
+  };
+
+  return (
+    <div>
+      <StyledOriginal
+        className="d-flex gray-6 py-1 px-3 rounded text-sm mb-2"
+        onClick={() => setIsCollapse(true)}
+      >
+        <span className="gray-6 text-semi-bold flex-shrink-0 mr-1">
+          <FileTextOutlined className="mr-1" />
+          Original:
+        </span>
+        <Typography.Text className="gray-6" ellipsis={!isCollapse}>
+          {title}
+        </Typography.Text>
+      </StyledOriginal>
+      <div className="d-flex mb-4">
+        <div className="lh-xs" style={{ paddingTop: 2 }}>
+          <Tag className={clsx('ant-tag__reference', { isRevise })}>
+            <span className="mr-1 lh-xs">{getReferenceIcon(type)}</span>
+            {referenceNum}
+          </Tag>
+        </div>
+        <div className="flex-grow-1">
+          <Typography.Text className="gray-8">
+            {isEdit ? (
+              <Input.TextArea
+                defaultValue={correctionPrompt}
+                onPressEnter={handleEdit}
+                onBlur={handleEdit}
+                autoSize
+                autoFocus
+              />
+            ) : (
+              correctionPrompt
+            )}
+            {!isEdit && (
+              <span className="gray-6 ml-2">
+                <EditOutlined className="gray-6 mr-2" onClick={openEdit} />
+                <Popconfirm
+                  title="Are you sure?"
+                  okText="Confirm"
+                  okButtonProps={{ danger: true }}
+                  onConfirm={openDelete}
+                >
+                  <DeleteOutlined className="red-5" />
+                </Popconfirm>
+              </span>
+            )}
+          </Typography.Text>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ReviewIterator = makeIterable(ReviewTemplate);
+
+export default function ReviewDrawer(props: Props) {
+  const {
+    visible,
+    references,
+    onClose,
+    onSaveCorrectionPrompt,
+    onRemoveCorrectionPrompt,
+  } = props;
+
+  const changedReferences = useMemo(() => {
+    return (references || []).filter(
+      (reference) => !!reference.correctionPrompt,
+    );
+  }, [references]);
+
+  useEffect(() => {
+    if (changedReferences.length === 0) {
+      onClose();
+    }
+  }, [changedReferences]);
+
+  const submit = async () => {
+    // TODO: call correction ask api
+  };
+  return (
+    <Drawer
+      visible={visible}
+      title={`Review changes (${changedReferences.length})`}
+      width={520}
+      closable
+      destroyOnClose
+      maskClosable={false}
+      onClose={onClose}
+      footer={
+        <Space className="d-flex justify-end">
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="primary" onClick={submit}>
+            Submit
+          </Button>
+        </Space>
+      }
+    >
+      <ReviewIterator
+        data={changedReferences}
+        saveCorrectionPrompt={onSaveCorrectionPrompt}
+        removeCorrectionPrompt={onRemoveCorrectionPrompt}
+      />
+    </Drawer>
+  );
+}

--- a/wren-ui/src/components/pages/home/thread/feedback/index.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/index.tsx
@@ -1,5 +1,8 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 import ReferenceSideFloat from '@/components/pages/home/thread/feedback/ReferenceSideFloat';
+import AdjustmentSideFloat from '@/components/pages/home/thread/feedback/AdjustmentSideFloat';
+import ReviewDrawer from '@/components/pages/home/thread/feedback/ReviewDrawer';
+import useDrawerAction from '@/hooks/useDrawerAction';
 import { ReferenceTypes } from './utils';
 
 type ContextProps = {
@@ -69,9 +72,18 @@ export default function Feedback(props: Props) {
   const { headerSlot, bodySlot } = props;
 
   const [correctionPrompts, setCorrectionPrompts] = useState({});
+  const reviewDrawer = useDrawerAction();
 
   const saveCorrectionPrompt = (id: string, value: string) => {
     setCorrectionPrompts({ ...correctionPrompts, [id]: value });
+  };
+
+  const removeCorrectionPrompt = (id: string) => {
+    setCorrectionPrompts({ ...correctionPrompts, [id]: undefined });
+  };
+
+  const resetAllCorrectionPrompts = () => {
+    setCorrectionPrompts({});
   };
 
   const references = useMemo(() => {
@@ -88,7 +100,17 @@ export default function Feedback(props: Props) {
 
   return (
     <FeedbackContext.Provider value={contextValue}>
-      <div>{headerSlot}</div>
+      <div className="d-flex">
+        {headerSlot}
+        <div className="flex-shrink-0 pl-5">
+          <AdjustmentSideFloat
+            className="mb-4"
+            references={references}
+            onOpenReviewDrawer={reviewDrawer.openDrawer}
+            onResetAllChanges={resetAllCorrectionPrompts}
+          />
+        </div>
+      </div>
       <div className="d-flex">
         {bodySlot}
         <div className="flex-shrink-0 pl-5">
@@ -98,6 +120,13 @@ export default function Feedback(props: Props) {
           />
         </div>
       </div>
+      <ReviewDrawer
+        {...reviewDrawer.state}
+        onClose={reviewDrawer.closeDrawer}
+        references={references}
+        onSaveCorrectionPrompt={saveCorrectionPrompt}
+        onRemoveCorrectionPrompt={removeCorrectionPrompt}
+      />
     </FeedbackContext.Provider>
   );
 }

--- a/wren-ui/src/components/pages/home/thread/feedback/index.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/index.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo, useState } from 'react';
-import ReferenceSideFloat from './ReferenceSideFloat';
+import ReferenceSideFloat from '@/components/pages/home/thread/feedback/ReferenceSideFloat';
 import { ReferenceTypes } from './utils';
 
 type ContextProps = {
@@ -94,7 +94,7 @@ export default function Feedback(props: Props) {
         <div className="flex-shrink-0 pl-5">
           <ReferenceSideFloat
             references={references}
-            saveCorrectionPrompt={saveCorrectionPrompt}
+            onSaveCorrectionPrompt={saveCorrectionPrompt}
           />
         </div>
       </div>

--- a/wren-ui/src/components/pages/home/thread/feedback/index.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/index.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 import ReferenceSideFloat from '@/components/pages/home/thread/feedback/ReferenceSideFloat';
-import AdjustmentSideFloat from '@/components/pages/home/thread/feedback/AdjustmentSideFloat';
+import FeedbackSideFloat from '@/components/pages/home/thread/feedback/FeedbackSideFloat';
 import ReviewDrawer from '@/components/pages/home/thread/feedback/ReviewDrawer';
 import useDrawerAction from '@/hooks/useDrawerAction';
 import { ReferenceTypes } from './utils';
@@ -103,7 +103,7 @@ export default function Feedback(props: Props) {
       <div className="d-flex">
         {headerSlot}
         <div className="flex-shrink-0 pl-5">
-          <AdjustmentSideFloat
+          <FeedbackSideFloat
             className="mb-4"
             references={references}
             onOpenReviewDrawer={reviewDrawer.openDrawer}

--- a/wren-ui/src/components/pages/home/thread/index.tsx
+++ b/wren-ui/src/components/pages/home/thread/index.tsx
@@ -28,6 +28,10 @@ const StyledThread = styled.div`
   }
 `;
 
+const StyledContainer = styled.div`
+  max-width: 1030px;
+`;
+
 const AnswerResultTemplate = ({
   index,
   id,
@@ -44,7 +48,7 @@ const AnswerResultTemplate = ({
   const isLastThreadResponse = id === lastResponseId;
 
   return (
-    <div className="d-inline-block text-left" key={`${id}-${index}`}>
+    <StyledContainer className="mx-auto" key={`${id}-${index}`}>
       {index > 0 && <Divider />}
       {error ? (
         <Alert
@@ -68,7 +72,7 @@ const AnswerResultTemplate = ({
           isLastThreadResponse={isLastThreadResponse}
         />
       )}
-    </div>
+    </StyledContainer>
   );
 };
 
@@ -101,7 +105,7 @@ export default function Thread(props: Props) {
   }, [divRef, data]);
 
   return (
-    <StyledThread className="text-center px-4 mt-12" ref={divRef}>
+    <StyledThread className="px-4 mt-12" ref={divRef}>
       <AnswerResultIterator
         data={data?.responses || []}
         onOpenSaveAsViewModal={onOpenSaveAsViewModal}

--- a/wren-ui/src/styles/utilities/spacing.less
+++ b/wren-ui/src/styles/utilities/spacing.less
@@ -60,3 +60,8 @@
 }
 
 .make-spacing-classes();
+
+.mx-auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}

--- a/wren-ui/src/styles/utilities/text.less
+++ b/wren-ui/src/styles/utilities/text.less
@@ -36,6 +36,10 @@
   font-weight: 700 !important;
 }
 
+.text-semi-bold {
+  font-weight: 600 !important;
+}
+
 .text-medium {
   font-weight: 500 !important;
 }


### PR DESCRIPTION
## Description
- Add Pending Feedback Fixed Block
    - Name: FeedbackSideFloat
    - Review Feedback Drawer, name: ReviewDrawer
    - Collapse feature
    - Edit feature
        - Swap to Input if clicking edit icon
        - Remove revised in reference if clicking delete icon
- Interact with References UI

## UI Screenshots
<img width="1439" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/9be70604-c3b4-4943-bf0c-f096139541e0">

<img width="1452" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/e19cf050-0ee4-42ba-98c6-10528ec01d25">

<img width="1450" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/91bd3a89-2429-41e4-842e-795e215f8e37">

<img width="1451" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/4e57826f-2875-4aa8-8c29-2745b0c389b5">

<img width="1439" alt="image" src="https://github.com/Canner/WrenAI/assets/9657305/58b5c30f-87df-4b1a-a07b-ed7947f519e8">




