### PR TITLE
Feat: #748 Automatic GitHub Action Contributor List

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,8 +17,5 @@ jobs:
         steps:
             - name: Contribute List
               uses: akhilmhdh/contributors-readme-action@v2.3.10
-              with:
-                  use_username: true
-                  columns_per_row: 8
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,6 @@ jobs:
             - name: Contribute List
               uses: akhilmhdh/contributors-readme-action@v2.3.10
               with:
-                  image_size: 75  
                   use_username: true
                   columns_per_row: 8
               env:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
                     <sub><b>fredalai</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/chilijung">
                     <img src="https://avatars.githubusercontent.com/u/1216029?v=4" width="100;" alt="chilijung"/>
@@ -192,8 +194,6 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
                     <sub><b>imAsterSun</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/Ayushjhawar8">
                     <img src="https://avatars.githubusercontent.com/u/111112495?v=4" width="100;" alt="Ayushjhawar8"/>
@@ -222,6 +222,8 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
                     <sub><b>goldmedal</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/eltociear">
                     <img src="https://avatars.githubusercontent.com/u/22633385?v=4" width="100;" alt="eltociear"/>
@@ -250,8 +252,6 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
                     <sub><b>kpman</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/grieve54706">
                     <img src="https://avatars.githubusercontent.com/u/8724385?v=4" width="100;" alt="grieve54706"/>
