### PR TITLE
feat(wren-ai-service): optional attribute user_id for Langfuse metadata

### DIFF
--- a/wren-ai-service/src/utils.py
+++ b/wren-ai-service/src/utils.py
@@ -169,6 +169,8 @@ def trace_metadata(func):
             metadata["thread_id"] = request.thread_id
         if hasattr(request, "mdl_hash"):
             metadata["mdl_hash"] = request.mdl_hash
+        if hasattr(request, "user_id"):
+            metadata["user_id"] = request.user_id
 
         return metadata
 
@@ -177,19 +179,19 @@ def trace_metadata(func):
         results = await func(*args, **kwargs)
 
         addition = {}
-        if results and isinstance(results, dict):
+        if isinstance(results, dict):
             additional_metadata = results.get("metadata", {})
-            for key, value in additional_metadata.items():
-                addition[key] = value
+            addition.update(additional_metadata)
 
         metadata = extract(*args)
         langfuse_metadata = {
             **MODELS_METADATA,
             **addition,
             "mdl_hash": metadata.get("mdl_hash"),
+            "project_id": metadata.get("project_id"),
         }
         langfuse_context.update_current_trace(
-            user_id=metadata.get("project_id"),
+            user_id=metadata.get("user_id"),
             session_id=metadata.get("thread_id"),
             release=SERVICE_VERSION,
             metadata=langfuse_metadata,

--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -32,6 +32,7 @@ class AskRequest(BaseModel):
     # so we need to support as a choice, and will remove it in the future
     mdl_hash: Optional[str] = Field(validation_alias=AliasChoices("mdl_hash", "id"))
     thread_id: Optional[str] = None
+    user_id: Optional[str] = None
     history: Optional[AskResponseDetails] = None
 
     @property

--- a/wren-ai-service/src/web/v1/services/ask_details.py
+++ b/wren-ai-service/src/web/v1/services/ask_details.py
@@ -26,6 +26,7 @@ class AskDetailsRequest(BaseModel):
     mdl_hash: Optional[str] = None
     thread_id: Optional[str] = None
     project_id: Optional[str] = None
+    user_id: Optional[str] = None
 
     @property
     def query_id(self) -> str:

--- a/wren-ai-service/src/web/v1/services/indexing.py
+++ b/wren-ai-service/src/web/v1/services/indexing.py
@@ -17,6 +17,7 @@ class SemanticsPreparationRequest(BaseModel):
     # so we need to support as a choice, and will remove it in the future
     mdl_hash: str = Field(validation_alias=AliasChoices("mdl_hash", "id"))
     project_id: Optional[str] = None
+    user_id: Optional[str] = None
 
 
 class SemanticsPreparationResponse(BaseModel):

--- a/wren-ai-service/tests/pytest/test_utils.py
+++ b/wren-ai-service/tests/pytest/test_utils.py
@@ -47,21 +47,31 @@ def test_service_metadata(mocker: MockFixture):
 
 
 def test_trace_metadata(mocker: MockFixture):
-    metadata = mocker.patch("src.utils.MODELS_METADATA", {"mdl_hash": None})
+    metadata = mocker.patch("src.utils.MODELS_METADATA", {})
     version = mocker.patch("src.utils.SERVICE_VERSION", "0.8.0-mock")
     function = mocker.patch(
         "src.utils.langfuse_context.update_current_trace", return_value=None
     )
 
+    class Request:
+        project_id = "mock-project-id"
+        thread_id = "mock-thread-id"
+        mdl_hash = "mock-mdl-hash"
+        user_id = "mock-user-id"
+
     @utils.trace_metadata
-    async def my_function(a: str, b: str):
+    async def my_function(_: str, b: Request):
         return "Hello, World!"
 
-    asyncio.run(my_function("Hello", "World!"))
+    asyncio.run(my_function("", Request()))
 
     function.assert_called_once_with(
-        user_id=None,
-        session_id=None,
+        user_id="mock-user-id",
+        session_id="mock-thread-id",
         release=version,
-        metadata=metadata,
+        metadata={
+            "mdl_hash": "mock-mdl-hash",
+            "project_id": "mock-project-id",
+            **metadata,
+        },
     )


### PR DESCRIPTION
Before this PR, we used the project ID as the user ID for Langfuse. In our team discussion, we decided to include the project ID in the metadata and introduce an optional user_id attribute for API requests. We also ensured that the logic remains consistent.