### PR TITLE
fix(wren-ai-service): error handling for evaluation process

### DIFF
--- a/wren-ai-service/eval/evaluation.py
+++ b/wren-ai-service/eval/evaluation.py
@@ -12,6 +12,8 @@ from langfuse import Langfuse
 from langfuse.decorators import langfuse_context, observe
 
 sys.path.append(f"{Path().parent.resolve()}")
+import traceback
+
 from eval.metrics.column import (
     AccuracyMetric,
     AnswerRelevancyMetric,
@@ -69,9 +71,9 @@ class Evaluator:
                 test_case = LLMTestCase(**formatter(prediction))
                 result = evaluate([test_case], self._metrics)[0]
                 self._score_metrics(test_case, result)
-            except Exception as e:
+            except Exception:
                 self._failed_count += 1
-                print(f"Error: {e}")
+                traceback.print_exc()
 
         self._average_score(meta)
 

--- a/wren-ai-service/eval/metrics/column.py
+++ b/wren-ai-service/eval/metrics/column.py
@@ -17,12 +17,13 @@ class AccuracyMetric(BaseMetric):
         return asyncio.run(self.a_measure(test_case))
 
     def is_subset(self, expected: pd.DataFrame, actual: pd.DataFrame) -> bool:
-        is_column_subset = set(actual.columns).issubset(set(expected.columns))
-
-        if not is_column_subset:
+        if not set(actual.columns).issubset(set(expected.columns)):
             return False
 
         common_columns = actual.columns
+        if common_columns.empty:
+            return False
+
         expected_sorted = expected[sorted(common_columns)]
         actual_sorted = actual[sorted(common_columns)]
 


### PR DESCRIPTION
This PR aims to add error handling to the evaluation process to prevent errors from affecting the results and also add a condition to avoid the error for Accuracy Metric. Additionally, it introduces a "failed count" metadata field into the summary trace, which will help us easily track the number of successful and failed traces.