### PR TITLE
fix(wren-ai-service): put the lacking project id for previewing data in the question recommendation

### DIFF
--- a/wren-ai-service/src/web/v1/services/question_recommendation.py
+++ b/wren-ai-service/src/web/v1/services/question_recommendation.py
@@ -79,6 +79,7 @@ class QuestionRecommendation:
                 contexts=documents,
                 exclude=[],
                 configuration=Configuration(),
+                project_id=project_id,
             )
 
             post_process = generated_sql["post_process"]


### PR DESCRIPTION
This PR adds the `project_id` parameter to ensure proper project context is maintained during SQL generation.

## Why
- Ensures SQL generation is scoped to the correct project context
- Maintains data isolation between different projects