### PR TITLE
chore(wren-ui): change alpine to bookworm-slim

### DIFF
--- a/wren-ui/Dockerfile
+++ b/wren-ui/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:18-alpine AS base
+FROM node:18-bookworm-slim AS base
 
 # Install dependencies only when needed
 FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat python3 make g++ bash curl
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager


### PR DESCRIPTION
Context:
One community member reported that wren-ui docker image couldn't run in his environment(x86-64, Ubuntu, docker error code: 132). He solved the issue by changing the base image. Then we found that there are truly potential issues using alpine as base image. So, we change the base image from `alpine` to `bookworm-slim`. 

ref: https://snyk.io/blog/choosing-the-best-node-js-docker-image/

Result:
tested in local environment

original:
- image: ghcr.io/canner/wren-ui:0.18.0
- size: 184MB

new
- image: wrenai-wren-ui:latest
- size: 249MB