### PR TITLE
Fix(wren-ui): Fix getting incorrect native sql issue

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
@@ -86,6 +86,11 @@ export interface IbisBaseOptions {
 export interface IbisQueryOptions extends IbisBaseOptions {
   limit?: number;
 }
+export interface IbisDryPlanOptions {
+  dataSource: DataSourceName;
+  mdl: Manifest;
+  sql: string;
+}
 
 export interface IIbisAdaptor {
   query: (
@@ -102,6 +107,7 @@ export interface IIbisAdaptor {
     connectionInfo: WREN_AI_CONNECTION_INFO,
   ) => Promise<RecommendConstraint[]>;
 
+  getNativeSql: (options: IbisDryPlanOptions) => Promise<string>;
   validate: (
     dataSource: DataSourceName,
     rule: ValidationRules,
@@ -122,6 +128,26 @@ export class IbisAdaptor implements IIbisAdaptor {
 
   constructor({ ibisServerEndpoint }: { ibisServerEndpoint: string }) {
     this.ibisServerBaseUrl = `${ibisServerEndpoint}/v2/connector`;
+  }
+  public async getNativeSql(options: IbisDryPlanOptions): Promise<string> {
+    const { dataSource, mdl, sql } = options;
+    const body = {
+      sql,
+      manifestStr: Buffer.from(JSON.stringify(mdl)).toString('base64'),
+    };
+    try {
+      const res = await axios.post(
+        `${this.ibisServerBaseUrl}/${dataSourceUrlMap[dataSource]}/dry-plan`,
+        body,
+      );
+      return res.data;
+    } catch (e) {
+      logger.debug(`Got error when dry plan with ibis: ${e.response.data}`);
+      throw Errors.create(Errors.GeneralErrorCodes.DRY_PLAN_ERROR, {
+        customMessage: e.response.data,
+        originalError: e,
+      });
+    }
   }
 
   public async query(

--- a/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenEngineAdaptor.ts
@@ -278,7 +278,10 @@ export class WrenEngineAdaptor implements IWrenEngineAdaptor {
       return res.data;
     } catch (err: any) {
       logger.debug(`Got error when getting native SQL: ${err.message}`);
-      throw err;
+      Errors.create(Errors.GeneralErrorCodes.DRY_PLAN_ERROR, {
+        customMessage: err.message,
+        originalError: err,
+      });
     }
   }
 

--- a/wren-ui/src/apollo/server/utils/error.ts
+++ b/wren-ui/src/apollo/server/utils/error.ts
@@ -32,6 +32,7 @@ export enum GeneralErrorCodes {
 
   // dry run error
   DRY_RUN_ERROR = 'DRY_RUN_ERROR',
+  DRY_PLAN_ERROR = 'DRY_PLAN_ERROR',
 }
 
 export const errorMessages = {
@@ -72,6 +73,7 @@ export const errorMessages = {
 
   // dry run error
   [GeneralErrorCodes.DRY_RUN_ERROR]: 'Dry run sql statement error',
+  [GeneralErrorCodes.DRY_PLAN_ERROR]: 'Dry plan error',
 };
 
 export const shortMessages = {
@@ -89,6 +91,7 @@ export const shortMessages = {
   [GeneralErrorCodes.INVALID_CALCULATED_FIELD]: 'Invalid calculated field',
   [GeneralErrorCodes.INVALID_VIEW_CREATION]: 'Invalid view creation',
   [GeneralErrorCodes.DRY_RUN_ERROR]: 'Dry run sql statement error',
+  [GeneralErrorCodes.DRY_PLAN_ERROR]: 'Dry plan error',
 };
 
 export const create = (


### PR DESCRIPTION
Fix issue https://github.com/Canner/WrenAI/issues/520 

We previously used Wren Engine to do dry-plan. Now, when the data source is not DuckDB, we use ibis server for dry-plan.