### PR TITLE
feat(wren-ai-service): semantics description pipeline to generate or optimize the user description

### DIFF
--- a/wren-ai-service/config.example.yaml
+++ b/wren-ai-service/config.example.yaml
@@ -103,3 +103,5 @@ pipes:
   - name: sql_regeneration
     llm: openai_llm.gpt-4o-mini
     engine: wren_ui
+  - name: semantics_description
+    llm: openai_llm.gpt-4o-mini

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -21,6 +21,7 @@ from src.pipelines.indexing import indexing
 from src.pipelines.retrieval import historical_question, retrieval
 from src.web.v1.services.ask import AskService
 from src.web.v1.services.ask_details import AskDetailsService
+from src.web.v1.services.semantics_description import SemanticsDescription
 from src.web.v1.services.semantics_preparation import SemanticsPreparationService
 from src.web.v1.services.sql_answer import SqlAnswerService
 from src.web.v1.services.sql_expansion import SqlExpansionService
@@ -32,6 +33,7 @@ logger = logging.getLogger("wren-ai-service")
 
 @dataclass
 class ServiceContainer:
+    semantics_description: SemanticsDescription
     semantics_preparation_service: SemanticsPreparationService
     ask_service: AskService
     sql_answer_service: SqlAnswerService

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -8,6 +8,7 @@ from src.core.pipeline import PipelineComponent
 from src.core.provider import EmbedderProvider, LLMProvider
 from src.pipelines.generation import (
     followup_sql_generation,
+    semantics_description,
     sql_answer,
     sql_breakdown,
     sql_correction,
@@ -57,7 +58,14 @@ def create_service_container(
     query_cache: Optional[dict] = {},
 ) -> ServiceContainer:
     return ServiceContainer(
-        semantics_description=SemanticsDescription(pipelines={}, **query_cache),
+        semantics_description=SemanticsDescription(
+            pipelines={
+                "semantics_description": semantics_description.SemanticsDescription(
+                    **pipe_components["semantics_description"],
+                )
+            },
+            **query_cache,
+        ),
         semantics_preparation_service=SemanticsPreparationService(
             pipelines={
                 "indexing": indexing.Indexing(

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -57,6 +57,7 @@ def create_service_container(
     query_cache: Optional[dict] = {},
 ) -> ServiceContainer:
     return ServiceContainer(
+        semantics_description=SemanticsDescription(pipelines={}, **query_cache),
         semantics_preparation_service=SemanticsPreparationService(
             pipelines={
                 "indexing": indexing.Indexing(

--- a/wren-ai-service/src/pipelines/generation/semantics_description.py
+++ b/wren-ai-service/src/pipelines/generation/semantics_description.py
@@ -143,10 +143,7 @@ Please provide a brief description for the model and each column based on the us
 
 
 class SemanticsDescription(BasicPipeline):
-    def __init__(
-        self,
-        llm_provider: LLMProvider,
-    ):
+    def __init__(self, llm_provider: LLMProvider, **_):
         self._components = {
             "prompt_builder": PromptBuilder(template=user_prompt_template),
             "generator": llm_provider.get_generator(system_prompt=system_prompt),

--- a/wren-ai-service/src/pipelines/generation/semantics_description.py
+++ b/wren-ai-service/src/pipelines/generation/semantics_description.py
@@ -1,0 +1,219 @@
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import orjson
+from hamilton import base
+from hamilton.experimental.h_async import AsyncDriver
+from haystack.components.builders.prompt_builder import PromptBuilder
+from langfuse.decorators import observe
+
+from src.core.pipeline import BasicPipeline, async_validate
+from src.core.provider import LLMProvider
+
+logger = logging.getLogger("wren-ai-service")
+
+
+## Start of Pipeline
+def picked_models(mdl: dict, selected_models: list[str]) -> list[dict]:
+    def extract(model: dict) -> dict:
+        return {
+            "name": model["name"],
+            "columns": model["columns"],
+            "properties": model["properties"],
+        }
+
+    return [
+        extract(model) for model in mdl["models"] if model["name"] in selected_models
+    ]
+
+
+def prompt(
+    picked_models: list[dict],
+    user_prompt: str,
+    prompt_builder: PromptBuilder,
+) -> dict:
+    return prompt_builder.run(picked_models=picked_models, user_prompt=user_prompt)
+
+
+async def generate(prompt: dict, generator: Any) -> dict:
+    return await generator.run(prompt=prompt.get("prompt"))
+
+
+def post_process(generate: dict) -> dict:
+    def normalize(text: str) -> str:
+        text = text.replace("\n", " ")
+        text = " ".join(text.split())
+        # Convert the normalized text to a dictionary
+        try:
+            text_dict = orjson.loads(text.strip())
+            return text_dict
+        except orjson.JSONDecodeError as e:
+            logger.error(f"Error decoding JSON: {e}")
+            return {}  # Return an empty dictionary if JSON decoding fails
+
+    reply = generate.get("replies")[0]  # Expecting only one reply
+    normalized = normalize(reply)
+
+    return {model["name"]: model for model in normalized["models"]}
+
+
+## End of Pipeline
+
+system_prompt = """ 
+I have a data model represented in JSON format, with the following structure:
+
+```
+[
+    {'name': 'model', 'columns': [
+            {'name': 'column_1', 'type': 'type', 'notNull': True, 'properties': {}
+            },
+            {'name': 'column_2', 'type': 'type', 'notNull': True, 'properties': {}
+            },
+            {'name': 'column_3', 'type': 'type', 'notNull': False, 'properties': {}
+            }
+        ], 'properties': {}
+    }
+]
+```
+
+Your task is to update this JSON structure by adding a `description` field inside both the `properties` attribute of each `column` and the `model` itself. 
+Each `description` should be derived from a user-provided input that explains the purpose or context of the `model` and its respective columns. 
+Follow these steps:
+1. **For the `model`**: Prompt the user to provide a brief description of the model's overall purpose or its context. Insert this description in the `properties` field of the `model`.
+2. **For each `column`**: Ask the user to describe each column's role or significance. Each column's description should be added under its respective `properties` field in the format: `'description': 'user-provided text'`.
+3. Ensure that the output is a well-formatted JSON structure, preserving the input's original format and adding the appropriate `description` fields.
+
+### Output Format:
+
+```
+[
+    {
+        "name": "model",
+        "columns": [
+            {
+                "name": "column_1",
+                "properties": {
+                    "description": "<description for column_1>"
+                }
+            },
+            {
+                "name": "column_2",
+                "properties": {
+                    "description": "<description for column_1>"
+                }
+            },
+            {
+                "name": "column_3",
+                "properties": {
+                    "description": "<description for column_1>"
+                }
+            }
+        ],
+        "properties": {
+            "description": "<description for model>"
+        }
+    }
+]
+```
+
+Make sure that the descriptions are concise, informative, and contextually appropriate based on the input provided by the user.
+"""
+
+user_prompt_template = """
+
+### Input
+User's prompt: {{ user_prompt }}
+Picked models: {{ picked_models }}
+
+Please provide a brief description for the model and each column based on the user's prompt.
+"""
+
+
+class SemanticsDescription(BasicPipeline):
+    def __init__(
+        self,
+        llm_provider: LLMProvider,
+    ):
+        self._components = {
+            "prompt_builder": PromptBuilder(template=user_prompt_template),
+            "generator": llm_provider.get_generator(system_prompt=system_prompt),
+        }
+
+        super().__init__(
+            AsyncDriver({}, sys.modules[__name__], result_builder=base.DictResult())
+        )
+
+    def visualize(
+        self,
+        user_prompt: str,
+        selected_models: list[str],
+        mdl: dict,
+    ) -> None:
+        destination = "outputs/pipelines/generation"
+        if not Path(destination).exists():
+            Path(destination).mkdir(parents=True, exist_ok=True)
+
+        self._pipe.visualize_execution(
+            [""],
+            output_file_path=f"{destination}/semantics_description.dot",
+            inputs={
+                "user_prompt": user_prompt,
+                "selected_models": selected_models,
+                "mdl": mdl,
+                **self._components,
+            },
+            show_legend=True,
+            orient="LR",
+        )
+
+    @observe(name="Semantics Description Generation")
+    async def run(
+        self,
+        user_prompt: str,
+        selected_models: list[str],
+        mdl: dict,
+    ) -> dict:
+        logger.info("Semantics Description Generation pipeline is running...")
+        return await self._pipe.execute(
+            ["post_process"],
+            inputs={
+                "user_prompt": user_prompt,
+                "selected_models": selected_models,
+                "mdl": mdl,
+                **self._components,
+            },
+        )
+
+
+if __name__ == "__main__":
+    from src.core.engine import EngineConfig
+    from src.core.pipeline import async_validate
+    from src.providers import init_providers
+    from src.utils import init_langfuse, load_env_vars
+
+    load_env_vars()
+    init_langfuse()
+
+    llm_provider, _, _, _ = init_providers(EngineConfig())
+    pipeline = SemanticsDescription(llm_provider=llm_provider)
+
+    with open("src/pipelines/prototype/example.json", "r") as file:
+        mdl = json.load(file)
+
+    input = {
+        "user_prompt": "The Orders and Customers dataset is utilized to analyze customer behavior and preferences over time, enabling the improvement of marketing strategies. By examining purchasing patterns and trends, businesses can tailor their marketing efforts to better meet customer needs and enhance engagement.",
+        "selected_models": ["orders", "customers"],
+        "mdl": mdl,
+    }
+
+    # pipeline.visualize(**input)
+    async_validate(lambda: pipeline.run(**input))
+
+    # expected = {
+    #     "model_name": ["column1", "column2"],
+    # }
+
+    # langfuse_context.flush()

--- a/wren-ai-service/src/pipelines/generation/semantics_description.py
+++ b/wren-ai-service/src/pipelines/generation/semantics_description.py
@@ -100,8 +100,9 @@ Follow these steps:
 ### Output Format:
 
 ```
-[
-    {
+{
+    "models": [
+        {
         "name": "model",
         "columns": [
             {
@@ -124,10 +125,11 @@ Follow these steps:
             }
         ],
         "properties": {
-            "description": "<description for model>"
+                "description": "<description for model>"
+            }
         }
-    }
-]
+    ]
+}
 ```
 
 Make sure that the descriptions are concise, informative, and contextually appropriate based on the input provided by the user.

--- a/wren-ai-service/src/pipelines/generation/semantics_description.py
+++ b/wren-ai-service/src/pipelines/generation/semantics_description.py
@@ -213,12 +213,21 @@ if __name__ == "__main__":
     llm_provider, _, _, _ = init_providers(EngineConfig())
     pipeline = SemanticsDescription(llm_provider=llm_provider)
 
-    with open("src/pipelines/prototype/example.json", "r") as file:
+    with open("sample/college_3_bigquery_mdl.json", "r") as file:
         mdl = json.load(file)
 
     input = {
-        "user_prompt": "The Orders and Customers dataset is utilized to analyze customer behavior and preferences over time, enabling the improvement of marketing strategies. By examining purchasing patterns and trends, businesses can tailor their marketing efforts to better meet customer needs and enhance engagement.",
-        "selected_models": ["orders", "customers"],
+        "user_prompt": "Track student enrollments, grades, and GPA calculations to monitor academic performance and identify areas for student support",
+        "selected_models": [
+            "Student",
+            "Minor_in",
+            "Member_of",
+            "Gradeconversion",
+            "Faculty",
+            "Enrolled_in",
+            "Department",
+            "Course",
+        ],
         "mdl": mdl,
     }
 

--- a/wren-ai-service/src/web/v1/routers/__init__.py
+++ b/wren-ai-service/src/web/v1/routers/__init__.py
@@ -9,6 +9,7 @@ from src.globals import (
     get_service_container,
     get_service_metadata,
 )
+from src.web.v1.routers import semantics_description
 from src.web.v1.services.ask import (
     AskRequest,
     AskResponse,
@@ -57,6 +58,7 @@ from src.web.v1.services.sql_regeneration import (
 )
 
 router = APIRouter()
+router.include_router(semantics_description.router)
 
 
 @router.post("/semantics-preparations")

--- a/wren-ai-service/src/web/v1/routers/semantics_description.py
+++ b/wren-ai-service/src/web/v1/routers/semantics_description.py
@@ -1,0 +1,47 @@
+import uuid
+from dataclasses import asdict
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+
+from src.globals import (
+    ServiceContainer,
+    ServiceMetadata,
+    get_service_container,
+    get_service_metadata,
+)
+from src.web.v1.services.semantics_description import SemanticsDescription
+
+router = APIRouter()
+
+
+@router.post("/semantics-descriptions", response_model=SemanticsDescription.Response)
+async def generate(
+    request: SemanticsDescription.Request,
+    background_tasks: BackgroundTasks,
+    service_container: ServiceContainer = Depends(get_service_container),
+    service_metadata: ServiceMetadata = Depends(get_service_metadata),
+) -> SemanticsDescription.Response:
+    id = str(uuid.uuid4())
+    request.id = id
+    service = service_container.semantics_description
+
+    service[request] = SemanticsDescription.Response(id=id)
+
+    background_tasks.add_task(
+        service.generate, request, service_metadata=asdict(service_metadata)
+    )
+    return service[request]
+
+
+@router.get(
+    "/semantics-descriptions/{id}",
+    response_model=SemanticsDescription.Response,
+)
+async def get(
+    id: str,
+    service_container: ServiceContainer = Depends(get_service_container),
+) -> SemanticsDescription.Response:
+    request = SemanticsDescription.Request()
+    request.id = id
+
+    return service_container.semantics_description[request]

--- a/wren-ai-service/src/web/v1/routers/semantics_description.py
+++ b/wren-ai-service/src/web/v1/routers/semantics_description.py
@@ -1,7 +1,9 @@
 import uuid
 from dataclasses import asdict
+from typing import Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends
+from pydantic import BaseModel
 
 from src.globals import (
     ServiceContainer,
@@ -13,35 +15,101 @@ from src.web.v1.services.semantics_description import SemanticsDescription
 
 router = APIRouter()
 
+"""
+Semantics Description Router
 
-@router.post("/semantics-descriptions", response_model=SemanticsDescription.Response)
+This router handles endpoints related to generating and retrieving semantic descriptions.
+
+Endpoints:
+1. POST /semantics-descriptions
+   - Generates a new semantic description
+   - Request body: PostRequest
+   - Response: PostResponse with a unique ID
+
+2. GET /semantics-descriptions/{id}
+   - Retrieves the status and result of a semantic description generation
+   - Path parameter: id (str)
+   - Response: GetResponse with status, response, and error information
+
+The semantic description generation is an asynchronous process. The POST endpoint
+initiates the generation and returns immediately with an ID. The GET endpoint can
+then be used to check the status and retrieve the result when it's ready.
+
+Usage:
+1. Send a POST request to start the generation process.
+2. Use the returned ID to poll the GET endpoint until the status is "finished" or "failed".
+
+Note: The actual generation is performed in the background using FastAPI's BackgroundTasks.
+"""
+
+
+class PostRequest(BaseModel):
+    _id: str | None = None
+    selected_models: list[str]
+    user_prompt: str
+    mdl: str
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @id.setter
+    def id(self, id: str):
+        self._id = id
+
+
+class PostResponse(BaseModel):
+    id: str
+
+
+@router.post(
+    "/semantics-descriptions",
+    response_model=PostResponse,
+)
 async def generate(
-    request: SemanticsDescription.Request,
+    request: PostRequest,
     background_tasks: BackgroundTasks,
     service_container: ServiceContainer = Depends(get_service_container),
     service_metadata: ServiceMetadata = Depends(get_service_metadata),
-) -> SemanticsDescription.Response:
+) -> PostResponse:
     id = str(uuid.uuid4())
     request.id = id
     service = service_container.semantics_description
 
-    service[request] = SemanticsDescription.Response(id=id)
+    service[id] = SemanticsDescription.Resource(id=id)
+    SemanticsDescription.Input(
+        id=id,
+        selected_models=request.selected_models,
+        user_prompt=request.user_prompt,
+        mdl=request.mdl,
+    )
 
     background_tasks.add_task(
         service.generate, request, service_metadata=asdict(service_metadata)
     )
-    return service[request]
+    return PostResponse(id=id)
+
+
+class GetResponse(BaseModel):
+    id: str
+    status: Literal["generating", "finished", "failed"]
+    response: Optional[dict]
+    error: Optional[dict]
 
 
 @router.get(
     "/semantics-descriptions/{id}",
-    response_model=SemanticsDescription.Response,
+    response_model=GetResponse,
 )
 async def get(
     id: str,
     service_container: ServiceContainer = Depends(get_service_container),
-) -> SemanticsDescription.Response:
-    request = SemanticsDescription.Request()
-    request.id = id
+) -> GetResponse:
+    resource = service_container.semantics_description[id]
 
-    return service_container.semantics_description[request]
+    return GetResponse(
+        id=resource.id,
+        status=resource.status,
+        response=resource.response,
+        error=resource.error and resource.error.model_dump(),
+    )

--- a/wren-ai-service/src/web/v1/routers/semantics_description.py
+++ b/wren-ai-service/src/web/v1/routers/semantics_description.py
@@ -70,18 +70,9 @@ Note: The actual generation is performed in the background using FastAPI's Backg
 
 
 class PostRequest(BaseModel):
-    _id: str | None = None
     selected_models: list[str]
     user_prompt: str
     mdl: str
-
-    @property
-    def id(self) -> str:
-        return self._id
-
-    @id.setter
-    def id(self, id: str):
-        self._id = id
 
 
 class PostResponse(BaseModel):
@@ -99,11 +90,10 @@ async def generate(
     service_metadata: ServiceMetadata = Depends(get_service_metadata),
 ) -> PostResponse:
     id = str(uuid.uuid4())
-    request.id = id
     service = service_container.semantics_description
 
     service[id] = SemanticsDescription.Resource(id=id)
-    SemanticsDescription.Input(
+    input = SemanticsDescription.Input(
         id=id,
         selected_models=request.selected_models,
         user_prompt=request.user_prompt,
@@ -111,7 +101,7 @@ async def generate(
     )
 
     background_tasks.add_task(
-        service.generate, request, service_metadata=asdict(service_metadata)
+        service.generate, input, service_metadata=asdict(service_metadata)
     )
     return PostResponse(id=id)
 

--- a/wren-ai-service/src/web/v1/routers/semantics_description.py
+++ b/wren-ai-service/src/web/v1/routers/semantics_description.py
@@ -24,12 +24,38 @@ Endpoints:
 1. POST /semantics-descriptions
    - Generates a new semantic description
    - Request body: PostRequest
-   - Response: PostResponse with a unique ID
+     {
+       "selected_models": ["model1", "model2"],  # List of model names to describe
+       "user_prompt": "Describe these models",   # User's instruction for description
+       "mdl": "{ ... }"                          # JSON string of the MDL (Model Definition Language)
+     }
+   - Response: PostResponse
+     {
+       "id": "unique-uuid"                       # Unique identifier for the generated description
+     }
 
 2. GET /semantics-descriptions/{id}
    - Retrieves the status and result of a semantic description generation
    - Path parameter: id (str)
-   - Response: GetResponse with status, response, and error information
+   - Response: GetResponse
+     {
+       "id": "unique-uuid",                      # Unique identifier of the description
+       "status": "generating" | "finished" | "failed",
+       "response": {                             # Present only if status is "finished"
+         "model1": {
+           "columns": [...],
+           "properties": {...}
+         },
+         "model2": {
+           "columns": [...],
+           "properties": {...}
+         }
+       },
+       "error": {                                # Present only if status is "failed"
+         "code": "OTHERS",
+         "message": "Error description"
+       }
+     }
 
 The semantic description generation is an asynchronous process. The POST endpoint
 initiates the generation and returns immediately with an ID. The GET endpoint can

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -114,7 +114,7 @@ class SemanticsDescription:
         # todo: implement the service flow
         pass
 
-    def get(self, request: Request) -> Response:
+    def __getitem__(self, request: Request) -> Response:
         response = self._cache.get(request.id)
 
         if response is None:
@@ -125,6 +125,9 @@ class SemanticsDescription:
             return self.Response()
 
         return response
+
+    def __setitem__(self, request: Request, value: Response):
+        self._cache[request.id] = value
 
 
 router = APIRouter()
@@ -142,12 +145,12 @@ async def generate(
     service = service_container.semantics_description
 
     # todo: consider to simplify the code by using the service_container
-    service._cache[request.id] = SemanticsDescription.Response(id=id)
+    service[request] = SemanticsDescription.Response(id=id)
 
     background_tasks.add_task(
         service.generate, request, service_metadata=asdict(service_metadata)
     )
-    return service._cache[request.id]
+    return service[request]
 
 
 @router.get(
@@ -158,6 +161,4 @@ async def get(
     id: str,
     service_container: ServiceContainer = Depends(get_service_container),
 ) -> SemanticsDescription.Response:
-    return service_container.semantics_description.get(
-        SemanticsDescription.Request(id=id)
-    )
+    return service_container.semantics_description[SemanticsDescription.Request(id=id)]

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -13,71 +13,13 @@ logger = logging.getLogger("wren-ai-service")
 
 
 class SemanticsDescription:
-    """
-    SemanticsDescription Service
+    class Input(BaseModel):
+        id: str
+        selected_models: list[str]
+        user_prompt: str
+        mdl: str
 
-    This service provides endpoints for generating and optimizing semantic descriptions
-    based on user prompts and selected models.
-
-    Endpoints:
-    1. POST /v1/semantics-descriptions
-       Generate a new semantic description.
-
-       Request body:
-       {
-           "selected_models": ["model1", "model2"],  # List of selected model names
-           "user_prompt": "Describe the data model",  # User's prompt for description
-           "mdl": "..."  # MDL (Model Definition Language) string
-       }
-
-       Response:
-       {
-           "id": "unique_id",  # Unique identifier for the generated description
-       }
-
-    2. GET /v1/semantics-descriptions/{id}
-       Retrieve the status and result of a semantic description generation.
-
-       Path parameter:
-       - id: Unique identifier of the semantic description resource.
-
-       Response:
-       {
-           "id": "unique_id",
-           "status": "finished",  # Can be "generating", "finished", or "failed"
-           "response": {  # Present only if status is "finished"
-               // Generated semantic description
-           },
-           "error": {  # Present only if status is "failed"
-               "code": "OTHERS",
-               "message": "Error description"
-           }
-       }
-
-    Usage:
-    1. Call the POST endpoint to initiate a semantic description generation.
-    2. Use the returned ID to poll the GET endpoint until the status is "finished" or "failed".
-    3. Once finished, retrieve the generated description from the "response" field.
-
-    Note: The generation process may take some time, so implement appropriate polling
-    intervals when checking the status.
-    """
-
-    class Request(BaseModel):
-        _id: str | None = None
-        selected_models: list[str] = []
-        user_prompt: str = ""
-        mdl: str | None = None
-
-        @property
-        def id(self) -> str:
-            return self._id
-
-        @id.setter
-        def id(self, id: str):
-            self._id = id
-
-    class Response(BaseModel):
+    class Resource(BaseModel):
         class Error(BaseModel):
             code: Literal["OTHERS"]
             message: str
@@ -94,27 +36,24 @@ class SemanticsDescription:
         ttl: int = 120,
     ):
         self._pipelines = pipelines
-        self._cache: Dict[str, SemanticsDescription.Response] = TTLCache(
+        self._cache: Dict[str, SemanticsDescription.Resource] = TTLCache(
             maxsize=maxsize, ttl=ttl
         )
 
-    def _handle_exception(self, request: Request, error_message: str):
-        self._cache[request.id] = self.Response(
+    def _handle_exception(self, request: Input, error_message: str):
+        self[request.id] = self.Resource(
             id=request.id,
             status="failed",
-            error=self.Response.Error(code="OTHERS", message=error_message),
+            error=self.Resource.Error(code="OTHERS", message=error_message),
         )
         logger.error(error_message)
 
     @observe(name="Generate Semantics Description")
     @trace_metadata
-    async def generate(self, request: Request, **kwargs) -> Response:
+    async def generate(self, request: Input, **kwargs) -> Resource:
         logger.info("Generate Semantics Description pipeline is running...")
 
         try:
-            if request.mdl is None:
-                raise ValueError("MDL must be provided")
-
             mdl_dict = orjson.loads(request.mdl)
 
             input = {
@@ -125,7 +64,7 @@ class SemanticsDescription:
 
             resp = await self._pipelines["semantics_description"].run(**input)
 
-            self._cache[request.id] = self.Response(
+            self[request.id] = self.Resource(
                 id=request.id, status="finished", response=resp.get("normalize")
             )
         except orjson.JSONDecodeError as e:
@@ -136,23 +75,21 @@ class SemanticsDescription:
                 f"An error occurred during semantics description generation: {str(e)}",
             )
 
-        return self._cache[request.id]
+        return self[request.id]
 
-    def __getitem__(self, request: Request) -> Response:
-        response = self._cache.get(request.id)
+    def __getitem__(self, id: int) -> Resource:
+        response = self._cache.get(id)
 
         if response is None:
-            message = (
-                f"Semantics Description Resource with ID '{request.id}' not found."
-            )
+            message = f"Semantics Description Resource with ID '{id}' not found."
             logger.exception(message)
-            return self.Response(
-                id=request.id,
+            return self.Resource(
+                id=id,
                 status="failed",
-                error=self.Response.Error(code="OTHERS", message=message),
+                error=self.Resource.Error(code="OTHERS", message=message),
             )
 
         return response
 
-    def __setitem__(self, request: Request, value: Response):
-        self._cache[request.id] = value
+    def __setitem__(self, id: int, value: Resource):
+        self._cache[id] = value

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -77,7 +77,7 @@ class SemanticsDescription:
 
         return self[request.id]
 
-    def __getitem__(self, id: int) -> Resource:
+    def __getitem__(self, id: str) -> Resource:
         response = self._cache.get(id)
 
         if response is None:
@@ -91,5 +91,5 @@ class SemanticsDescription:
 
         return response
 
-    def __setitem__(self, id: int, value: Resource):
+    def __setitem__(self, id: str, value: Resource):
         self._cache[id] = value

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -33,7 +33,6 @@ class SemanticsDescription:
        Response:
        {
            "id": "unique_id",  # Unique identifier for the generated description
-           "status": "generating"  # Initial status
        }
 
     2. GET /v1/semantics-descriptions/{id}
@@ -84,7 +83,7 @@ class SemanticsDescription:
             message: str
 
         id: str
-        status: Literal["generating", "finished", "failed"] = "generating"
+        status: Literal["generating", "finished", "failed"] = None
         response: Optional[dict] = None
         error: Optional[Error] = None
 

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -1,0 +1,163 @@
+import logging
+import uuid
+from dataclasses import asdict
+from typing import Dict, Literal, Optional
+
+from cachetools import TTLCache
+from fastapi import APIRouter, BackgroundTasks, Depends
+from langfuse.decorators import observe
+from pydantic import BaseModel
+
+from src.core.pipeline import BasicPipeline
+from src.globals import (
+    ServiceContainer,
+    ServiceMetadata,
+    get_service_container,
+    get_service_metadata,
+)
+from src.utils import trace_metadata
+
+logger = logging.getLogger("wren-ai-service")
+
+
+class SemanticsDescription:
+    """
+    SemanticsDescription Service
+
+    This service provides endpoints for generating and optimizing semantic descriptions
+    based on user prompts and selected models.
+
+    Endpoints:
+    1. POST /v1/semantics-descriptions
+       Generate a new semantic description.
+
+       Request body:
+       {
+           "selected_models": ["model1", "model2"],  # List of selected model names
+           "user_prompt": "Describe the data model",  # User's prompt for description
+           "mdl": "..."  # MDL (Model Definition Language) string
+       }
+
+       Response:
+       {
+           "id": "unique_id",  # Unique identifier for the generated description
+           "status": "generating"  # Initial status
+       }
+
+    2. GET /v1/semantics-descriptions/{id}
+       Retrieve the status and result of a semantic description generation.
+
+       Path parameter:
+       - id: Unique identifier of the semantic description resource.
+
+       Response:
+       {
+           "id": "unique_id",
+           "status": "finished",  # Can be "generating", "finished", or "failed"
+           "response": {  # Present only if status is "finished"
+               // Generated semantic description
+           },
+           "error": {  # Present only if status is "failed"
+               "code": "OTHERS",
+               "message": "Error description"
+           }
+       }
+
+    Usage:
+    1. Call the POST endpoint to initiate a semantic description generation.
+    2. Use the returned ID to poll the GET endpoint until the status is "finished" or "failed".
+    3. Once finished, retrieve the generated description from the "response" field.
+
+    Note: The generation process may take some time, so implement appropriate polling
+    intervals when checking the status.
+    """
+
+    class Request(BaseModel):
+        _id: str | None = None
+        selected_models: list[str] = []
+        user_prompt: str = ""
+        mdl: str
+
+        @property
+        def id(self) -> str:
+            return self._id
+
+        @id.setter
+        def id(self, id: str):
+            self._id = id
+
+    class Response(BaseModel):
+        class Error(BaseModel):
+            code: Literal["OTHERS"]
+            message: str
+
+        id: str
+        status: Literal["generating", "finished", "failed"] = "generating"
+        response: Optional[dict] = None
+        error: Optional[Error] = None
+
+    def __init__(
+        self,
+        pipelines: Dict[str, BasicPipeline],
+        maxsize: int = 1_000_000,
+        ttl: int = 120,
+    ):
+        self._pipelines = pipelines
+        self._cache: Dict[str, SemanticsDescription.Response] = TTLCache(
+            maxsize=maxsize, ttl=ttl
+        )
+
+    @observe(name="Generate Semantics Description")
+    @trace_metadata
+    async def generate(self, request: Request, **kwargs) -> Response:
+        logger.info("Generate Semantics Description pipeline is running...")
+        # todo: implement the service flow
+        pass
+
+    def get(self, request: Request) -> Response:
+        response = self._cache.get(request.id)
+
+        if response is None:
+            # todo: error handling
+            logger.error(
+                f"Semantics Description Resource with ID '{request.id}' not found."
+            )
+            return self.Response()
+
+        return response
+
+
+router = APIRouter()
+
+
+@router.post("/v1/semantics-descriptions", response_model=SemanticsDescription.Response)
+async def generate(
+    request: SemanticsDescription.Request,
+    background_tasks: BackgroundTasks,
+    service_container: ServiceContainer = Depends(get_service_container),
+    service_metadata: ServiceMetadata = Depends(get_service_metadata),
+) -> SemanticsDescription.Response:
+    id = str(uuid.uuid4())
+    request.id = id
+    service = service_container.semantics_description
+
+    # todo: consider to simplify the code by using the service_container
+    service._cache[request.id] = SemanticsDescription.Response(id=id)
+
+    background_tasks.add_task(
+        service.generate, request, service_metadata=asdict(service_metadata)
+    )
+    return service._cache[request.id]
+
+
+@router.get(
+    "/v1/semantics-descriptions/{id}",
+    response_model=SemanticsDescription.Response,
+)
+async def get(
+    id: str,
+    service_container: ServiceContainer = Depends(get_service_container),
+) -> SemanticsDescription.Response:
+    return service_container.semantics_description.get(
+        SemanticsDescription.Request(id=id)
+    )

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Literal, Optional
 
+import orjson
 from cachetools import TTLCache
 from langfuse.decorators import observe
 from pydantic import BaseModel
@@ -98,12 +99,45 @@ class SemanticsDescription:
             maxsize=maxsize, ttl=ttl
         )
 
+    def _handle_exception(self, request: Request, error_message: str):
+        self._cache[request.id] = self.Response(
+            id=request.id,
+            status="failed",
+            error=self.Response.Error(code="OTHERS", message=error_message),
+        )
+        logger.error(error_message)
+
     @observe(name="Generate Semantics Description")
     @trace_metadata
     async def generate(self, request: Request, **kwargs) -> Response:
         logger.info("Generate Semantics Description pipeline is running...")
-        # todo: implement the service flow
-        pass
+
+        try:
+            if request.mdl is None:
+                raise ValueError("MDL must be provided")
+
+            mdl_dict = orjson.loads(request.mdl)
+
+            input = {
+                "user_prompt": request.user_prompt,
+                "selected_models": request.selected_models,
+                "mdl": mdl_dict,
+            }
+
+            resp = await self._pipelines["semantics_description"].run(**input)
+
+            self._cache[request.id] = self.Response(
+                id=request.id, status="finished", response=resp.get("normalize")
+            )
+        except orjson.JSONDecodeError as e:
+            self._handle_exception(request, f"Failed to parse MDL: {str(e)}")
+        except Exception as e:
+            self._handle_exception(
+                request,
+                f"An error occurred during semantics description generation: {str(e)}",
+            )
+
+        return self._cache[request.id]
 
     def __getitem__(self, request: Request) -> Response:
         response = self._cache.get(request.id)

--- a/wren-ai-service/tests/pytest/services/test_semantics_description.py
+++ b/wren-ai-service/tests/pytest/services/test_semantics_description.py
@@ -1,0 +1,125 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.web.v1.services.semantics_description import SemanticsDescription
+
+
+@pytest.fixture
+def semantics_description_service():
+    mock_pipeline = AsyncMock()
+    mock_pipeline.run.return_value = {
+        "normalize": {
+            "model1": {
+                "columns": [],
+                "properties": {"description": "Test description"},
+            }
+        }
+    }
+
+    pipelines = {"semantics_description": mock_pipeline}
+    return SemanticsDescription(pipelines=pipelines)
+
+
+@pytest.mark.asyncio
+async def test_generate_semantics_description(
+    semantics_description_service: SemanticsDescription,
+):
+    request = SemanticsDescription.Request(
+        user_prompt="Describe the model",
+        selected_models=["model1"],
+        mdl='{"models": [{"name": "model1", "columns": []}]}',
+    )
+    request.id = "test_id"
+
+    response = await semantics_description_service.generate(request)
+
+    assert response.id == "test_id"
+    assert response.status == "finished"
+    assert response.response == {
+        "model1": {
+            "columns": [],
+            "properties": {"description": "Test description"},
+        }
+    }
+    assert response.error is None
+
+
+@pytest.mark.asyncio
+async def test_generate_semantics_description_with_invalid_mdl(
+    semantics_description_service: SemanticsDescription,
+):
+    request = SemanticsDescription.Request(
+        user_prompt="Describe the model",
+        selected_models=["model1"],
+        mdl="invalid_json",
+    )
+    request.id = "test_id"
+
+    response = await semantics_description_service.generate(request)
+
+    assert response.id == "test_id"
+    assert response.status == "failed"
+    assert response.response is None
+    assert response.error.code == "OTHERS"
+    assert "Failed to parse MDL" in response.error.message
+
+
+@pytest.mark.asyncio
+async def test_generate_semantics_description_with_exception(
+    semantics_description_service: SemanticsDescription,
+):
+    request = SemanticsDescription.Request(
+        user_prompt="Describe the model",
+        selected_models=["model1"],
+        mdl='{"models": [{"name": "model1", "columns": []}]}',
+    )
+    request.id = "test_id"
+
+    semantics_description_service._pipelines[
+        "semantics_description"
+    ].run.side_effect = Exception("Test exception")
+
+    response = await semantics_description_service.generate(request)
+
+    assert response.id == "test_id"
+    assert response.status == "failed"
+    assert response.response is None
+    assert response.error.code == "OTHERS"
+    assert (
+        "An error occurred during semantics description generation"
+        in response.error.message
+    )
+
+
+def test_get_semantics_description_result(
+    semantics_description_service: SemanticsDescription,
+):
+    request = SemanticsDescription.Request()
+    request.id = "test_id"
+
+    expected_response = SemanticsDescription.Response(
+        id="test_id",
+        status="finished",
+        response={"model1": {"description": "Test description"}},
+    )
+    semantics_description_service._cache["test_id"] = expected_response
+
+    result = semantics_description_service[request]
+
+    assert result == expected_response
+
+
+def test_get_non_existent_semantics_description_result(
+    semantics_description_service: SemanticsDescription,
+):
+    request = SemanticsDescription.Request()
+    request.id = "non_existent_id"
+
+    result = semantics_description_service[request]
+
+    assert result.id == "non_existent_id"
+    assert result.status == "failed"
+    assert result.response is None
+    assert result.error.code == "OTHERS"
+    assert "not found" in result.error.message

--- a/wren-ai-service/tests/pytest/services/test_semantics_description.py
+++ b/wren-ai-service/tests/pytest/services/test_semantics_description.py
@@ -25,12 +25,12 @@ def semantics_description_service():
 async def test_generate_semantics_description(
     semantics_description_service: SemanticsDescription,
 ):
-    request = SemanticsDescription.Request(
+    request = SemanticsDescription.Input(
+        id="test_id",
         user_prompt="Describe the model",
         selected_models=["model1"],
         mdl='{"models": [{"name": "model1", "columns": []}]}',
     )
-    request.id = "test_id"
 
     response = await semantics_description_service.generate(request)
 
@@ -49,12 +49,12 @@ async def test_generate_semantics_description(
 async def test_generate_semantics_description_with_invalid_mdl(
     semantics_description_service: SemanticsDescription,
 ):
-    request = SemanticsDescription.Request(
+    request = SemanticsDescription.Input(
+        id="test_id",
         user_prompt="Describe the model",
         selected_models=["model1"],
         mdl="invalid_json",
     )
-    request.id = "test_id"
 
     response = await semantics_description_service.generate(request)
 
@@ -69,12 +69,12 @@ async def test_generate_semantics_description_with_invalid_mdl(
 async def test_generate_semantics_description_with_exception(
     semantics_description_service: SemanticsDescription,
 ):
-    request = SemanticsDescription.Request(
+    request = SemanticsDescription.Input(
+        id="test_id",
         user_prompt="Describe the model",
         selected_models=["model1"],
         mdl='{"models": [{"name": "model1", "columns": []}]}',
     )
-    request.id = "test_id"
 
     semantics_description_service._pipelines[
         "semantics_description"
@@ -95,17 +95,16 @@ async def test_generate_semantics_description_with_exception(
 def test_get_semantics_description_result(
     semantics_description_service: SemanticsDescription,
 ):
-    request = SemanticsDescription.Request()
-    request.id = "test_id"
+    id = "test_id"
 
-    expected_response = SemanticsDescription.Response(
-        id="test_id",
+    expected_response = SemanticsDescription.Resource(
+        id=id,
         status="finished",
         response={"model1": {"description": "Test description"}},
     )
-    semantics_description_service._cache["test_id"] = expected_response
+    semantics_description_service._cache[id] = expected_response
 
-    result = semantics_description_service[request]
+    result = semantics_description_service[id]
 
     assert result == expected_response
 
@@ -113,10 +112,9 @@ def test_get_semantics_description_result(
 def test_get_non_existent_semantics_description_result(
     semantics_description_service: SemanticsDescription,
 ):
-    request = SemanticsDescription.Request()
-    request.id = "non_existent_id"
+    id = "non_existent_id"
 
-    result = semantics_description_service[request]
+    result = semantics_description_service[id]
 
     assert result.id == "non_existent_id"
     assert result.status == "failed"


### PR DESCRIPTION
This PR introduces the `SemanticsDescription` service, which provides endpoints for generating and optimizing semantic descriptions based on user prompts and selected models.

## Web API Specification

### 1. Generate Semantic Description

**Endpoint:** `POST /v1/semantics-descriptions`

**Request Body:**
```json
{
    "selected_models": ["model1", "model2"],
    "user_prompt": "Describe the data model",
    "mdl": "..."
}
```

**Response:**
```json
{
    "id": "unique_id",
}
```

### 2. Retrieve Semantic Description

**Endpoint:** `GET /v1/semantics-descriptions/{id}`

**Path Parameter:**
- `id`: Unique identifier of the semantic description resource

**Response:**
```json
{
   "id":"unique_id",
   "status":"finished",
   "response":{
      "model1":{
         "name":"model1",
         "columns":[
            {
               "name":"col1",
               "properties":{
                  "description":"Unique identifier for each record in the example model."
               }
            }
         ],
         "properties":{
            "description":"This model is used for analysis purposes, capturing key attributes of records."
         }
      }
   }
}
```

or, in case of an error:

```json
{
    "id": "unique_id",
    "status": "failed",
    "error": {
        "code": "OTHERS",
        "message": "Error description"
    }
}
```

## Usage

1. Call the POST endpoint to initiate a semantic description generation.
2. Use the returned ID to poll the GET endpoint until the status is "finished" or "failed".
3. Once finished, retrieve the generated description from the "response" field.

## Notes

- The generation process may take some time, so implement appropriate polling intervals when checking the status.
- Error handling has been implemented to catch and report various exceptions that may occur during the process.

## Screenshots

<img width="1593" alt="image" src="https://github.com/user-attachments/assets/469a48b3-e171-4efd-b78b-15149156bb14">
<img width="1593" alt="image" src="https://github.com/user-attachments/assets/9a7924db-501b-403a-aa4c-1b1dd6e8682d">

