### PR TITLE
fix(wren-ui): Displayed password placeholder for Data Source Settings

### DIFF
--- a/wren-ui/src/hooks/useSetupConnection.tsx
+++ b/wren-ui/src/hooks/useSetupConnection.tsx
@@ -31,19 +31,16 @@ export const transformFormToProperties = (
       configurations,
       extensions: properties.extensions.filter((i) => i),
     };
-  } else if (dataSourceType === DataSourceName.POSTGRES) {
-    return {
-      ...properties,
-      // remove password placeholder if user doesn't change the password
-      password:
-        properties?.password === PASSWORD_PLACEHOLDER
-          ? undefined
-          : properties?.password,
-      ssl: properties?.ssl,
-    };
   }
 
-  return properties;
+  return {
+    ...properties,
+    // remove password placeholder if user doesn't change the password
+    password:
+      properties?.password === PASSWORD_PLACEHOLDER
+        ? undefined
+        : properties?.password,
+  };
 };
 
 export const transformPropertiesToForm = (

--- a/wren-ui/src/hooks/useSetupConnection.tsx
+++ b/wren-ui/src/hooks/useSetupConnection.tsx
@@ -65,14 +65,13 @@ export const transformPropertiesToForm = (
         : [{ key: '', value: '' }],
       extensions: extensions.length ? extensions : [''],
     };
-  } else if (dataSourceType === DataSourceName.POSTGRES) {
-    return {
-      ...properties,
-      // provide a password placeholder to UI
-      password: properties?.password || PASSWORD_PLACEHOLDER,
-    };
   }
-  return properties;
+  
+  return {
+    ...properties,
+    // provide a password placeholder to UI
+    password: properties?.password || PASSWORD_PLACEHOLDER,
+  };
 };
 
 export default function useSetupConnection() {


### PR DESCRIPTION
Fix #712 

### Description
I have resolved the issue where the password field appeared empty on the Data Source Settings page for connected ClickHouse, MSSQL, MySQL, Postgres, and Trino data source. Your review would be greatly appreciated, thanks in advance!
### Screenshots
<img src="https://github.com/user-attachments/assets/0c08cee6-450f-4bd6-a6f3-b16272d6cd48" width=300 height=320 />
<img src="https://github.com/user-attachments/assets/524d4ed9-abed-4e4c-b210-dd8152ddc398" width=300 height=320 />
<img src="https://github.com/user-attachments/assets/c322be14-f3f8-49d4-939a-96e420de5141" width=300 height=320 />
<img src="https://github.com/user-attachments/assets/8483cbb0-25da-48a9-ada5-b90830b71ae7" width=300 height=320 />

