### PR TITLE
chore(wren-ai-service): Refine mdl preparation script

### DIFF
--- a/wren-ai-service/eval/preparation.py
+++ b/wren-ai-service/eval/preparation.py
@@ -1,4 +1,5 @@
 import argparse
+import csv
 from pathlib import Path
 
 import orjson
@@ -33,9 +34,11 @@ def gen_eval_preparation_data_from_json_to_csv(mdl_path: str):
                 ]
             )
 
-    with open(f"{Path(mdl_path).stem}.csv", "w") as file:
+    with open(f"{Path(mdl_path).stem}.csv", "w", newline="\n") as file:
+        writer = csv.writer(file, quoting=csv.QUOTE_MINIMAL)
+
         for row in csv_data:
-            file.write(",".join(row) + "\n")
+            writer.writerow(row)
 
 
 def gen_new_mdl_from_csv(mdl_path: str, csv_path: str):
@@ -45,51 +48,55 @@ def gen_new_mdl_from_csv(mdl_path: str, csv_path: str):
     with open(mdl_path) as file:
         mdl = orjson.loads(file.read())
 
-    with open(csv_path) as file:
-        csv_data = [line.strip().split(",") for line in file.readlines()]
+    with open(csv_path, newline="\n") as file:
+        csv_data = csv.reader(file)
 
-    csv_data_by_table = {}
+        csv_data_by_table = {}
 
-    for row in csv_data[1:]:
-        model_name = row[0]
-        if model_name not in csv_data_by_table:
-            csv_data_by_table[model_name] = {
-                "model": {
-                    "displayName": row[1],
-                    "description": row[2],
-                },
-                "columns": {},
+        for row in csv_data:
+            model_name = row[0]
+            if model_name not in csv_data_by_table:
+                csv_data_by_table[model_name] = {
+                    "model": {
+                        "displayName": row[1],
+                        "description": row[2],
+                    },
+                    "columns": {},
+                }
+
+            csv_data_by_table[model_name]["columns"][row[3]] = {
+                "displayName": row[4],
+                "description": row[5],
             }
 
-        csv_data_by_table[model_name]["columns"][row[3]] = {
-            "displayName": row[4],
-            "description": row[5],
-        }
-
-    for model in mdl["models"]:
-        if model["name"] in csv_data_by_table:
-            if csv_data_by_table[model["name"]]["model"]["displayName"]:
-                model["properties"]["displayName"] = csv_data_by_table[model["name"]][
-                    "model"
-                ]["displayName"]
-            if csv_data_by_table[model["name"]]["model"]["description"]:
-                model["properties"]["description"] = csv_data_by_table[model["name"]][
-                    "model"
-                ]["description"]
-            for column in model["columns"]:
-                if column["name"] in csv_data_by_table[model["name"]]["columns"]:
-                    if csv_data_by_table[model["name"]]["columns"][column["name"]][
-                        "displayName"
-                    ]:
-                        column["properties"]["displayName"] = csv_data_by_table[
-                            model["name"]
-                        ]["columns"][column["name"]]["displayName"]
-                    if csv_data_by_table[model["name"]]["columns"][column["name"]][
-                        "description"
-                    ]:
-                        column["properties"]["description"] = csv_data_by_table[
-                            model["name"]
-                        ]["columns"][column["name"]]["description"]
+        for model in mdl["models"]:
+            if model["name"] in csv_data_by_table:
+                if "properties" not in model:
+                    model["properties"] = {}
+                if csv_data_by_table[model["name"]]["model"]["displayName"]:
+                    model["properties"]["displayName"] = csv_data_by_table[
+                        model["name"]
+                    ]["model"]["displayName"]
+                if csv_data_by_table[model["name"]]["model"]["description"]:
+                    model["properties"]["description"] = csv_data_by_table[
+                        model["name"]
+                    ]["model"]["description"]
+                for column in model["columns"]:
+                    if column["name"] in csv_data_by_table[model["name"]]["columns"]:
+                        if "properties" not in column:
+                            column["properties"] = {}
+                        if csv_data_by_table[model["name"]]["columns"][column["name"]][
+                            "displayName"
+                        ]:
+                            column["properties"]["displayName"] = csv_data_by_table[
+                                model["name"]
+                            ]["columns"][column["name"]]["displayName"]
+                        if csv_data_by_table[model["name"]]["columns"][column["name"]][
+                            "description"
+                        ]:
+                            column["properties"]["description"] = csv_data_by_table[
+                                model["name"]
+                            ]["columns"][column["name"]]["description"]
 
     with open(f"{Path(mdl_path).stem}_new.json", "w") as file:
         file.write(orjson.dumps(mdl).decode())

--- a/wren-ai-service/eval/preparation.py
+++ b/wren-ai-service/eval/preparation.py
@@ -48,10 +48,10 @@ def gen_new_mdl_from_csv(mdl_path: str, csv_path: str):
     with open(mdl_path) as file:
         mdl = orjson.loads(file.read())
 
+    csv_data_by_table = {}
+
     with open(csv_path, newline="\n") as file:
         csv_data = csv.reader(file)
-
-        csv_data_by_table = {}
 
         for row in csv_data:
             model_name = row[0]


### PR DESCRIPTION
- Deal with models and columns without `properties` keys
- Use csv read/write functions can escape commas within quotes, prevent descriptions containing commas breaking the csv structure. 
  - Note: Still recommend to save the output csv file as xlsx file, if expecting users to edit descriptions with Excel.