### PR TITLE
fix(wren-ui): see an error when editing a relationship in the defined relationships step of onboarding

### DIFF
--- a/wren-ui/src/components/modals/RelationModal.tsx
+++ b/wren-ui/src/components/modals/RelationModal.tsx
@@ -37,6 +37,7 @@ type Props = ModalAction<RelationFieldValue, RelationFormValues> & {
   model: string;
   loading?: boolean;
   relations: SelectedRecommendRelations;
+  isRecommendMode?: boolean;
 };
 
 export default function RelationModal(props: Props) {
@@ -49,6 +50,7 @@ export default function RelationModal(props: Props) {
     relations,
     visible,
     formMode,
+    isRecommendMode,
   } = props;
   const [form] = Form.useForm();
 
@@ -113,7 +115,7 @@ export default function RelationModal(props: Props) {
           rules={[
             ({ getFieldValue }) => ({
               validator: createRelationshipFromFieldValidator(
-                isUpdateMode,
+                isUpdateMode || isRecommendMode,
                 relations,
                 getFieldValue,
               ),
@@ -136,7 +138,7 @@ export default function RelationModal(props: Props) {
           rules={[
             ({ getFieldValue }) => ({
               validator: createRelationshipToFieldValidator(
-                isUpdateMode,
+                isUpdateMode || isRecommendMode,
                 relations,
                 getFieldValue,
               ),

--- a/wren-ui/src/components/pages/setup/DefineRelations.tsx
+++ b/wren-ui/src/components/pages/setup/DefineRelations.tsx
@@ -361,6 +361,7 @@ export default function DefineRelations(props: Props) {
             : undefined
         }
         relations={relations}
+        isRecommendMode={Boolean(selectedRelation?.defaultValue)}
       />
     </div>
   );

--- a/wren-ui/src/components/pages/setup/DefineRelations.tsx
+++ b/wren-ui/src/components/pages/setup/DefineRelations.tsx
@@ -37,7 +37,7 @@ export interface SelectedRecommendRelations {
 interface Props {
   fetching: boolean;
   recommendRelations: SelectedRecommendRelations;
-  recommendNameMappping: Record<string, string>;
+  recommendNameMapping: Record<string, string>;
   onNext: (data: { relations: SelectedRecommendRelations }) => void;
   onBack: () => void;
   onSkip: () => void;
@@ -53,7 +53,7 @@ interface EditableRelationTableProps {
   }) => void;
   onDeleteRow: (modelName: string, selectedRelation: RelationsDataType) => void;
   relations: RelationsDataType[];
-  recommendNameMappping: Record<string, string>;
+  recommendNameMapping: Record<string, string>;
 }
 
 function EditableRelationTable(props: EditableRelationTableProps) {
@@ -63,7 +63,7 @@ function EditableRelationTable(props: EditableRelationTableProps) {
     onSetRelation,
     onDeleteRow,
     relations,
-    recommendNameMappping,
+    recommendNameMapping,
   } = props;
 
   const columns: ColumnsType<RelationsDataType> = [
@@ -130,12 +130,12 @@ function EditableRelationTable(props: EditableRelationTableProps) {
       <ModelRelationSelectionTable
         columns={columns}
         dataSource={relations}
-        tableTitle={recommendNameMappping[modelName]}
+        tableTitle={recommendNameMapping[modelName]}
         extra={(onCollapseOpen) => (
           <Button
             onClick={(event) => {
               onSetRelation({ modelName });
-              onCollapseOpen(event, recommendNameMappping[modelName]);
+              onCollapseOpen(event, recommendNameMapping[modelName]);
             }}
             size="small"
             title="Add relationship"
@@ -156,7 +156,7 @@ export default function DefineRelations(props: Props) {
   const {
     fetching,
     recommendRelations,
-    recommendNameMappping,
+    recommendNameMapping,
     onBack,
     onNext,
     onSkip,
@@ -298,7 +298,7 @@ export default function DefineRelations(props: Props) {
               relations={relations}
               onSetRelation={onSetRelation}
               onDeleteRow={onDeleteRow}
-              recommendNameMappping={recommendNameMappping}
+              recommendNameMapping={recommendNameMapping}
             />
           ),
         )}

--- a/wren-ui/src/hooks/useSetupRelations.tsx
+++ b/wren-ui/src/hooks/useSetupRelations.tsx
@@ -91,12 +91,12 @@ export default function useSetupRelations() {
           });
 
           acc['recommendRelations'][referenceName] = newRelations;
-          acc['recommendNameMappping'][referenceName] = displayName;
+          acc['recommendNameMapping'][referenceName] = displayName;
           return acc;
         },
         {
           recommendRelations: {},
-          recommendNameMappping: {},
+          recommendNameMapping: {},
         },
       ),
     [autoGenerateRelation],


### PR DESCRIPTION
## Describe the bug
The user can see the **`This relationship already exists.`** error when editing a relationship in the Define relationships step of onboarding.

### To Reproduce
Steps to reproduce the behavior:
1. Start onboarding flow
2. Use a database with primary and foreign keys (E.g., [Pagila database](https://neon.tech/docs/import/import-sample-data#pagila-database))
3. Complete the connection to the database, select all tables, and successfully enter the Define relationships step page.
4. After seeing the recommended relationships appear on the table, edit a relationship
5. See **`This relationship already exists.`** error


<img width="1440" alt="截圖 2024-10-31 上午12 03 31" src="https://github.com/user-attachments/assets/cef79105-e19e-4150-b0de-8a66a4833d4b">

## Expected behavior
Will not see the error message when editing a relationship in the Define relationships step of onboarding.

## UI Screenshots

### Will not see the error message when editing a relationship in the Define relationships step of onboarding.
![截圖 2024-11-06 下午1 23 19](https://github.com/user-attachments/assets/e3c4ced1-0bad-4621-8b3d-d10f02c5e268)


### Rule validator works well
![截圖 2024-11-06 下午1 22 44](https://github.com/user-attachments/assets/7aa6a653-b9d7-40f4-8e35-a3b1ad0880d5)

### Update relationship
![截圖 2024-11-06 下午1 23 45](https://github.com/user-attachments/assets/95385012-a3bf-4c39-a0a4-47903ff5e5f6)

![截圖 2024-11-06 下午1 23 41](https://github.com/user-attachments/assets/6f8fda52-0669-43a4-9190-cded2f4c6d53)
![截圖 2024-11-06 下午2 39 56](https://github.com/user-attachments/assets/ef054d47-d696-4219-839f-31d6a0e81cfd)


