### PR TITLE
feat(wren-ui): Create Regenerated Response API & Add Regenerated Information in Thread Detail UI

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -71,6 +71,13 @@ export type ConnectionInfo = {
   username?: Maybe<Scalars['String']>;
 };
 
+export type CorrectionDetail = {
+  __typename?: 'CorrectionDetail';
+  correction: Scalars['String'];
+  id: Scalars['Int'];
+  type: ReferenceType;
+};
+
 export type CreateCalculatedFieldInput = {
   expression: ExpressionName;
   lineage: Array<Scalars['Int']>;
@@ -82,6 +89,11 @@ export type CreateModelInput = {
   fields: Array<Scalars['String']>;
   primaryKey?: InputMaybe<Scalars['String']>;
   sourceTableName: Scalars['String'];
+};
+
+export type CreateRegeneratedThreadResponseInput = {
+  corrections: Array<CreateThreadResponseCorrectionInput>;
+  responseId: Scalars['Int'];
 };
 
 export type CreateSimpleMetricInput = {
@@ -102,6 +114,14 @@ export type CreateThreadInput = {
   sql?: InputMaybe<Scalars['String']>;
   summary?: InputMaybe<Scalars['String']>;
   viewId?: InputMaybe<Scalars['Int']>;
+};
+
+export type CreateThreadResponseCorrectionInput = {
+  correction: Scalars['String'];
+  id: Scalars['Int'];
+  reference: Scalars['String'];
+  stepIndex: Scalars['Int'];
+  type: ReferenceType;
 };
 
 export type CreateThreadResponseInput = {
@@ -400,6 +420,7 @@ export type Mutation = {
   createAskingTask: Task;
   createCalculatedField: Scalars['JSON'];
   createModel: Scalars['JSON'];
+  createRegeneratedThreadResponse: ThreadResponse;
   createRelation: Scalars['JSON'];
   createThread: Thread;
   createThreadResponse: ThreadResponse;
@@ -450,6 +471,12 @@ export type MutationCreateCalculatedFieldArgs = {
 
 export type MutationCreateModelArgs = {
   data: CreateModelInput;
+};
+
+
+export type MutationCreateRegeneratedThreadResponseArgs = {
+  data: CreateRegeneratedThreadResponseInput;
+  threadId: Scalars['Int'];
 };
 
 
@@ -704,6 +731,14 @@ export type RecommendRelations = {
   relations: Array<Maybe<Relation>>;
 };
 
+export enum ReferenceType {
+  FIELD = 'FIELD',
+  FILTER = 'FILTER',
+  GROUP_BY = 'GROUP_BY',
+  QUERY_FROM = 'QUERY_FROM',
+  SORTING = 'SORTING'
+}
+
 export type Relation = {
   __typename?: 'Relation';
   fromColumnId: Scalars['Int'];
@@ -827,6 +862,7 @@ export type Thread = {
 
 export type ThreadResponse = {
   __typename?: 'ThreadResponse';
+  corrections?: Maybe<Array<CorrectionDetail>>;
   detail?: Maybe<ThreadResponseDetail>;
   error?: Maybe<Error>;
   id: Scalars['Int'];

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -85,15 +85,15 @@ export type CreateCalculatedFieldInput = {
   name: Scalars['String'];
 };
 
+export type CreateCorrectedThreadResponseInput = {
+  corrections: Array<CreateThreadResponseCorrectionInput>;
+  responseId: Scalars['Int'];
+};
+
 export type CreateModelInput = {
   fields: Array<Scalars['String']>;
   primaryKey?: InputMaybe<Scalars['String']>;
   sourceTableName: Scalars['String'];
-};
-
-export type CreateRegeneratedThreadResponseInput = {
-  corrections: Array<CreateThreadResponseCorrectionInput>;
-  responseId: Scalars['Int'];
 };
 
 export type CreateSimpleMetricInput = {
@@ -419,8 +419,8 @@ export type Mutation = {
   cancelAskingTask: Scalars['Boolean'];
   createAskingTask: Task;
   createCalculatedField: Scalars['JSON'];
+  createCorrectedThreadResponse: ThreadResponse;
   createModel: Scalars['JSON'];
-  createRegeneratedThreadResponse: ThreadResponse;
   createRelation: Scalars['JSON'];
   createThread: Thread;
   createThreadResponse: ThreadResponse;
@@ -469,14 +469,14 @@ export type MutationCreateCalculatedFieldArgs = {
 };
 
 
-export type MutationCreateModelArgs = {
-  data: CreateModelInput;
+export type MutationCreateCorrectedThreadResponseArgs = {
+  data: CreateCorrectedThreadResponseInput;
+  threadId: Scalars['Int'];
 };
 
 
-export type MutationCreateRegeneratedThreadResponseArgs = {
-  data: CreateRegeneratedThreadResponseInput;
-  threadId: Scalars['Int'];
+export type MutationCreateModelArgs = {
+  data: CreateModelInput;
 };
 
 

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -96,13 +96,13 @@ export type GetNativeSqlQueryVariables = Types.Exact<{
 
 export type GetNativeSqlQuery = { __typename?: 'Query', nativeSql: string };
 
-export type CreateRegeneratedThreadResponseMutationVariables = Types.Exact<{
+export type CreateCorrectedThreadResponseMutationVariables = Types.Exact<{
   threadId: Types.Scalars['Int'];
-  data: Types.CreateRegeneratedThreadResponseInput;
+  data: Types.CreateCorrectedThreadResponseInput;
 }>;
 
 
-export type CreateRegeneratedThreadResponseMutation = { __typename?: 'Mutation', createRegeneratedThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null } };
+export type CreateCorrectedThreadResponseMutation = { __typename?: 'Mutation', createCorrectedThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null } };
 
 export const CommonErrorFragmentDoc = gql`
     fragment CommonError on Error {
@@ -612,9 +612,9 @@ export function useGetNativeSqlLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type GetNativeSqlQueryHookResult = ReturnType<typeof useGetNativeSqlQuery>;
 export type GetNativeSqlLazyQueryHookResult = ReturnType<typeof useGetNativeSqlLazyQuery>;
 export type GetNativeSqlQueryResult = Apollo.QueryResult<GetNativeSqlQuery, GetNativeSqlQueryVariables>;
-export const CreateRegeneratedThreadResponseDocument = gql`
-    mutation CreateRegeneratedThreadResponse($threadId: Int!, $data: CreateRegeneratedThreadResponseInput!) {
-  createRegeneratedThreadResponse(threadId: $threadId, data: $data) {
+export const CreateCorrectedThreadResponseDocument = gql`
+    mutation CreateCorrectedThreadResponse($threadId: Int!, $data: CreateCorrectedThreadResponseInput!) {
+  createCorrectedThreadResponse(threadId: $threadId, data: $data) {
     ...CommonResponse
     error {
       ...CommonError
@@ -623,30 +623,30 @@ export const CreateRegeneratedThreadResponseDocument = gql`
 }
     ${CommonResponseFragmentDoc}
 ${CommonErrorFragmentDoc}`;
-export type CreateRegeneratedThreadResponseMutationFn = Apollo.MutationFunction<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>;
+export type CreateCorrectedThreadResponseMutationFn = Apollo.MutationFunction<CreateCorrectedThreadResponseMutation, CreateCorrectedThreadResponseMutationVariables>;
 
 /**
- * __useCreateRegeneratedThreadResponseMutation__
+ * __useCreateCorrectedThreadResponseMutation__
  *
- * To run a mutation, you first call `useCreateRegeneratedThreadResponseMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateRegeneratedThreadResponseMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useCreateCorrectedThreadResponseMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateCorrectedThreadResponseMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [createRegeneratedThreadResponseMutation, { data, loading, error }] = useCreateRegeneratedThreadResponseMutation({
+ * const [createCorrectedThreadResponseMutation, { data, loading, error }] = useCreateCorrectedThreadResponseMutation({
  *   variables: {
  *      threadId: // value for 'threadId'
  *      data: // value for 'data'
  *   },
  * });
  */
-export function useCreateRegeneratedThreadResponseMutation(baseOptions?: Apollo.MutationHookOptions<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>) {
+export function useCreateCorrectedThreadResponseMutation(baseOptions?: Apollo.MutationHookOptions<CreateCorrectedThreadResponseMutation, CreateCorrectedThreadResponseMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>(CreateRegeneratedThreadResponseDocument, options);
+        return Apollo.useMutation<CreateCorrectedThreadResponseMutation, CreateCorrectedThreadResponseMutationVariables>(CreateCorrectedThreadResponseDocument, options);
       }
-export type CreateRegeneratedThreadResponseMutationHookResult = ReturnType<typeof useCreateRegeneratedThreadResponseMutation>;
-export type CreateRegeneratedThreadResponseMutationResult = Apollo.MutationResult<CreateRegeneratedThreadResponseMutation>;
-export type CreateRegeneratedThreadResponseMutationOptions = Apollo.BaseMutationOptions<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>;
+export type CreateCorrectedThreadResponseMutationHookResult = ReturnType<typeof useCreateCorrectedThreadResponseMutation>;
+export type CreateCorrectedThreadResponseMutationResult = Apollo.MutationResult<CreateCorrectedThreadResponseMutation>;
+export type CreateCorrectedThreadResponseMutationOptions = Apollo.BaseMutationOptions<CreateCorrectedThreadResponseMutation, CreateCorrectedThreadResponseMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -5,7 +5,7 @@ import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type CommonErrorFragment = { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null };
 
-export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null };
+export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null };
 
 export type SuggestedQuestionsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -29,14 +29,14 @@ export type ThreadQueryVariables = Types.Exact<{
 }>;
 
 
-export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, summary: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null }> } };
+export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, summary: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null }> } };
 
 export type ThreadResponseQueryVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
 }>;
 
 
-export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null } };
+export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null } };
 
 export type CreateAskingTaskMutationVariables = Types.Exact<{
   data: Types.AskingTaskInput;
@@ -65,7 +65,7 @@ export type CreateThreadResponseMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null } };
+export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null } };
 
 export type UpdateThreadMutationVariables = Types.Exact<{
   where: Types.ThreadUniqueWhereInput;
@@ -96,6 +96,14 @@ export type GetNativeSqlQueryVariables = Types.Exact<{
 
 export type GetNativeSqlQuery = { __typename?: 'Query', nativeSql: string };
 
+export type CreateRegeneratedThreadResponseMutationVariables = Types.Exact<{
+  threadId: Types.Scalars['Int'];
+  data: Types.CreateRegeneratedThreadResponseInput;
+}>;
+
+
+export type CreateRegeneratedThreadResponseMutation = { __typename?: 'Mutation', createRegeneratedThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, summary: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null, corrections?: Array<{ __typename?: 'CorrectionDetail', id: number, type: Types.ReferenceType, correction: string }> | null } };
+
 export const CommonErrorFragmentDoc = gql`
     fragment CommonError on Error {
   code
@@ -124,6 +132,11 @@ export const CommonResponseFragmentDoc = gql`
       statement
       displayName
     }
