### PR TITLE
fix(wren-ui): Fix select models duplicated keys issue

### DIFF
--- a/wren-ui/src/components/table/MultiSelectBox.tsx
+++ b/wren-ui/src/components/table/MultiSelectBox.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useContext } from 'react';
 import styled from 'styled-components';
-import { isString } from 'lodash';
+import { isString, difference } from 'lodash';
 import { Input, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { SearchOutlined } from '@ant-design/icons';
@@ -100,19 +100,27 @@ export default function MultiSelectBox(props: Props) {
           selectedRowKeys: Array.from(selectedRowKeys),
           onSelect: (record) => onSelect(record['value']),
           onChange(keys) {
-            // if more than 1 rows selected and there is only one possibility, if user selects all rows.
-            if (keys.length !== 1) {
-              if (keys.length === 0) {
-                setSelectedRowKeys(new Set());
-                onChange && onChange([]);
-                return;
-              }
+            // deselect all
+            if (keys.length === 0) {
+              const tableKeys = dataSource.map((item) => item.value);
+              const newSelectedRowKeys = difference(
+                [...selectedRowKeys.values()],
+                tableKeys,
+              );
+              const newSelectedRowKeySet = new Set(newSelectedRowKeys);
+              setSelectedRowKeys(newSelectedRowKeySet);
+              onChange && onChange(Array.from(newSelectedRowKeySet));
+              return;
+            }
+            // select all
+            if (keys.length === dataSource.length) {
               const newSelectedRowKeys = [
                 ...selectedRowKeys,
                 ...(keys as string[]),
               ];
-              setSelectedRowKeys(new Set(newSelectedRowKeys));
-              onChange && onChange(newSelectedRowKeys);
+              const newSelectedRowKeysSet = new Set(newSelectedRowKeys);
+              setSelectedRowKeys(newSelectedRowKeysSet);
+              onChange && onChange(Array.from(newSelectedRowKeysSet));
             }
           },
         }}


### PR DESCRIPTION
## Description
In #491 using onChange to handle select all & deselect all click,
the if condition didn't bypass select one click successfully (it happens when the `selectedKeys` already had 1 key), causing onSelect & onChange to update `selectedKeys` at the same time, so there are duplicated keys inside.

![image](https://github.com/user-attachments/assets/56866536-6019-4135-b792-4861a4e33e0e)
