### PR TITLE
feat(wren-ai-service): add all nested columns properties into column comment

### DIFF
--- a/wren-ai-service/src/pipelines/indexing/indexing.py
+++ b/wren-ai-service/src/pipelines/indexing/indexing.py
@@ -246,6 +246,13 @@ class DDLConverter:
                             "alias": column["properties"].pop("displayName", ""),
                             "description": column["properties"].pop("description", ""),
                         }
+                        nested_cols = {
+                            k: v
+                            for k, v in column["properties"].items()
+                            if k.startswith("nested")
+                        }
+                        if nested_cols:
+                            column_properties["nested_columns"] = nested_cols
                         comment = (
                             f"-- {orjson.dumps(column_properties).decode("utf-8")}\n  "
                         )


### PR DESCRIPTION
This PR addresses an issue with the handling of nested properties in the `properties` dictionary.

#### Example Input
```json
{
  "models": [
    {
      "name": "test",
      "columns": [
        {
          "name": "test",
          "type": "test",
          "properties": {
            "displayName": "test",
            "description": "test",
            "nestedDisplayName.city.tree": "Tree",
            "nestedDescription.city.tree": "The customer City, where ...",
            "nestedDisplayName.city.author": "The Author",
            "nestedDescription.city.author": "The Author of the city, where ...",
            "nestedDescription.city.author.name": "The name of the author"
          }
        }
      ]
    }
  ],
  "views": [],
  "relationships": [],
  "metrics": []
}
```

#### Document Format
```python
{
  'type': 'TABLE_COLUMNS',
  'columns': [
    {
      'type': 'COLUMN',
      'comment': '-- {"alias":"test","description":"test","nested_columns":{"nestedDisplayName.city.tree":"Tree","nestedDescription.city.tree":"The customer City, where ...","nestedDisplayName.city.author":"The Author","nestedDescription.city.author":"The Author of the city, where ...","nestedDescription.city.author.name":"The name of the author"}}\n ',
      'name': 'test',
      'data_type': 'test',
      'is_primary_key': False
    }
  ]
}
```

### Screenshots
<img width="1593" alt="image" src="https://github.com/user-attachments/assets/a1e44c4e-c88b-42e7-9329-cb2c0b4070e6">
