### PR TITLE
feat(wren-ai-service): remove relation columns before generating semantics description and error code enhancement

### DIFF
--- a/wren-ai-service/src/pipelines/generation/semantics_description.py
+++ b/wren-ai-service/src/pipelines/generation/semantics_description.py
@@ -19,10 +19,14 @@ logger = logging.getLogger("wren-ai-service")
 ## Start of Pipeline
 @observe(capture_input=False)
 def picked_models(mdl: dict, selected_models: list[str]) -> list[dict]:
+    def remove_relation_columns(columns: list[dict]) -> list[dict]:
+        # remove columns that have a relationship property
+        return [column for column in columns if "relationship" not in column]
+
     def extract(model: dict) -> dict:
         return {
             "name": model["name"],
-            "columns": model["columns"],
+            "columns": remove_relation_columns(model["columns"]),
             "properties": model["properties"],
         }
 

--- a/wren-ai-service/tests/pytest/services/test_relationship_recommendation.py
+++ b/wren-ai-service/tests/pytest/services/test_relationship_recommendation.py
@@ -37,7 +37,7 @@ async def test_recommend_invalid_mdl(relationship_recommendation_service):
 
     assert response.id == "test_id"
     assert response.status == "failed"
-    assert response.error.code == "OTHERS"
+    assert response.error.code == "MDL_PARSE_ERROR"
     assert "Failed to parse MDL" in response.error.message
 
 
@@ -80,7 +80,7 @@ def test_getitem_not_found(relationship_recommendation_service):
 
     assert response.id == "non_existent_id"
     assert response.status == "failed"
-    assert response.error.code == "OTHERS"
+    assert response.error.code == "RESOURCE_NOT_FOUND"
     assert "not found" in response.error.message
 
 

--- a/wren-ai-service/tests/pytest/services/test_semantics_description.py
+++ b/wren-ai-service/tests/pytest/services/test_semantics_description.py
@@ -61,7 +61,7 @@ async def test_generate_semantics_description_with_invalid_mdl(
     assert response.id == "test_id"
     assert response.status == "failed"
     assert response.response is None
-    assert response.error.code == "OTHERS"
+    assert response.error.code == "MDL_PARSE_ERROR"
     assert "Failed to parse MDL" in response.error.message
 
 
@@ -119,5 +119,5 @@ def test_get_non_existent_semantics_description_result(
     assert result.id == "non_existent_id"
     assert result.status == "failed"
     assert result.response is None
-    assert result.error.code == "OTHERS"
+    assert result.error.code == "RESOURCE_NOT_FOUND"
     assert "not found" in result.error.message


### PR DESCRIPTION
This pull request introduces several changes to enhance error handling and data processing within the `wren-ai-service` module. The key updates include adding new error codes, improving exception handling, and refining data extraction methods.

### Error Handling Enhancements:

Added following error codes in relationship recommendation and semantics description services:

- MDL_PARSE_ERROR: it means that the MDL is not valid by the JSON format
- RESOURCE_NOT_FOUND: it means that the ID didn't target a specified resource.

### Data Processing Improvements:

* Added a new helper function `remove_relation_columns` to filter out columns with a relationship property during data extraction.


#### Endpoint Testing Input
```json
{
  "selected_models": [
    "example", "example2"
  ],
  "user_prompt": "demo prompt",
  "mdl": "{\"catalog\":\"example\",\"schema\":\"example\",\"models\":[{\"name\":\"example\",\"properties\":{},\"refSql\":\"select * from example\",\"columns\":[{\"name\":\"id\",\"type\":\"INTEGER\",\"notNull\":true,\"isCalculated\":false,\"expression\":\"id\",\"properties\":{}},{\"name\":\"name\",\"type\":\"VARCHAR\",\"notNull\":true,\"isCalculated\":false,\"expression\":\"name\",\"properties\":{}}]},{\"name\":\"example2\",\"properties\":{},\"refSql\":\"select * from example2\",\"columns\":[{\"name\":\"id\",\"type\":\"INTEGER\",\"notNull\":true,\"isCalculated\":false,\"expression\":\"id\",\"properties\":{}},{\"name\":\"example_relationship\",\"type\":\"example\",\"notNull\":true,\"isCalculated\":false,\"relationship\":\"example_example2\",\"properties\":{}}]}]}"
}
```

### Screenshots
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/b4133739-1d70-4883-82cb-aee30f19cdba">
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/e0c0e336-7c0a-4c40-80fe-61d259e5c82d">
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/ee814996-cc25-47de-8f7c-726e2dc23b93">
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/2cfb053f-b766-49f3-9f7c-a49c6433e419">

