### PR TITLE
fix(wren-ui): Stop polling if users click candidate during generating

### DIFF
--- a/wren-ui/src/components/pages/home/prompt/index.tsx
+++ b/wren-ui/src/components/pages/home/prompt/index.tsx
@@ -33,6 +33,7 @@ interface Props {
 interface Attributes {
   setValue: (value: string) => void;
   submit: () => void;
+  close: () => void;
 }
 
 const PromptStyle = styled.div`
@@ -140,6 +141,7 @@ export default forwardRef<Attributes, Props>(function Prompt(props, ref) {
     () => ({
       setValue: (value: string) => setInputValue(value),
       submit: submitAsk,
+      close: closeResult,
     }),
     [question, isProcessing, setInputValue],
   );

--- a/wren-ui/src/hooks/useAskPrompt.tsx
+++ b/wren-ui/src/hooks/useAskPrompt.tsx
@@ -52,9 +52,12 @@ export default function useAskPrompt(threadId?: number) {
     }
   };
 
+  const stopPolling = () => askingTaskResult.stopPolling();
+
   return {
     data,
     onStop,
     onSubmit,
+    stopPolling,
   };
 }

--- a/wren-ui/src/pages/home/index.tsx
+++ b/wren-ui/src/pages/home/index.tsx
@@ -41,6 +41,7 @@ export default function Home() {
 
   const onSelect = async (payload) => {
     try {
+      askPrompt.stopPolling();
       const response = await createThread({ variables: { data: payload } });
       router.push(Path.Home + `/${response.data.createThread.id}`);
     } catch (error) {


### PR DESCRIPTION
## Description
- Stop continuing polling if the user clicks candidate first when generating results
- Stop polling & close prompt results if users change threads
