### PR TITLE
fix(wren-ui/e2e): Update E2E test for navigation change

### DIFF
--- a/wren-ui/e2e/commonTests/home.ts
+++ b/wren-ui/e2e/commonTests/home.ts
@@ -143,7 +143,7 @@ export const askSuggestionQuestionTest = async ({
 };
 
 export const followUpQuestionTest = async ({ page, baseURL, question }) => {
-  await page.goto('/');
+  await page.goto('/home');
   await expect(page).toHaveURL('/home', { timeout: 60000 });
 
   // click existing thread

--- a/wren-ui/e2e/commonTests/home.ts
+++ b/wren-ui/e2e/commonTests/home.ts
@@ -92,7 +92,7 @@ export const askSuggestionQuestionTest = async ({
   baseURL,
   suggestedQuestion,
 }) => {
-  await page.goto('/');
+  await page.goto('/home');
   await expect(page).toHaveURL('/home', { timeout: 60000 });
 
   await page.getByText(suggestedQuestion).click();

--- a/wren-ui/e2e/commonTests/onboarding.ts
+++ b/wren-ui/e2e/commonTests/onboarding.ts
@@ -14,5 +14,5 @@ export const saveRecommendedRelationships = async ({ page }) => {
   await page.goto('/setup/relationships');
 
   await page.getByRole('button', { name: 'Finish' }).click();
-  await expect(page).toHaveURL('/home', { timeout: 60000 });
+  await expect(page).toHaveURL('/modeling', { timeout: 60000 });
 };

--- a/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleECommerce.spec.ts
@@ -17,8 +17,11 @@ test.describe('Test E-commerce sample dataset', () => {
   test('Starting E-commerce dataset successfully', async ({ page }) => {
     await page.goto('/setup/connection');
     await page.getByRole('button', { name: 'E-commerce' }).click();
-    await expect(page).toHaveURL('/home', { timeout: 60000 });
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+  });
 
+  test('Check suggested questions', async ({ page }) => {
+    await page.goto('/home');
     for (const question of suggestedQuestions) {
       await expect(page.getByText(question)).toBeVisible();
     }

--- a/wren-ui/e2e/specs/connectSampleHR.spec.ts
+++ b/wren-ui/e2e/specs/connectSampleHR.spec.ts
@@ -11,16 +11,21 @@ test.describe('Test HR sample dataset', () => {
     await helper.resetDatabase();
   });
 
-  test('Select HR dataset and check suggested questions', async ({ page }) => {
+  test('Starting HR dataset successfully', async ({ page }) => {
     await page.goto('/setup/connection');
     await page.getByRole('button', { name: 'Human Resource' }).click();
-    await expect(page).toHaveURL('/home', { timeout: 60000 });
+    await expect(page).toHaveURL('/modeling', { timeout: 60000 });
+  });
+
+  test('Check suggested questions', async ({ page }) => {
+    await page.goto('/home');
     for (const suggestedQuestion of suggestedQuestions) {
       await expect(page.getByText(suggestedQuestion.question)).toBeVisible();
     }
   });
 
-  test('Ask first suggested question', async ({ page, baseURL }) => {
+  test('Use suggestion question', async ({ page, baseURL }) => {
+    // select first suggested question
     await homeHelper.askSuggestionQuestionTest({
       page,
       baseURL,


### PR DESCRIPTION
### Description
This issue was identified as a navigation change introduced in PR #843, which redirects to the Modeling page after onboarding. Fix #922.

### Screenshots

- PostgreSQL
  <img width="564" alt="Screenshot 2024-11-19 at 7 29 39 AM" src="https://github.com/user-attachments/assets/df8166ec-618e-4aef-bac2-8a13d8c2af50">

- Trino
  <img width="564" alt="Screenshot 2024-11-19 at 7 44 38 AM" src="https://github.com/user-attachments/assets/5fefbc44-d3d0-44e8-a19c-f2b0619487a3">

