### PR TITLE
feat(wren-ai-service): kubernetes session affinity for ai service

### DIFF
--- a/deployment/kustomizations/README.md
+++ b/deployment/kustomizations/README.md
@@ -93,6 +93,16 @@ helm install \
   --set installCRDs=true
 kubectl get pods -n cert-manager
 
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+helm install \
+  istio-base istio/base \
+  --namespace istio-system \
+  --set defaultRevision=default \
+  --create-namespace
+helm install istiod istio/istiod -n istio-system --wait
+kubectl get pods -n istio-system
+
 ##########
 # Use the `Steps to deploy` section to continue as you would on a production k8s cluster.
 ```

--- a/deployment/kustomizations/istio/destination-rule.yaml
+++ b/deployment/kustomizations/istio/destination-rule.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: wren-ai-service-destination
+  namespace: wren
+spec:
+  host: wren-ai-service-svc.wren.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: "user-session" # Use a custom header for sticky sessions

--- a/deployment/kustomizations/istio/virtual-service.yaml
+++ b/deployment/kustomizations/istio/virtual-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: wren-ai-service-virtualservice
+  namespace: wren
+spec:
+  hosts:
+    - wren-ai-service-svc.wren.svc.cluster.local
+  http:
+    - match:
+        - uri:
+            prefix: "/" # Matches all requests to the service
+      route:
+        - destination:
+            host: wren-ai-service-svc.wren.svc.cluster.local
+            port:
+              number: 5555

--- a/deployment/kustomizations/kustomization.yaml
+++ b/deployment/kustomizations/kustomization.yaml
@@ -14,8 +14,7 @@ kind: Kustomization
 # Namespace for all resources here and in the Helm charts
 namespace: wren
 helmCharts:
-
-### Uncomment if you are planing to use postgresql
+  ### Uncomment if you are planing to use postgresql
   - name: postgresql
     repo: https://repo.vmware.com/bitnami-files
     version: 15.5.5
@@ -34,7 +33,6 @@ helmCharts:
     # The Same Namespace
     namespace: wren
 
-
 images:
   - name: ghcr.io/canner/wren-bootstrap
     newTag: 0.1.5 # WREN_BOOTSTRAP_VERSION
@@ -43,7 +41,7 @@ images:
   - name: ghcr.io/canner/wren-ui
     newTag: 0.9.2 # WREN_UI_VERSION
   - name: ghcr.io/canner/wren-ai-service
-    newTag: 0.8.2 # WREN_AI_SERVICE_VERSION
+    newTag: 0.8.3 # WREN_AI_SERVICE_VERSION
   - name: ghcr.io/canner/wren-engine-ibis
     newTag: 0.9.0 # IBIS_SERVER_VERSION
 
@@ -54,9 +52,11 @@ resources:
   - base/deploy-wren-ai-service.yaml
   - base/pvc.yaml
   - base/svc.yaml
+  - istio/destination-rule.yaml
+  - istio/virtual-service.yaml
 ### Modify these examples first and uncomment them:
-  # - examples/ingress-wren_example.yaml
-  # - examples/certificate-wren_example.yaml
+# - examples/ingress-wren_example.yaml
+# - examples/certificate-wren_example.yaml
 ### Usually you do not need to generate a certificate for Qdrant
 #  - examples/certificate-qdrant_example.yaml
 ### Best practice is to create and deploy Secrets manually, not as part of kustomization or GitOps!


### PR DESCRIPTION
This PR introduces support for session affinity settings in the Kubernetes deployment of the AI service. As the AI service is stateful, scaling replicas can lead to increased errors for "query not found" if results are retrieved from the wrong pod. To address this, we are using Istio to manage session affinity and improve reliability.

### How to validate?

1. Scale up the replicas of the service on the Kubernetes cluster:
    ```bash
    kubectl scale deploy wren-ai-service-deployment --replicas=2
    ```

2. Create a test pod:
    ```bash
    echo 'apiVersion: v1
    kind: Pod
    metadata:
      name: test-pod
      namespace: wren
    spec:
      containers:
      - name: curl-container
        image: curlimages/curl:7.85.0
        command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]  
      restartPolicy: Never
    ' | kubectl apply -f -
    ```

3. Access the test pod:
    ```bash
    kubectl exec -it test-pod -n wren -- /bin/sh
    ```

4. Validate the health check endpoint with a header and trace the result in pod log:
    ```bash
    curl -H 'user-session: sid-1' wren-ai-service-svc:5555/health
    ```


### See Also
- https://github.com/istio/istio/issues/12178
- https://istio.io/latest/docs/reference/config/networking/destination-rule/
- https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService