### PR TITLE
chore(wren-ai-service): custom dependabot commit message and labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/wren-ai-service"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(wren-ai-service)"
+    labels:
+      - "dependencies"
+      - "python"
+      - "ci/ai-service"
+      - "module/ai-service"


### PR DESCRIPTION
This PR aims to update the Dependabot PR commit message to 'wren-ai-service,' eliminating the need for manual modifications for each PR. Thanks to @grieve54706 for suggesting this great feature!

See also:
-  https://github.com/Canner/wren-engine/blob/main/.github/dependabot.yml
 - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
