### PR TITLE
fix(wren-ui): Create thread from view summary value change to question

### DIFF
--- a/wren-ui/src/components/pages/home/prompt/index.tsx
+++ b/wren-ui/src/components/pages/home/prompt/index.tsx
@@ -143,7 +143,7 @@ export default forwardRef<Attributes, Props>(function Prompt(props, ref) {
 
     let data = null;
     if (isSavedViewCandidate) {
-      data = { viewId: payload.viewId };
+      data = { viewId: payload.viewId, question };
     } else if (question) {
       data = {
         sql: payload.sql,


### PR DESCRIPTION
## Description
This PR fixes the `summary` property to correctly use the input question when users create a thread from a view. It is related to #928, which addressed issues with creating threads from views.
