### PR TITLE
chore(wren-ui): improve host validator for data sources

### DIFF
--- a/wren-ui/src/components/learning/guide/stories.tsx
+++ b/wren-ui/src/components/learning/guide/stories.tsx
@@ -55,7 +55,7 @@ const playDataModelingGuide = (
               <img
                 className="mb-4"
                 src="/images/learning/data-modeling.jpg"
-                alt="ata-modeling-guide"
+                alt="data-modeling-guide"
               />
             </div>
             Data modeling guide

--- a/wren-ui/src/components/pages/setup/dataSources/ClickHouseProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/ClickHouseProperties.tsx
@@ -1,6 +1,7 @@
 import { Form, Input, Switch } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
+import { hostValidator } from '@/utils/validator';
 
 interface Props {
   mode?: FORM_MODE;
@@ -31,7 +32,7 @@ export default function ClickHouseProperties(props: Props) {
         rules={[
           {
             required: true,
-            message: ERROR_TEXTS.CONNECTION.HOST.REQUIRED,
+            validator: hostValidator,
           },
         ]}
       >

--- a/wren-ui/src/components/pages/setup/dataSources/MySQLProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/MySQLProperties.tsx
@@ -1,6 +1,7 @@
 import { Form, Input } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
+import { hostValidator } from '@/utils/validator';
 
 interface Props {
   mode?: FORM_MODE;
@@ -31,7 +32,7 @@ export default function MySQLProperties(props: Props) {
         rules={[
           {
             required: true,
-            message: ERROR_TEXTS.CONNECTION.HOST.REQUIRED,
+            validator: hostValidator,
           },
         ]}
       >

--- a/wren-ui/src/components/pages/setup/dataSources/PostgreSQLProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/PostgreSQLProperties.tsx
@@ -1,6 +1,7 @@
 import { Form, Input, Switch } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
+import { hostValidator } from '@/utils/validator';
 
 interface Props {
   mode?: FORM_MODE;
@@ -31,7 +32,7 @@ export default function PostgreSQLProperties(props: Props) {
         rules={[
           {
             required: true,
-            message: ERROR_TEXTS.CONNECTION.HOST.REQUIRED,
+            validator: hostValidator,
           },
         ]}
       >

--- a/wren-ui/src/components/pages/setup/dataSources/SQLServerProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/SQLServerProperties.tsx
@@ -1,6 +1,7 @@
 import { Form, Input, Switch } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
+import { hostValidator } from '@/utils/validator';
 
 interface Props {
   mode?: FORM_MODE;
@@ -31,7 +32,7 @@ export default function SQLServerProperties(props: Props) {
         rules={[
           {
             required: true,
-            message: ERROR_TEXTS.CONNECTION.HOST.REQUIRED,
+            validator: hostValidator,
           },
         ]}
       >

--- a/wren-ui/src/components/pages/setup/dataSources/TrinoProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/TrinoProperties.tsx
@@ -1,6 +1,7 @@
 import { Form, Input, Switch } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
+import { hostValidator } from '@/utils/validator';
 
 interface Props {
   mode?: FORM_MODE;
@@ -30,7 +31,7 @@ export default function TrinoProperties({ mode }: Props) {
         rules={[
           {
             required: true,
-            message: ERROR_TEXTS.CONNECTION.HOST.REQUIRED,
+            validator: hostValidator,
           },
         ]}
       >

--- a/wren-ui/src/utils/error/dictionary.ts
+++ b/wren-ui/src/utils/error/dictionary.ts
@@ -25,6 +25,8 @@ export const ERROR_TEXTS = {
     },
     HOST: {
       REQUIRED: 'Please input host.',
+      INVALID:
+        "Invalid host. Use 'host.docker.internal' on macOS/Windows to connect to the local database.",
     },
     PORT: {
       REQUIRED: 'Please input port.',

--- a/wren-ui/src/utils/validator/hostValidator.ts
+++ b/wren-ui/src/utils/validator/hostValidator.ts
@@ -1,0 +1,13 @@
+import { ERROR_TEXTS } from '@/utils/error';
+
+export const hostValidator = (_, value) => {
+  if (!value) {
+    return Promise.reject(ERROR_TEXTS.CONNECTION.HOST.REQUIRED);
+  }
+
+  if (['localhost', '127.0.0.1'].includes(value)) {
+    return Promise.reject(ERROR_TEXTS.CONNECTION.HOST.INVALID);
+  }
+
+  return Promise.resolve();
+};

--- a/wren-ui/src/utils/validator/index.ts
+++ b/wren-ui/src/utils/validator/index.ts
@@ -1,3 +1,4 @@
 export * from './calculatedFieldValidator';
 export * from './viewValidator';
 export * from './relationshipValidator';
+export * from './hostValidator';


### PR DESCRIPTION
## Description
This PR adds validation to the **Host** field in the database connection settings to guide users on correctly setting up a local database in a Docker environment.

## Task
 - Add frontend validation for the **Host** field.
   - Apply ClickHouse, MySQL, PostgreSQL, SQLServer, Trino

## Expected behavior
Show the error message - `Invalid host. Use 'host.docker.internal' on macOS/Windows to connect to the local database.` when a user fills **localhost** or **127.0.0.1** value as the host.

## UI screenshots
<img width="1440" alt="截圖 2024-10-30 下午9 06 20" src="https://github.com/user-attachments/assets/27f5d716-46b7-4dff-ac59-2f903f8dd43b">

<img width="1440" alt="截圖 2024-10-30 下午9 01 38" src="https://github.com/user-attachments/assets/c6fcf67d-8145-4b30-ac6e-78814e795a23">


<img width="1440" alt="截圖 2024-10-30 下午9 09 01" src="https://github.com/user-attachments/assets/42cc1bd4-dd7d-4a2a-9854-680293c31663">

<img width="1440" alt="截圖 2024-10-30 下午9 09 16" src="https://github.com/user-attachments/assets/d338c8d3-e69a-41d5-a495-896651527fab">
