### PR TITLE
fix(wren-ui): UI layout is broken when selecting a sample dataset

### DIFF
--- a/wren-ui/src/components/pages/setup/ButtonItem.tsx
+++ b/wren-ui/src/components/pages/setup/ButtonItem.tsx
@@ -96,7 +96,7 @@ export default function ButtonItem(props: IterableComponent<Props>) {
       loading={loading}
       onClick={() => onSelect(value)}
     >
-      <div className="d-flex align-center">
+      <div className="d-flex align-center" style={{ width: '100%' }}>
         {logo ? (
           <Image
             className="mr-2"


### PR DESCRIPTION
## Description
 UI layout is broken when selecting a sample dataset

###  Video (Bug)
https://github.com/user-attachments/assets/7edff7d7-452d-4a79-bb8e-97431497f5e7

