### PR TITLE
feat(wren-ai-service): minimize the duration for empty document and async helper for model preprocessor

### DIFF
--- a/wren-ai-service/src/pipelines/common.py
+++ b/wren-ai-service/src/pipelines/common.py
@@ -494,7 +494,9 @@ def dry_run_pipeline(pipeline_cls: BasicPipeline, pipeline_name: str, **kwargs):
     from src.config import settings
     from src.core.pipeline import async_validate
     from src.providers import generate_components
-    from src.utils import init_langfuse
+    from src.utils import init_langfuse, setup_custom_logger
+
+    setup_custom_logger("wren-ai-service", level_str=settings.logging_level)
 
     pipe_components = generate_components(settings.components)
     pipeline = pipeline_cls(**pipe_components[pipeline_name])

--- a/wren-ai-service/src/pipelines/indexing/__init__.py
+++ b/wren-ai-service/src/pipelines/indexing/__init__.py
@@ -11,6 +11,7 @@ from haystack.document_stores.types import DocumentStore, DuplicatePolicy
 logger = logging.getLogger("wren-ai-service")
 
 
+@component
 class DocumentCleaner:
     """
     This component is used to clear all the documents in the specified document store(s).
@@ -20,6 +21,7 @@ class DocumentCleaner:
     def __init__(self, stores: List[DocumentStore]) -> None:
         self._stores = stores
 
+    @component.output_types()
     async def run(self, project_id: Optional[str] = None) -> None:
         async def _clear_documents(
             store: DocumentStore, project_id: Optional[str] = None

--- a/wren-ai-service/src/pipelines/indexing/__init__.py
+++ b/wren-ai-service/src/pipelines/indexing/__init__.py
@@ -11,7 +11,6 @@ from haystack.document_stores.types import DocumentStore, DuplicatePolicy
 logger = logging.getLogger("wren-ai-service")
 
 
-@component
 class DocumentCleaner:
     """
     This component is used to clear all the documents in the specified document store(s).
@@ -21,8 +20,7 @@ class DocumentCleaner:
     def __init__(self, stores: List[DocumentStore]) -> None:
         self._stores = stores
 
-    @component.output_types(mdl=str)
-    async def run(self, mdl: str, project_id: Optional[str] = None) -> str:
+    async def run(self, project_id: Optional[str] = None) -> None:
         async def _clear_documents(
             store: DocumentStore, project_id: Optional[str] = None
         ) -> None:
@@ -45,7 +43,6 @@ class DocumentCleaner:
         await asyncio.gather(
             *[_clear_documents(store, project_id) for store in self._stores]
         )
-        return {"mdl": mdl}
 
 
 @component

--- a/wren-ai-service/src/pipelines/indexing/db_schema.py
+++ b/wren-ai-service/src/pipelines/indexing/db_schema.py
@@ -398,9 +398,10 @@ class DBSchema(BasicPipeline):
 
     @observe(name="Clean Documents for DB Schema")
     async def clean(self, project_id: Optional[str] = None) -> None:
