### PR TITLE
feat(wren-ui/e2e): Added E2E tests for Snowflake Data Source

### DIFF
--- a/wren-ui/e2e/config.ts
+++ b/wren-ui/e2e/config.ts
@@ -57,6 +57,13 @@ const defaultTestConfig = {
     database: 'clickhouse-database',
     ssl: false,
   },
+  snowflake: {
+    username: 'snowflake-username',
+    password: 'snowflake-password',
+    account: 'snowflake-account',
+    database: 'snowflake-database',
+    schema: 'snowflake-schema',
+  },
 };
 
 let userTestConfig = {};

--- a/wren-ui/e2e/specs/connectSnowflake.spec.ts
+++ b/wren-ui/e2e/specs/connectSnowflake.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { getTestConfig } from '../config';
+import * as helper from '../helper';
+import * as onboarding from '../commonTests/onboarding';
+
+const testConfig = getTestConfig();
+
+test.describe('Test Snowflake data source', () => {
+  test.beforeAll(async () => {
+    await helper.resetDatabase();
+  });
+
+  test('Connect Snowflake data source successfully', async ({ page }) => {
+    await page.goto('/setup/connection');
+
+    await page.locator('button').filter({ hasText: 'Snowflake' }).click();
+
+    await page.getByLabel('Display name').click();
+    await page.getByLabel('Display name').fill('test-snowflake');
+    await page.getByLabel('Username').click();
+    await page.getByLabel('Username').fill(testConfig.snowflake.username);
+    await page.getByLabel('Password').click();
+    await page.getByLabel('Password').fill(testConfig.snowflake.password);
+    await page.getByLabel('Account').click();
+    await page.getByLabel('Account').fill(testConfig.snowflake.account);
+    await page.getByLabel('Database name').click();
+    await page.getByLabel('Database name').fill(testConfig.snowflake.database);
+    await page.getByLabel('Schema').click();
+    await page.getByLabel('Schema').fill(testConfig.snowflake.schema);
+
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL('/setup/models', { timeout: 60000 });
+  });
+
+  test('Setup all models', onboarding.setupModels);
+
+  test(
+    'Save recommended relationships',
+    onboarding.saveRecommendedRelationships,
+  );
+});


### PR DESCRIPTION
### Description
This PR adds E2E tests for the Snowflake data source implemented in #911 and has been verified locally with the results as shown below. Your review would be greatly appreciated—thank you in advance @fredalai 😊.

### Screenshots
<img width="996" alt="Screenshot 2024-11-19 at 8 51 56 PM" src="https://github.com/user-attachments/assets/9fac3c19-6b14-42e4-a990-3d11f08c3a29">
