### PR TITLE
feat(wren-ui): Modify step's preview data empty state wording

### DIFF
--- a/wren-ui/src/components/dataPreview/PreviewData.tsx
+++ b/wren-ui/src/components/dataPreview/PreviewData.tsx
@@ -37,10 +37,11 @@ interface Props {
   };
   loading: boolean;
   error?: ApolloError;
+  locale?: { emptyText: React.ReactNode };
 }
 
 export default function PreviewData(props: Props) {
-  const { previewData, loading, error } = props;
+  const { previewData, loading, error, locale } = props;
 
   const columns = useMemo(
     () => previewData && getPreviewColumns(previewData.columns),
@@ -66,6 +67,7 @@ export default function PreviewData(props: Props) {
       columns={columns}
       data={previewData?.data || []}
       loading={loading}
+      locale={locale}
     />
   );
 }

--- a/wren-ui/src/components/dataPreview/PreviewDataContent.tsx
+++ b/wren-ui/src/components/dataPreview/PreviewDataContent.tsx
@@ -11,6 +11,7 @@ interface Props {
   columns: TableColumn[];
   data: Array<any[]>;
   loading: boolean;
+  locale?: { emptyText: React.ReactNode };
 }
 
 const getValueByValueType = (value: any) =>
@@ -32,7 +33,7 @@ const convertResultData = (data: Array<any>, columns) => {
 };
 
 export default function PreviewDataContent(props: Props) {
-  const { columns = [], data = [], loading } = props;
+  const { columns = [], data = [], loading, locale } = props;
   const hasColumns = !!columns.length;
 
   const dynamicWidth = useMemo(() => {
@@ -64,6 +65,7 @@ export default function PreviewDataContent(props: Props) {
       size="small"
       scroll={{ y: 280, x: dynamicWidth }}
       loading={loading}
+      locale={locale}
     />
   );
 }

--- a/wren-ui/src/components/pages/home/promptThread/CollapseContent.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/CollapseContent.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import dynamic from 'next/dynamic';
-import { Button, Switch, Typography } from 'antd';
+import { Button, Switch, Typography, Empty } from 'antd';
 import styled from 'styled-components';
 import CheckOutlined from '@ant-design/icons/CheckOutlined';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
@@ -114,7 +114,17 @@ export default function CollapseContent(props: Props) {
       )}
       {isPreviewData && (
         <div className="my-3">
-          <PreviewData {...previewDataResult} />
+          <PreviewData
+            {...previewDataResult}
+            locale={{
+              emptyText: (
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description="Sorry, we couldn't find any records that match your search criteria."
+                />
+              ),
+            }}
+          />
         </div>
       )}
       {(isViewSQL || isPreviewData) && (


### PR DESCRIPTION
## Description
- Changing step preview empty state
   `No Data` to `Sorry, we couldn't find any records that match your search criteria.`

## UI Screenshot
<img width="880" alt="image" src="https://github.com/user-attachments/assets/aef38e5d-8dce-45f8-a69b-7f0e2d8dfff7">
