### PR TITLE
chore(wren-ai-service): manual running pytest to avoid auth issue from forked repo

### DIFF
--- a/.github/workflows/ai-service-test.yaml
+++ b/.github/workflows/ai-service-test.yaml
@@ -11,6 +11,7 @@ on:
       - "wren-ai-service/**"
   pull_request:
     types: [synchronize, labeled]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -45,7 +46,7 @@ jobs:
       - name: Install Just
         uses: extractions/setup-just@v2
         with:
-          just-version: '1.31.0'
+          just-version: "1.31.0"
       - name: Prepare testing environment and Run tests
         run: |
           just test


### PR DESCRIPTION
We encountered an issue similar to the one documented in [this GitHub Actions run](https://github.com/Canner/WrenAI/actions/runs/11230538407/job/31218085695). To address this, we have added the `workflow_dispatch` event to the GitHub Actions workflow. This change allows maintainers to manually trigger the `pytest` job from the Actions page, enabling contributors to validate their changes more effectively.

This enhancement provides a temporary solution to the issue at hand. In the future, we may explore additional methods to improve our testing workflow further.