### PR TITLE
Update sf-hamilton dependency in pyproject.toml 

### DIFF
--- a/wren-ai-service/pyproject.toml
+++ b/wren-ai-service/pyproject.toml
@@ -20,7 +20,7 @@ tqdm = "==4.66.4"
 numpy = "==1.26.4"
 sqlparse = "==0.5.0"
 orjson = "==3.10.3"
-sf-hamilton = {version = "==1.69.0", extras = ["visualization"]}
+sf-hamilton = {version = "^1.83.2", extras = ["visualization"]}
 aiohttp = {extras = ["speedups"], version = "==3.10.2"}
 ollama-haystack = "==0.0.6"
 langfuse = "==2.43.3"


### PR DESCRIPTION
An exact version pin is problematic, since it means that you don't get updates and improvements. Hamilton follows semantic versioning, so a ^1.83.2 will mean that anything greater but less than 2.0.0 is good, and nothing backwards incompatible would be introduced with this way of specifying the dependency; we make sure that things don't break for existing users. Only with a major version bump would we introduce backwards incompatible changes.

This will help us on the Hamilton side too because we'll have most users on the latest version, rather than pinned at specific old points in time.