### PR TITLE
feat(wren-ui): integrate API to support text-based answer

### DIFF
--- a/wren-ui/e2e/commonTests/home.ts
+++ b/wren-ui/e2e/commonTests/home.ts
@@ -79,7 +79,7 @@ export const waitingForThreadResponse = async (page: Page, baseURL: string) => {
         response.status() === 200 &&
         responseBody &&
         [AskingTaskStatus.FAILED, AskingTaskStatus.FINISHED].includes(
-          responseData?.status,
+          responseData?.breakdownDetail?.status,
         )
       );
     },

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -137,8 +137,8 @@ export enum DataSourceName {
   MSSQL = 'MSSQL',
   MYSQL = 'MYSQL',
   POSTGRES = 'POSTGRES',
-  TRINO = 'TRINO',
   SNOWFLAKE = 'SNOWFLAKE',
+  TRINO = 'TRINO'
 }
 
 export type DetailStep = {
@@ -445,6 +445,9 @@ export type Mutation = {
   deploy: Scalars['JSON'];
   generateProjectRecommendationQuestions: Scalars['Boolean'];
   generateThreadRecommendationQuestions: Scalars['Boolean'];
+  generateThreadResponseAnswer: ThreadResponse;
+  generateThreadResponseBreakdown: ThreadResponse;
+  previewBreakdownData: Scalars['JSON'];
   previewData: Scalars['JSON'];
   previewModelData: Scalars['JSON'];
   previewSql: Scalars['JSON'];
@@ -548,6 +551,23 @@ export type MutationDeployArgs = {
 
 export type MutationGenerateThreadRecommendationQuestionsArgs = {
   threadId: Scalars['Int'];
+};
+
+
+export type MutationGenerateThreadResponseAnswerArgs = {
+  responseId: Scalars['Int'];
+  threadId: Scalars['Int'];
+};
+
+
+export type MutationGenerateThreadResponseBreakdownArgs = {
+  responseId: Scalars['Int'];
+  threadId: Scalars['Int'];
+};
+
+
+export type MutationPreviewBreakdownDataArgs = {
+  where: PreviewDataInput;
 };
 
 
@@ -947,19 +967,41 @@ export type Thread = {
 
 export type ThreadResponse = {
   __typename?: 'ThreadResponse';
-  detail?: Maybe<ThreadResponseDetail>;
-  error?: Maybe<Error>;
+  answerDetail?: Maybe<ThreadResponseAnswerDetail>;
+  breakdownDetail?: Maybe<ThreadResponseBreakdownDetail>;
   id: Scalars['Int'];
   question: Scalars['String'];
-  status: AskingTaskStatus;
+  sql: Scalars['String'];
+  threadId: Scalars['Int'];
+  view?: Maybe<ViewInfo>;
 };
 
-export type ThreadResponseDetail = {
-  __typename?: 'ThreadResponseDetail';
+export type ThreadResponseAnswerDetail = {
+  __typename?: 'ThreadResponseAnswerDetail';
+  content?: Maybe<Scalars['String']>;
+  error?: Maybe<Error>;
+  numRowsUsedInLLM?: Maybe<Scalars['Int']>;
+  queryId?: Maybe<Scalars['String']>;
+  status?: Maybe<ThreadResponseAnswerStatus>;
+};
+
+export enum ThreadResponseAnswerStatus {
+  FAILED = 'FAILED',
+  FETCHING_DATA = 'FETCHING_DATA',
+  FINISHED = 'FINISHED',
+  INTERRUPTED = 'INTERRUPTED',
+  NOT_STARTED = 'NOT_STARTED',
+  PREPROCESSING = 'PREPROCESSING',
+  STREAMING = 'STREAMING'
+}
+
+export type ThreadResponseBreakdownDetail = {
+  __typename?: 'ThreadResponseBreakdownDetail';
   description?: Maybe<Scalars['String']>;
-  sql?: Maybe<Scalars['String']>;
-  steps: Array<DetailStep>;
-  view?: Maybe<ViewInfo>;
+  error?: Maybe<Error>;
+  queryId?: Maybe<Scalars['String']>;
+  status: AskingTaskStatus;
+  steps?: Maybe<Array<DetailStep>>;
 };
 
 export type ThreadUniqueWhereInput = {

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -556,13 +556,11 @@ export type MutationGenerateThreadRecommendationQuestionsArgs = {
 
 export type MutationGenerateThreadResponseAnswerArgs = {
   responseId: Scalars['Int'];
-  threadId: Scalars['Int'];
 };
 
 
 export type MutationGenerateThreadResponseBreakdownArgs = {
   responseId: Scalars['Int'];
-  threadId: Scalars['Int'];
 };
 
 

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -5,7 +5,11 @@ import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
 export type CommonErrorFragment = { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null };
 
-export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null };
+export type CommonBreakdownDetailFragment = { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null };
+
+export type CommonAnswerDetailFragment = { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null };
+
+export type CommonResponseFragment = { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null };
 
 export type CommonRecommendedQuestionsTaskFragment = { __typename?: 'RecommendedQuestionsTask', status: Types.RecommendedQuestionsTaskStatus, questions: Array<{ __typename?: 'ResultQuestion', question: string, category: string, sql: string }>, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null };
 
@@ -31,14 +35,14 @@ export type ThreadQueryVariables = Types.Exact<{
 }>;
 
 
-export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null }> } };
+export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null }> } };
 
 export type ThreadResponseQueryVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
 }>;
 
 
