### PR TITLE
chore(submodule): make submodule wren-engine follow main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "wren-engine"]
 	path = wren-engine
 	url = git@github.com:Canner/wren-engine.git
+	branch = main


### PR DESCRIPTION
Dear team,

Would you mind having the submodule `wren-engine` follow the main branch?