-        await self._pipe.execute(
-            ["clean_documents"],
-            inputs={"project_id": project_id, "mdl_str": "", **self._components},
+        await clean(
+            embedding={"documents": []},
+            cleaner=self._components["cleaner"],
+            project_id=project_id,
         )
 
 

--- a/wren-ai-service/src/pipelines/indexing/db_schema.py
+++ b/wren-ai-service/src/pipelines/indexing/db_schema.py
@@ -315,12 +315,11 @@ async def embedding(chunk: Dict[str, Any], embedder: Any) -> Dict[str, Any]:
 
 @observe(capture_input=False, capture_output=False)
 async def clean(
-    mdl_str: str,
-    cleaner: DocumentCleaner,
     embedding: Dict[str, Any],
+    cleaner: DocumentCleaner,
     project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    await cleaner.run(mdl=mdl_str, project_id=project_id)
+    await cleaner.run(project_id=project_id)
     return embedding
 
 

--- a/wren-ai-service/src/pipelines/indexing/historical_question.py
+++ b/wren-ai-service/src/pipelines/indexing/historical_question.py
@@ -95,19 +95,9 @@ class ViewChunker:
 
 ## Start of Pipeline
 @observe(capture_input=False, capture_output=False)
-async def clean_documents(
-    mdl_str: str, cleaner: DocumentCleaner, project_id: Optional[str] = None
-) -> Dict[str, Any]:
-    return await cleaner.run(mdl=mdl_str, project_id=project_id)
-
-
-@observe(capture_input=False, capture_output=False)
 @extract_fields(dict(mdl=Dict[str, Any]))
-def validate_mdl(
-    clean_documents: Dict[str, Any], validator: MDLValidator
-) -> Dict[str, Any]:
-    mdl = clean_documents.get("mdl")
-    res = validator.run(mdl=mdl)
+def validate_mdl(mdl_str: str, validator: MDLValidator) -> Dict[str, Any]:
+    res = validator.run(mdl=mdl_str)
     return dict(mdl=res["mdl"])
 
 
@@ -125,9 +115,20 @@ async def embedding(chunk: Dict[str, Any], embedder: Any) -> Dict[str, Any]:
     return await embedder.run(documents=chunk["documents"])
 
 
+@observe(capture_input=False, capture_output=False)
+async def clean(
+    mdl_str: str,
+    cleaner: DocumentCleaner,
+    embedding: Dict[str, Any],
+    project_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    await cleaner.run(mdl=mdl_str, project_id=project_id)
+    return embedding
+
+
 @observe(capture_input=False)
-async def write(embedding: Dict[str, Any], writer: DocumentWriter) -> None:
-    return await writer.run(documents=embedding["documents"])
+async def write(clean: Dict[str, Any], writer: DocumentWriter) -> None:
+    return await writer.run(documents=clean["documents"])
 
 
 ## End of Pipeline

--- a/wren-ai-service/src/pipelines/indexing/historical_question.py
+++ b/wren-ai-service/src/pipelines/indexing/historical_question.py
@@ -197,9 +197,10 @@ class HistoricalQuestion(BasicPipeline):
 
     @observe(name="Clean Documents for Historical Question")
     async def clean(self, project_id: Optional[str] = None) -> None:
-        await self._pipe.execute(
-            ["clean_documents"],
-            inputs={"project_id": project_id, "mdl_str": "", **self._components},
+        await clean(
+            embedding={"documents": []},
+            cleaner=self._components["cleaner"],
+            project_id=project_id,
         )
 
 

--- a/wren-ai-service/src/pipelines/indexing/historical_question.py
+++ b/wren-ai-service/src/pipelines/indexing/historical_question.py
@@ -117,12 +117,11 @@ async def embedding(chunk: Dict[str, Any], embedder: Any) -> Dict[str, Any]:
 
 @observe(capture_input=False, capture_output=False)
 async def clean(
-    mdl_str: str,
-    cleaner: DocumentCleaner,
     embedding: Dict[str, Any],
+    cleaner: DocumentCleaner,
     project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    await cleaner.run(mdl=mdl_str, project_id=project_id)
+    await cleaner.run(project_id=project_id)
     return embedding
 
 

--- a/wren-ai-service/src/pipelines/indexing/table_description.py
+++ b/wren-ai-service/src/pipelines/indexing/table_description.py
@@ -179,9 +179,10 @@ class TableDescription(BasicPipeline):
 
     @observe(name="Clean Documents for Table Description")
     async def clean(self, project_id: Optional[str] = None) -> None:
-        await self._pipe.execute(
-            ["clean_documents"],
-            inputs={"project_id": project_id, "mdl_str": "", **self._components},
+        await clean(
+            embedding={"documents": []},
+            cleaner=self._components["cleaner"],
+            project_id=project_id,
         )
 
 

--- a/wren-ai-service/src/pipelines/indexing/table_description.py
+++ b/wren-ai-service/src/pipelines/indexing/table_description.py
@@ -98,12 +98,11 @@ async def embedding(chunk: Dict[str, Any], embedder: Any) -> Dict[str, Any]:
 
 @observe(capture_input=False, capture_output=False)
 async def clean(
-    mdl_str: str,
-    cleaner: DocumentCleaner,
     embedding: Dict[str, Any],
+    cleaner: DocumentCleaner,
     project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    await cleaner.run(mdl=mdl_str, project_id=project_id)
+    await cleaner.run(project_id=project_id)
     return embedding
 
 

--- a/wren-ai-service/src/pipelines/indexing/table_description.py
+++ b/wren-ai-service/src/pipelines/indexing/table_description.py
@@ -76,19 +76,9 @@ class TableDescriptionChunker:
 
 ## Start of Pipeline
 @observe(capture_input=False, capture_output=False)
-async def clean_documents(
-    mdl_str: str, cleaner: DocumentCleaner, project_id: Optional[str] = None
-) -> Dict[str, Any]:
-    return await cleaner.run(mdl=mdl_str, project_id=project_id)
-
-
-@observe(capture_input=False, capture_output=False)
 @extract_fields(dict(mdl=Dict[str, Any]))
-def validate_mdl(
-    clean_documents: Dict[str, Any], validator: MDLValidator
-) -> Dict[str, Any]:
-    mdl = clean_documents.get("mdl")
-    res = validator.run(mdl=mdl)
+def validate_mdl(mdl_str: str, validator: MDLValidator) -> Dict[str, Any]:
+    res = validator.run(mdl=mdl_str)
     return dict(mdl=res["mdl"])
 
 
@@ -106,12 +96,20 @@ async def embedding(chunk: Dict[str, Any], embedder: Any) -> Dict[str, Any]:
     return await embedder.run(documents=chunk["documents"])
 
 
-@observe(capture_input=False)
-async def write(
+@observe(capture_input=False, capture_output=False)
+async def clean(
+    mdl_str: str,
+    cleaner: DocumentCleaner,
     embedding: Dict[str, Any],
-    writer: DocumentWriter,
-) -> None:
-    return await writer.run(documents=embedding["documents"])
+    project_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    await cleaner.run(mdl=mdl_str, project_id=project_id)
+    return embedding
+
+
+@observe(capture_input=False)
+async def write(clean: Dict[str, Any], writer: DocumentWriter) -> None:
+    return await writer.run(documents=clean["documents"])
 
 
 ## End of Pipeline

--- a/wren-ai-service/tests/pytest/pipelines/indexing/test_db_schema.py
+++ b/wren-ai-service/tests/pytest/pipelines/indexing/test_db_schema.py
@@ -8,15 +8,17 @@ from pytest_mock import MockFixture
 from src.pipelines.indexing.db_schema import DBSchema, DDLChunker
 
 
-def test_empty_mdl():
+@pytest.mark.asyncio
+async def test_empty_mdl():
     chunker = DDLChunker()
     mdl = {"models": [], "views": [], "relationships": [], "metrics": []}
 
-    document = chunker.run(mdl, column_batch_size=1)
+    document = await chunker.run(mdl, column_batch_size=1)
     assert document == {"documents": []}
 
 
-def test_single_model():
+@pytest.mark.asyncio
+async def test_single_model():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -33,7 +35,7 @@ def test_single_model():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -47,7 +49,8 @@ def test_single_model():
     )
 
 
-def test_multiple_models():
+@pytest.mark.asyncio
+async def test_multiple_models():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -71,7 +74,7 @@ def test_multiple_models():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_1: Document = actual["documents"][0]
@@ -95,7 +98,8 @@ def test_multiple_models():
     )
 
 
-def test_column_is_primary_key():
+@pytest.mark.asyncio
+async def test_column_is_primary_key():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -115,7 +119,7 @@ def test_column_is_primary_key():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -136,7 +140,8 @@ def test_column_is_primary_key():
     )
 
 
-def test_column_with_properties():
+@pytest.mark.asyncio
+async def test_column_with_properties():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -159,7 +164,7 @@ def test_column_with_properties():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -190,7 +195,8 @@ def test_column_with_properties():
     )
 
 
-def test_column_with_nested_columns():
+@pytest.mark.asyncio
+async def test_column_with_nested_columns():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -215,7 +221,7 @@ def test_column_with_nested_columns():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -236,7 +242,8 @@ def test_column_with_nested_columns():
     )
 
 
-def test_column_with_calculated_property():
+@pytest.mark.asyncio
+async def test_column_with_calculated_property():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -257,7 +264,7 @@ def test_column_with_calculated_property():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -278,7 +285,8 @@ def test_column_with_calculated_property():
     )
 
 
-def test_column_with_relationship():
+@pytest.mark.asyncio
+async def test_column_with_relationship():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -320,7 +328,7 @@ def test_column_with_relationship():
         "metrics": [],
     }
 
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 6
 
     document_0: Document = actual["documents"][0]
@@ -373,7 +381,8 @@ def test_column_with_relationship():
     )
 
 
