### PR TITLE
feat(wren-ai-service): prompt enhancement to focus on localization language

### DIFF
--- a/wren-ai-service/src/pipelines/generation/question_recommendation.py
+++ b/wren-ai-service/src/pipelines/generation/question_recommendation.py
@@ -150,9 +150,8 @@ Categories: {{categories}}
 {% endif %}
 
 Current Date: {{current_date}}
-Localization Language: {{language}}
 
-Please generate {{max_questions}} insightful questions for each of the {{max_categories}} categories based on the provided data model, using the localization language provided{% if user_question %} and the user's question{% endif %}.
+Please generate {{max_questions}} insightful questions for each of the {{max_categories}} categories based on the provided data model. Both the questions and category names should be translated into {{language}}{% if user_question %} and be related to the user's question{% endif %}. The output format should maintain the structure but with localized text.
 """
 
 


### PR DESCRIPTION
## Changes
- Enhanced question recommendation pipeline to fully localize both questions and category names

## Before & After Example
```json
// Before
{
  "question": "在 Wren AI Cloud 平台中，有多少用戶的電子郵件已經驗證？",
  "category": "user_profile"
}

// After
{
  "question": "在過去一年中，多少用戶的電子郵件已經驗證？",
  "category": "用戶資料"
}
```