### PR TITLE
feat(wren-ai-service): batch processing to produce the semantics description for a large MDL

### DIFF
--- a/wren-ai-service/src/pipelines/generation/semantics_description.py
+++ b/wren-ai-service/src/pipelines/generation/semantics_description.py
@@ -64,7 +64,7 @@ def normalize(generate: dict) -> dict:
             return text_dict
         except orjson.JSONDecodeError as e:
             logger.error(f"Error decoding JSON: {e}")
-            return {}  # Return an empty dictionary if JSON decoding fails
+            return {"models": []}  # Return an empty list if JSON decoding fails
 
     logger.debug(
         f"generate: {orjson.dumps(generate, option=orjson.OPT_INDENT_2).decode()}"

--- a/wren-ai-service/src/web/v1/routers/semantics_description.py
+++ b/wren-ai-service/src/web/v1/routers/semantics_description.py
@@ -41,28 +41,28 @@ Endpoints:
      {
        "id": "unique-uuid",                      # Unique identifier of the description
        "status": "generating" | "finished" | "failed",
-       "response": {                             # Present only if status is "finished"
-         "model1": {
+       "response": [                             # Present only if status is "finished" or "generating"
+         {
            "name": "model1",
            "columns": [
-              {
-                 "name": "col1",
-                 "description": "Unique identifier for each record in the example model."
-              }
+             {
+               "name": "col1", 
+               "description": "Unique identifier for each record in the example model."
+             }
            ],
            "description": "This model is used for analysis purposes, capturing key attributes of records."
          },
-         "model2": {
-           "name": "model2",
+         {
+           "name": "model2", 
            "columns": [
-              {
-                 "name": "col1",
-                 "description": "Unique identifier for each record in the example model."
-              }
+             {
+               "name": "col1",
+               "description": "Unique identifier for each record in the example model."
+             }
            ],
            "description": "This model is used for analysis purposes, capturing key attributes of records."
          }
-       },
+       ],
        "error": {                                # Present only if status is "failed"
          "code": "OTHERS",
          "message": "Error description"

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -56,7 +56,7 @@ class SemanticsDescription:
         logger.error(error_message)
 
     def _chunking(
-        self, mdl_dict: dict, request: Input, chunk_size: int = 10
+        self, mdl_dict: dict, request: Input, chunk_size: int = 1
     ) -> list[dict]:
         template = {
             "user_prompt": request.user_prompt,
@@ -75,7 +75,7 @@ class SemanticsDescription:
 
         current = self[request_id]
         current.response = current.response or {}
-        current.response.update(resp)
+        current.response.update(resp.get("normalize"))
 
     @observe(name="Generate Semantics Description")
     @trace_metadata

--- a/wren-ai-service/src/web/v1/services/semantics_description.py
+++ b/wren-ai-service/src/web/v1/services/semantics_description.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Dict, Literal, Optional
 
@@ -54,6 +55,28 @@ class SemanticsDescription:
         )
         logger.error(error_message)
 
+    def _chunking(
+        self, mdl_dict: dict, request: Input, chunk_size: int = 10
+    ) -> list[dict]:
+        template = {
+            "user_prompt": request.user_prompt,
+            "mdl": mdl_dict,
+        }
+        return [
+            {
+                **template,
+                "selected_models": request.selected_models[i : i + chunk_size],
+            }
+            for i in range(0, len(request.selected_models), chunk_size)
+        ]
+
+    async def _generate_task(self, request_id: str, chunk: dict):
+        resp = await self._pipelines["semantics_description"].run(**chunk)
+
+        current = self[request_id]
+        current.response = current.response or {}
+        current.response.update(resp)
+
     @observe(name="Generate Semantics Description")
     @trace_metadata
     async def generate(self, request: Input, **kwargs) -> Resource:
@@ -62,17 +85,12 @@ class SemanticsDescription:
         try:
             mdl_dict = orjson.loads(request.mdl)
 
-            input = {
-                "user_prompt": request.user_prompt,
-                "selected_models": request.selected_models,
-                "mdl": mdl_dict,
-            }
+            chunks = self._chunking(mdl_dict, request)
+            tasks = [self._generate_task(request.id, chunk) for chunk in chunks]
 
-            resp = await self._pipelines["semantics_description"].run(**input)
+            await asyncio.gather(*tasks)
 
-            self[request.id] = self.Resource(
-                id=request.id, status="finished", response=resp.get("normalize")
-            )
+            self[request.id].status = "finished"
         except orjson.JSONDecodeError as e:
             self._handle_exception(
                 request,

--- a/wren-ai-service/tests/pytest/services/test_semantics_description.py
+++ b/wren-ai-service/tests/pytest/services/test_semantics_description.py
@@ -146,7 +146,8 @@ async def test_batch_processing_with_multiple_models(
         {"normalize": {"model3": {"description": "Description 3"}}},
     ]
 
-    response = await service.generate(request)
+    await service.generate(request)
+    response = service[request.id]
 
     assert response.id == "test_id"
     assert response.status == "finished"
@@ -201,7 +202,8 @@ async def test_batch_processing_partial_failure(
         Exception("Failed processing model2"),
     ]
 
-    response = await service.generate(request)
+    await service.generate(request)
+    response = service[request.id]
 
     assert response.id == "test_id"
     assert response.status == "failed"
@@ -241,7 +243,8 @@ async def test_concurrent_updates_no_race_condition(
     ]
 
     # Generate response which will process chunks concurrently
-    response = await service.generate(request)
+    await service.generate(request)
+    response = service[request.id]
 
     assert response.status == "finished"
     assert response.response is not None


### PR DESCRIPTION
This PR introduces improvements to the Semantics Description pipeline by implementing chunked processing and updating error handling:

1. Chunked Processing:
   - Added `_chunking` method to process models in smaller batches
   - Implemented concurrent processing using `asyncio.gather`
   - Default chunk size of 1 model per request

2. Error Handling:
   - Modified normalize function to return `{"models": []}` instead of `{}` on JSON decode error
   - Enhanced error logging and handling

3. Documentation:
   - Updated API documentation to accurately reflect the response structure
   - Added detailed examples in the docstring

## Detailed Changes

### 1. Chunked Processing Implementation
```python:wren-ai-service/src/web/v1/services/semantics_description.py
def _chunking(self, mdl_dict: dict, request: Input, chunk_size: int = 1) -> list[dict]:
    template = {
        "user_prompt": request.user_prompt,
        "mdl": mdl_dict,
    }
    return [
        {
            **template,
            "selected_models": request.selected_models[i : i + chunk_size],
        }
        for i in range(0, len(request.selected_models), chunk_size)
    ]
```


### 2. Error Handling Update
```python:wren-ai-service/src/pipelines/generation/semantics_description.py
def normalize(generate: dict) -> dict:
    # ... existing code ...
    except orjson.JSONDecodeError as e:
        logger.error(f"Error decoding JSON: {e}")
        return {"models": []}  # Return empty list instead of empty dict
```


## Benefits

1. Improved Performance:
   - Parallel processing of model descriptions
   - Better resource utilization through chunking

2. Better Error Handling:
   - Consistent response structure even in error cases
   - More informative error messages

3. Enhanced Documentation:
   - Clearer API documentation
   - Better examples for API consumers

## Testing

```python


if __name__ == "__main__":
    import json
    import uuid

    from langfuse.decorators import langfuse_context
    from src.utils import load_env_vars

    from src.globals import create_service_container
    from src.providers import generate_components

    env = load_env_vars()
    with open("sample/pagila_postgres_mdl.json", "r") as file:
        mdl = json.load(file)
    models = [
        "public_actor",
        "public_actor_info",
        "public_address",
        "public_category",
        "public_city",
        "public_country",
        "public_customer",
        "public_customer_list",
        "public_film",
        "public_film_actor",
        "public_film_category",
        "public_film_list",
        "public_inventory",
        "public_language",
        "public_nicer_but_slower_film_list",
        "public_payment",
        "public_payment_p2022_01",
        "public_payment_p2022_02",
        "public_payment_p2022_03",
        "public_payment_p2022_04",
        "public_payment_p2022_05",
        "public_payment_p2022_06",
        "public_payment_p2022_07",
        "public_rental",
        "public_sales_by_film_category",
        "public_sales_by_store",
        "public_staff",
        "public_staff_list",
        "public_store",
    ]

    pipe_components = generate_components()
    container = create_service_container(pipe_components)
    service = container.semantics_description
    id = str(uuid.uuid4())
    service[id] = SemanticsDescription.Resource(id=id)

    input = SemanticsDescription.Input(
        id=id,
        selected_models=models,
        user_prompt="",
        mdl=json.dumps(mdl),
    )

    asyncio.run(service.generate(input))
    print(service[id])

    langfuse_context.flush()
```