### PR TITLE
feat(wren-ai-service): add historical queries in view chunk for follow-up question

### DIFF
--- a/wren-ai-service/src/pipelines/indexing/indexing.py
+++ b/wren-ai-service/src/pipelines/indexing/indexing.py
@@ -100,7 +100,9 @@ class ViewChunker:
     def run(self, mdl: Dict[str, Any], id: Optional[str] = None) -> None:
         def _get_content(view: Dict[str, Any]) -> str:
             properties = view.get("properties", {})
-            return str(properties.get("question", ""))
+            historical_queries = properties.get("historical_queries", [])
+            question = properties.get("question", "")
+            return " ".join(historical_queries) + " " + question
 
         def _get_meta(view: Dict[str, Any]) -> Dict[str, Any]:
             properties = view.get("properties", {})

--- a/wren-ai-service/src/pipelines/indexing/indexing.py
+++ b/wren-ai-service/src/pipelines/indexing/indexing.py
@@ -102,7 +102,8 @@ class ViewChunker:
             properties = view.get("properties", {})
             historical_queries = properties.get("historical_queries", [])
             question = properties.get("question", "")
-            return " ".join(historical_queries) + " " + question
+
+            return " ".join(historical_queries + [question])
 
         def _get_meta(view: Dict[str, Any]) -> Dict[str, Any]:
             properties = view.get("properties", {})

--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -140,16 +140,16 @@ class AskService:
                     status="understanding",
                 )
 
+            query_for_retrieval = (
+                ask_request.history.summary + " " + ask_request.query
+                if ask_request.history
+                else ask_request.query
+            )
             if not self._is_stopped(query_id):
                 self._ask_results[query_id] = AskResultResponse(
                     status="searching",
                 )
 
-                query_for_retrieval = (
-                    ask_request.history.summary + " " + ask_request.query
-                    if ask_request.history
-                    else ask_request.query
-                )
                 retrieval_result = await self._pipelines["retrieval"].run(
                     query=query_for_retrieval,
                     id=ask_request.project_id,
@@ -176,7 +176,7 @@ class AskService:
                 )
 
                 historical_question = await self._pipelines["historical_question"].run(
-                    query=ask_request.query,
+                    query=query_for_retrieval,
                     id=ask_request.project_id,
                 )
 

--- a/wren-ai-service/tests/pytest/pipelines/test_view_chunker.py
+++ b/wren-ai-service/tests/pytest/pipelines/test_view_chunker.py
@@ -186,3 +186,61 @@ def test_multi_views():
         "viewId": "fake-id-2",
     }
     assert document_2.content == "How many books are there?"
+
+
+def test_view_with_historical_query():
+    chunker = ViewChunker()
+    mdl = {
+        "views": [
+            {
+                "name": "book",
+                "statement": "SELECT * FROM book where created_at = 2020",
+                "properties": {
+                    "question": "in 2020",
+                    "summary": "Retrieve the number of books in 2020",
+                    "viewId": "fake-id-1",
+                    "historical_queries": ["Retrieve the number of books"],
+                },
+            }
+        ]
+    }
+
+    actual = chunker.run(mdl)
+    assert len(actual["documents"]) == 1
+
+    document: Document = actual["documents"][0]
+    assert document.meta == {
+        "summary": "Retrieve the number of books in 2020",
+        "statement": "SELECT * FROM book where created_at = 2020",
+        "viewId": "fake-id-1",
+    }
+    assert document.content == "Retrieve the number of books in 2020"
+
+
+def test_view_with_historical_queries():
+    chunker = ViewChunker()
+    mdl = {
+        "views": [
+            {
+                "name": "book",
+                "statement": "SELECT * FROM book where city = 'taipei' and created_at = 2020",
+                "properties": {
+                    "question": "in 2020",
+                    "summary": "Retrieve the number of books in taipei in 2020",
+                    "viewId": "fake-id-1",
+                    "historical_queries": ["Retrieve the number of books", "in taipei"],
+                },
+            }
+        ]
+    }
+
+    actual = chunker.run(mdl)
+    assert len(actual["documents"]) == 1
+
+    document: Document = actual["documents"][0]
+    assert document.meta == {
+        "summary": "Retrieve the number of books in taipei in 2020",
+        "statement": "SELECT * FROM book where city = 'taipei' and created_at = 2020",
+        "viewId": "fake-id-1",
+    }
+    assert document.content == "Retrieve the number of books in taipei in 2020"