-def test_column_batch_size():
+@pytest.mark.asyncio
+async def test_column_batch_size():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -390,7 +399,7 @@ def test_column_batch_size():
         "relationships": [],
         "metrics": [],
     }
-    actual = chunker.run(mdl, column_batch_size=2)
+    actual = await chunker.run(mdl, column_batch_size=2)
     assert len(actual["documents"]) == 3
 
     document_0: Document = actual["documents"][0]
@@ -435,7 +444,8 @@ def test_column_batch_size():
     )
 
 
-def test_view():
+@pytest.mark.asyncio
+async def test_view():
     chunker = DDLChunker()
     mdl = {
         "models": [],
@@ -443,7 +453,7 @@ def test_view():
         "relationships": [],
         "metrics": [],
     }
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document_0: Document = actual["documents"][0]
@@ -458,7 +468,8 @@ def test_view():
     )
 
 
-def test_view_with_properties():
+@pytest.mark.asyncio
+async def test_view_with_properties():
     chunker = DDLChunker()
     mdl = {
         "models": [],
@@ -472,7 +483,7 @@ def test_view_with_properties():
         "relationships": [],
         "metrics": [],
     }
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document_0: Document = actual["documents"][0]
@@ -487,7 +498,8 @@ def test_view_with_properties():
     )
 
 