-export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null } };
+export type ThreadResponseQuery = { __typename?: 'Query', threadResponse: { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null } };
 
 export type CreateAskingTaskMutationVariables = Types.Exact<{
   data: Types.AskingTaskInput;
@@ -67,7 +71,7 @@ export type CreateThreadResponseMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, question: string, status: Types.AskingTaskStatus, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null, detail?: { __typename?: 'ThreadResponseDetail', sql?: string | null, description?: string | null, steps: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }>, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null } | null } };
+export type CreateThreadResponseMutation = { __typename?: 'Mutation', createThreadResponse: { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null } };
 
 export type UpdateThreadMutationVariables = Types.Exact<{
   where: Types.ThreadUniqueWhereInput;
@@ -84,12 +88,19 @@ export type DeleteThreadMutationVariables = Types.Exact<{
 
 export type DeleteThreadMutation = { __typename?: 'Mutation', deleteThread: boolean };
 
-export type PreviewDataMutationVariables = Types.Exact<{
+export type PreviewTextBasedAnswerDataMutationVariables = Types.Exact<{
   where: Types.PreviewDataInput;
 }>;
 
 
-export type PreviewDataMutation = { __typename?: 'Mutation', previewData: any };
+export type PreviewTextBasedAnswerDataMutation = { __typename?: 'Mutation', previewData: any };
+
+export type PreviewBreakdownDataMutationVariables = Types.Exact<{
+  where: Types.PreviewDataInput;
+}>;
+
+
+export type PreviewBreakdownDataMutation = { __typename?: 'Mutation', previewBreakdownData: any };
 
 export type GetNativeSqlQueryVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
@@ -136,28 +147,22 @@ export type GenerateThreadRecommendationQuestionsMutationVariables = Types.Exact
 
 export type GenerateThreadRecommendationQuestionsMutation = { __typename?: 'Mutation', generateThreadRecommendationQuestions: boolean };
 
-export const CommonResponseFragmentDoc = gql`
-    fragment CommonResponse on ThreadResponse {
-  id
-  question
-  status
-  detail {
-    sql
-    description
-    steps {
-      summary
-      sql
-      cteName
-    }
-    view {
-      id
-      name
-      statement
-      displayName
-    }
-  }
-}
-    `;
+export type GenerateThreadResponseBreakdownMutationVariables = Types.Exact<{
+  threadId: Types.Scalars['Int'];
+  responseId: Types.Scalars['Int'];
+}>;
+
+
+export type GenerateThreadResponseBreakdownMutation = { __typename?: 'Mutation', generateThreadResponseBreakdown: { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null } };
+
+export type GenerateThreadResponseAnswerMutationVariables = Types.Exact<{
+  threadId: Types.Scalars['Int'];
+  responseId: Types.Scalars['Int'];
+}>;
+
+
+export type GenerateThreadResponseAnswerMutation = { __typename?: 'Mutation', generateThreadResponseAnswer: { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null } };
+
 export const CommonErrorFragmentDoc = gql`
     fragment CommonError on Error {
   code
@@ -166,6 +171,53 @@ export const CommonErrorFragmentDoc = gql`
   stacktrace
 }
     `;
+export const CommonBreakdownDetailFragmentDoc = gql`
+    fragment CommonBreakdownDetail on ThreadResponseBreakdownDetail {
+  queryId
+  status
+  description
+  steps {
+    summary
+    sql
+    cteName
+  }
+  error {
+    ...CommonError
+  }
+}
+    ${CommonErrorFragmentDoc}`;
+export const CommonAnswerDetailFragmentDoc = gql`
+    fragment CommonAnswerDetail on ThreadResponseAnswerDetail {
+  queryId
+  status
+  content
+  numRowsUsedInLLM
+  error {
+    ...CommonError
+  }
+}
+    ${CommonErrorFragmentDoc}`;
+export const CommonResponseFragmentDoc = gql`
+    fragment CommonResponse on ThreadResponse {
+  id
+  threadId
+  question
+  sql
+  view {
+    id
+    name
+    statement
+    displayName
+  }
+  breakdownDetail {
+    ...CommonBreakdownDetail
+  }
+  answerDetail {
+    ...CommonAnswerDetail
+  }
+}
+    ${CommonBreakdownDetailFragmentDoc}
+${CommonAnswerDetailFragmentDoc}`;
 export const CommonRecommendedQuestionsTaskFragmentDoc = gql`
     fragment CommonRecommendedQuestionsTask on RecommendedQuestionsTask {
   status
@@ -307,14 +359,10 @@ export const ThreadDocument = gql`
     sql
     responses {
       ...CommonResponse
-      error {
-        ...CommonError
-      }
     }
   }
 }
-    ${CommonResponseFragmentDoc}
-${CommonErrorFragmentDoc}`;
+    ${CommonResponseFragmentDoc}`;
 
 /**
  * __useThreadQuery__
@@ -347,13 +395,9 @@ export const ThreadResponseDocument = gql`
     query ThreadResponse($responseId: Int!) {
   threadResponse(responseId: $responseId) {
     ...CommonResponse
-    error {
-      ...CommonError
-    }
   }
 }
-    ${CommonResponseFragmentDoc}
-${CommonErrorFragmentDoc}`;
+    ${CommonResponseFragmentDoc}`;
 
 /**
  * __useThreadResponseQuery__
@@ -484,12 +528,6 @@ export const CreateThreadResponseDocument = gql`
     mutation CreateThreadResponse($threadId: Int!, $data: CreateThreadResponseInput!) {
   createThreadResponse(threadId: $threadId, data: $data) {
     ...CommonResponse
-    error {
-      code
-      shortMessage
-      message
-      stacktrace
-    }
   }
 }
     ${CommonResponseFragmentDoc}`;
@@ -587,37 +625,68 @@ export function useDeleteThreadMutation(baseOptions?: Apollo.MutationHookOptions
 export type DeleteThreadMutationHookResult = ReturnType<typeof useDeleteThreadMutation>;
 export type DeleteThreadMutationResult = Apollo.MutationResult<DeleteThreadMutation>;
 export type DeleteThreadMutationOptions = Apollo.BaseMutationOptions<DeleteThreadMutation, DeleteThreadMutationVariables>;
-export const PreviewDataDocument = gql`
-    mutation PreviewData($where: PreviewDataInput!) {
+export const PreviewTextBasedAnswerDataDocument = gql`
+    mutation PreviewTextBasedAnswerData($where: PreviewDataInput!) {
   previewData(where: $where)
 }
     `;
-export type PreviewDataMutationFn = Apollo.MutationFunction<PreviewDataMutation, PreviewDataMutationVariables>;
+export type PreviewTextBasedAnswerDataMutationFn = Apollo.MutationFunction<PreviewTextBasedAnswerDataMutation, PreviewTextBasedAnswerDataMutationVariables>;
 
 /**
- * __usePreviewDataMutation__
+ * __usePreviewTextBasedAnswerDataMutation__
  *
- * To run a mutation, you first call `usePreviewDataMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `usePreviewDataMutation` returns a tuple that includes:
+ * To run a mutation, you first call `usePreviewTextBasedAnswerDataMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `usePreviewTextBasedAnswerDataMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [previewDataMutation, { data, loading, error }] = usePreviewDataMutation({
+ * const [previewTextBasedAnswerDataMutation, { data, loading, error }] = usePreviewTextBasedAnswerDataMutation({
  *   variables: {
  *      where: // value for 'where'
  *   },
  * });
  */
-export function usePreviewDataMutation(baseOptions?: Apollo.MutationHookOptions<PreviewDataMutation, PreviewDataMutationVariables>) {
+export function usePreviewTextBasedAnswerDataMutation(baseOptions?: Apollo.MutationHookOptions<PreviewTextBasedAnswerDataMutation, PreviewTextBasedAnswerDataMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<PreviewDataMutation, PreviewDataMutationVariables>(PreviewDataDocument, options);
+        return Apollo.useMutation<PreviewTextBasedAnswerDataMutation, PreviewTextBasedAnswerDataMutationVariables>(PreviewTextBasedAnswerDataDocument, options);
       }
-export type PreviewDataMutationHookResult = ReturnType<typeof usePreviewDataMutation>;
-export type PreviewDataMutationResult = Apollo.MutationResult<PreviewDataMutation>;
-export type PreviewDataMutationOptions = Apollo.BaseMutationOptions<PreviewDataMutation, PreviewDataMutationVariables>;
+export type PreviewTextBasedAnswerDataMutationHookResult = ReturnType<typeof usePreviewTextBasedAnswerDataMutation>;
+export type PreviewTextBasedAnswerDataMutationResult = Apollo.MutationResult<PreviewTextBasedAnswerDataMutation>;
+export type PreviewTextBasedAnswerDataMutationOptions = Apollo.BaseMutationOptions<PreviewTextBasedAnswerDataMutation, PreviewTextBasedAnswerDataMutationVariables>;
+export const PreviewBreakdownDataDocument = gql`
+    mutation PreviewBreakdownData($where: PreviewDataInput!) {
+  previewBreakdownData(where: $where)
+}
+    `;
+export type PreviewBreakdownDataMutationFn = Apollo.MutationFunction<PreviewBreakdownDataMutation, PreviewBreakdownDataMutationVariables>;
+
+/**
+ * __usePreviewBreakdownDataMutation__
+ *
+ * To run a mutation, you first call `usePreviewBreakdownDataMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `usePreviewBreakdownDataMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [previewBreakdownDataMutation, { data, loading, error }] = usePreviewBreakdownDataMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function usePreviewBreakdownDataMutation(baseOptions?: Apollo.MutationHookOptions<PreviewBreakdownDataMutation, PreviewBreakdownDataMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<PreviewBreakdownDataMutation, PreviewBreakdownDataMutationVariables>(PreviewBreakdownDataDocument, options);
+      }
+export type PreviewBreakdownDataMutationHookResult = ReturnType<typeof usePreviewBreakdownDataMutation>;
+export type PreviewBreakdownDataMutationResult = Apollo.MutationResult<PreviewBreakdownDataMutation>;
+export type PreviewBreakdownDataMutationOptions = Apollo.BaseMutationOptions<PreviewBreakdownDataMutation, PreviewBreakdownDataMutationVariables>;
 export const GetNativeSqlDocument = gql`
     query GetNativeSQL($responseId: Int!) {
   nativeSql(responseId: $responseId)
@@ -849,3 +918,71 @@ export function useGenerateThreadRecommendationQuestionsMutation(baseOptions?: A
 export type GenerateThreadRecommendationQuestionsMutationHookResult = ReturnType<typeof useGenerateThreadRecommendationQuestionsMutation>;
 export type GenerateThreadRecommendationQuestionsMutationResult = Apollo.MutationResult<GenerateThreadRecommendationQuestionsMutation>;
 export type GenerateThreadRecommendationQuestionsMutationOptions = Apollo.BaseMutationOptions<GenerateThreadRecommendationQuestionsMutation, GenerateThreadRecommendationQuestionsMutationVariables>;
+export const GenerateThreadResponseBreakdownDocument = gql`
+    mutation GenerateThreadResponseBreakdown($threadId: Int!, $responseId: Int!) {
+  generateThreadResponseBreakdown(threadId: $threadId, responseId: $responseId) {
+    ...CommonResponse
+  }
+}
+    ${CommonResponseFragmentDoc}`;
+export type GenerateThreadResponseBreakdownMutationFn = Apollo.MutationFunction<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>;
+
+/**
+ * __useGenerateThreadResponseBreakdownMutation__
+ *
+ * To run a mutation, you first call `useGenerateThreadResponseBreakdownMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGenerateThreadResponseBreakdownMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [generateThreadResponseBreakdownMutation, { data, loading, error }] = useGenerateThreadResponseBreakdownMutation({
+ *   variables: {
+ *      threadId: // value for 'threadId'
+ *      responseId: // value for 'responseId'
+ *   },
+ * });
+ */
+export function useGenerateThreadResponseBreakdownMutation(baseOptions?: Apollo.MutationHookOptions<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>(GenerateThreadResponseBreakdownDocument, options);
+      }
+export type GenerateThreadResponseBreakdownMutationHookResult = ReturnType<typeof useGenerateThreadResponseBreakdownMutation>;
+export type GenerateThreadResponseBreakdownMutationResult = Apollo.MutationResult<GenerateThreadResponseBreakdownMutation>;
+export type GenerateThreadResponseBreakdownMutationOptions = Apollo.BaseMutationOptions<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>;
+export const GenerateThreadResponseAnswerDocument = gql`
+    mutation GenerateThreadResponseAnswer($threadId: Int!, $responseId: Int!) {
+  generateThreadResponseAnswer(threadId: $threadId, responseId: $responseId) {
+    ...CommonResponse
+  }
+}
+    ${CommonResponseFragmentDoc}`;
+export type GenerateThreadResponseAnswerMutationFn = Apollo.MutationFunction<GenerateThreadResponseAnswerMutation, GenerateThreadResponseAnswerMutationVariables>;
+
+/**
+ * __useGenerateThreadResponseAnswerMutation__
+ *
+ * To run a mutation, you first call `useGenerateThreadResponseAnswerMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGenerateThreadResponseAnswerMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [generateThreadResponseAnswerMutation, { data, loading, error }] = useGenerateThreadResponseAnswerMutation({
+ *   variables: {
+ *      threadId: // value for 'threadId'
+ *      responseId: // value for 'responseId'
+ *   },
+ * });
+ */
+export function useGenerateThreadResponseAnswerMutation(baseOptions?: Apollo.MutationHookOptions<GenerateThreadResponseAnswerMutation, GenerateThreadResponseAnswerMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<GenerateThreadResponseAnswerMutation, GenerateThreadResponseAnswerMutationVariables>(GenerateThreadResponseAnswerDocument, options);
+      }
+export type GenerateThreadResponseAnswerMutationHookResult = ReturnType<typeof useGenerateThreadResponseAnswerMutation>;
+export type GenerateThreadResponseAnswerMutationResult = Apollo.MutationResult<GenerateThreadResponseAnswerMutation>;
+export type GenerateThreadResponseAnswerMutationOptions = Apollo.BaseMutationOptions<GenerateThreadResponseAnswerMutation, GenerateThreadResponseAnswerMutationVariables>;

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -148,7 +148,6 @@ export type GenerateThreadRecommendationQuestionsMutationVariables = Types.Exact
 export type GenerateThreadRecommendationQuestionsMutation = { __typename?: 'Mutation', generateThreadRecommendationQuestions: boolean };
 
 export type GenerateThreadResponseBreakdownMutationVariables = Types.Exact<{
-  threadId: Types.Scalars['Int'];
   responseId: Types.Scalars['Int'];
 }>;
 
@@ -156,7 +155,6 @@ export type GenerateThreadResponseBreakdownMutationVariables = Types.Exact<{
 export type GenerateThreadResponseBreakdownMutation = { __typename?: 'Mutation', generateThreadResponseBreakdown: { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null } };
 
 export type GenerateThreadResponseAnswerMutationVariables = Types.Exact<{
-  threadId: Types.Scalars['Int'];
   responseId: Types.Scalars['Int'];
 }>;
 
@@ -919,8 +917,8 @@ export type GenerateThreadRecommendationQuestionsMutationHookResult = ReturnType
 export type GenerateThreadRecommendationQuestionsMutationResult = Apollo.MutationResult<GenerateThreadRecommendationQuestionsMutation>;
 export type GenerateThreadRecommendationQuestionsMutationOptions = Apollo.BaseMutationOptions<GenerateThreadRecommendationQuestionsMutation, GenerateThreadRecommendationQuestionsMutationVariables>;
 export const GenerateThreadResponseBreakdownDocument = gql`
-    mutation GenerateThreadResponseBreakdown($threadId: Int!, $responseId: Int!) {
-  generateThreadResponseBreakdown(threadId: $threadId, responseId: $responseId) {
+    mutation GenerateThreadResponseBreakdown($responseId: Int!) {
+  generateThreadResponseBreakdown(responseId: $responseId) {
     ...CommonResponse
   }
 }
@@ -940,7 +938,6 @@ export type GenerateThreadResponseBreakdownMutationFn = Apollo.MutationFunction<
  * @example
  * const [generateThreadResponseBreakdownMutation, { data, loading, error }] = useGenerateThreadResponseBreakdownMutation({
  *   variables: {
- *      threadId: // value for 'threadId'
  *      responseId: // value for 'responseId'
  *   },
  * });
@@ -953,8 +950,8 @@ export type GenerateThreadResponseBreakdownMutationHookResult = ReturnType<typeo
 export type GenerateThreadResponseBreakdownMutationResult = Apollo.MutationResult<GenerateThreadResponseBreakdownMutation>;
 export type GenerateThreadResponseBreakdownMutationOptions = Apollo.BaseMutationOptions<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>;
 export const GenerateThreadResponseAnswerDocument = gql`
-    mutation GenerateThreadResponseAnswer($threadId: Int!, $responseId: Int!) {
-  generateThreadResponseAnswer(threadId: $threadId, responseId: $responseId) {
+    mutation GenerateThreadResponseAnswer($responseId: Int!) {
+  generateThreadResponseAnswer(responseId: $responseId) {
     ...CommonResponse
   }
 }
@@ -974,7 +971,6 @@ export type GenerateThreadResponseAnswerMutationFn = Apollo.MutationFunction<Gen
  * @example
  * const [generateThreadResponseAnswerMutation, { data, loading, error }] = useGenerateThreadResponseAnswerMutation({
  *   variables: {
- *      threadId: // value for 'threadId'
  *      responseId: // value for 'responseId'
  *   },
  * });

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -9,27 +9,60 @@ const COMMON_ERROR = gql`
   }
 `;
 
+const COMMON_BREAKDOWN_DETAIL = gql`
+  fragment CommonBreakdownDetail on ThreadResponseBreakdownDetail {
+    queryId
+    status
+    description
+    steps {
+      summary
+      sql
+      cteName
+    }
+    error {
+      ...CommonError
+    }
+  }
+
+  ${COMMON_ERROR}
+`;
+
+const COMMON_ANSWER_DETAIL = gql`
+  fragment CommonAnswerDetail on ThreadResponseAnswerDetail {
+    queryId
+    status
+    content
+    numRowsUsedInLLM
+    error {
+      ...CommonError
+    }
+  }
+
+  ${COMMON_ERROR}
+`;
+
 const COMMON_RESPONSE = gql`
   fragment CommonResponse on ThreadResponse {
     id
+    threadId
     question
-    status
-    detail {
-      sql
-      description
-      steps {
-        summary
-        sql
-        cteName
-      }
-      view {
-        id
-        name
-        statement
-        displayName
-      }
+    sql
+    view {
+      id
+      name
+      statement
+      displayName
+    }
+    breakdownDetail {
+      ...CommonBreakdownDetail
+    }
+    answerDetail {
+      ...CommonAnswerDetail
     }
   }
+
+  ${COMMON_BREAKDOWN_DETAIL}
+  ${COMMON_ANSWER_DETAIL}
 `;
 
 const COMMON_RECOMMENDED_QUESTIONS_TASK = gql`
@@ -98,27 +131,19 @@ export const THREAD = gql`
       sql
       responses {
         ...CommonResponse
-        error {
-          ...CommonError
-        }
       }
     }
   }
   ${COMMON_RESPONSE}
-  ${COMMON_ERROR}
 `;
 
 export const THREAD_RESPONSE = gql`
   query ThreadResponse($responseId: Int!) {
     threadResponse(responseId: $responseId) {
       ...CommonResponse
-      error {
-        ...CommonError
-      }
     }
   }
   ${COMMON_RESPONSE}
-  ${COMMON_ERROR}
 `;
 
 export const CREATE_ASKING_TASK = gql`
@@ -151,16 +176,9 @@ export const CREATE_THREAD_RESPONSE = gql`
   ) {
     createThreadResponse(threadId: $threadId, data: $data) {
       ...CommonResponse
-      error {
-        code
-        shortMessage
-        message
-        stacktrace
-      }
     }
   }
   ${COMMON_RESPONSE}
-  ${COMMON_ERROR}
 `;
 
 export const UPDATE_THREAD = gql`
@@ -182,9 +200,15 @@ export const DELETE_THREAD = gql`
   }
 `;
 
-export const PREVIEW_DATA = gql`
-  mutation PreviewData($where: PreviewDataInput!) {
+export const PREVIEW_TEXT_BASED_ANSWER = gql`
+  mutation PreviewTextBasedAnswerData($where: PreviewDataInput!) {
     previewData(where: $where)
+  }
+`;
+
+export const PREVIEW_BREAKDOWN_DATA = gql`
+  mutation PreviewBreakdownData($where: PreviewDataInput!) {
+    previewBreakdownData(where: $where)
   }
 `;
 
@@ -243,4 +267,27 @@ export const GENERATE_THREAD_RECOMMENDATION_QUESTIONS = gql`
   mutation GenerateThreadRecommendationQuestions($threadId: Int!) {
     generateThreadRecommendationQuestions(threadId: $threadId)
   }
+`;
+
+export const GENERATE_THREAD_RESPONSE_BREAKDOWN = gql`
+  mutation GenerateThreadResponseBreakdown($threadId: Int!, $responseId: Int!) {
+    generateThreadResponseBreakdown(
+      threadId: $threadId
+      responseId: $responseId
+    ) {
+      ...CommonResponse
+    }
+  }
+
+  ${COMMON_RESPONSE}
+`;
+
+export const GENERATE_THREAD_RESPONSE_ANSWER = gql`
+  mutation GenerateThreadResponseAnswer($threadId: Int!, $responseId: Int!) {
+    generateThreadResponseAnswer(threadId: $threadId, responseId: $responseId) {
+      ...CommonResponse
+    }
+  }
+
+  ${COMMON_RESPONSE}
 `;

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -270,11 +270,8 @@ export const GENERATE_THREAD_RECOMMENDATION_QUESTIONS = gql`
 `;
 
 export const GENERATE_THREAD_RESPONSE_BREAKDOWN = gql`
-  mutation GenerateThreadResponseBreakdown($threadId: Int!, $responseId: Int!) {
-    generateThreadResponseBreakdown(
-      threadId: $threadId
-      responseId: $responseId
-    ) {
+  mutation GenerateThreadResponseBreakdown($responseId: Int!) {
+    generateThreadResponseBreakdown(responseId: $responseId) {
       ...CommonResponse
     }
   }
@@ -283,8 +280,8 @@ export const GENERATE_THREAD_RESPONSE_BREAKDOWN = gql`
 `;
 
 export const GENERATE_THREAD_RESPONSE_ANSWER = gql`
-  mutation GenerateThreadResponseAnswer($threadId: Int!, $responseId: Int!) {
-    generateThreadResponseAnswer(threadId: $threadId, responseId: $responseId) {
+  mutation GenerateThreadResponseAnswer($responseId: Int!) {
+    generateThreadResponseAnswer(responseId: $responseId) {
       ...CommonResponse
     }
   }

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -874,16 +874,10 @@ export const typeDefs = gql`
     previewBreakdownData(where: PreviewDataInput!): JSON!
 
     # Generate Thread Response Breakdown
-    generateThreadResponseBreakdown(
-      threadId: Int!
-      responseId: Int!
-    ): ThreadResponse!
+    generateThreadResponseBreakdown(responseId: Int!): ThreadResponse!
 
     # Generate Thread Response Answer
-    generateThreadResponseAnswer(
-      threadId: Int!
-      responseId: Int!
-    ): ThreadResponse!
+    generateThreadResponseAnswer(responseId: Int!): ThreadResponse!
 
     # Settings
     resetCurrentProject: Boolean!

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -109,9 +109,10 @@ export default function AnswerResult(props: Props) {
     recommendedQuestionsProps.show,
   );
 
-  const hasTextBasedAnswer = useMemo(() => {
-    // existing thread response's answerDetail is null
-    return isEmpty(breakdownDetail) || !isEmpty(answerDetail);
+  const isBreakdownOnly = useMemo(() => {
+    // we support rendering different types of answers now, so we need to check if it's old data.
+    // existing thread response's answerDetail is null.
+    return answerDetail === null && !isEmpty(breakdownDetail);
   }, [answerDetail, breakdownDetail]);
 
   const onTabClick = (activeKey: string) => {
@@ -127,7 +128,7 @@ export default function AnswerResult(props: Props) {
     <div style={resultStyle} className="adm-answer-result">
       <QuestionTitle className="mb-6" question={question} />
       <StyledTabs type="card" size="small" onTabClick={onTabClick}>
-        {hasTextBasedAnswer && (
+        {!isBreakdownOnly && (
           <Tabs.TabPane
             key={ANSWER_TAB_KEYS.ANSWER}
             tab={

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+import { isEmpty } from 'lodash';
 import clsx from 'clsx';
 import { Typography, Tabs } from 'antd';
 import styled from 'styled-components';
@@ -89,9 +91,8 @@ export default function AnswerResult(props: Props) {
     recommendedQuestionsProps,
   } = props;
 
-  const { question, error } = threadResponse;
-
-  const { view, sql } = threadResponse?.detail || {};
+  const { answerDetail, breakdownDetail, id, question, sql, view } =
+    threadResponse;
 
   const resultStyle = isLastThreadResponse
     ? { minHeight: 'calc(100vh - (194px))' }
@@ -102,8 +103,10 @@ export default function AnswerResult(props: Props) {
     recommendedQuestionsProps.show,
   );
 
-  // TODO: existing thread response doesn't have a text-based answer
-  const hasTextBasedAnswer = true;
+  const hasTextBasedAnswer = useMemo(() => {
+    // existing thread response's answerDetail is null
+    return isEmpty(breakdownDetail) || !isEmpty(answerDetail);
+  }, [answerDetail, breakdownDetail]);
 
   return (
     <div style={resultStyle} className="adm-answer-result">
@@ -143,17 +146,10 @@ export default function AnswerResult(props: Props) {
           />
         </Tabs.TabPane>
       </StyledTabs>
-      {!error && (
-        <ViewBlock
-          view={view}
-          onClick={() =>
-            onOpenSaveAsViewModal({
-              sql,
-              responseId: threadResponse.id,
-            })
-          }
-        />
-      )}
+      <ViewBlock
+        view={view}
+        onClick={() => onOpenSaveAsViewModal({ sql, responseId: id })}
+      />
       {renderRecommendedQuestions(
         isLastThreadResponse,
         recommendedQuestionProps,

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -1,18 +1,15 @@
 import clsx from 'clsx';
-import Link from 'next/link';
-import { Button, Skeleton, Typography, Alert } from 'antd';
+import { Skeleton, Typography, Alert } from 'antd';
 import styled from 'styled-components';
-import { Path } from '@/utils/enum';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import MessageOutlined from '@ant-design/icons/MessageOutlined';
-import SaveOutlined from '@ant-design/icons/SaveOutlined';
-import FileDoneOutlined from '@ant-design/icons/FileDoneOutlined';
 import StepContent from '@/components/pages/home/promptThread/StepContent';
 import { getIsFinished } from '@/hooks/useAskPrompt';
 import { RecommendedQuestionsProps } from '@/components/pages/home/promptThread';
 import RecommendedQuestions, {
   getRecommendedQuestionProps,
 } from '@/components/pages/home/RecommendedQuestions';
+import ViewBlock from '@/components/pages/home/promptThread/ViewBlock';
 import { ThreadResponse } from '@/apollo/client/graphql/__types__';
 
 const { Title, Text } = Typography;
@@ -93,8 +90,6 @@ export default function AnswerResult(props: Props) {
 
   const loading = !getIsFinished(status);
 
-  const isViewSaved = !!view;
-
   const resultStyle = isLastThreadResponse
     ? { minHeight: 'calc(100vh - (194px))' }
     : null;
@@ -144,35 +139,15 @@ export default function AnswerResult(props: Props) {
                 />
               ))}
             </StyledAnswer>
-            {isViewSaved ? (
-              <div className="mt-2 gray-6 text-medium">
-                <FileDoneOutlined className="mr-2" />
-                Generated from saved view{' '}
-                <Link
-                  className="gray-7"
-                  href={`${Path.Modeling}?viewId=${view.id}&openMetadata=true`}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  {view.displayName}
-                </Link>
-              </div>
-            ) : (
-              <Button
-                className="mt-2 gray-6"
-                type="text"
-                size="small"
-                icon={<SaveOutlined />}
-                onClick={() =>
-                  onOpenSaveAsViewModal({
-                    sql,
-                    responseId: threadResponse.id,
-                  })
-                }
-              >
-                Save as View
-              </Button>
-            )}
+            <ViewBlock
+              view={view}
+              onClick={() =>
+                onOpenSaveAsViewModal({
+                  sql,
+                  responseId: threadResponse.id,
+                })
+              }
+            />
             {renderRecommendedQuestions(
               isLastThreadResponse,
               recommendedQuestionProps,

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -102,21 +102,30 @@ export default function AnswerResult(props: Props) {
     recommendedQuestionsProps.show,
   );
 
+  // TODO: existing thread response doesn't have a text-based answer
+  const hasTextBasedAnswer = true;
+
   return (
     <div style={resultStyle} className="adm-answer-result">
       <QuestionTitle className="mb-6" question={question} />
       <StyledTabs type="card" size="small">
-        <Tabs.TabPane
-          key="answer"
-          tab={
-            <>
-              <CheckCircleFilled className="mr-2 green-6" />
-              <Text>Answer</Text>
-            </>
-          }
-        >
-          <TextBasedAnswer />
-        </Tabs.TabPane>
+        {hasTextBasedAnswer && (
+          <Tabs.TabPane
+            key="answer"
+            tab={
+              <>
+                <CheckCircleFilled className="mr-2 green-6" />
+                <Text>Answer</Text>
+              </>
+            }
+          >
+            <TextBasedAnswer
+              threadResponse={threadResponse}
+              isLastThreadResponse={isLastThreadResponse}
+              onInitPreviewDone={onInitPreviewDone}
+            />
+          </Tabs.TabPane>
+        )}
         <Tabs.TabPane
           key="view-sql"
           tab={

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -14,6 +14,7 @@ import ViewBlock from '@/components/pages/home/promptThread/ViewBlock';
 import BreakdownAnswer from '@/components/pages/home/promptThread/BreakdownAnswer';
 import TextBasedAnswer from '@/components/pages/home/promptThread/TextBasedAnswer';
 import { ThreadResponse } from '@/apollo/client/graphql/__types__';
+import { ANSWER_TAB_KEYS } from '@/utils/enum';
 
 const { Title, Text } = Typography;
 
@@ -50,6 +51,9 @@ export interface Props {
 
   // recommended questions
   recommendedQuestionsProps: RecommendedQuestionsProps;
+
+  onRegenerateTextBasedAnswer: (responseId: number) => void;
+  onGenerateBreakdownAnswer: (threadId: number, responseId: number) => void;
 }
 
 const QuestionTitle = (props) => {
@@ -89,9 +93,11 @@ export default function AnswerResult(props: Props) {
     onOpenSaveAsViewModal,
     onInitPreviewDone,
     recommendedQuestionsProps,
+    onGenerateBreakdownAnswer,
+    onRegenerateTextBasedAnswer,
   } = props;
 
-  const { answerDetail, breakdownDetail, id, question, sql, view } =
+  const { answerDetail, breakdownDetail, id, question, sql, threadId, view } =
     threadResponse;
 
   const resultStyle = isLastThreadResponse
@@ -108,13 +114,22 @@ export default function AnswerResult(props: Props) {
     return isEmpty(breakdownDetail) || !isEmpty(answerDetail);
   }, [answerDetail, breakdownDetail]);
 
+  const onTabClick = (activeKey: string) => {
+    if (
+      activeKey === ANSWER_TAB_KEYS.VIEW_SQL &&
+      !threadResponse.breakdownDetail
+    ) {
+      onGenerateBreakdownAnswer(threadId, id);
+    }
+  };
+
   return (
     <div style={resultStyle} className="adm-answer-result">
       <QuestionTitle className="mb-6" question={question} />
-      <StyledTabs type="card" size="small">
+      <StyledTabs type="card" size="small" onTabClick={onTabClick}>
         {hasTextBasedAnswer && (
           <Tabs.TabPane
-            key="answer"
+            key={ANSWER_TAB_KEYS.ANSWER}
             tab={
               <>
                 <CheckCircleFilled className="mr-2 green-6" />
@@ -126,11 +141,12 @@ export default function AnswerResult(props: Props) {
               threadResponse={threadResponse}
               isLastThreadResponse={isLastThreadResponse}
               onInitPreviewDone={onInitPreviewDone}
+              onRegenerateTextBasedAnswer={onRegenerateTextBasedAnswer}
             />
           </Tabs.TabPane>
         )}
         <Tabs.TabPane
-          key="view-sql"
+          key={ANSWER_TAB_KEYS.VIEW_SQL}
           tab={
             <>
               <CodeFilled className="mr-2 gray-7" />

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -97,7 +97,7 @@ export default function AnswerResult(props: Props) {
     onRegenerateTextBasedAnswer,
   } = props;
 
-  const { answerDetail, breakdownDetail, id, question, sql, threadId, view } =
+  const { answerDetail, breakdownDetail, id, question, sql, view } =
     threadResponse;
 
   const resultStyle = isLastThreadResponse

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -53,7 +53,7 @@ export interface Props {
   recommendedQuestionsProps: RecommendedQuestionsProps;
 
   onRegenerateTextBasedAnswer: (responseId: number) => void;
-  onGenerateBreakdownAnswer: (threadId: number, responseId: number) => void;
+  onGenerateBreakdownAnswer: (responseId: number) => void;
 }
 
 const QuestionTitle = (props) => {
@@ -120,7 +120,7 @@ export default function AnswerResult(props: Props) {
       activeKey === ANSWER_TAB_KEYS.VIEW_SQL &&
       !threadResponse.breakdownDetail
     ) {
-      onGenerateBreakdownAnswer(threadId, id);
+      onGenerateBreakdownAnswer(id);
     }
   };
 

--- a/wren-ui/src/components/pages/home/promptThread/BreakdownAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/BreakdownAnswer.tsx
@@ -1,0 +1,67 @@
+import clsx from 'clsx';
+import { Alert, Skeleton } from 'antd';
+import styled from 'styled-components';
+import { getIsFinished } from '@/hooks/useAskPrompt';
+import { Props as AnswerResultProps } from '@/components/pages/home/promptThread/AnswerResult';
+import StepContent from '@/components/pages/home/promptThread/StepContent';
+
+const StyledSkeleton = styled(Skeleton)`
+  padding: 16px;
+  .ant-skeleton-paragraph {
+    margin-bottom: 0;
+  }
+`;
+
+export default function BreakdownAnswer(
+  props: Pick<
+    AnswerResultProps,
+    'motion' | 'threadResponse' | 'isLastThreadResponse' | 'onInitPreviewDone'
+  >,
+) {
+  const { isLastThreadResponse, motion, onInitPreviewDone, threadResponse } =
+    props;
+
+  const { error, status } = threadResponse;
+  const { description, sql, steps } = threadResponse?.detail || {};
+  const loading = !getIsFinished(status);
+
+  if (error) {
+    return (
+      <Alert
+        className="m-4"
+        message={error.shortMessage}
+        description={error.message}
+        type="error"
+        showIcon
+      />
+    );
+  }
+
+  return (
+    <StyledSkeleton
+      active
+      loading={loading}
+      paragraph={{ rows: 4 }}
+      title={false}
+    >
+      <div className={clsx({ 'promptThread-answer': motion })}>
+        <div className="text-md gray-10 p-3 pr-10 pt-6">
+          <div className="pl-7 pb-5">{description}</div>
+          {(steps || []).map((step, index) => (
+            <StepContent
+              isLastStep={index === steps.length - 1}
+              key={`${step.summary}-${index}`}
+              sql={step.sql}
+              fullSql={sql}
+              stepIndex={index}
+              summary={step.summary}
+              threadResponseId={threadResponse.id}
+              onInitPreviewDone={onInitPreviewDone}
+              isLastThreadResponse={isLastThreadResponse}
+            />
+          ))}
+        </div>
+      </div>
+    </StyledSkeleton>
+  );
+}

--- a/wren-ui/src/components/pages/home/promptThread/BreakdownAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/BreakdownAnswer.tsx
@@ -21,8 +21,10 @@ export default function BreakdownAnswer(
   const { isLastThreadResponse, motion, onInitPreviewDone, threadResponse } =
     props;
 
-  const { error, status } = threadResponse;
-  const { description, sql, steps } = threadResponse?.detail || {};
+  const { id, sql } = threadResponse;
+  const { description, error, status, steps } =
+    threadResponse?.breakdownDetail || {};
+
   const loading = !getIsFinished(status);
 
   if (error) {
@@ -55,7 +57,7 @@ export default function BreakdownAnswer(
               fullSql={sql}
               stepIndex={index}
               summary={step.summary}
-              threadResponseId={threadResponse.id}
+              threadResponseId={id}
               onInitPreviewDone={onInitPreviewDone}
               isLastThreadResponse={isLastThreadResponse}
             />

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from 'antd';
+import styled from 'styled-components';
+
+const StyledSkeleton = styled(Skeleton)`
+  padding: 16px;
+  .ant-skeleton-paragraph {
+    margin-bottom: 0;
+  }
+`;
+
+export default function TextBasedAnswer() {
+  return (
+    <StyledSkeleton
+      active
+      loading={false}
+      paragraph={{ rows: 4 }}
+      title={false}
+    >
+      <div className="text-md gray-10 p-3 pr-10 pt-6">Coming soon</div>
+    </StyledSkeleton>
+  );
+}

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -25,7 +25,8 @@ export default function TextBasedAnswer(
   >,
 ) {
   const { isLastThreadResponse, onInitPreviewDone, threadResponse } = props;
-  const { error, id } = threadResponse;
+  const { id } = threadResponse;
+  const { error } = threadResponse?.answerDetail || {};
 
   const [_, answerStreamTaskResult] = useTextBasedAnswerStreamTask();
 
@@ -57,7 +58,6 @@ export default function TextBasedAnswer(
     }
   }, [isLastThreadResponse, rowsUsed]);
 
-  // TODO: handle error, check error source comes from where
   if (error) {
     return (
       <Alert

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -1,5 +1,15 @@
-import { Skeleton } from 'antd';
+import { useEffect } from 'react';
+import { Alert, Button, Empty, Skeleton, Typography } from 'antd';
 import styled from 'styled-components';
+import { BinocularsIcon } from '@/utils/icons';
+import { nextTick } from '@/utils/time';
+import useTextBasedAnswerStreamTask from '@/hooks/useTextBasedAnswerStreamTask';
+import { Props as AnswerResultProps } from '@/components/pages/home/promptThread/AnswerResult';
+import MarkdownBlock from '@/components/editor/MarkdownBlock';
+import PreviewData from '@/components/dataPreview/PreviewData';
+import { usePreviewDataMutation } from '@/apollo/client/graphql/home.generated';
+
+const { Text } = Typography;
 
 const StyledSkeleton = styled(Skeleton)`
   padding: 16px;
@@ -8,7 +18,58 @@ const StyledSkeleton = styled(Skeleton)`
   }
 `;
 
-export default function TextBasedAnswer() {
+export default function TextBasedAnswer(
+  props: Pick<
+    AnswerResultProps,
+    'threadResponse' | 'isLastThreadResponse' | 'onInitPreviewDone'
+  >,
+) {
+  const { isLastThreadResponse, onInitPreviewDone, threadResponse } = props;
+  const { error, id } = threadResponse;
+
+  const [_, answerStreamTaskResult] = useTextBasedAnswerStreamTask();
+
+  const answerStreamTask = answerStreamTaskResult.data;
+
+  // TODO: num_rows_used_in_llm is 0 then don't show preview data with button
+  const rowsUsed = 0;
+
+  const [previewData, previewDataResult] = usePreviewDataMutation({
+    onError: (error) => console.error(error),
+  });
+
+  const onPreviewData = async () => {
+    await previewData({
+      variables: { where: { responseId: id } },
+    });
+  };
+
+  const autoTriggerPreviewDataButton = async () => {
+    await nextTick();
+    await onPreviewData();
+    await nextTick();
+    onInitPreviewDone();
+  };
+
+  useEffect(() => {
+    if (isLastThreadResponse && rowsUsed > 0) {
+      autoTriggerPreviewDataButton();
+    }
+  }, [isLastThreadResponse, rowsUsed]);
+
+  // TODO: handle error, check error source comes from where
+  if (error) {
+    return (
+      <Alert
+        className="m-4"
+        message={error.shortMessage}
+        description={error.message}
+        type="error"
+        showIcon
+      />
+    );
+  }
+
   return (
     <StyledSkeleton
       active
@@ -16,7 +77,50 @@ export default function TextBasedAnswer() {
       paragraph={{ rows: 4 }}
       title={false}
     >
-      <div className="text-md gray-10 p-3 pr-10 pt-6">Coming soon</div>
+      <div className="text-md gray-10 p-4 pr-6">
+        <MarkdownBlock content={answerStreamTask} />
+        {rowsUsed > 0 && (
+          <div className="mt-6">
+            <Button
+              size="small"
+              icon={
+                <BinocularsIcon
+                  style={{
+                    paddingBottom: 2,
+                    marginRight: 8,
+                  }}
+                />
+              }
+              loading={previewDataResult.loading}
+              onClick={onPreviewData}
+              data-ph-capture="true"
+              data-ph-capture-attribute-name="cta_text-answer_preview_data"
+            >
+              View results
+            </Button>
+
+            <div className="mt-2 mb-3">
+              <Text type="secondary" className="text-sm">
+                Considering the limit of context window, we only use {rowsUsed}{' '}
+                rows of results to generate the answer.
+              </Text>
+              <PreviewData
+                error={previewDataResult.error}
+                loading={previewDataResult.loading}
+                previewData={previewDataResult?.data?.previewData}
+                locale={{
+                  emptyText: (
+                    <Empty
+                      image={Empty.PRESENTED_IMAGE_SIMPLE}
+                      description="Sorry, we couldn't find any records that match your search criteria."
+                    />
+                  ),
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </StyledSkeleton>
   );
 }

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -70,6 +70,12 @@ export default function TextBasedAnswer(
     }
   }, [status]);
 
+  useEffect(() => {
+    return () => {
+      answerStreamTaskResult.onReset();
+    };
+  }, []);
+
   const rowsUsed = useMemo(
     () =>
       status === ThreadResponseAnswerStatus.FINISHED ? numRowsUsedInLLM : 0,

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -161,17 +161,19 @@ export default function TextBasedAnswer(
               View results
             </Button>
 
-            <div className="mt-2 mb-3">
-              <Text type="secondary" className="text-sm">
-                Considering the limit of context window, we only use {rowsUsed}{' '}
-                rows of results to generate the answer.
-              </Text>
-              <PreviewData
-                error={previewDataResult.error}
-                loading={previewDataResult.loading}
-                previewData={previewDataResult?.data?.previewData}
-              />
-            </div>
+            {previewDataResult?.data?.previewData && (
+              <div className="mt-2 mb-3">
+                <Text type="secondary" className="text-sm">
+                  Considering the limit of context window, we only use{' '}
+                  {rowsUsed} rows of results to generate the answer.
+                </Text>
+                <PreviewData
+                  error={previewDataResult.error}
+                  loading={previewDataResult.loading}
+                  previewData={previewDataResult?.data?.previewData}
+                />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Skeleton, Typography } from 'antd';
 import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import styled from 'styled-components';
 import { BinocularsIcon } from '@/utils/icons';
 import { nextTick } from '@/utils/time';
@@ -56,19 +57,25 @@ export default function TextBasedAnswer(
     useTextBasedAnswerStreamTask();
 
   const answerStreamTask = answerStreamTaskResult.data;
+
+  const isStreaming = useMemo(
+    () => status === ThreadResponseAnswerStatus.STREAMING,
+    [status],
+  );
+
   useEffect(() => {
-    if (status === ThreadResponseAnswerStatus.STREAMING) {
+    if (isStreaming) {
       setTextAnswer(answerStreamTask);
     } else {
       setTextAnswer(content);
     }
-  }, [answerStreamTask, status, content]);
+  }, [answerStreamTask, isStreaming, content]);
 
   useEffect(() => {
-    if (status === ThreadResponseAnswerStatus.STREAMING) {
+    if (isStreaming) {
       fetchAnswerStreamingTask(id);
     }
-  }, [status]);
+  }, [isStreaming, id]);
 
   useEffect(() => {
     return () => {
@@ -136,6 +143,7 @@ export default function TextBasedAnswer(
     >
       <div className="text-md gray-10 p-4 pr-6">
         <MarkdownBlock content={textAnswer} />
+        {isStreaming && <LoadingOutlined className="geekblue-6" spin />}
         {status === ThreadResponseAnswerStatus.INTERRUPTED && (
           <div className="mt-2 text-right">
             <Button

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -96,13 +96,15 @@ export default function TextBasedAnswer(
   const autoTriggerPreviewDataButton = async () => {
     await nextTick();
     await onPreviewData();
-    await nextTick();
-    onInitPreviewDone();
   };
 
   useEffect(() => {
-    if (isLastThreadResponse && allowPreviewData) {
-      autoTriggerPreviewDataButton();
+    if (isLastThreadResponse) {
+      if (allowPreviewData) {
+        autoTriggerPreviewDataButton();
+      }
+
+      onInitPreviewDone();
     }
   }, [isLastThreadResponse, allowPreviewData]);
 

--- a/wren-ui/src/components/pages/home/promptThread/ViewBlock.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/ViewBlock.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { Button } from 'antd';
+import FileDoneOutlined from '@ant-design/icons/FileDoneOutlined';
+import SaveOutlined from '@ant-design/icons/SaveOutlined';
+import { Path } from '@/utils/enum';
+import { ViewInfo } from '@/apollo/client/graphql/__types__';
+
+interface Props {
+  view?: ViewInfo;
+  onClick: () => void;
+}
+
+export default function ViewBlock({ view, onClick }: Props) {
+  const isViewSaved = !!view;
+
+  if (isViewSaved) {
+    return (
+      <div className="mt-2 gray-6 text-medium">
+        <FileDoneOutlined className="mr-2" />
+        Generated from saved view{' '}
+        <Link
+          className="gray-7"
+          href={`${Path.Modeling}?viewId=${view.id}&openMetadata=true`}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {view.displayName}
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      className="mt-2 gray-6"
+      type="text"
+      size="small"
+      icon={<SaveOutlined />}
+      onClick={onClick}
+    >
+      Save as View
+    </Button>
+  );
+}

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -130,7 +130,7 @@ export default function PromptThread(props: Props) {
   useEffect(() => {
     motionResponsesRef.current = (data.thread?.responses || []).reduce(
       (result, item) => {
-        result[item.id] = !getIsFinished(item?.status);
+        result[item.id] = !getIsFinished(item?.breakdownDetail?.status);
         return result;
       },
       {},

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -4,7 +4,7 @@ import { Divider } from 'antd';
 import styled from 'styled-components';
 import AnswerResult from './AnswerResult';
 import { makeIterable, IterableComponent } from '@/utils/iteration';
-import { getIsFinished } from '@/hooks/useAskPrompt';
+import { getAnswerIsFinished } from '@/components/pages/home/promptThread/TextBasedAnswer';
 import {
   DetailedThread,
   RecommendedQuestionsTask,
@@ -141,13 +141,21 @@ export default function PromptThread(props: Props) {
   useEffect(() => {
     motionResponsesRef.current = (data.thread?.responses || []).reduce(
       (result, item) => {
-        result[item.id] = !getIsFinished(item?.breakdownDetail?.status);
+        result[item.id] = !getAnswerIsFinished(item?.answerDetail?.status);
         return result;
       },
       {},
     );
-    const lastResponseMotion = Object.values(motionResponsesRef.current).pop();
-    triggerScrollToBottom(lastResponseMotion ? 'smooth' : 'auto');
+
+    if (
+      data.thread?.responses?.length >
+      Object.keys(motionResponsesRef.current).length
+    ) {
+      const lastResponseMotion = Object.values(
+        motionResponsesRef.current,
+      ).pop();
+      triggerScrollToBottom(lastResponseMotion ? 'smooth' : 'auto');
+    }
   }, [data.thread?.responses]);
 
   const onInitPreviewDone = () => {

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -26,6 +26,8 @@ interface Props {
   };
   onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
   onSelect: ({ question, sql }: SelectQuestionProps) => void;
+  onRegenerateTextBasedAnswer: (responseId: number) => void;
+  onGenerateBreakdownAnswer: (threadId: number, responseId: number) => void;
 }
 
 const StyledPromptThread = styled.div`
@@ -53,12 +55,17 @@ const StyledPromptThread = styled.div`
 `;
 
 const AnswerResultTemplate: React.FC<
-  IterableComponent<ThreadResponse> & {
-    motion: boolean;
-    onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
-    onInitPreviewDone: () => void;
-    recommendedQuestionsProps: RecommendedQuestionsProps;
-  }
+  IterableComponent<ThreadResponse> &
+    Pick<
+      Props,
+      | 'onOpenSaveAsViewModal'
+      | 'onRegenerateTextBasedAnswer'
+      | 'onGenerateBreakdownAnswer'
+    > & {
+      motion: boolean;
+      onInitPreviewDone: () => void;
+      recommendedQuestionsProps: RecommendedQuestionsProps;
+    }
 > = ({
   data,
   index,
@@ -66,6 +73,8 @@ const AnswerResultTemplate: React.FC<
   recommendedQuestionsProps,
   onOpenSaveAsViewModal,
   onInitPreviewDone,
+  onGenerateBreakdownAnswer,
+  onRegenerateTextBasedAnswer,
   ...threadResponse
 }) => {
   const { id } = threadResponse;
@@ -82,6 +91,8 @@ const AnswerResultTemplate: React.FC<
         onInitPreviewDone={onInitPreviewDone}
         threadResponse={threadResponse}
         recommendedQuestionsProps={recommendedQuestionsProps}
+        onGenerateBreakdownAnswer={onGenerateBreakdownAnswer}
+        onRegenerateTextBasedAnswer={onRegenerateTextBasedAnswer}
       />
     </div>
   );
@@ -93,7 +104,7 @@ export default function PromptThread(props: Props) {
   const router = useRouter();
   const divRef = useRef<HTMLDivElement>(null);
   const motionResponsesRef = useRef<Record<number, boolean>>({});
-  const { data, onOpenSaveAsViewModal, onSelect } = props;
+  const { data, onSelect, ...restProps } = props;
 
   const responses = useMemo(
     () =>
@@ -146,8 +157,8 @@ export default function PromptThread(props: Props) {
   return (
     <StyledPromptThread className="mt-12" ref={divRef}>
       <AnswerResultIterator
+        {...restProps}
         data={responses}
-        onOpenSaveAsViewModal={onOpenSaveAsViewModal}
         onInitPreviewDone={onInitPreviewDone}
         recommendedQuestionsProps={{
           data: data.recommendedQuestions,

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -27,7 +27,7 @@ interface Props {
   onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
   onSelect: ({ question, sql }: SelectQuestionProps) => void;
   onRegenerateTextBasedAnswer: (responseId: number) => void;
-  onGenerateBreakdownAnswer: (threadId: number, responseId: number) => void;
+  onGenerateBreakdownAnswer: (responseId: number) => void;
 }
 
 const StyledPromptThread = styled.div`

--- a/wren-ui/src/hooks/useAnswerStepContent.tsx
+++ b/wren-ui/src/hooks/useAnswerStepContent.tsx
@@ -3,7 +3,7 @@ import copy from 'copy-to-clipboard';
 import { message } from 'antd';
 import { COLLAPSE_CONTENT_TYPE } from '@/utils/enum';
 import useNativeSQL from '@/hooks/useNativeSQL';
-import { usePreviewDataMutation } from '@/apollo/client/graphql/home.generated';
+import { usePreviewBreakdownDataMutation } from '@/apollo/client/graphql/home.generated';
 
 const getTextButton = (isActive: boolean) => ({
   type: 'text',
@@ -65,7 +65,7 @@ export default function useAnswerStepContent({
   const [collapseContentType, setCollapseContentType] =
     useState<COLLAPSE_CONTENT_TYPE>(COLLAPSE_CONTENT_TYPE.NONE);
 
-  const [previewData, previewDataResult] = usePreviewDataMutation({
+  const [previewData, previewDataResult] = usePreviewBreakdownDataMutation({
     onError: (error) => console.error(error),
   });
 
@@ -122,7 +122,7 @@ export default function useAnswerStepContent({
       previewDataResult: {
         error: previewDataResult.error,
         loading: previewDataLoading,
-        previewData: previewDataResult?.data?.previewData,
+        previewData: previewDataResult?.data?.previewBreakdownData,
       },
       nativeSQLResult,
       onCopyFullSQL,

--- a/wren-ui/src/hooks/useTextBasedAnswerStreamTask.tsx
+++ b/wren-ui/src/hooks/useTextBasedAnswerStreamTask.tsx
@@ -1,0 +1,61 @@
+import { useRef, useState } from 'react';
+
+type TextBasedAnswerStreamTaskReturn = [
+  (queryId: string) => void,
+  {
+    data: string;
+    loading: boolean;
+    onReset: () => void;
+  },
+];
+
+/**
+ * TODO:
+ * 1. call /sql-answers API with polling way to obtain the result and status, when the status is preprocessing,
+ *    trigger fetchAnswerStreamingTask function to get streaming data.
+ */
+export default function useTextBasedAnswerStreamTask() {
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [data, setData] = useState<string>('');
+
+  const onReset = () => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current?.close();
+      eventSourceRef.current = null;
+    }
+    setData('');
+  };
+
+  const fetchAnswerStreamingTask = (responseId: string) => {
+    setLoading(true);
+    onReset();
+
+    const eventSource = new EventSource(
+      `/api/ask_task/streaming_answer?responseId=${responseId}`,
+    );
+
+    eventSource.onmessage = (event) => {
+      const eventData = JSON.parse(event.data);
+      if (eventData.done) {
+        eventSource.close();
+        setLoading(false);
+      } else {
+        setData((state) => state + (eventData?.message || ''));
+      }
+    };
+
+    eventSource.onerror = (error) => {
+      console.error(error);
+      eventSource.close();
+      setLoading(false);
+    };
+
+    eventSourceRef.current = eventSource;
+  };
+
+  return [
+    fetchAnswerStreamingTask,
+    { data, loading, onReset },
+  ] as TextBasedAnswerStreamTaskReturn;
+}

--- a/wren-ui/src/hooks/useTextBasedAnswerStreamTask.tsx
+++ b/wren-ui/src/hooks/useTextBasedAnswerStreamTask.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 
 type TextBasedAnswerStreamTaskReturn = [
-  (queryId: string) => void,
+  (responseId: number) => void,
   {
     data: string;
     loading: boolean;
@@ -9,11 +9,6 @@ type TextBasedAnswerStreamTaskReturn = [
   },
 ];
 
-/**
- * TODO:
- * 1. call /sql-answers API with polling way to obtain the result and status, when the status is preprocessing,
- *    trigger fetchAnswerStreamingTask function to get streaming data.
- */
 export default function useTextBasedAnswerStreamTask() {
   const eventSourceRef = useRef<EventSource | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -27,7 +22,7 @@ export default function useTextBasedAnswerStreamTask() {
     setData('');
   };
 
-  const fetchAnswerStreamingTask = (responseId: string) => {
+  const fetchAnswerStreamingTask = (responseId: number) => {
     setLoading(true);
     onReset();
 

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -159,10 +159,10 @@ export default function HomeThread() {
       const response = await createThreadResponse({
         variables: { threadId: thread.id, data: payload },
       });
+      setShowRecommendedQuestions(false);
       await generateThreadRecommendationQuestions({
         variables: { threadId: thread.id },
       });
-      setShowRecommendedQuestions(false);
       await fetchThreadResponse({
         variables: { responseId: response.data.createThreadResponse.id },
       });

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -135,6 +135,11 @@ export default function HomeThread() {
     });
   };
 
+  const onRegenerateTextBasedAnswer = async (responseId: number) => {
+    await onGenerateThreadResponseAnswer(threadId, responseId);
+    fetchThreadResponse({ variables: { responseId } });
+  };
+
   const onGenerateThreadResponseBreakdown = async (
     threadId: number,
     responseId: number,
@@ -142,6 +147,7 @@ export default function HomeThread() {
     await generateThreadResponseBreakdown({
       variables: { threadId, responseId },
     });
+    fetchThreadResponse({ variables: { responseId } });
   };
 
   // stop all requests when change thread
@@ -238,6 +244,8 @@ export default function HomeThread() {
         data={result}
         onOpenSaveAsViewModal={saveAsViewModal.openModal}
         onSelect={onSelect}
+        onRegenerateTextBasedAnswer={onRegenerateTextBasedAnswer}
+        onGenerateBreakdownAnswer={onGenerateThreadResponseBreakdown}
       />
       <div className="py-12" />
       <Prompt ref={$prompt} {...askPrompt} onSelect={onSelect} />

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -93,7 +93,7 @@ export default function HomeThread() {
     [threadResponseResult.data],
   );
   const isFinished = useMemo(
-    () => getIsFinished(threadResponse?.status),
+    () => getIsFinished(threadResponse?.breakdownDetail?.status),
     [threadResponse],
   );
 
@@ -112,7 +112,7 @@ export default function HomeThread() {
 
   useEffect(() => {
     const unfinishedRespose = (thread?.responses || []).find(
-      (response) => !getIsFinished(response.status),
+      (response) => !getIsFinished(response.breakdownDetail?.status),
     );
 
     if (unfinishedRespose) {

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -126,26 +126,18 @@ export default function HomeThread() {
     [threadResponse],
   );
 
-  const onGenerateThreadResponseAnswer = async (
-    threadId: number,
-    responseId: number,
-  ) => {
-    await generateThreadResponseAnswer({
-      variables: { threadId, responseId },
-    });
+  const onGenerateThreadResponseAnswer = async (responseId: number) => {
+    await generateThreadResponseAnswer({ variables: { responseId } });
   };
 
   const onRegenerateTextBasedAnswer = async (responseId: number) => {
-    await onGenerateThreadResponseAnswer(threadId, responseId);
+    await onGenerateThreadResponseAnswer(responseId);
     fetchThreadResponse({ variables: { responseId } });
   };
 
-  const onGenerateThreadResponseBreakdown = async (
-    threadId: number,
-    responseId: number,
-  ) => {
+  const onGenerateThreadResponseBreakdown = async (responseId: number) => {
     await generateThreadResponseBreakdown({
-      variables: { threadId, responseId },
+      variables: { responseId },
     });
     fetchThreadResponse({ variables: { responseId } });
   };
@@ -170,10 +162,7 @@ export default function HomeThread() {
 
     if (unfinishedRespose) {
       if (unfinishedRespose.answerDetail?.status === null) {
-        onGenerateThreadResponseAnswer(
-          unfinishedRespose.threadId,
-          unfinishedRespose.id,
-        );
+        onGenerateThreadResponseAnswer(unfinishedRespose.id);
       }
 
       fetchThreadResponse({ variables: { responseId: unfinishedRespose.id } });
@@ -225,9 +214,7 @@ export default function HomeThread() {
 
       const responseId = response.data.createThreadResponse.id;
       await Promise.all([
-        generateThreadResponseAnswer({
-          variables: { threadId, responseId },
-        }),
+        generateThreadResponseAnswer({ variables: { responseId } }),
         generateThreadRecommendationQuestions({ variables: { threadId } }),
         fetchThreadResponse({ variables: { responseId } }),
       ]);

--- a/wren-ui/src/utils/enum/home.ts
+++ b/wren-ui/src/utils/enum/home.ts
@@ -14,3 +14,8 @@ export enum PROCESS_STATE {
   FAILED,
   NO_RESULT,
 }
+
+export enum ANSWER_TAB_KEYS {
+  ANSWER = 'answer',
+  VIEW_SQL = 'view-sql',
+}

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -110,6 +110,24 @@ class CreateThreadResponseErrorHandler extends ErrorHandler {
   }
 }
 
+class GenerateThreadResponseAnswerErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to generate thread response answer.';
+    }
+  }
+}
+
+class GenerateThreadResponseBreakdownErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to generate thread response breakdown SQL answer.';
+    }
+  }
+}
+
 class CreateViewErrorHandler extends ErrorHandler {
   public getErrorMessage(error: GraphQLError) {
     switch (error.extensions?.code) {
@@ -258,6 +276,16 @@ errorHandlers.set(
   'CreateThreadResponse',
   new CreateThreadResponseErrorHandler(),
 );
+
+errorHandlers.set(
+  'GenerateThreadResponseAnswer',
+  new GenerateThreadResponseAnswerErrorHandler(),
+);
+errorHandlers.set(
+  'GenerateThreadResponseBreakdown',
+  new GenerateThreadResponseBreakdownErrorHandler(),
+);
+
 errorHandlers.set('CreateView', new CreateViewErrorHandler());
 errorHandlers.set('UpdateDataSource', new UpdateDataSourceErrorHandler());
 errorHandlers.set('CreateModel', new CreateModelErrorHandler());


### PR DESCRIPTION
## Description
 - Support Text to Answer UI

### Backend PR: https://github.com/Canner/WrenAI/pull/986


### AI service image
```bash
WREN_AI_SERVICE_VERSION=text2answer-streaming-v3
```

### Tasks
- Answer Result UI
    - **Answer** tab
        - The tab will be hidden for existing thread responses.
        - Content
		    - status
		        - Start streaming data if threadResponse.answerDetail.status === `STREAMING` 
	        - Preview data
	            - Show a small string above the table
	                - `Considering the limit of context window, we only use {X} rows of results to generate the answer.`
	            - `numRowsUsedInLLM` **=== 0**
	                - Hide **View results** button and preview data table
	                - Do not call preview data API
	        - Handle error alert block
		    - Show regenerate answer button if the process is not completed (`INTERRUPTED` status)
		    - Show preview data when the last thread response (& `numRowsUsedInLLM` > 0)
    - **View SQL** tab
        - Move the original UI (breakdown answer) into it
     - Show the view block (Save as view/view info) and recommended questions block
- Text-based Answer
    - Trigger generateThreadResponseAnswer API when entering a new thread page
    - Trigger generateThreadResponseAnswer API when asking a follow-up question
- Breakdown Answer
  - Trigger generateThreadResponseBreakdown API when switching to the tab if there is no breakdown detail data

## UI & Video
### Existing thread response - Without **Answer** tab
![截圖 2024-12-12 下午3 47 01](https://github.com/user-attachments/assets/d2e3ee2b-2ee7-47d5-8a70-93e1f69c287a)


### New thread - With **Answer** tab and **View SQL** tab
![截圖 2024-12-12 下午1 18 15](https://github.com/user-attachments/assets/c7a82f94-e9fd-4392-994b-ac25635805ba)
![截圖 2024-12-12 下午3 53 48](https://github.com/user-attachments/assets/d124e89e-3d08-4f48-9d94-d808997fc5f9)
