### PR TITLE
chore(wren-ai-service): add correlation ID to langfuse

### DIFF
--- a/wren-ai-service/src/pipelines/common.py
+++ b/wren-ai-service/src/pipelines/common.py
@@ -88,14 +88,14 @@ class SQLBreakdownGenPostProcessor:
         project_id: str | None = None,
     ):
         async with aiohttp.ClientSession() as session:
-            status, _, error = await self._engine.execute_sql(
+            status, _, addition = await self._engine.execute_sql(
                 sql,
                 session,
                 project_id=project_id,
             )
 
         if not status:
-            logger.exception(f"SQL is not executable: {error}")
+            logger.exception(f"SQL is not executable: {addition["error_message"]}")
 
         return status
 
@@ -151,7 +151,7 @@ class SQLGenPostProcessor:
             quoted_sql, no_error = add_quotes(result["sql"])
 
             if no_error:
-                status, _, error = await self._engine.execute_sql(
+                status, _, addition = await self._engine.execute_sql(
                     quoted_sql, session, project_id=project_id
                 )
 
@@ -159,6 +159,7 @@ class SQLGenPostProcessor:
                     valid_generation_results.append(
                         {
                             "sql": quoted_sql,
+                            "correlation_id": addition["correlation_id"],
                         }
                     )
                 else:
@@ -166,7 +167,8 @@ class SQLGenPostProcessor:
                         {
                             "sql": quoted_sql,
                             "type": "DRY_RUN",
-                            "error": error,
+                            "error": addition["error_message"],
+                            "correlation_id": addition["correlation_id"],
                         }
                     )
             else:

--- a/wren-ai-service/src/providers/engine/wren.py
+++ b/wren-ai-service/src/providers/engine/wren.py
@@ -49,11 +49,16 @@ class WrenUI(Engine):
         ) as response:
             res = await response.json()
             if data := res.get("data"):
-                return True, data, None
+                return True, data, {
+                    "correlation_id": res.get("correlationId"),
+                }
             return (
                 False,
                 None,
-                res.get("errors", [{}])[0].get("message", "Unknown error"),
+                {
+                    "error_message": res.get("errors", [{}])[0].get("message", "Unknown error"),
+                    "correlation_id": res.get("extensions", {}).get("other", {}).get("correlationId"),
+                }
             )
 
 

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -933,14 +933,13 @@ export class ModelResolver {
       ? await ctx.projectService.getProjectById(projectId)
       : await ctx.projectService.getCurrentProject();
     const { manifest } = await ctx.deployService.getLastDeployment(project.id);
-    const previewRes = await ctx.queryService.preview(sql, {
+    return await ctx.queryService.preview(sql, {
       project,
       limit: limit,
       modelingOnly: false,
       manifest,
       dryRun,
     });
-    return dryRun ? { dryRun: 'success' } : previewRes;
   }
 
   public async getNativeSql(

--- a/wren-ui/src/apollo/server/services/queryService.ts
+++ b/wren-ui/src/apollo/server/services/queryService.ts
@@ -25,11 +25,9 @@ export interface ColumnMetadata {
   type: string;
 }
 
-export interface PreviewDataResponse {
-  correlationId?: string;
-  processTime?: string;
-  columns?: ColumnMetadata[];
-  data?: any[][];
+export interface PreviewDataResponse extends IbisResponse {
+  columns: ColumnMetadata[];
+  data: any[][];
 }
 
 export interface DescribeStatementResponse {
@@ -60,7 +58,7 @@ export interface IQueryService {
   preview(
     sql: string,
     options: PreviewOptions,
-  ): Promise<PreviewDataResponse | boolean>;
+  ): Promise<IbisResponse| PreviewDataResponse | boolean>;
 
   describeStatement(
     sql: string,
@@ -97,7 +95,7 @@ export class QueryService implements IQueryService {
   public async preview(
     sql: string,
     options: PreviewOptions,
-  ): Promise<PreviewDataResponse | boolean> {
+  ): Promise<IbisResponse | PreviewDataResponse | boolean> {
     const { project, manifest: mdl, limit, dryRun } = options;
     const { type: dataSource, connectionInfo } = project;
     if (this.useEngine(dataSource)) {
@@ -177,7 +175,7 @@ export class QueryService implements IQueryService {
     dataSource: DataSourceName,
     connectionInfo: any,
     mdl: Manifest
-  ): Promise<PreviewDataResponse> {
+  ): Promise<IbisResponse> {
     const event = TelemetryEvent.IBIS_DRY_RUN;
     try {
       const res = await this.ibisAdaptor.dryRun(sql, {


### PR DESCRIPTION
Add correlation ID from the ibis server to the Langfuse.

The AI team usually provides the issues from the Langfuse, if we want to find the ibis log for the issue, we need to find it by time, and the time is not completely correct.

The correlation ID is from the ibis-server. The AI service gets data and the correlation ID through the web API, and the AI service sends Langfuse logs. So, we must explain the correlation ID and return it to the AI service.