-def test_metric():
+@pytest.mark.asyncio
+async def test_metric():
     chunker = DDLChunker()
     mdl = {
         "models": [],
@@ -506,7 +518,7 @@ def test_metric():
             }
         ],
     }
-    actual = chunker.run(mdl, column_batch_size=1)
+    actual = await chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document_0: Document = actual["documents"][0]

--- a/wren-ai-service/tests/pytest/pipelines/indexing/test_indexing.py
+++ b/wren-ai-service/tests/pytest/pipelines/indexing/test_indexing.py
@@ -31,14 +31,12 @@ async def test_document_cleaner():
     cleaner = DocumentCleaner(stores=[store1, store2])
 
     # Test without project_id
-    result = await cleaner.run(mdl="test")
-    assert result["mdl"] == "test"
+    await cleaner.run()
     assert store1.deleted
     assert store2.deleted
 
     # Test with project_id
-    result = await cleaner.run(mdl="test", project_id="123")
-    assert result["mdl"] == "test"
+    await cleaner.run(project_id="123")
     assert store1.deleted
     assert store2.deleted
 


### PR DESCRIPTION
## Changes
1. **Document Cleaning Logic Refactoring**
   - Moved document cleaning operation to after embedding generation to minimize the duration for empty document

2. **Async Implementation Updates**
   - Added async support to `DDLChunker` methods
   - Converted `_get_ddl_commands` and `_model_preprocessor` to async methods
   - Implemented `asyncio.gather()` for parallel processing of model preprocessing

3. **Pipeline Flow Optimization**
   - Updated pipeline steps order: validate → chunk → embed → clean → write
   - Consistent implementation across all indexing pipelines (db_schema, historical_question, table_description)

4. **Logging Improvements**
   - Added custom logger setup in `dry_run_pipeline`