--- a/wren-ai-service/tests/pytest/pipelines/test_view_chunker.py
+++ b/wren-ai-service/tests/pytest/pipelines/test_view_chunker.py
@@ -1,18 +1,18 @@
 from haystack import Document
 
-from src.pipelines.indexing.indexing import ViewConverter
+from src.pipelines.indexing.indexing import ViewChunker
 
 
 def test_empty_views():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {"views": []}
 
-    document = converter.run(mdl)
+    document = chunker.run(mdl)
     assert document == {"documents": []}
 
 
 def test_single_view():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {
         "views": [
             {
@@ -27,7 +27,7 @@ def test_single_view():
         ]
     }
 
-    actual = converter.run(mdl)
+    actual = chunker.run(mdl)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -40,7 +40,7 @@ def test_single_view():
 
 
 def test_view_missing_properties():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {
         "views": [
             {
@@ -50,7 +50,7 @@ def test_view_missing_properties():
         ]
     }
 
-    actual = converter.run(mdl)
+    actual = chunker.run(mdl)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -63,7 +63,7 @@ def test_view_missing_properties():
 
 
 def test_view_missing_question():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {
         "views": [
             {
@@ -77,7 +77,7 @@ def test_view_missing_question():
         ]
     }
 
-    actual = converter.run(mdl)
+    actual = chunker.run(mdl)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -90,7 +90,7 @@ def test_view_missing_question():
 
 
 def test_view_missing_summary():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {
         "views": [
             {
@@ -104,7 +104,7 @@ def test_view_missing_summary():
         ]
     }
 
-    actual = converter.run(mdl)
+    actual = chunker.run(mdl)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -117,7 +117,7 @@ def test_view_missing_summary():
 
 
 def test_view_missing_id():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {
         "views": [
             {
@@ -131,7 +131,7 @@ def test_view_missing_id():
         ]
     }
 
-    actual = converter.run(mdl)
+    actual = chunker.run(mdl)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -144,7 +144,7 @@ def test_view_missing_id():
 
 
 def test_multi_views():
-    converter = ViewConverter()
+    chunker = ViewChunker()
     mdl = {
         "views": [
             {
@@ -168,7 +168,7 @@ def test_multi_views():
         ]
     }
 
-    actual = converter.run(mdl)
+    actual = chunker.run(mdl)
     assert len(actual["documents"]) == 2
 
     document_1: Document = actual["documents"][0]


### PR DESCRIPTION
# Description

This PR enhances the view chunking process to include historical queries, improving the context for follow-up questions in the AI service.

## Key Changes

1. Renamed `ViewConverter` to `ViewChunker` for clarity.
2. Updated `ViewChunker` to include historical queries in the content:
   - Now combines `historical_queries` with the current question.
   - Example JSON configuration:
     ```yaml
     {
         "views": [
             {
                 "name": "book",
                 "statement": "SELECT * FROM book where created_at = 2020",
                 "properties": {
                     "question": "in 2020",
                     "summary": "Retrieve the number of books in 2020",
                     "viewId": "fake-id-1",
                     "historical_queries": [
                         "Retrieve the number of books"
                     ]
                 }
             }
         ]
     }
     ```
3. Modified `AskService` to use a combined query for retrieval:
   - Includes history summary and current query when available.
5. Refactored `Indexing` class to use a component dictionary for better organization.
6. Updated tests to reflect these changes and added new tests for historical queries.

## Impact

These changes will improve the AI's ability to understand and respond to follow-up questions by providing more context from previous interactions. This should lead to more accurate and relevant responses to retrieve the saved view.

## Screenshots
- saved view includes the historical query's summary
<img width="986" alt="image" src="https://github.com/user-attachments/assets/0cb5693f-1a7f-41f0-8189-a50f958cab3d">

- run a follow-up query that based on a similar query to validate
<img width="873" alt="image" src="https://github.com/user-attachments/assets/6f8a9420-ca75-472a-9e41-9b1e42f243fd">

