### PR TITLE
fix(wren-ai-service): error handling for accuracy metric to avoid the select all query failed

### DIFF
--- a/wren-ai-service/eval/.env.example
+++ b/wren-ai-service/eval/.env.example
@@ -5,4 +5,4 @@ bigquery.project-id=
 bigquery.dataset-id=
 bigquery.credentials-key=
 BATCH_SIZE=4
-BATCH_INTERVAL=10
+BATCH_INTERVAL=1

--- a/wren-ai-service/eval/evaluation.py
+++ b/wren-ai-service/eval/evaluation.py
@@ -62,7 +62,7 @@ class Evaluator:
 
             try:
                 test_case = LLMTestCase(**formatter(prediction))
-                result = evaluate([test_case], self._metrics)[0]
+                result = evaluate([test_case], self._metrics, ignore_errors=True)[0]
                 self._score_metrics(test_case, result)
                 [metric.collect(test_case, result) for metric in self._post_metrics]
             except Exception:
@@ -74,13 +74,13 @@ class Evaluator:
     def _score_metrics(self, test_case: LLMTestCase, result: TestResult) -> None:
         for metric in result.metrics_metadata:
             name = metric.metric
-            score = metric.score
+            score = metric.score or 0
 
             self._langfuse.score(
                 trace_id=test_case.additional_metadata["trace_id"],
                 name=name,
                 value=score,
-                comment=metric.reason,
+                comment=metric.reason or metric.error,
                 source="eval",
             )
 

--- a/wren-ai-service/eval/prediction.py
+++ b/wren-ai-service/eval/prediction.py
@@ -33,7 +33,7 @@ def generate_meta(
 ) -> Dict[str, Any]:
     return {
         "user_id": "wren-evaluator",  # this property is using for langfuse
-        "session_id": f"eval_{uuid.uuid4()}",
+        "session_id": f"eval_{pipe}_{uuid.uuid4()}",
         "date": datetime.now(),
         "dataset_id": dataset["dataset_id"],
         "evaluation_dataset": path,


### PR DESCRIPTION
This PR addresses error handling for failed metrics computation and includes the pipeline name in the evaluation results.

### Screenshots

<img width="1595" alt="image" src="https://github.com/user-attachments/assets/491d4701-c218-4fae-a366-ff267a982147">

<img width="1593" alt="image" src="https://github.com/user-attachments/assets/e49fe2ff-9869-458c-b2f2-f84481c64026">
