### PR TITLE
fix(wren-ui): Separate view step sql & view full sql condition

### DIFF
--- a/wren-ui/src/components/pages/home/promptThread/CollapseContent.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/CollapseContent.tsx
@@ -58,6 +58,7 @@ export default function CollapseContent(props: Props) {
     onChangeNativeSQL,
     nativeSQLResult,
   } = props;
+  const isStepViewSQL = !isViewFullSQL && isViewSQL;
 
   const { hasNativeSQL, dataSourceType } = nativeSQLResult;
   const showNativeSQL = Boolean(attributes.isLastStep) && hasNativeSQL;
@@ -127,7 +128,7 @@ export default function CollapseContent(props: Props) {
           />
         </div>
       )}
-      {(isViewSQL || isPreviewData) && (
+      {(isStepViewSQL || isPreviewData) && (
         <div className="d-flex justify-space-between">
           <Button
             className="gray-6"


### PR DESCRIPTION
## Description
In PR #899, adding `isViewSQL` caused confusion within the `CollapseContent` template condition. This fix introduces `isViewStepSQL` to more clearly separate the conditions.