### PR TITLE
chore(wren-launcher): simplify launcher choosing custom

### DIFF
--- a/wren-launcher/go.mod
+++ b/wren-launcher/go.mod
@@ -138,7 +138,7 @@ require (
 	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/wren-launcher/go.sum
+++ b/wren-launcher/go.sum
@@ -630,8 +630,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
-golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
 golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=

--- a/wren-launcher/utils/docker.go
+++ b/wren-launcher/utils/docker.go
@@ -228,7 +228,7 @@ func mergeEnvContent(newEnvFile string, envFileContent string) (string, error) {
 	return envFileContent, nil
 }
 
-func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostPort int, aiPort int, projectDir string, telemetryEnabled bool) error {
+func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostPort int, aiPort int, projectDir string, telemetryEnabled bool, llmProvider string) error {
 	// download docker-compose file
 	composeFile := path.Join(projectDir, "docker-compose.yaml")
 	pterm.Info.Println("Downloading docker-compose file to", composeFile)
@@ -237,54 +237,66 @@ func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostP
 		return err
 	}
 
-	userUUID, err := prepareUserUUID(projectDir)
-	if err != nil {
-		return err
-	}
+	if strings.ToLower(llmProvider) == "openai" {
+		userUUID, err := prepareUserUUID(projectDir)
+		if err != nil {
+			return err
+		}
 
-	// download env file
-	envExampleFile := path.Join(projectDir, ".env.example")
-	pterm.Info.Println("Downloading env file to", envExampleFile)
-	err = downloadFile(envExampleFile, DOCKER_COMPOSE_ENV_URL)
-	if err != nil {
-		return err
-	}
+		// download env file
+		envExampleFile := path.Join(projectDir, ".env.example")
+		pterm.Info.Println("Downloading env file to", envExampleFile)
+		err = downloadFile(envExampleFile, DOCKER_COMPOSE_ENV_URL)
+		if err != nil {
+			return err
+		}
 
-	// read the file
-	envExampleFileContent, err := os.ReadFile(envExampleFile)
-	if err != nil {
-		return err
-	}
+		// read the file
+		envExampleFileContent, err := os.ReadFile(envExampleFile)
+		if err != nil {
+			return err
+		}
 
-	// replace the content with regex
-	envFileContent := replaceEnvFileContent(
-		string(envExampleFileContent),
-		projectDir,
-		openaiApiKey,
-		openaiGenerationModel,
-		hostPort,
-		aiPort,
-		userUUID,
-		telemetryEnabled,
-	)
-	newEnvFile := getEnvFilePath(projectDir)
+		// replace the content with regex
+		envFileContent := replaceEnvFileContent(
+			string(envExampleFileContent),
+			projectDir,
+			openaiApiKey,
+			openaiGenerationModel,
+			hostPort,
+			aiPort,
+			userUUID,
+			telemetryEnabled,
+		)
+		newEnvFile := getEnvFilePath(projectDir)
 
-	// merge the env file content with the existing env file
-	envFileContent, err = mergeEnvContent(newEnvFile, envFileContent)
-	if err != nil {
-		return err
-	}
+		// merge the env file content with the existing env file
+		envFileContent, err = mergeEnvContent(newEnvFile, envFileContent)
+		if err != nil {
+			return err
+		}
 
-	// write the file
-	err = os.WriteFile(newEnvFile, []byte(envFileContent), 0644)
-	if err != nil {
-		return err
-	}
+		// write the file
+		err = os.WriteFile(newEnvFile, []byte(envFileContent), 0644)
+		if err != nil {
+			return err
+		}
 
-	// remove the old env file
-	err = os.Remove(envExampleFile)
-	if err != nil {
-		return err
+		// remove the old env file
+		err = os.Remove(envExampleFile)
+		if err != nil {
+			return err
+		}
+	} else if strings.ToLower(llmProvider) == "custom" {
+		// if .env file does not exist, return error
+		if _, err := os.Stat(getEnvFilePath(projectDir)); os.IsNotExist(err) {
+			return fmt.Errorf(".env file does not exist, please download the env file from %s to ~/.wrenai, rename it to .env and fill in the required information", DOCKER_COMPOSE_ENV_URL)
+		}
+
+		// if config.yaml file does not exist, return error
+		if _, err := os.Stat(getConfigFilePath(projectDir)); os.IsNotExist(err) {
+			return fmt.Errorf("config.yaml file does not exist, please download the config.yaml file from %s to ~/.wrenai, rename it to config.yaml and fill in the required information", AI_SERVICE_CONFIG_URL)
+		}
 	}
 
 	return nil
@@ -292,6 +304,10 @@ func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostP
 
 func getEnvFilePath(projectDir string) string {
 	return path.Join(projectDir, ".env")
+}
+
+func getConfigFilePath(projectDir string) string {
+	return path.Join(projectDir, "config.yaml")
 }
 
 func RunDockerCompose(projectName string, projectDir string, llmProvider string) error {
@@ -341,6 +357,22 @@ func RunDockerCompose(projectName string, projectDir string, llmProvider string)
 		return err
 	}
 
+	if strings.ToLower(llmProvider) == "custom" {
+		// Create up options for force recreating only wren-ai-service
+		upOptions := api.UpOptions{
+			Create: api.CreateOptions{
+				Recreate: api.RecreateForce,
+				Services: []string{"wren-ai-service"},
+			},
+		}
+		
+		// Run the up command with specific options for wren-ai-service
+		err = apiService.Up(ctx, projectType, upOptions)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -384,8 +416,38 @@ func findWrenUIContainer() (types.Container, error) {
 	return types.Container{}, fmt.Errorf("WrenUI container not found")
 }
 
+func findAIServiceContainer() (types.Container, error) {
+	containers, err := listProcess()
+	if err != nil {
+		return types.Container{}, err
+	}
+
+	for _, container := range containers {
+		if container.Labels["com.docker.compose.project"] == "wrenai" && container.Labels["com.docker.compose.service"] == "wren-ai-service" {
+			return container, nil
+		}
+	}
+
+	return types.Container{}, fmt.Errorf("WrenAI service container not found")
+}
+
 func IfPortUsedByWrenUI(port int) bool {
 	container, err := findWrenUIContainer()
+	if err != nil {
+		return false
+	}
+
+	for _, containerPort := range container.Ports {
+		if containerPort.PublicPort == uint16(port) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IfPortUsedByAIService(port int) bool {
+	container, err := findAIServiceContainer()
 	if err != nil {
 		return false
 	}
@@ -413,9 +475,8 @@ func CheckUIServiceStarted(url string) error {
 	return nil
 }
 
-func CheckAIServiceStarted(port int) error {
+func CheckAIServiceStarted(url string) error {
 	// health check
-	url := fmt.Sprintf("http://localhost:%d/health", port)
 	resp, err := http.Get(url)
 	if err != nil {
 		return err

--- a/wren-launcher/utils/network.go
+++ b/wren-launcher/utils/network.go
@@ -23,7 +23,7 @@ func FindAvailablePort(defaultPort int) int {
 		if !ifPortUsed(port) {
 			// Return the port if it's not used
 			return port
-		} else if IfPortUsedByWrenUI(port) {
+		} else if IfPortUsedByWrenUI(port) || IfPortUsedByAIService(port) {
 			// Return the port if it's used, but used by wrenAI
 			return port
 		}


### PR DESCRIPTION
This PR simplifies how users use custom LLMs. Before, users need to manually type docker compose command to restart wren-ai-service. This PR makes the Wren AI launching process a lot easier:
1. fill in required information in .env and config.yaml
2. run launcher and choose Custom

This PR also fixes a Go security issue