@@ -266,6 +266,8 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
                     <sub><b>RoacherM</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/Innovatorcloudy">
                     <img src="https://avatars.githubusercontent.com/u/183274513?v=4" width="100;" alt="Innovatorcloudy"/>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Want to contribute to Wren AI? Check out our [Contribution Guidelines](https://g
 Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI community channels. Users are **highly encouraged** to read and adhere to them to avoid repercussions.
 
 ## Our Contributors ❤️
-<!-- Do not manually edit this section! It should get updated using the Github action "Manually update contributors list" -->
+<!-- Do not manually edit this section! It should get updated using the Github action -->
 <!-- readme: contributors -start -->
 <table>
 	<tbody>

--- a/README.md
+++ b/README.md
@@ -138,56 +138,56 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
 		<tr>
             <td align="center">
                 <a href="https://github.com/cyyeh">
-                    <img src="https://avatars.githubusercontent.com/u/11023068?v=4" width="75;" alt="cyyeh"/>
+                    <img src="https://avatars.githubusercontent.com/u/11023068?v=4" width="100;" alt="cyyeh"/>
                     <br />
                     <sub><b>cyyeh</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/onlyjackfrost">
-                    <img src="https://avatars.githubusercontent.com/u/38731840?v=4" width="75;" alt="onlyjackfrost"/>
+                    <img src="https://avatars.githubusercontent.com/u/38731840?v=4" width="100;" alt="onlyjackfrost"/>
                     <br />
                     <sub><b>onlyjackfrost</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/wwwy3y3">
-                    <img src="https://avatars.githubusercontent.com/u/1208829?v=4" width="75;" alt="wwwy3y3"/>
+                    <img src="https://avatars.githubusercontent.com/u/1208829?v=4" width="100;" alt="wwwy3y3"/>
                     <br />
                     <sub><b>wwwy3y3</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/andreashimin">
-                    <img src="https://avatars.githubusercontent.com/u/9657305?v=4" width="75;" alt="andreashimin"/>
+                    <img src="https://avatars.githubusercontent.com/u/9657305?v=4" width="100;" alt="andreashimin"/>
                     <br />
                     <sub><b>andreashimin</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/paopa">
-                    <img src="https://avatars.githubusercontent.com/u/52045032?v=4" width="75;" alt="paopa"/>
+                    <img src="https://avatars.githubusercontent.com/u/52045032?v=4" width="100;" alt="paopa"/>
                     <br />
                     <sub><b>paopa</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/fredalai">
-                    <img src="https://avatars.githubusercontent.com/u/42527625?v=4" width="75;" alt="fredalai"/>
+                    <img src="https://avatars.githubusercontent.com/u/42527625?v=4" width="100;" alt="fredalai"/>
                     <br />
                     <sub><b>fredalai</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/chilijung">
-                    <img src="https://avatars.githubusercontent.com/u/1216029?v=4" width="75;" alt="chilijung"/>
+                    <img src="https://avatars.githubusercontent.com/u/1216029?v=4" width="100;" alt="chilijung"/>
                     <br />
                     <sub><b>chilijung</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/imAsterSun">
-                    <img src="https://avatars.githubusercontent.com/u/61279528?v=4" width="75;" alt="imAsterSun"/>
+                    <img src="https://avatars.githubusercontent.com/u/61279528?v=4" width="100;" alt="imAsterSun"/>
                     <br />
                     <sub><b>imAsterSun</b></sub>
                 </a>
@@ -195,57 +195,57 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
 		</tr>
 		<tr>
             <td align="center">
-                <a href="https://github.com/qdrddr">
-                    <img src="https://avatars.githubusercontent.com/u/564658?v=4" width="75;" alt="qdrddr"/>
-                    <br />
-                    <sub><b>qdrddr</b></sub>
-                </a>
-            </td>
-            <td align="center">
                 <a href="https://github.com/Ayushjhawar8">
-                    <img src="https://avatars.githubusercontent.com/u/111112495?v=4" width="75;" alt="Ayushjhawar8"/>
+                    <img src="https://avatars.githubusercontent.com/u/111112495?v=4" width="100;" alt="Ayushjhawar8"/>
                     <br />
                     <sub><b>Ayushjhawar8</b></sub>
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/qdrddr">
+                    <img src="https://avatars.githubusercontent.com/u/564658?v=4" width="100;" alt="qdrddr"/>
+                    <br />
+                    <sub><b>qdrddr</b></sub>
+                </a>
+            </td>
+            <td align="center">
                 <a href="https://github.com/kushal34712">
-                    <img src="https://avatars.githubusercontent.com/u/98145879?v=4" width="75;" alt="kushal34712"/>
+                    <img src="https://avatars.githubusercontent.com/u/98145879?v=4" width="100;" alt="kushal34712"/>
                     <br />
                     <sub><b>kushal34712</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/goldmedal">
-                    <img src="https://avatars.githubusercontent.com/u/6974913?v=4" width="75;" alt="goldmedal"/>
+                    <img src="https://avatars.githubusercontent.com/u/6974913?v=4" width="100;" alt="goldmedal"/>
                     <br />
                     <sub><b>goldmedal</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/eltociear">
-                    <img src="https://avatars.githubusercontent.com/u/22633385?v=4" width="75;" alt="eltociear"/>
+                    <img src="https://avatars.githubusercontent.com/u/22633385?v=4" width="100;" alt="eltociear"/>
                     <br />
                     <sub><b>eltociear</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/himanshu634">
-                    <img src="https://avatars.githubusercontent.com/u/61757460?v=4" width="75;" alt="himanshu634"/>
+                    <img src="https://avatars.githubusercontent.com/u/61757460?v=4" width="100;" alt="himanshu634"/>
                     <br />
                     <sub><b>himanshu634</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/AryanK1511">
-                    <img src="https://avatars.githubusercontent.com/u/101019909?v=4" width="75;" alt="AryanK1511"/>
+                    <img src="https://avatars.githubusercontent.com/u/101019909?v=4" width="100;" alt="AryanK1511"/>
                     <br />
                     <sub><b>AryanK1511</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/kpman">
-                    <img src="https://avatars.githubusercontent.com/u/2382594?v=4" width="75;" alt="kpman"/>
+                    <img src="https://avatars.githubusercontent.com/u/2382594?v=4" width="100;" alt="kpman"/>
                     <br />
                     <sub><b>kpman</b></sub>
                 </a>
@@ -254,49 +254,49 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
 		<tr>
             <td align="center">
                 <a href="https://github.com/grieve54706">
-                    <img src="https://avatars.githubusercontent.com/u/8724385?v=4" width="75;" alt="grieve54706"/>
+                    <img src="https://avatars.githubusercontent.com/u/8724385?v=4" width="100;" alt="grieve54706"/>
                     <br />
                     <sub><b>grieve54706</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/RoacherM">
-                    <img src="https://avatars.githubusercontent.com/u/33534878?v=4" width="75;" alt="RoacherM"/>
+                    <img src="https://avatars.githubusercontent.com/u/33534878?v=4" width="100;" alt="RoacherM"/>
                     <br />
                     <sub><b>RoacherM</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Innovatorcloudy">
-                    <img src="https://avatars.githubusercontent.com/u/183274513?v=4" width="75;" alt="Innovatorcloudy"/>
+                    <img src="https://avatars.githubusercontent.com/u/183274513?v=4" width="100;" alt="Innovatorcloudy"/>
                     <br />
                     <sub><b>Innovatorcloudy</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/sahil9001">
-                    <img src="https://avatars.githubusercontent.com/u/32628578?v=4" width="75;" alt="sahil9001"/>
+                    <img src="https://avatars.githubusercontent.com/u/32628578?v=4" width="100;" alt="sahil9001"/>
                     <br />
                     <sub><b>sahil9001</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/yb-sid">
-                    <img src="https://avatars.githubusercontent.com/u/129207298?v=4" width="75;" alt="yb-sid"/>
+                    <img src="https://avatars.githubusercontent.com/u/129207298?v=4" width="100;" alt="yb-sid"/>
                     <br />
                     <sub><b>yb-sid</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/Prototype4988">
-                    <img src="https://avatars.githubusercontent.com/u/55426963?v=4" width="75;" alt="Prototype4988"/>
+                    <img src="https://avatars.githubusercontent.com/u/55426963?v=4" width="100;" alt="Prototype4988"/>
                     <br />
                     <sub><b>Prototype4988</b></sub>
                 </a>
             </td>
             <td align="center">
                 <a href="https://github.com/iamawanishmaurya">
-                    <img src="https://avatars.githubusercontent.com/u/65104100?v=4" width="75;" alt="iamawanishmaurya"/>
+                    <img src="https://avatars.githubusercontent.com/u/65104100?v=4" width="100;" alt="iamawanishmaurya"/>
                     <br />
                     <sub><b>iamawanishmaurya</b></sub>
                 </a>

--- a/README.md
+++ b/README.md
@@ -133,4 +133,175 @@ Do note that our [Code of Conduct](./CODE_OF_CONDUCT.md) applies to all Wren AI 
 ## Our Contributors ❤️
 <!-- Do not manually edit this section! It should get updated using the Github action "Manually update contributors list" -->
 <!-- readme: contributors -start -->
+<table>
+	<tbody>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/cyyeh">
+                    <img src="https://avatars.githubusercontent.com/u/11023068?v=4" width="75;" alt="cyyeh"/>
+                    <br />
+                    <sub><b>cyyeh</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/onlyjackfrost">
+                    <img src="https://avatars.githubusercontent.com/u/38731840?v=4" width="75;" alt="onlyjackfrost"/>
+                    <br />
+                    <sub><b>onlyjackfrost</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/wwwy3y3">
+                    <img src="https://avatars.githubusercontent.com/u/1208829?v=4" width="75;" alt="wwwy3y3"/>
+                    <br />
+                    <sub><b>wwwy3y3</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/andreashimin">
+                    <img src="https://avatars.githubusercontent.com/u/9657305?v=4" width="75;" alt="andreashimin"/>
+                    <br />
+                    <sub><b>andreashimin</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/paopa">
+                    <img src="https://avatars.githubusercontent.com/u/52045032?v=4" width="75;" alt="paopa"/>
+                    <br />
+                    <sub><b>paopa</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/fredalai">
+                    <img src="https://avatars.githubusercontent.com/u/42527625?v=4" width="75;" alt="fredalai"/>
+                    <br />
+                    <sub><b>fredalai</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/chilijung">
+                    <img src="https://avatars.githubusercontent.com/u/1216029?v=4" width="75;" alt="chilijung"/>
+                    <br />
+                    <sub><b>chilijung</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/imAsterSun">
+                    <img src="https://avatars.githubusercontent.com/u/61279528?v=4" width="75;" alt="imAsterSun"/>
+                    <br />
+                    <sub><b>imAsterSun</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/qdrddr">
+                    <img src="https://avatars.githubusercontent.com/u/564658?v=4" width="75;" alt="qdrddr"/>
+                    <br />
+                    <sub><b>qdrddr</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/Ayushjhawar8">
+                    <img src="https://avatars.githubusercontent.com/u/111112495?v=4" width="75;" alt="Ayushjhawar8"/>
+                    <br />
+                    <sub><b>Ayushjhawar8</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/kushal34712">
+                    <img src="https://avatars.githubusercontent.com/u/98145879?v=4" width="75;" alt="kushal34712"/>
+                    <br />
+                    <sub><b>kushal34712</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/goldmedal">
+                    <img src="https://avatars.githubusercontent.com/u/6974913?v=4" width="75;" alt="goldmedal"/>
+                    <br />
+                    <sub><b>goldmedal</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/eltociear">
+                    <img src="https://avatars.githubusercontent.com/u/22633385?v=4" width="75;" alt="eltociear"/>
+                    <br />
+                    <sub><b>eltociear</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/himanshu634">
+                    <img src="https://avatars.githubusercontent.com/u/61757460?v=4" width="75;" alt="himanshu634"/>
+                    <br />
+                    <sub><b>himanshu634</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/AryanK1511">
+                    <img src="https://avatars.githubusercontent.com/u/101019909?v=4" width="75;" alt="AryanK1511"/>
+                    <br />
+                    <sub><b>AryanK1511</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/kpman">
+                    <img src="https://avatars.githubusercontent.com/u/2382594?v=4" width="75;" alt="kpman"/>
+                    <br />
+                    <sub><b>kpman</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/grieve54706">
+                    <img src="https://avatars.githubusercontent.com/u/8724385?v=4" width="75;" alt="grieve54706"/>
+                    <br />
+                    <sub><b>grieve54706</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/RoacherM">
+                    <img src="https://avatars.githubusercontent.com/u/33534878?v=4" width="75;" alt="RoacherM"/>
+                    <br />
+                    <sub><b>RoacherM</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/Innovatorcloudy">
+                    <img src="https://avatars.githubusercontent.com/u/183274513?v=4" width="75;" alt="Innovatorcloudy"/>
+                    <br />
+                    <sub><b>Innovatorcloudy</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/sahil9001">
+                    <img src="https://avatars.githubusercontent.com/u/32628578?v=4" width="75;" alt="sahil9001"/>
+                    <br />
+                    <sub><b>sahil9001</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/yb-sid">
+                    <img src="https://avatars.githubusercontent.com/u/129207298?v=4" width="75;" alt="yb-sid"/>
+                    <br />
+                    <sub><b>yb-sid</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/Prototype4988">
+                    <img src="https://avatars.githubusercontent.com/u/55426963?v=4" width="75;" alt="Prototype4988"/>
+                    <br />
+                    <sub><b>Prototype4988</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/iamawanishmaurya">
+                    <img src="https://avatars.githubusercontent.com/u/65104100?v=4" width="75;" alt="iamawanishmaurya"/>
+                    <br />
+                    <sub><b>iamawanishmaurya</b></sub>
+                </a>
+            </td>
+		</tr>
+	<tbody>
+</table>
 <!-- readme: contributors -end -->


### PR DESCRIPTION
### Description
Automatically updates the contributors list in the README using GitHub Actions. Fetches contributor data and displays it with avatars and GitHub profile links.

### Changes Made
- Added GitHub Action to auto-update README with contributors.
- Updated README to include contributors section.

### Fixes
Fixes issue #748 

### Additional Context
This automation ensures the list is always current after each contribution.
