### PR TITLE
feat(wren-ui): Implement project language setting

### DIFF
--- a/wren-ui/migrations/20241021073019_update_project_language.js
+++ b/wren-ui/migrations/20241021073019_update_project_language.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('project', (table) => {
+    table
+      .string('language')
+      .comment('The project language applied to AI')
+      .defaultTo('EN');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('project', (table) => {
+    table.dropColumn('language');
+  });
+};

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -200,6 +200,7 @@ export type DetailedModel = {
 
 export type DetailedNestedColumn = {
   __typename?: 'DetailedNestedColumn';
+  columnPath: Array<Scalars['String']>;
   displayName: Scalars['String'];
   id: Scalars['Int'];
   properties?: Maybe<Scalars['JSON']>;
@@ -366,6 +367,7 @@ export type FieldInfo = {
   expression?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   isCalculated: Scalars['Boolean'];
+  nestedColumns?: Maybe<Array<NestedFieldInfo>>;
   notNull: Scalars['Boolean'];
   properties?: Maybe<Scalars['JSON']>;
   referenceName: Scalars['String'];
@@ -437,6 +439,7 @@ export type Mutation = {
   startSampleDataset: Scalars['JSON'];
   triggerDataSourceDetection: Scalars['Boolean'];
   updateCalculatedField: Scalars['JSON'];
+  updateCurrentProject: Scalars['Boolean'];
   updateDataSource: DataSource;
   updateModel: Scalars['JSON'];
   updateModelMetadata: Scalars['Boolean'];
@@ -570,6 +573,11 @@ export type MutationUpdateCalculatedFieldArgs = {
 };
 
 
+export type MutationUpdateCurrentProjectArgs = {
+  data: UpdateCurrentProjectInput;
+};
+
+
 export type MutationUpdateDataSourceArgs = {
   data: UpdateDataSourceInput;
 };
@@ -614,6 +622,17 @@ export type MutationValidateViewArgs = {
   data: ValidateViewInput;
 };
 
+export type NestedFieldInfo = {
+  __typename?: 'NestedFieldInfo';
+  columnPath: Array<Scalars['String']>;
+  displayName: Scalars['String'];
+  id: Scalars['Int'];
+  properties: Scalars['JSON'];
+  referenceName: Scalars['String'];
+  sourceColumnName: Scalars['String'];
+  type: Scalars['String'];
+};
+
 export enum NodeType {
   CALCULATED_FIELD = 'CALCULATED_FIELD',
   FIELD = 'FIELD',
@@ -652,6 +671,19 @@ export type PreviewViewDataInput = {
   id: Scalars['Int'];
   limit?: InputMaybe<Scalars['Int']>;
 };
+
+export enum ProjectLanguage {
+  DE = 'DE',
+  EN = 'EN',
+  ES = 'ES',
+  FR = 'FR',
+  JA = 'JA',
+  KO = 'KO',
+  PT = 'PT',
+  RU = 'RU',
+  ZH_CN = 'ZH_CN',
+  ZH_TW = 'ZH_TW'
+}
 
 export type Query = {
   __typename?: 'Query';
@@ -799,6 +831,7 @@ export enum SchemaChangeType {
 export type Settings = {
   __typename?: 'Settings';
   dataSource: DataSource;
+  language: ProjectLanguage;
   productVersion: Scalars['String'];
 };
 
@@ -887,6 +920,10 @@ export type UpdateColumnMetadataInput = {
   description?: InputMaybe<Scalars['String']>;
   displayName?: InputMaybe<Scalars['String']>;
   id: Scalars['Int'];
+};
+
+export type UpdateCurrentProjectInput = {
+  language: ProjectLanguage;
 };
 
 export type UpdateDataSourceInput = {

--- a/wren-ui/src/apollo/client/graphql/settings.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/settings.generated.ts
@@ -6,12 +6,19 @@ const defaultOptions = {} as const;
 export type GetSettingsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type GetSettingsQuery = { __typename?: 'Query', settings: { __typename?: 'Settings', productVersion: string, dataSource: { __typename?: 'DataSource', type: Types.DataSourceName, properties: any, sampleDataset?: Types.SampleDatasetName | null } } };
+export type GetSettingsQuery = { __typename?: 'Query', settings: { __typename?: 'Settings', productVersion: string, language: Types.ProjectLanguage, dataSource: { __typename?: 'DataSource', type: Types.DataSourceName, properties: any, sampleDataset?: Types.SampleDatasetName | null } } };
 
 export type ResetCurrentProjectMutationVariables = Types.Exact<{ [key: string]: never; }>;
 
 
 export type ResetCurrentProjectMutation = { __typename?: 'Mutation', resetCurrentProject: boolean };
+
+export type UpdateCurrentProjectMutationVariables = Types.Exact<{
+  data: Types.UpdateCurrentProjectInput;
+}>;
+
+
+export type UpdateCurrentProjectMutation = { __typename?: 'Mutation', updateCurrentProject: boolean };
 
 
 export const GetSettingsDocument = gql`
@@ -23,6 +30,7 @@ export const GetSettingsDocument = gql`
       properties
       sampleDataset
     }
+    language
   }
 }
     `;
@@ -83,3 +91,34 @@ export function useResetCurrentProjectMutation(baseOptions?: Apollo.MutationHook
 export type ResetCurrentProjectMutationHookResult = ReturnType<typeof useResetCurrentProjectMutation>;
 export type ResetCurrentProjectMutationResult = Apollo.MutationResult<ResetCurrentProjectMutation>;
 export type ResetCurrentProjectMutationOptions = Apollo.BaseMutationOptions<ResetCurrentProjectMutation, ResetCurrentProjectMutationVariables>;
+export const UpdateCurrentProjectDocument = gql`
+    mutation UpdateCurrentProject($data: UpdateCurrentProjectInput!) {
+  updateCurrentProject(data: $data)
+}
+    `;
+export type UpdateCurrentProjectMutationFn = Apollo.MutationFunction<UpdateCurrentProjectMutation, UpdateCurrentProjectMutationVariables>;
+
+/**
+ * __useUpdateCurrentProjectMutation__
+ *
+ * To run a mutation, you first call `useUpdateCurrentProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateCurrentProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateCurrentProjectMutation, { data, loading, error }] = useUpdateCurrentProjectMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateCurrentProjectMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCurrentProjectMutation, UpdateCurrentProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateCurrentProjectMutation, UpdateCurrentProjectMutationVariables>(UpdateCurrentProjectDocument, options);
+      }
+export type UpdateCurrentProjectMutationHookResult = ReturnType<typeof useUpdateCurrentProjectMutation>;
+export type UpdateCurrentProjectMutationResult = Apollo.MutationResult<UpdateCurrentProjectMutation>;
+export type UpdateCurrentProjectMutationOptions = Apollo.BaseMutationOptions<UpdateCurrentProjectMutation, UpdateCurrentProjectMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/settings.ts
+++ b/wren-ui/src/apollo/client/graphql/settings.ts
@@ -9,6 +9,7 @@ export const GET_SETTINGS = gql`
         properties
         sampleDataset
       }
+      language
     }
   }
 `;
@@ -16,5 +17,11 @@ export const GET_SETTINGS = gql`
 export const RESET_CURRENT_PROJECT = gql`
   mutation ResetCurrentProject {
     resetCurrentProject
+  }
+`;
+
+export const UPDATE_CURRENT_PROJECT = gql`
+  mutation UpdateCurrentProject($data: UpdateCurrentProjectInput!) {
+    updateCurrentProject(data: $data)
   }
 `;

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -27,7 +27,20 @@ enum WrenAISystemStatus {
   FAILED = 'FAILED',
 }
 
-export interface deployData {
+export enum WrenAILanguage {
+  EN = 'English',
+  ES = 'Spanish',
+  FR = 'French',
+  ZH_TW = 'Traditional Chinese',
+  ZH_CN = 'Simplified Chinese',
+  DE = 'German',
+  PT = 'Portuguese',
+  RU = 'Russian',
+  JA = 'Japanese',
+  KO = 'Korean',
+}
+
+export interface DeployData {
   manifest: Manifest;
   hash: string;
 }
@@ -45,10 +58,15 @@ export interface AskHistory {
   steps: Array<AskStep>;
 }
 
+export interface AskConfigurations {
+  language: string;
+}
+
 export interface AskInput {
   query: string;
   deployId: string;
   history?: AskHistory;
+  configurations?: AskConfigurations;
 }
 
 export interface AsyncQueryResponse {
@@ -81,6 +99,7 @@ export interface AskDetailInput {
   query: string;
   sql: string;
   summary: string;
+  configurations?: AskConfigurations;
 }
 
 export type AskDetailResult = AskResponse<
@@ -109,7 +128,7 @@ const getAISerciceError = (error: any) => {
 };
 
 export interface IWrenAIAdaptor {
-  deploy(deployData: deployData): Promise<WrenAIDeployResponse>;
+  deploy(deployData: DeployData): Promise<WrenAIDeployResponse>;
 
   /**
    * Ask AI service a question.
@@ -149,6 +168,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
         query: input.query,
         id: input.deployId,
         history: this.transfromHistoryInput(input.history),
+        configurations: input.configurations,
       });
       return { queryId: res.data.query_id };
     } catch (err: any) {
@@ -223,7 +243,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
     }
   }
 
-  public async deploy(deployData: deployData): Promise<WrenAIDeployResponse> {
+  public async deploy(deployData: DeployData): Promise<WrenAIDeployResponse> {
     const { manifest, hash } = deployData;
     try {
       const res = await axios.post(

--- a/wren-ui/src/apollo/server/repositories/projectRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/projectRepository.ts
@@ -82,6 +82,7 @@ export interface Project {
   schema: string; // Schema name
   sampleDataset: string; // Sample dataset name
   connectionInfo: WREN_AI_CONNECTION_INFO;
+  language?: string; // Project language
 }
 
 export interface IProjectRepository extends IBasicRepository<Project> {

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -85,6 +85,7 @@ const resolvers = {
 
     // Settings
     resetCurrentProject: projectResolver.resetCurrentProject,
+    updateCurrentProject: projectResolver.updateCurrentProject,
     updateDataSource: projectResolver.updateDataSource,
 
     // preview

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -50,6 +50,7 @@ export enum OnboardingStatusEnum {
 export class ProjectResolver {
   constructor() {
     this.getSettings = this.getSettings.bind(this);
+    this.updateCurrentProject = this.updateCurrentProject.bind(this);
     this.resetCurrentProject = this.resetCurrentProject.bind(this);
     this.saveDataSource = this.saveDataSource.bind(this);
     this.updateDataSource = this.updateDataSource.bind(this);
@@ -80,7 +81,21 @@ export class ProjectResolver {
         } as DataSourceProperties,
         sampleDataset: project.sampleDataset,
       },
+      language: project.language,
     };
+  }
+
+  public async updateCurrentProject(
+    _root: any,
+    arg: { data: { language: string } },
+    ctx: IContext,
+  ) {
+    const { language } = arg.data;
+    const project = await ctx.projectService.getCurrentProject();
+    await ctx.projectRepository.updateOne(project.id, {
+      language,
+    });
+    return true;
   }
 
   public async resetCurrentProject(_root: any, _arg: any, ctx: IContext) {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -53,6 +53,19 @@ export const typeDefs = gql`
     MODIFIED_COLUMNS
   }
 
+  enum ProjectLanguage {
+    EN
+    ES
+    FR
+    ZH_TW
+    ZH_CN
+    DE
+    PT
+    RU
+    JA
+    KO
+  }
+
   type DataSource {
     type: DataSourceName!
     properties: JSON!
@@ -635,9 +648,14 @@ export const typeDefs = gql`
     properties: JSON!
   }
 
+  input UpdateCurrentProjectInput {
+    language: ProjectLanguage!
+  }
+
   type Settings {
     productVersion: String!
     dataSource: DataSource!
+    language: ProjectLanguage!
   }
 
   type GetMDLResult {
@@ -791,6 +809,7 @@ export const typeDefs = gql`
 
     # Settings
     resetCurrentProject: Boolean!
+    updateCurrentProject(data: UpdateCurrentProjectInput!): Boolean!
     updateDataSource(data: UpdateDataSourceInput!): DataSource!
 
     # preview

--- a/wren-ui/src/components/settings/ProjectSettings.tsx
+++ b/wren-ui/src/components/settings/ProjectSettings.tsx
@@ -1,11 +1,33 @@
-import { Button, Modal } from 'antd';
+import { Button, Modal, Select, Row, Col, Form, message } from 'antd';
 import { useRouter } from 'next/router';
 import { Path } from '@/utils/enum';
-import { useResetCurrentProjectMutation } from '@/apollo/client/graphql/settings.generated';
+import {
+  useResetCurrentProjectMutation,
+  useUpdateCurrentProjectMutation,
+} from '@/apollo/client/graphql/settings.generated';
+import { getLanguageText } from '@/utils/language';
+import { ProjectLanguage } from '@/apollo/client/graphql/__types__';
 
-export default function ProjectSettings() {
+interface Props {
+  data: { language: string };
+}
+
+export default function ProjectSettings(props: Props) {
+  const { data } = props;
   const router = useRouter();
+  const [form] = Form.useForm();
   const [resetCurrentProject, { client }] = useResetCurrentProjectMutation();
+  const languageOptions = Object.keys(ProjectLanguage).map((key) => {
+    return { label: getLanguageText(key as ProjectLanguage), value: key };
+  });
+
+  const [updateCurrentProject, { loading }] = useUpdateCurrentProjectMutation({
+    refetchQueries: ['GetSettings'],
+    onError: (error) => console.error(error),
+    onCompleted: () => {
+      message.success('Successfully updated project language.');
+    },
+  });
 
   const reset = () => {
     Modal.confirm({
@@ -20,8 +42,49 @@ export default function ProjectSettings() {
     });
   };
 
+  const submit = () => {
+    form
+      .validateFields()
+      .then((values) => {
+        updateCurrentProject({ variables: { data: values } });
+      })
+      .catch((error) => console.error(error));
+  };
+
   return (
     <div className="py-3 px-4">
+      <Form
+        form={form}
+        layout="vertical"
+        initialValues={{ language: data.language }}
+      >
+        <Form.Item
+          label="Project language"
+          extra="This setting will affect the language in which the AI responds to you."
+        >
+          <Row gutter={16} wrap={false}>
+            <Col className="flex-grow-1">
+              <Form.Item name="language" noStyle>
+                <Select
+                  placeholder="Select a language"
+                  showSearch
+                  options={languageOptions}
+                />
+              </Form.Item>
+            </Col>
+            <Col>
+              <Button
+                type="primary"
+                style={{ width: 70 }}
+                onClick={submit}
+                loading={loading}
+              >
+                Save
+              </Button>
+            </Col>
+          </Row>
+        </Form.Item>
+      </Form>
       <div className="gray-8 mb-2">Reset project</div>
       <Button type="primary" style={{ width: 70 }} danger onClick={reset}>
         Reset

--- a/wren-ui/src/components/settings/index.tsx
+++ b/wren-ui/src/components/settings/index.tsx
@@ -57,7 +57,7 @@ const DynamicComponent = ({
   refetch: () => void;
   closeModal: () => void;
 }) => {
-  const { dataSource } = data || {};
+  const { dataSource, language } = data || {};
   return (
     {
       [SETTINGS.DATA_SOURCE]: (
@@ -69,7 +69,7 @@ const DynamicComponent = ({
           closeModal={closeModal}
         />
       ),
-      [SETTINGS.PROJECT]: <ProjectSettings />,
+      [SETTINGS.PROJECT]: <ProjectSettings data={{ language }} />,
     }[menu] || null
   );
 };

--- a/wren-ui/src/utils/language.ts
+++ b/wren-ui/src/utils/language.ts
@@ -1,0 +1,15 @@
+import { ProjectLanguage } from '@/apollo/client/graphql/__types__';
+
+export const getLanguageText = (language: ProjectLanguage) =>
+  ({
+    [ProjectLanguage.EN]: 'English',
+    [ProjectLanguage.ES]: 'Spanish',
+    [ProjectLanguage.FR]: 'French',
+    [ProjectLanguage.ZH_TW]: 'Traditional Chinese',
+    [ProjectLanguage.ZH_CN]: 'Simplified Chinese',
+    [ProjectLanguage.DE]: 'German',
+    [ProjectLanguage.PT]: 'Portuguese',
+    [ProjectLanguage.RU]: 'Russian',
+    [ProjectLanguage.JA]: 'Japanese',
+    [ProjectLanguage.KO]: 'Korean',
+  })[language] || language;


### PR DESCRIPTION
## Description
This feature aims to provide users with a project language setting.
When users ask, the AI service should return the result matching the selected language.

### Features
- Provide `UpdateCurrentProject` API to update language
- Add `language` in `Settings` API
- Pass `configurations` to AI service

## Screenshots
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/194e4197-71af-4b49-bd88-221ee4803a63">
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/360c8334-3442-46eb-9a68-2ae02b1521ac">
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/4d4c7b10-a39f-4a91-a77e-5483c21b00c1">
