### PR TITLE
Ensure answers correctly indicate their associated view

### DIFF
--- a/wren-ui/src/components/pages/home/prompt/Result.tsx
+++ b/wren-ui/src/components/pages/home/prompt/Result.tsx
@@ -42,7 +42,7 @@ interface Props {
     recommendedQuestions: RecommendedQuestionsTask;
   };
   error?: any;
-  onSelectResult: (payload: { sql: string }) => void;
+  onSelectResult: (payload: { sql: string; viewId: number | null }) => void;
   onSelectQuestion: ({
     question,
     sql,
@@ -153,7 +153,8 @@ const Finished = (props: Props) => {
   useEffect(() => {
     if (candidates.length) {
       const [result] = candidates;
-      onSelectResult && onSelectResult({ sql: result.sql });
+      onSelectResult &&
+        onSelectResult({ sql: result.sql, viewId: result.view?.id });
     }
   }, [data]);
 


### PR DESCRIPTION
**This PR fixes #880**

This update ensures that the `viewId` is correctly returned to the user. Previously, only the `sql` was passed with `onSelectResult`. Now, we include the `viewId` with:  

```javascript
onSelectResult && onSelectResult({ sql: result.sql, viewId: result.view?.id });
```  

A video is included to demonstrate that the functionality now works as expected.  

https://github.com/user-attachments/assets/0723833c-37e7-40b3-8c41-5de141bf6c63

Special thanks to @cyyeh for collaborating on this fix and helping bring it to completion!