### PR TITLE
fix(wren-ai-service): expend the timeout and move the waiting check mechanism when force deploying

### DIFF
--- a/wren-ai-service/entrypoint.sh
+++ b/wren-ai-service/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 INTERVAL=1
-TIMEOUT=10
+TIMEOUT=60
 
 # Wait for qdrant to be responsive
 echo "Waiting for qdrant to start..."

--- a/wren-ai-service/entrypoint.sh
+++ b/wren-ai-service/entrypoint.sh
@@ -21,26 +21,27 @@ echo "qdrant has started."
 # Start wren-ai-service in the background
 uvicorn src.__main__:app --host 0.0.0.0 --port $WREN_AI_SERVICE_PORT --loop uvloop --http httptools &
 
-# Wait for the server to be responsive
-echo "Waiting for wren-ai-service to start..."
-current=0
-
-while ! nc -z localhost $WREN_AI_SERVICE_PORT; do   
-    sleep $INTERVAL
-    current=$((current + INTERVAL))
-    if [ $current -eq $TIMEOUT ]; then
-        echo "Timeout: wren-ai-service did not start within $TIMEOUT seconds"
-        exit 1
-    fi
-done
-echo "wren-ai-service has started."
-
 if [[ -n "$SHOULD_FORCE_DEPLOY" ]]; then
+
+    # Wait for the server to be responsive
+    echo "Waiting for wren-ai-service to start..."
+    current=0
+
+    while ! nc -z localhost $WREN_AI_SERVICE_PORT; do
+        sleep $INTERVAL
+        current=$((current + INTERVAL))
+        if [ $current -eq $TIMEOUT ]; then
+            echo "Timeout: wren-ai-service did not start within $TIMEOUT seconds"
+            exit 1
+        fi
+    done
+    echo "wren-ai-service has started."
+
     # Wait for wren-ui to be responsive
     echo "Waiting for wren-ui to start..."
     current=0
 
-    while ! nc -z -w 5 wren-ui $WREN_UI_PORT && ! nc -z -w 5 host.docker.internal $WREN_UI_PORT; do   
+    while ! nc -z wren-ui $WREN_UI_PORT && ! nc -z host.docker.internal $WREN_UI_PORT; do
         sleep $INTERVAL
         current=$((current + INTERVAL))
         if [ $current -eq $TIMEOUT ]; then


### PR DESCRIPTION
This PR aims to extend the timeout, as the AI service startup process sometimes requires additional time. It also moves the checking mechanism that activates when force deployment is enabled.