### PR TITLE
docs: update dead link in `wren-ui/README.md`

### DIFF
--- a/wren-ui/README.md
+++ b/wren-ui/README.md
@@ -151,7 +151,7 @@ ibis-server:
 ```
 Then refer to the README.md or CONTRIBUTION.md file the module for starting the module from the source code. 
 
-eg: refer to the [ai-service README](https://github.com/Canner/WrenAI-saas/blob/main/wren-ai-service/README.md#start-the-service-for-development) to start the ai-service from the source code.
+eg: refer to the [ai-service README](https://github.com/Canner/WrenAI/blob/main/wren-ai-service/README.md#start-the-service-for-development) to start the ai-service from the source code.
 
 
 


### PR DESCRIPTION
This PR updates the dead link in:
https://github.com/Canner/WrenAI/blob/c9706b52c455ea811b77fb80055ded76ef4144ad/wren-ui/README.md?plain=1#L154

Similar to #769.