### PR TITLE
chore(wren-ui): adjust text-based answer view results remark

### DIFF
--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -179,8 +179,8 @@ export default function TextBasedAnswer(
             {previewDataResult?.data?.previewData && (
               <div className="mt-2 mb-3">
                 <Text type="secondary" className="text-sm">
-                  Considering the limit of context window, we only use{' '}
-                  {rowsUsed} rows of results to generate the answer.
+                  Considering the limit of the context window, we retrieve up to
+                  500 rows of results to generate the answer.
                 </Text>
                 <PreviewData
                   error={previewDataResult.error}


### PR DESCRIPTION
## Description
adjust text `Considering the limit of the context window, we retrieve up to 500 rows of results to generate the answer.`

<img width="845" alt="image" src="https://github.com/user-attachments/assets/2b559972-b50e-4cef-8c52-628a1e0136fb" />
