### PR TITLE
Trigger a mouse event every time the ReactFlow component is clicked

### DIFF
--- a/wren-ui/src/components/diagram/index.tsx
+++ b/wren-ui/src/components/diagram/index.tsx
@@ -109,6 +109,29 @@ const ReactFlowDiagram = forwardRef(function ReactFlowDiagram(
     setForceRender(!forceRender);
   };
 
+  const triggerMouseDown = (event: React.MouseEvent | MouseEvent) => {
+    const mouseDownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      button: 0,
+    });
+    document.dispatchEvent(mouseDownEvent);
+  };
+
+  const isTargetInDropdown = (target: EventTarget | null) => {
+    const dropdowns = document.querySelectorAll('.ant-dropdown');
+    return Array.from(dropdowns).some((dropdown) =>
+      dropdown.contains(target as Node),
+    );
+  };
+
+  const dispatchMouseEvent = (event: React.MouseEvent | MouseEvent) => {
+    if (!event.isTrusted || isTargetInDropdown(event.target)) return;
+    triggerMouseDown(event);
+  };
+
   return (
     <>
       <DiagramContext.Provider value={{ onMoreClick, onNodeClick, onAddClick }}>
@@ -123,6 +146,7 @@ const ReactFlowDiagram = forwardRef(function ReactFlowDiagram(
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           maxZoom={1}
+          onPointerDown={(event) => dispatchMouseEvent(event)}
           proOptions={{ hideAttribution: true }}
         >
           <MiniMap style={minimapStyle} zoomable pannable />


### PR DESCRIPTION
This PR fixes #713 .

### Issue Recap
Initially, I tried updating the **ReactFlow** library to version 12, hoping that would solve the issue, but it didn’t work. After further investigation, I found [this discussion](https://github.com/xyflow/xyflow/discussions/3912) detailing our exact use case. The [response from the maintainer](https://github.com/xyflow/xyflow/discussions/3912#discussioncomment-8476769) identified the underlying cause: the problem stems from the **d3 zoom** library that **ReactFlow** uses under the hood. 

When disabling pointer events (as suggested), it allowed me to detect clicks, but this also disabled the drag functionality, which isn’t ideal for our use case.

### My Solution

To resolve this, I implemented a workaround that triggers a `mousedown` event programmatically whenever a click occurs inside the **ReactFlow** component, ensuring that the dropdown closes as expected without disabling any essential functionality like dragging.

#### Here’s what I did:

1. **Added a function** to programmatically trigger the `mousedown` event:
   ```js
   const dispatchMouseEvent = (event: React.MouseEvent | MouseEvent) => {
       if (event.isTrusted) {
         const mouseDownEvent = new MouseEvent('mousedown', {
           bubbles: true,
           cancelable: true,
           clientX: event.clientX,
           clientY: event.clientY,
           button: 0,
         });
         document.dispatchEvent(mouseDownEvent);
       }
   };
   ```

   This function triggers a `mousedown` event every time it's called. The frontend library we’re using (Ant Design) automatically closes the dropdown whenever a `mousedown` event is detected, so this is the key to solving the problem.

2. **Triggered the function** on relevant events in the **ReactFlow** component:
   ```jsx
   <ReactFlow
       nodes={nodes}
       edges={edges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onEdgeMouseEnter={onEdgeMouseEnter}
       onEdgeMouseLeave={onEdgeMouseLeave}
       onInit={onInit}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       maxZoom={1}
       onPaneClick={(event) => dispatchMouseEvent(event)}
       onPointerDown={(event) => dispatchMouseEvent(event)}
       proOptions={{ hideAttribution: true }}
   >
   ```

   By calling the `dispatchMouseEvent` function inside `onPaneClick` and `onPointerDown`, we ensure that a `mousedown` event is triggered whenever someone clicks or presses inside the **ReactFlow** component, resulting in the dropdown closing. This way, no library update is required, and we preserve the drag functionality.

I’ve also recorded a video demonstrating the fix in action. It works perfectly now, and I believe this is the best way to resolve the issue.

https://github.com/user-attachments/assets/7228ede9-0970-4234-88d4-e300627e3737

Let me know your thoughts, and feel free to merge this PR if you’re satisfied with the solution.
