### PR TITLE
feat(wren-ui): Adjust x-axis label angle

### DIFF
--- a/wren-ui/src/components/chart/handler.ts
+++ b/wren-ui/src/components/chart/handler.ts
@@ -102,6 +102,7 @@ const config: Config = {
     labelColor: COLOR.GRAY_8,
     labelFont: ' Roboto, Arial, Noto Sans, sans-serif',
   },
+  axisX: { labelAngle: -45 },
   line: {
     color: DEFAULT_COLOR,
   },


### PR DESCRIPTION
## Description
add -45 angle to x-axis label

<img width="714" alt="image" src="https://github.com/user-attachments/assets/13adadcb-dc2b-42bb-ad3f-b701c7bc6aef" />
