### PR TITLE
chore(wren-ai-service): fix docker-compose-dev.yaml

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -59,7 +59,6 @@ services:
       - wren
     depends_on:
       - qdrant
-      - wren-ui
 
   ibis-server:
     image: ghcr.io/canner/wren-engine-ibis:${IBIS_SERVER_VERSION}


### PR DESCRIPTION
remove wren-ui from `depends_on` in wren-ai-service