+  }
+  corrections {
+    id
+    type
+    correction
   }
 }
     `;
@@ -435,14 +448,12 @@ export const CreateThreadResponseDocument = gql`
   createThreadResponse(threadId: $threadId, data: $data) {
     ...CommonResponse
     error {
-      code
-      shortMessage
-      message
-      stacktrace
+      ...CommonError
     }
   }
 }
-    ${CommonResponseFragmentDoc}`;
+    ${CommonResponseFragmentDoc}
+${CommonErrorFragmentDoc}`;
 export type CreateThreadResponseMutationFn = Apollo.MutationFunction<CreateThreadResponseMutation, CreateThreadResponseMutationVariables>;
 
 /**
@@ -601,3 +612,41 @@ export function useGetNativeSqlLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type GetNativeSqlQueryHookResult = ReturnType<typeof useGetNativeSqlQuery>;
 export type GetNativeSqlLazyQueryHookResult = ReturnType<typeof useGetNativeSqlLazyQuery>;
 export type GetNativeSqlQueryResult = Apollo.QueryResult<GetNativeSqlQuery, GetNativeSqlQueryVariables>;
+export const CreateRegeneratedThreadResponseDocument = gql`
+    mutation CreateRegeneratedThreadResponse($threadId: Int!, $data: CreateRegeneratedThreadResponseInput!) {
+  createRegeneratedThreadResponse(threadId: $threadId, data: $data) {
+    ...CommonResponse
+    error {
+      ...CommonError
+    }
+  }
+}
+    ${CommonResponseFragmentDoc}
+${CommonErrorFragmentDoc}`;
+export type CreateRegeneratedThreadResponseMutationFn = Apollo.MutationFunction<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>;
+
+/**
+ * __useCreateRegeneratedThreadResponseMutation__
+ *
+ * To run a mutation, you first call `useCreateRegeneratedThreadResponseMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateRegeneratedThreadResponseMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createRegeneratedThreadResponseMutation, { data, loading, error }] = useCreateRegeneratedThreadResponseMutation({
+ *   variables: {
+ *      threadId: // value for 'threadId'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useCreateRegeneratedThreadResponseMutation(baseOptions?: Apollo.MutationHookOptions<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>(CreateRegeneratedThreadResponseDocument, options);
+      }
+export type CreateRegeneratedThreadResponseMutationHookResult = ReturnType<typeof useCreateRegeneratedThreadResponseMutation>;
+export type CreateRegeneratedThreadResponseMutationResult = Apollo.MutationResult<CreateRegeneratedThreadResponseMutation>;
+export type CreateRegeneratedThreadResponseMutationOptions = Apollo.BaseMutationOptions<CreateRegeneratedThreadResponseMutation, CreateRegeneratedThreadResponseMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -30,6 +30,11 @@ const COMMON_RESPONSE = gql`
         displayName
       }
     }
+    corrections {
+      id
+      type
+      correction
+    }
   }
 `;
 
@@ -139,10 +144,7 @@ export const CREATE_THREAD_RESPONSE = gql`
     createThreadResponse(threadId: $threadId, data: $data) {
       ...CommonResponse
       error {
-        code
-        shortMessage
-        message
-        stacktrace
+        ...CommonError
       }
     }
   }
@@ -178,5 +180,19 @@ export const PREVIEW_DATA = gql`
 export const GET_NATIVE_SQL = gql`
   query GetNativeSQL($responseId: Int!) {
     nativeSql(responseId: $responseId)
+  }
+`;
+
+export const CREATE_REGENERATED_THREAD_RESPONSE = gql`
+  mutation CreateRegeneratedThreadResponse(
+    $threadId: Int!
+    $data: CreateRegeneratedThreadResponseInput!
+  ) {
+    createRegeneratedThreadResponse(threadId: $threadId, data: $data) {
+      ...CommonResponse
+      error {
+        ...CommonError
+      }
+    }
   }
 `;

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -183,12 +183,12 @@ export const GET_NATIVE_SQL = gql`
   }
 `;
 
-export const CREATE_REGENERATED_THREAD_RESPONSE = gql`
-  mutation CreateRegeneratedThreadResponse(
+export const CREATE_CORRECTED_THREAD_RESPONSE = gql`
+  mutation CreateCorrectedThreadResponse(
     $threadId: Int!
-    $data: CreateRegeneratedThreadResponseInput!
+    $data: CreateCorrectedThreadResponseInput!
   ) {
-    createRegeneratedThreadResponse(threadId: $threadId, data: $data) {
+    createCorrectedThreadResponse(threadId: $threadId, data: $data) {
       ...CommonResponse
       error {
         ...CommonError

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -131,18 +131,21 @@ export interface CorrectionObject<T> {
   value: string;
 }
 
-export interface AskCorrection {
+export interface AskCorrectionInput {
   before: CorrectionObject<ExplanationType>;
   after: CorrectionObject<ExpressionType>;
 }
 
-export interface AskStepWithCorrections extends AskStep {
-  corrections: AskCorrection[];
+export interface AskStepWithCorrectionsInput {
+  summary: string;
+  sql: string;
+  cte_name: string;
+  corrections: AskCorrectionInput[];
 }
 
 export interface RegenerateAskDetailInput {
   description: string;
-  steps: AskStepWithCorrections[];
+  steps: AskStepWithCorrectionsInput[];
 }
 
 const getAIServiceError = (error: any) => {

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -80,12 +80,14 @@ export enum AskCandidateType {
   LLM = 'LLM',
 }
 
-export enum ExplainType {
+// The enum key's name refer to schema.ts > ReferenceType
+// It helps mapping AI service enum values: selectItems, relation, filter, sortings, groupByKeys
+export enum ExplanationType {
+  FIELD = 'selectItems',
+  QUERY_FROM = 'relation',
   FILTER = 'filter',
-  SELECT_ITEMS = 'selectItems',
-  RELATION = 'relation',
-  GROUP_BY_KEYS = 'groupByKeys',
-  SORTINGS = 'sortings',
+  SORTING = 'sortings',
+  GROUP_BY = 'groupByKeys',
 }
 
 // UI currently only support nl_expression
@@ -130,7 +132,7 @@ export interface CorrectionObject<T> {
 }
 
 export interface AskCorrection {
-  before: CorrectionObject<ExplainType>;
+  before: CorrectionObject<ExplanationType>;
   after: CorrectionObject<ExpressionType>;
 }
 

--- a/wren-ui/src/apollo/server/repositories/threadResponseRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/threadResponseRepository.ts
@@ -28,6 +28,7 @@ export interface ThreadResponse {
   status: string; // Thread response status
   detail: ThreadResponseDetail; // Thread response detail
   error: object; // Thread response error
+  corrections: object; // Previous thread response corrections
 }
 
 export interface ThreadResponseWithThreadContext extends ThreadResponse {
@@ -114,7 +115,7 @@ export class ThreadResponseRepository
     }
     const camelCaseData = mapKeys(data, (_value, key) => camelCase(key));
     const formattedData = mapValues(camelCaseData, (value, key) => {
-      if (['error', 'detail'].includes(key)) {
+      if (['error', 'detail', 'corrections'].includes(key)) {
         // The value from Sqlite will be string type, while the value from PG is JSON object
         if (typeof value === 'string') {
           return value ? JSON.parse(value) : value;

--- a/wren-ui/src/apollo/server/repositories/threadResponseRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/threadResponseRepository.ts
@@ -77,27 +77,9 @@ export class ThreadResponseRepository
       query.orderBy('created_at', 'desc').limit(limit);
     }
 
-    return (await query)
-      .map((res) => {
-        // turn object keys into camelCase
-        return mapKeys(res, (_, key) => camelCase(key));
-      })
-      .map((res) => {
-        // JSON.parse detail and error
-        const detail =
-          res.detail && typeof res.detail === 'string'
-            ? JSON.parse(res.detail)
-            : res.detail;
-        const error =
-          res.error && typeof res.error === 'string'
-            ? JSON.parse(res.error)
-            : res.error;
-        return {
-          ...res,
-          detail: detail || null,
-          error: error || null,
-        };
-      }) as ThreadResponseWithThreadContext[];
+    return (await query).map((res) =>
+      this.transformFromDBData(res),
+    ) as ThreadResponseWithThreadContext[];
   }
 
   public async updateOne(

--- a/wren-ui/src/apollo/server/repositories/threadResponseRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/threadResponseRepository.ts
@@ -4,7 +4,14 @@ import {
   IBasicRepository,
   IQueryOptions,
 } from './baseRepository';
-import { camelCase, isPlainObject, mapKeys, mapValues } from 'lodash';
+import {
+  camelCase,
+  snakeCase,
+  Dictionary,
+  isPlainObject,
+  mapKeys,
+  mapValues,
+} from 'lodash';
 import { AskResultStatus, WrenAIError } from '../adaptors/wrenAIAdaptor';
 
 export interface DetailStep {
@@ -19,6 +26,12 @@ export interface ThreadResponseDetail {
   steps: Array<DetailStep>;
 }
 
+export interface PrevCorrection {
+  id: number;
+  type: string;
+  correction: string;
+}
+
 export interface ThreadResponse {
   id: number; // ID
   threadId: number; // Reference to thread.id
@@ -28,7 +41,7 @@ export interface ThreadResponse {
   status: string; // Thread response status
   detail: ThreadResponseDetail; // Thread response detail
   error: object; // Thread response error
-  corrections: object; // Previous thread response corrections
+  corrections: PrevCorrection[]; // Previous thread response corrections
 }
 
 export interface ThreadResponseWithThreadContext extends ThreadResponse {
@@ -108,6 +121,24 @@ export class ThreadResponseRepository
       .returning('*');
     return this.transformFromDBData(result);
   }
+
+  protected override transformToDBData = (data: any) => {
+    if (!isPlainObject(data)) {
+      throw new Error('Unexpected dbdata');
+    }
+    const formattedData = mapValues(data, (value, key) => {
+      if (['error', 'detail', 'corrections'].includes(key)) {
+        // The value from Sqlite will be string type, while the value from PG is JSON object
+        if (value) {
+          return typeof value === 'string' ? value : JSON.stringify(value);
+        } else {
+          return value;
+        }
+      }
+      return value;
+    }) as Dictionary<any>;
+    return mapKeys(formattedData, (_value, key) => snakeCase(key));
+  };
 
   protected override transformFromDBData = (data: any): ThreadResponse => {
     if (!isPlainObject(data)) {

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -78,8 +78,7 @@ const resolvers = {
     updateThread: askingResolver.updateThread,
     deleteThread: askingResolver.deleteThread,
     createThreadResponse: askingResolver.createThreadResponse,
-    createRegeneratedThreadResponse:
-      askingResolver.createRegeneratedThreadResponse,
+    createCorrectedThreadResponse: askingResolver.createCorrectedThreadResponse,
     previewData: askingResolver.previewData,
 
     // Views

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -78,6 +78,8 @@ const resolvers = {
     updateThread: askingResolver.updateThread,
     deleteThread: askingResolver.deleteThread,
     createThreadResponse: askingResolver.createThreadResponse,
+    createRegeneratedThreadResponse:
+      askingResolver.createRegeneratedThreadResponse,
     previewData: askingResolver.previewData,
 
     // Views

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -54,8 +54,8 @@ export class AskingResolver {
     this.deleteThread = this.deleteThread.bind(this);
     this.listThreads = this.listThreads.bind(this);
     this.createThreadResponse = this.createThreadResponse.bind(this);
-    this.createRegeneratedThreadResponse =
-      this.createRegeneratedThreadResponse.bind(this);
+    this.createCorrectedThreadResponse =
+      this.createCorrectedThreadResponse.bind(this);
     this.getResponse = this.getResponse.bind(this);
     this.getSuggestedQuestions = this.getSuggestedQuestions.bind(this);
   }
@@ -260,7 +260,7 @@ export class AskingResolver {
     return response;
   }
 
-  public async createRegeneratedThreadResponse(
+  public async createCorrectedThreadResponse(
     _root: any,
     args: {
       threadId: number;
@@ -280,7 +280,7 @@ export class AskingResolver {
     const { threadId, data } = args;
 
     const askingService = ctx.askingService;
-    const response = await askingService.createRegeneratedThreadResponse(
+    const response = await askingService.createCorrectedThreadResponse(
       threadId,
       data,
     );

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -190,6 +190,7 @@ export class AskingResolver {
           status: response.status,
           detail: response.detail,
           error: response.error,
+          corrections: response.corrections,
         });
 
         return acc;

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -257,6 +257,34 @@ export class AskingResolver {
     return response;
   }
 
+  public async createRegeneratedThreadResponse(
+    _root: any,
+    args: {
+      threadId: number;
+      data: {
+        question?: string;
+        sql?: string;
+        summary?: string;
+        corrections?: {
+          type: string;
+          explanation: string;
+          correction: string;
+        }[];
+      };
+    },
+    ctx: IContext,
+  ): Promise<ThreadResponse> {
+    const { threadId, data } = args;
+
+    const askingService = ctx.askingService;
+    const response = await askingService.createRegeneratedThreadResponse(
+      threadId,
+      data,
+    );
+    ctx.telemetry.send_event('feedback_to_regenerate_answer', {});
+    return response;
+  }
+
   public async getResponse(
     _root: any,
     args: { responseId: number },

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -54,6 +54,8 @@ export class AskingResolver {
     this.deleteThread = this.deleteThread.bind(this);
     this.listThreads = this.listThreads.bind(this);
     this.createThreadResponse = this.createThreadResponse.bind(this);
+    this.createRegeneratedThreadResponse =
+      this.createRegeneratedThreadResponse.bind(this);
     this.getResponse = this.getResponse.bind(this);
     this.getSuggestedQuestions = this.getSuggestedQuestions.bind(this);
   }
@@ -262,12 +264,12 @@ export class AskingResolver {
     args: {
       threadId: number;
       data: {
-        question?: string;
-        sql?: string;
-        summary?: string;
-        corrections?: {
+        responseId: number;
+        corrections: {
+          id: number;
           type: string;
-          explanation: string;
+          stepIndex: number;
+          reference: string;
           correction: string;
         }[];
       };
@@ -281,7 +283,7 @@ export class AskingResolver {
       threadId,
       data,
     );
-    ctx.telemetry.send_event('feedback_to_regenerate_answer', {});
+    ctx.telemetry.send_event('regenerate_asked_question', {});
     return response;
   }
 

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -527,6 +527,19 @@ export const typeDefs = gql`
     viewId: Int
   }
 
+  input CreateThreadResponseCorrectionInput {
+    id: Int!
+    stepIndex: Int!
+    type: ReferenceType!
+    reference: String!
+    correction: String!
+  }
+
+  input CreateRegeneratedThreadResponseInput {
+    responseId: Int!
+    corrections: [CreateThreadResponseCorrectionInput!]!
+  }
+
   input ThreadUniqueWhereInput {
     id: Int!
   }
@@ -557,6 +570,12 @@ export const typeDefs = gql`
     steps: [DetailStep!]!
   }
 
+  type CorrectionDetail {
+    id: Int!
+    type: ReferenceType!
+    correction: String!
+  }
+
   type ThreadResponse {
     id: Int!
     question: String!
@@ -564,6 +583,7 @@ export const typeDefs = gql`
     status: AskingTaskStatus!
     detail: ThreadResponseDetail
     error: Error
+    corrections: [CorrectionDetail!]
   }
 
   # Thread only consists of basic information of a thread
@@ -764,6 +784,10 @@ export const typeDefs = gql`
     createThreadResponse(
       threadId: Int!
       data: CreateThreadResponseInput!
+    ): ThreadResponse!
+    createRegeneratedThreadResponse(
+      threadId: Int!
+      data: CreateRegeneratedThreadResponseInput!
     ): ThreadResponse!
     previewData(where: PreviewDataInput!): JSON!
 

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -491,6 +491,14 @@ export const typeDefs = gql`
     LLM # LLM type candidate is created by LLM
   }
 
+  enum ReferenceType {
+    FIELD
+    QUERY_FROM
+    FILTER
+    SORTING
+    GROUP_BY
+  }
+
   type ResultCandidate {
     type: ResultCandidateType!
     sql: String!

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -535,7 +535,7 @@ export const typeDefs = gql`
     correction: String!
   }
 
-  input CreateRegeneratedThreadResponseInput {
+  input CreateCorrectedThreadResponseInput {
     responseId: Int!
     corrections: [CreateThreadResponseCorrectionInput!]!
   }
@@ -785,9 +785,9 @@ export const typeDefs = gql`
       threadId: Int!
       data: CreateThreadResponseInput!
     ): ThreadResponse!
-    createRegeneratedThreadResponse(
+    createCorrectedThreadResponse(
       threadId: Int!
-      data: CreateRegeneratedThreadResponseInput!
+      data: CreateCorrectedThreadResponseInput!
     ): ThreadResponse!
     previewData(where: PreviewDataInput!): JSON!
 

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -380,10 +380,6 @@ export class AskingService implements IAskingService {
       id: threadId,
     });
 
-    if (!thread) {
-      throw new Error(`Thread ${threadId} not found`);
-    }
-
     const baseThreadResponse = await this.threadResponseRepository.findOneBy({
       id: input.responseId,
     });

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -51,7 +51,7 @@ export interface CorrectionInput {
   correction: string;
 }
 
-export interface RegeneratedDetailTaskInput {
+export interface CorrectedDetailTaskInput {
   responseId: number;
   corrections: CorrectionInput[];
 }
@@ -78,9 +78,9 @@ export interface IAskingService {
     threadId: number,
     input: AskingDetailTaskInput,
   ): Promise<ThreadResponse>;
-  createRegeneratedThreadResponse(
+  createCorrectedThreadResponse(
     threadId: number,
-    input: RegeneratedDetailTaskInput,
+    input: CorrectedDetailTaskInput,
   ): Promise<ThreadResponse>;
   getResponsesWithThread(
     threadId: number,
@@ -372,9 +372,9 @@ export class AskingService implements IAskingService {
     return threadResponse;
   }
 
-  public async createRegeneratedThreadResponse(
+  public async createCorrectedThreadResponse(
     threadId: number,
-    input: RegeneratedDetailTaskInput,
+    input: CorrectedDetailTaskInput,
   ): Promise<ThreadResponse> {
     const thread = await this.threadRepository.findOneBy({
       id: threadId,

--- a/wren-ui/src/components/pages/home/thread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/thread/AnswerResult.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
-import { Col, Button, Row, Skeleton, Typography } from 'antd';
+import { Col, Button, Row, Skeleton, Typography, Divider, Tag } from 'antd';
 import styled from 'styled-components';
 import { Path } from '@/utils/enum';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
+import ShareAltOutlined from '@ant-design/icons/ShareAltOutlined';
 import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
 import SaveOutlined from '@ant-design/icons/SaveOutlined';
 import FileDoneOutlined from '@ant-design/icons/FileDoneOutlined';
@@ -13,6 +14,8 @@ import {
   AskingTaskStatus,
   ThreadResponse,
 } from '@/apollo/client/graphql/__types__';
+import { makeIterable } from '@/utils/iteration';
+import { getReferenceIcon } from '@/components/pages/home/thread/feedback/utils';
 
 const { Title, Text } = Typography;
 
@@ -56,6 +59,69 @@ interface Props {
   onSubmitReviewDrawer: (variables: any) => Promise<void>;
 }
 
+const CorrectionTemplate = ({ id, type, correction }) => {
+  return (
+    <div className="my-1 gray-7">
+      <Tag className="ant-tag__reference bg-gray-7 gray-1">
+        <span className="mr-1 lh-xs">{getReferenceIcon(type)}</span>
+        {id}
+      </Tag>
+      {correction}
+    </div>
+  );
+};
+const CorrectionIterator = makeIterable(CorrectionTemplate);
+const RegenerateInformation = (props: ThreadResponse) => {
+  const { question, corrections } = props;
+  const [collapse, setCollapse] = useState(false);
+  const collapseText = collapse ? 'Hide' : 'Show';
+  return (
+    <div className="rounded bg-gray-3 gray-6 py-2 px-3 mb-2">
+      <div className="d-flex align-center gx-2">
+        <ShareAltOutlined />
+        <div className="flex-grow-1">Regenerated answer from</div>
+        <span
+          className="select-none cursor-pointer hover:underline"
+          onClick={() => setCollapse(!collapse)}
+        >
+          {collapseText} feedbacks
+        </span>
+      </div>
+      <Text className="gray-6 text-medium" ellipsis={!collapse}>
+        {question}
+      </Text>
+      {collapse && (
+        <div>
+          <Divider className="mt-3 mb-1" />
+          <div className="d-flex align-center gx-2">
+            <ShareAltOutlined />
+            <div>Feedbacks</div>
+          </div>
+          <CorrectionIterator data={corrections} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const QuestionInformation = (props) => {
+  const { question } = props;
+  const [ellipsis, setEllipsis] = useState(true);
+  return (
+    <StyledQuestion wrap={false} onClick={() => setEllipsis(!ellipsis)}>
+      <Col className="text-center" flex="96px">
+        <QuestionCircleOutlined className="mr-2 gray-6" />
+        <Text className="gray-6 text-base text-medium">Question:</Text>
+      </Col>
+      <Col flex="auto">
+        <Text className="gray-6" ellipsis={ellipsis}>
+          {question}
+        </Text>
+      </Col>
+    </StyledQuestion>
+  );
+};
+
 export default function AnswerResult(props: Props) {
   const {
     threadResponse,
@@ -65,7 +131,7 @@ export default function AnswerResult(props: Props) {
     onSubmitReviewDrawer,
   } = props;
 
-  const { id: responseId, question, summary, status } = threadResponse;
+  const { id: responseId, summary, status, corrections } = threadResponse;
   const {
     view,
     steps,
@@ -74,26 +140,19 @@ export default function AnswerResult(props: Props) {
   } = threadResponse?.detail || {};
 
   const isViewSaved = !!view;
+  const isRegenerated = !!corrections;
   const loading = status !== AskingTaskStatus.FINISHED;
 
-  const [ellipsis, setEllipsis] = useState(true);
+  const Information = isRegenerated
+    ? RegenerateInformation
+    : QuestionInformation;
 
   return (
     <Skeleton active loading={loading}>
       <FeedbackLayout
         headerSlot={
           <Wrapper>
-            <StyledQuestion wrap={false} onClick={() => setEllipsis(!ellipsis)}>
-              <Col className="text-center" flex="96px">
-                <QuestionCircleOutlined className="mr-2 gray-6" />
-                <Text className="gray-6 text-base text-medium">Question:</Text>
-              </Col>
-              <Col flex="auto">
-                <Text className="gray-6" ellipsis={ellipsis}>
-                  {question}
-                </Text>
-              </Col>
-            </StyledQuestion>
+            <Information {...threadResponse} />
             <Title className="mb-6 text-bold gray-10" level={3}>
               {summary}
             </Title>

--- a/wren-ui/src/components/pages/home/thread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/thread/AnswerResult.tsx
@@ -21,6 +21,7 @@ const { Title, Text } = Typography;
 
 const Wrapper = styled.div`
   width: 680px;
+  flex-shrink: 0;
 `;
 
 const StyledAnswer = styled(Typography)`

--- a/wren-ui/src/components/pages/home/thread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/thread/AnswerResult.tsx
@@ -9,6 +9,10 @@ import SaveOutlined from '@ant-design/icons/SaveOutlined';
 import FileDoneOutlined from '@ant-design/icons/FileDoneOutlined';
 import StepContent from '@/components/pages/home/thread/StepContent';
 import FeedbackLayout from '@/components/pages/home/thread/feedback';
+import {
+  AskingTaskStatus,
+  ThreadResponse,
+} from '@/apollo/client/graphql/__types__';
 
 const { Title, Text } = Typography;
 
@@ -45,41 +49,32 @@ const StyledQuestion = styled(Row)`
 `;
 
 interface Props {
-  loading: boolean;
-  question: string;
-  description: string;
-  answerResultSteps: Array<{
-    summary: string;
-    sql: string;
-  }>;
-  fullSql: string;
-  threadResponseId: number;
-  onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
+  threadResponse: ThreadResponse;
   isLastThreadResponse: boolean;
+  onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
   onTriggerScrollToBottom: () => void;
-  summary: string;
-  view?: {
-    id: number;
-    displayName: string;
-  };
+  onSubmitReviewDrawer: (variables: any) => Promise<void>;
 }
 
 export default function AnswerResult(props: Props) {
   const {
-    loading,
-    question,
-    description,
-    answerResultSteps,
-    fullSql,
-    threadResponseId,
+    threadResponse,
     isLastThreadResponse,
     onOpenSaveAsViewModal,
     onTriggerScrollToBottom,
-    summary,
-    view,
+    onSubmitReviewDrawer,
   } = props;
 
+  const { id: responseId, question, summary, status } = threadResponse;
+  const {
+    view,
+    steps,
+    description,
+    sql: fullSql,
+  } = threadResponse?.detail || {};
+
   const isViewSaved = !!view;
+  const loading = status !== AskingTaskStatus.FINISHED;
 
   const [ellipsis, setEllipsis] = useState(true);
 
@@ -112,15 +107,15 @@ export default function AnswerResult(props: Props) {
                 Summary
               </Text>
               <div className="pl-7 pb-5">{description}</div>
-              {(answerResultSteps || []).map((step, index) => (
+              {(steps || []).map((step, index) => (
                 <StepContent
-                  isLastStep={index === answerResultSteps.length - 1}
+                  isLastStep={index === steps.length - 1}
                   key={`${step.summary}-${index}`}
                   sql={step.sql}
                   fullSql={fullSql}
                   stepIndex={index}
                   summary={step.summary}
-                  threadResponseId={threadResponseId}
+                  threadResponseId={responseId}
                   onTriggerScrollToBottom={onTriggerScrollToBottom}
                   isLastThreadResponse={isLastThreadResponse}
                 />
@@ -146,10 +141,7 @@ export default function AnswerResult(props: Props) {
                 size="small"
                 icon={<SaveOutlined />}
                 onClick={() =>
-                  onOpenSaveAsViewModal({
-                    sql: fullSql,
-                    responseId: threadResponseId,
-                  })
+                  onOpenSaveAsViewModal({ sql: fullSql, responseId })
                 }
               >
                 Save as View
@@ -157,6 +149,8 @@ export default function AnswerResult(props: Props) {
             )}
           </Wrapper>
         }
+        threadResponse={threadResponse}
+        onSubmitReviewDrawer={onSubmitReviewDrawer}
       />
     </Skeleton>
   );

--- a/wren-ui/src/components/pages/home/thread/feedback/FeedbackSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/FeedbackSideFloat.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import styled from 'styled-components';
 import { Button, Popconfirm } from 'antd';
 import { FileTextOutlined } from '@ant-design/icons';
+import { Reference } from './utils';
 
 const StyledFeedbackSideFloat = styled.div`
   position: relative;
@@ -17,7 +18,7 @@ const StyledFeedbackSideFloat = styled.div`
 
 interface Props {
   className?: string;
-  references: any[];
+  references: Reference[];
   onOpenReviewDrawer: () => void;
   onResetAllChanges: () => void;
 }

--- a/wren-ui/src/components/pages/home/thread/feedback/FeedbackSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/FeedbackSideFloat.tsx
@@ -20,12 +20,16 @@ interface Props {
   className?: string;
   references: Reference[];
   onOpenReviewDrawer: () => void;
-  onResetAllChanges: () => void;
+  onResetAllCorrectionPrompts: () => void;
 }
 
 export default function FeedbackSideFloat(props: Props) {
-  const { className, references, onOpenReviewDrawer, onResetAllChanges } =
-    props;
+  const {
+    className,
+    references,
+    onOpenReviewDrawer,
+    onResetAllCorrectionPrompts,
+  } = props;
 
   const changedReferences = useMemo(() => {
     return (references || []).filter((item) => !!item.correctionPrompt);
@@ -52,7 +56,7 @@ export default function FeedbackSideFloat(props: Props) {
           title="Are you sure?"
           okText="Confirm"
           okButtonProps={{ danger: true }}
-          onConfirm={onResetAllChanges}
+          onConfirm={onResetAllCorrectionPrompts}
         >
           <Button className="text-sm gray-6 ml-2" type="text" size="small">
             Reset all

--- a/wren-ui/src/components/pages/home/thread/feedback/ReferenceSideFloat.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReferenceSideFloat.tsx
@@ -5,7 +5,8 @@ import { Tag, Typography, Button, Input } from 'antd';
 import { EditOutlined } from '@ant-design/icons';
 import { QuoteIcon } from '@/utils/icons';
 import { makeIterable } from '@/utils/iteration';
-import { ReferenceTypes, getReferenceIcon } from './utils';
+import { Reference, getReferenceIcon } from './utils';
+import { ReferenceType } from '@/apollo/client/graphql/__types__';
 
 const StyledReferenceSideFloat = styled.div`
   position: relative;
@@ -19,24 +20,19 @@ const StyledReferenceSideFloat = styled.div`
 `;
 
 interface Props {
-  references: any[];
+  references: Reference[];
   onSaveCorrectionPrompt?: (id: string, value: string) => void;
 }
 
 const COLLAPSE_LIMIT = 3;
 
-const ReferenceSummaryTemplate = ({
-  title,
-  type,
-  referenceNum,
-  correctionPrompt,
-}) => {
+const ReferenceSummaryTemplate = ({ id, title, type, correctionPrompt }) => {
   const isRevise = !!correctionPrompt;
   return (
     <div className="d-flex align-center my-1">
       <Tag className={clsx('ant-tag__reference', { isRevise })}>
         <span className="mr-1 lh-xs">{getReferenceIcon(type)}</span>
-        {referenceNum}
+        {id}
       </Tag>
       <Typography.Text className="gray-8" ellipsis>
         {title}
@@ -71,7 +67,6 @@ const ReferenceTemplate = ({
   id,
   title,
   type,
-  referenceNum,
   correctionPrompt,
   saveCorrectionPrompt,
 }) => {
@@ -94,7 +89,7 @@ const ReferenceTemplate = ({
       <div className="lh-xs" style={{ paddingTop: 2 }}>
         <Tag className={clsx('ant-tag__reference', { isRevise })}>
           <span className="mr-1 lh-xs">{getReferenceIcon(type)}</span>
-          {referenceNum}
+          {id}
         </Tag>
       </div>
       <div className="flex-grow-1">
@@ -143,33 +138,33 @@ const References = (props: Props) => {
   const { references, onSaveCorrectionPrompt } = props;
 
   const fieldReferences = references.filter(
-    (ref) => ref.type === ReferenceTypes.FIELD,
+    (ref) => ref.type === ReferenceType.FIELD,
   );
   const queryFromReferences = references.filter(
-    (ref) => ref.type === ReferenceTypes.QUERY_FROM,
+    (ref) => ref.type === ReferenceType.QUERY_FROM,
   );
   const filterReferences = references.filter(
-    (ref) => ref.type === ReferenceTypes.FILTER,
+    (ref) => ref.type === ReferenceType.FILTER,
   );
   const sortingReferences = references.filter(
-    (ref) => ref.type === ReferenceTypes.SORTING,
+    (ref) => ref.type === ReferenceType.SORTING,
   );
   const groupByReferences = references.filter(
-    (ref) => ref.type === ReferenceTypes.GROUP_BY,
+    (ref) => ref.type === ReferenceType.GROUP_BY,
   );
 
   const resources = [
-    { name: 'Fields', type: ReferenceTypes.FIELD, data: fieldReferences },
+    { name: 'Fields', type: ReferenceType.FIELD, data: fieldReferences },
     {
       name: 'Query from',
-      type: ReferenceTypes.QUERY_FROM,
+      type: ReferenceType.QUERY_FROM,
       data: queryFromReferences,
     },
-    { name: 'Filter', type: ReferenceTypes.FILTER, data: filterReferences },
-    { name: 'Sorting', type: ReferenceTypes.SORTING, data: sortingReferences },
+    { name: 'Filter', type: ReferenceType.FILTER, data: filterReferences },
+    { name: 'Sorting', type: ReferenceType.SORTING, data: sortingReferences },
     {
       name: 'Group by',
-      type: ReferenceTypes.GROUP_BY,
+      type: ReferenceType.GROUP_BY,
       data: groupByReferences,
     },
   ];

--- a/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
@@ -120,6 +120,7 @@ export default function ReviewDrawer(props: Props) {
     visible,
     references,
     onClose,
+    onSubmit,
     onSaveCorrectionPrompt,
     onRemoveCorrectionPrompt,
   } = props;
@@ -138,6 +139,11 @@ export default function ReviewDrawer(props: Props) {
 
   const submit = async () => {
     // TODO: call correction ask api
+    const data = {
+      responseId: 0,
+      corrections: [],
+    };
+    onSubmit && onSubmit(data);
   };
   return (
     <Drawer

--- a/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
@@ -23,8 +23,9 @@ import { CreateRegeneratedThreadResponseInput } from '@/apollo/client/graphql/__
 type Props = DrawerAction & {
   references: Reference[];
   threadResponseId: number;
-  onSaveCorrectionPrompt?: (id: string, value: string) => void;
-  onRemoveCorrectionPrompt?: (id: string) => void;
+  onSaveCorrectionPrompt: (id: string, value: string) => void;
+  onRemoveCorrectionPrompt: (id: string) => void;
+  onResetAllCorrectionPrompts: () => void;
 };
 
 const StyledOriginal = styled.div`
@@ -125,6 +126,7 @@ export default function ReviewDrawer(props: Props) {
     onSubmit,
     onSaveCorrectionPrompt,
     onRemoveCorrectionPrompt,
+    onResetAllCorrectionPrompts,
   } = props;
 
   const changedReferences = useMemo(() => {
@@ -140,18 +142,23 @@ export default function ReviewDrawer(props: Props) {
   }, [changedReferences]);
 
   const submit = useCallback(async () => {
-    // TODO: call correction ask api
-    const data: CreateRegeneratedThreadResponseInput = {
-      responseId: threadResponseId,
-      corrections: changedReferences.map((reference) => ({
-        id: reference.id,
-        type: reference.type,
-        reference: reference.title,
-        stepIndex: reference.stepIndex,
-        correction: reference.correctionPrompt,
-      })),
-    };
-    onSubmit && onSubmit(data);
+    try {
+      const data: CreateRegeneratedThreadResponseInput = {
+        responseId: threadResponseId,
+        corrections: changedReferences.map((reference) => ({
+          id: reference.id,
+          type: reference.type,
+          reference: reference.title,
+          stepIndex: reference.stepIndex,
+          correction: reference.correctionPrompt,
+        })),
+      };
+      await onSubmit(data);
+      onClose();
+      onResetAllCorrectionPrompts();
+    } catch (error) {
+      console.error(error);
+    }
   }, [changedReferences]);
 
   return (

--- a/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/ReviewDrawer.tsx
@@ -18,7 +18,7 @@ import {
 import { DrawerAction } from '@/hooks/useDrawerAction';
 import { makeIterable } from '@/utils/iteration';
 import { getReferenceIcon, Reference } from './utils';
-import { CreateRegeneratedThreadResponseInput } from '@/apollo/client/graphql/__types__';
+import { CreateCorrectedThreadResponseInput } from '@/apollo/client/graphql/__types__';
 
 type Props = DrawerAction & {
   references: Reference[];
@@ -143,7 +143,7 @@ export default function ReviewDrawer(props: Props) {
 
   const submit = useCallback(async () => {
     try {
-      const data: CreateRegeneratedThreadResponseInput = {
+      const data: CreateCorrectedThreadResponseInput = {
         responseId: threadResponseId,
         corrections: changedReferences.map((reference) => ({
           id: reference.id,

--- a/wren-ui/src/components/pages/home/thread/feedback/index.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/index.tsx
@@ -127,7 +127,7 @@ export default function Feedback(props: Props) {
             className="mb-4"
             references={references}
             onOpenReviewDrawer={reviewDrawer.openDrawer}
-            onResetAllChanges={resetAllCorrectionPrompts}
+            onResetAllCorrectionPrompts={resetAllCorrectionPrompts}
           />
         </div>
       </div>
@@ -148,6 +148,7 @@ export default function Feedback(props: Props) {
         onSubmit={onSubmitReviewDrawer}
         onSaveCorrectionPrompt={saveCorrectionPrompt}
         onRemoveCorrectionPrompt={removeCorrectionPrompt}
+        onResetAllCorrectionPrompts={resetAllCorrectionPrompts}
       />
     </FeedbackContext.Provider>
   );

--- a/wren-ui/src/components/pages/home/thread/feedback/index.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/index.tsx
@@ -3,8 +3,10 @@ import ReferenceSideFloat from '@/components/pages/home/thread/feedback/Referenc
 import FeedbackSideFloat from '@/components/pages/home/thread/feedback/FeedbackSideFloat';
 import ReviewDrawer from '@/components/pages/home/thread/feedback/ReviewDrawer';
 import useDrawerAction from '@/hooks/useDrawerAction';
-import { ReferenceTypes } from './utils';
-import { ThreadResponse } from '@/apollo/client/graphql/__types__';
+import {
+  ReferenceType,
+  ThreadResponse,
+} from '@/apollo/client/graphql/__types__';
 
 type ContextProps = {
   references: any[];
@@ -27,51 +29,51 @@ interface Props {
 
 const data = [
   {
-    id: '1',
-    type: ReferenceTypes.FIELD,
+    id: 1,
+    type: ReferenceType.FIELD,
     stepIndex: 0,
     title:
       "Selects the 'City' column from the 'customer_data' dataset to display the city name.",
     referenceNum: 1,
   },
   {
-    id: '2',
-    type: ReferenceTypes.FIELD,
+    id: 2,
+    type: ReferenceType.FIELD,
     stepIndex: 0,
     title: 'Reference 2',
     referenceNum: 2,
   },
   {
-    id: '3',
-    type: ReferenceTypes.QUERY_FROM,
+    id: 3,
+    type: ReferenceType.QUERY_FROM,
     stepIndex: 1,
     title: 'Reference 3',
     referenceNum: 3,
   },
   {
-    id: '4',
-    type: ReferenceTypes.QUERY_FROM,
+    id: 4,
+    type: ReferenceType.QUERY_FROM,
     stepIndex: 1,
     title: 'Reference 4',
     referenceNum: 4,
   },
   {
-    id: '5',
-    type: ReferenceTypes.FILTER,
+    id: 5,
+    type: ReferenceType.FILTER,
     stepIndex: 2,
     title: 'Reference 4',
     referenceNum: 4,
   },
   {
-    id: '6',
-    type: ReferenceTypes.SORTING,
+    id: 6,
+    type: ReferenceType.SORTING,
     stepIndex: 2,
     title: 'Reference 4',
     referenceNum: 4,
   },
   {
-    id: '7',
-    type: ReferenceTypes.GROUP_BY,
+    id: 7,
+    type: ReferenceType.GROUP_BY,
     stepIndex: 2,
     title: 'Reference 4',
     referenceNum: 4,
@@ -141,6 +143,7 @@ export default function Feedback(props: Props) {
       <ReviewDrawer
         {...reviewDrawer.state}
         onClose={reviewDrawer.closeDrawer}
+        threadResponseId={threadResponse.id}
         references={references}
         onSubmit={onSubmitReviewDrawer}
         onSaveCorrectionPrompt={saveCorrectionPrompt}

--- a/wren-ui/src/components/pages/home/thread/feedback/utils.tsx
+++ b/wren-ui/src/components/pages/home/thread/feedback/utils.tsx
@@ -4,24 +4,24 @@ import {
   GroupOutlined,
 } from '@ant-design/icons';
 import { ColumnsIcon, ModelIcon } from '@/utils/icons';
+import { ReferenceType } from '@/apollo/client/graphql/__types__';
 
-// TODO: Replace after provided by the backend
-export enum ReferenceTypes {
-  FIELD = 'FIELD',
-  QUERY_FROM = 'QUERY_FROM',
-  FILTER = 'FILTER',
-  SORTING = 'SORTING',
-  GROUP_BY = 'GROUP_BY',
-}
+export type Reference = {
+  id: number;
+  title: string;
+  type: ReferenceType;
+  stepIndex: number;
+  correctionPrompt?: string;
+};
 
 export const getReferenceIcon = (type) => {
   return (
     {
-      [ReferenceTypes.FIELD]: <ColumnsIcon />,
-      [ReferenceTypes.QUERY_FROM]: <ModelIcon />,
-      [ReferenceTypes.FILTER]: <FilterOutlined />,
-      [ReferenceTypes.SORTING]: <SortAscendingOutlined />,
-      [ReferenceTypes.GROUP_BY]: <GroupOutlined />,
+      [ReferenceType.FIELD]: <ColumnsIcon />,
+      [ReferenceType.QUERY_FROM]: <ModelIcon />,
+      [ReferenceType.FILTER]: <FilterOutlined />,
+      [ReferenceType.SORTING]: <SortAscendingOutlined />,
+      [ReferenceType.GROUP_BY]: <GroupOutlined />,
     }[type] || null
   );
 };

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -7,7 +7,7 @@ import useHomeSidebar from '@/hooks/useHomeSidebar';
 import SiderLayout from '@/components/layouts/SiderLayout';
 import Prompt from '@/components/pages/home/prompt';
 import {
-  useCreateRegeneratedThreadResponseMutation,
+  useCreateCorrectedThreadResponseMutation,
   useCreateThreadResponseMutation,
   useThreadQuery,
   useThreadResponseLazyQuery,
@@ -18,7 +18,7 @@ import Thread from '@/components/pages/home/thread';
 import SaveAsViewModal from '@/components/modals/SaveAsViewModal';
 import { useCreateViewMutation } from '@/apollo/client/graphql/view.generated';
 import {
-  CreateRegeneratedThreadResponseInput,
+  CreateCorrectedThreadResponseInput,
   CreateThreadResponseInput,
 } from '@/apollo/client/graphql/__types__';
 
@@ -78,9 +78,9 @@ export default function HomeThread() {
       },
     });
   const [createRegeneratedThreadResponse] =
-    useCreateRegeneratedThreadResponseMutation({
+    useCreateCorrectedThreadResponseMutation({
       onCompleted(next) {
-        const nextResponse = next.createRegeneratedThreadResponse;
+        const nextResponse = next.createCorrectedThreadResponse;
         addThreadResponse(nextResponse);
       },
     });
@@ -123,7 +123,7 @@ export default function HomeThread() {
   };
 
   const onSubmitReviewDrawer = async (
-    payload: CreateRegeneratedThreadResponseInput,
+    payload: CreateCorrectedThreadResponseInput,
   ) => {
     try {
       const response = await createRegeneratedThreadResponse({
@@ -131,7 +131,7 @@ export default function HomeThread() {
       });
       await fetchThreadResponse({
         variables: {
-          responseId: response.data.createRegeneratedThreadResponse.id,
+          responseId: response.data.createCorrectedThreadResponse.id,
         },
       });
     } catch (error) {

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -135,7 +135,7 @@ export default function HomeThread() {
         },
       });
     } catch (error) {
-      console.error(error);
+      throw error;
     }
   };
 

--- a/wren-ui/src/styles/utilities/display.less
+++ b/wren-ui/src/styles/utilities/display.less
@@ -21,6 +21,10 @@
   cursor: pointer !important;
 }
 
+.select-none {
+  user-select: none !important;
+}
+
 .overflow-hidden {
   overflow: hidden !important;
 }

--- a/wren-ui/src/styles/utilities/text.less
+++ b/wren-ui/src/styles/utilities/text.less
@@ -55,3 +55,11 @@
 .text-family-base {
   font-family: @font-family !important;
 }
+
+.underline {
+  text-decoration: underline !important;
+}
+
+.hover\:underline:hover {
+  text-decoration: underline !important;
+}

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -110,6 +110,15 @@ class CreateThreadResponseErrorHandler extends ErrorHandler {
   }
 }
 
+class CreateRegeneratedThreadResponseErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to create regenerated thread response.';
+    }
+  }
+}
+
 class CreateViewErrorHandler extends ErrorHandler {
   public getErrorMessage(error: GraphQLError) {
     switch (error.extensions?.code) {
@@ -257,6 +266,10 @@ errorHandlers.set('DeleteThread', new DeleteThreadErrorHandler());
 errorHandlers.set(
   'CreateThreadResponse',
   new CreateThreadResponseErrorHandler(),
+);
+errorHandlers.set(
+  'CreateRegeneratedThreadResponse',
+  new CreateRegeneratedThreadResponseErrorHandler(),
 );
 errorHandlers.set('CreateView', new CreateViewErrorHandler());
 errorHandlers.set('UpdateDataSource', new UpdateDataSourceErrorHandler());

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -110,11 +110,11 @@ class CreateThreadResponseErrorHandler extends ErrorHandler {
   }
 }
 
-class CreateRegeneratedThreadResponseErrorHandler extends ErrorHandler {
+class CreateCorrectedThreadResponseErrorHandler extends ErrorHandler {
   public getErrorMessage(error: GraphQLError) {
     switch (error.extensions?.code) {
       default:
-        return 'Failed to create regenerated thread response.';
+        return 'Failed to create corrected thread response.';
     }
   }
 }
@@ -268,8 +268,8 @@ errorHandlers.set(
   new CreateThreadResponseErrorHandler(),
 );
 errorHandlers.set(
-  'CreateRegeneratedThreadResponse',
-  new CreateRegeneratedThreadResponseErrorHandler(),
+  'CreateCorrectedThreadResponse',
+  new CreateCorrectedThreadResponseErrorHandler(),
 );
 errorHandlers.set('CreateView', new CreateViewErrorHandler());
 errorHandlers.set('UpdateDataSource', new UpdateDataSourceErrorHandler());


### PR DESCRIPTION
## Description
### API
- Add `createRegeneratedThreadResponse` API
- Request Structure
   ```graphql
  input CreateThreadResponseCorrectionInput {
    id: Int!
    stepIndex: Int!
    type: ReferenceType!
    reference: String!
    correction: String!
  }

  input CreateRegeneratedThreadResponseInput {
    responseId: Int!
    corrections: [CreateThreadResponseCorrectionInput!]!
  }
   ```
- Response structure refer to Create Thread Response
    - ps. client need to fetch Thread Response after Create Adjustment Response.
- Provide adjustment content in Thread & Thread response API
  ```graphql
  type ThreadResponse {
    ...
    question
    corrections: [{
      id
      type
      correction
    }]
  }
  ```

### UI
- Check thread response type if it is an regenerated response.
- Change thread detail original question block to regenerated information.

### UI Screenshot
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/78d90f21-9606-4a73-8547-e193a2e9cd90">
