### PR TITLE
chore(wren-ui): fix sed command in the Github action workflow

### DIFF
--- a/.github/workflows/ui-release-image-stable.yaml
+++ b/.github/workflows/ui-release-image-stable.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Update Wren-UI version
         run: |
           version=${{ github.event.inputs.version }}
-          sed -i '' 's/"version": "[^"]*"/"version": "'"$version"'"/' package.json
+          sed -i 's/"version": "[^"]*"/"version": "'"$version"'"/' package.json
           git add package.json
           git commit -m "update wren-ui version to $version"
           git push


### PR DESCRIPTION
fix sed command in the Github action workflow
- sed -i '' not suitable on linux based OS