### PR TITLE
chore(wren-ai-service): pr title validation

### DIFF
--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -2,10 +2,9 @@ name: Pull Request Title Validator
 
 on:
   pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
+    paths:
+      - "wren-ai-service/**"
+    types: [opened, edited, synchronize]
 
 permissions:
   pull-requests: read
@@ -16,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.2.0
+        uses: kontrolplane/pull-request-title-validator@v1.3.0
         with:
           types: "fix,feat,chore"
           socpes: "wren-ai-service"

--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -18,4 +18,4 @@ jobs:
         uses: kontrolplane/pull-request-title-validator@v1.3.0
         with:
           types: "fix,feat,chore"
-          scopes: "wren-ai-service"
+          scopes: "wren-ai-service,wren-ui"

--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -19,3 +19,4 @@ jobs:
         uses: kontrolplane/pull-request-title-validator@v1.2.0
         with:
           types: "fix,feat,chore"
+          socpes: "wren-ai-service"

--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -18,4 +18,4 @@ jobs:
         uses: kontrolplane/pull-request-title-validator@v1.3.0
         with:
           types: "fix,feat,chore"
-          socpes: "wren-ai-service"
+          scopes: "wren-ai-service"

--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -1,0 +1,21 @@
+name: Pull Request Title Validator
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validator:
+    name: validate-pull-request-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: validate pull request title
+        uses: kontrolplane/pull-request-title-validator@v1.2.0
+        with:
+          types: "fix,feat,chore"

--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "wren-ai-service/**"
+      - ".github/workflows/pull-request-title-validator.yaml"
+      - ".github/workflows/ai-service-*.yaml"
     types: [opened, edited, synchronize]
 
 permissions:

--- a/.github/workflows/pull-request-title-validator.yaml
+++ b/.github/workflows/pull-request-title-validator.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.3.0
+        uses: kontrolplane/pull-request-title-validator@v1.3.1
         with:
           types: "fix,feat,chore"
-          scopes: "wren-ai-service,wren-ui"
+          scopes: "wren-ai-service"


### PR DESCRIPTION
This PR aims to add a GitHub workflow to avoid the inconsistency PR title causes missing commits in release details for a tag. and we will use https://github.com/kontrolplane/pull-request-title-validator to address this issue.

## Screenshot
- The title matches the scopes
<img width="1593" alt="image" src="https://github.com/user-attachments/assets/bcae5b26-ff3b-4bfd-ad2f-0e27dea0de9d">


- The title doesn't matche the scopes
<img width="1593" alt="image" src="https://github.com/user-attachments/assets/414f3509-acaa-4522-9f6c-e360a00af01d">
