### PR TITLE
chore(wren-ai-service): change docker compose yaml env var setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ yarn-error.log*
 
 ## local env files
 .env*.local
+.env*
 .env.ai
 
 ## vercel

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,19 +24,19 @@ Path structure as following:
 
 ## How to start with OpenAI
 
-1. copy `.env.example` to `.env.local` and modify the OpenAI API key.
+1. copy `.env.example` to `.env` and modify the OpenAI API key.
 2. copy `config.example.yaml` to `config.yaml` for AI service configuration.
-3. start all services: `docker-compose --env-file .env.local up -d`.
-4. stop all services: `docker-compose --env-file .env.local down`.
+3. start all services: `docker-compose --env-file .env up -d`.
+4. stop all services: `docker-compose --env-file .env down`.
 
 ### Optional
 
-- If your port 3000 is occupied, you can modify the `HOST_PORT` in `.env.local`.
+- If your port 3000 is occupied, you can modify the `HOST_PORT` in `.env`.
 
 ## How to start with custom LLM
 
 To start with a custom LLM, the process is similar to starting with OpenAI. The main difference is that you need to modify the `config.yaml` file
-that we created on the previous step. After modifying the file, you can restart the services by running `docker-compose --env-file .env.local up -d --force-recreate wren-ai-service`.
+that we created on the previous step. After modifying the file, you can restart the services by running `docker-compose --env-file .env up -d --force-recreate wren-ai-service`.
 
 For detailed information on how to modify the configuration for different LLM providers and models, please refer to the [AI Service Configuration](../wren-ai-service/docs/configuration.md).
 This guide provides comprehensive instructions on setting up various LLM providers, embedders, and other components of the AI service.

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -40,22 +40,12 @@ services:
     ports:
       - ${AI_SERVICE_FORWARD_PORT}:${WREN_AI_SERVICE_PORT}
     environment:
-      WREN_AI_SERVICE_PORT: ${WREN_AI_SERVICE_PORT}
-      WREN_UI_PORT: ${WREN_UI_PORT}
-      QDRANT_HOST: ${QDRANT_HOST}
-      WREN_UI_ENDPOINT: ${WREN_UI_ENDPOINT}
-      LLM_OPENAI_API_KEY: ${LLM_OPENAI_API_KEY}
-      EMBEDDER_OPENAI_API_KEY: ${EMBEDDER_OPENAI_API_KEY}
-      LLM_AZURE_OPENAI_API_KEY: ${LLM_AZURE_OPENAI_API_KEY}
-      EMBEDDER_AZURE_OPENAI_API_KEY: ${EMBEDDER_AZURE_OPENAI_API_KEY}
-      QDRANT_API_KEY: ${QDRANT_API_KEY}
-      SHOULD_FORCE_DEPLOY: ${SHOULD_FORCE_DEPLOY}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY}
       # sometimes the console won't show print messages,
       # using PYTHONUNBUFFERED: 1 can fix this
       PYTHONUNBUFFERED: 1
       CONFIG_PATH: /app/data/config.yaml
+    env_file:
+      - ${PROJECT_DIR}/.env
     volumes:
       - ${PROJECT_DIR}/config.yaml:/app/data/config.yaml
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -52,22 +52,12 @@ services:
     ports:
       - ${AI_SERVICE_FORWARD_PORT}:${WREN_AI_SERVICE_PORT}
     environment:
-      WREN_AI_SERVICE_PORT: ${WREN_AI_SERVICE_PORT}
-      WREN_UI_PORT: ${WREN_UI_PORT}
-      QDRANT_HOST: ${QDRANT_HOST}
-      WREN_UI_ENDPOINT: http://wren-ui:${WREN_UI_PORT}
-      LLM_OPENAI_API_KEY: ${LLM_OPENAI_API_KEY}
-      EMBEDDER_OPENAI_API_KEY: ${EMBEDDER_OPENAI_API_KEY}
-      LLM_AZURE_OPENAI_API_KEY: ${LLM_AZURE_OPENAI_API_KEY}
-      EMBEDDER_AZURE_OPENAI_API_KEY: ${EMBEDDER_AZURE_OPENAI_API_KEY}
-      QDRANT_API_KEY: ${QDRANT_API_KEY}
-      SHOULD_FORCE_DEPLOY: ${SHOULD_FORCE_DEPLOY}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY}
       # sometimes the console won't show print messages,
       # using PYTHONUNBUFFERED: 1 can fix this
       PYTHONUNBUFFERED: 1
       CONFIG_PATH: /app/data/config.yaml
+    env_file:
+      - ${PROJECT_DIR}/.env
     volumes:
       - ${PROJECT_DIR}/config.yaml:/app/data/config.yaml
     networks:


### PR DESCRIPTION
use `env_file` instead of letting users manually insert environment variables
help users add other custom env var such as other LLM api keys for litellm without manually changing docker compose yaml file