### PR TITLE
fix(wren-ai-service): correct the wrong version in docker image

### DIFF
--- a/.github/workflows/ai-service-release-stable-image.yaml
+++ b/.github/workflows/ai-service-release-stable-image.yaml
@@ -78,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
This PR aims to fix #632. and it has been reproduced in [here](https://github.com/Canner/WrenAI/actions/runs/10678532991/job/29595791499). the problem is that we don't fetch the latest git ref in checkout action. refer to https://github.com/actions/checkout/issues/1327

### Screenshots
<img width="770" alt="image" src="https://github.com/user-attachments/assets/27820f2b-69e2-400b-a8eb-d81093fea770">

- see https://github.com/Canner/WrenAI/actions/runs/10678858613/job/29596820200, for the details of the fix