### PR TITLE
chore(wren-ai-service): make openai llm version fixed

### DIFF
--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -23,7 +23,7 @@ data:
   POSTHOG_HOST: "https://app.posthog.com"
   TELEMETRY_ENABLED: "false"
   # this is for telemetry to know the model, i think ai-service might be able to provide a endpoint to get the information
-  GENERATION_MODEL: "gpt-4o-mini"
+  GENERATION_MODEL: "gpt-4o-mini-2024-07-18"
 
   # service endpoints of AI service & engine service
   WREN_ENGINE_ENDPOINT: "http://wren-engine-svc:8080"
@@ -53,7 +53,7 @@ data:
     provider: litellm_llm
     timeout: 120
     models:
-    - model: gpt-4o-mini
+    - model: gpt-4o-mini-2024-07-18
       api_base: https://api.openai.com/v1
       api_key_name: LLM_OPENAI_API_KEY
       kwargs:
@@ -106,58 +106,58 @@ data:
         embedder: openai_embedder.text-embedding-3-large
         document_store: qdrant
       - name: db_schema_retrieval
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         embedder: openai_embedder.text-embedding-3-large
         document_store: qdrant
       - name: historical_question_retrieval
         embedder: openai_embedder.text-embedding-3-large
         document_store: qdrant
       - name: sql_generation
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: sql_correction
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: followup_sql_generation
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: sql_summary
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: sql_answer
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: preprocess_sql_data
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: sql_breakdown
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: sql_expansion
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: sql_explanation
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: sql_regeneration
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: semantics_description
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: relationship_recommendation
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         engine: wren_ui
       - name: question_recommendation
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: intent_classification
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
         embedder: openai_embedder.text-embedding-3-large
         document_store: qdrant
       - name: data_assistance
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: sql_executor
         engine: wren_ui
       - name: chart_generation
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
       - name: chart_adjustment
-        llm: litellm_llm.gpt-4o-mini
+        llm: litellm_llm.gpt-4o-mini-2024-07-18
     ---
     settings:
       column_indexing_batch_size: 50

--- a/docker/config.example.yaml
+++ b/docker/config.example.yaml
@@ -2,7 +2,7 @@ type: llm
 provider: litellm_llm
 timeout: 120
 models:
-- model: gpt-4o-mini
+- model: gpt-4o-mini-2024-07-18
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -11,7 +11,7 @@ models:
     max_tokens: 4096
     response_format:
       type: json_object
-- model: gpt-4o
+- model: gpt-4o-2024-08-06
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -56,58 +56,58 @@ pipes:
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: historical_question_retrieval
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_answer
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_explanation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_regeneration
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: relationship_recommendation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: intent_classification
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: preprocess_sql_data
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_executor
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: chart_adjustment
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
 ---
 settings:
   column_indexing_batch_size: 50

--- a/wren-ai-service/src/web/v1/services/__init__.py
+++ b/wren-ai-service/src/web/v1/services/__init__.py
@@ -28,7 +28,7 @@ class Configuration(BaseModel):
         end: str
 
     class Timezone(BaseModel):
-        name: str = "Asia/Taipei"
+        name: str = "UTC"
         utc_offset: str = ""  # Deprecated, will be removed in the future
 
     def show_current_time(self):

--- a/wren-ai-service/src/web/v1/services/__init__.py
+++ b/wren-ai-service/src/web/v1/services/__init__.py
@@ -41,7 +41,7 @@ class Configuration(BaseModel):
         return f'{current_time.strftime("%Y-%m-%d %A %H:%M:%S")}'  # YYYY-MM-DD weekday_name HH:MM:SS, ex: 2024-10-23 Wednesday 12:00:00
 
     fiscal_year: Optional[FiscalYear] = None
-    language: Optional[str] = "en"
+    language: Optional[str] = "English"
     timezone: Optional[Timezone] = Timezone()
 
 

--- a/wren-ai-service/tests/pytest/services/test_relationship_recommendation.py
+++ b/wren-ai-service/tests/pytest/services/test_relationship_recommendation.py
@@ -27,7 +27,7 @@ async def test_recommend_success(relationship_recommendation_service, mock_pipel
     assert response.id == "test_id"
     assert response.status == "finished"
     assert response.response == {"test": "data"}
-    mock_pipeline.run.assert_called_once_with(mdl={"key": "value"}, language="en")
+    mock_pipeline.run.assert_called_once_with(mdl={"key": "value"}, language="English")
 
 
 @pytest.mark.asyncio

--- a/wren-ai-service/tools/config/config.example.yaml
+++ b/wren-ai-service/tools/config/config.example.yaml
@@ -2,7 +2,7 @@ type: llm
 provider: litellm_llm
 timeout: 120
 models:
-- model: gpt-4o-mini
+- model: gpt-4o-mini-2024-07-18
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -11,7 +11,7 @@ models:
     max_tokens: 4096
     response_format:
       type: json_object
-- model: gpt-4o
+- model: gpt-4o-2024-08-06
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -70,56 +70,56 @@ pipes:
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: historical_question_retrieval
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_answer
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_explanation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_regeneration
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: relationship_recommendation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: chart_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: chart_adjustment
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: intent_classification
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: preprocess_sql_data
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_executor
     engine: wren_ui
 ---

--- a/wren-ai-service/tools/config/config.full.yaml
+++ b/wren-ai-service/tools/config/config.full.yaml
@@ -2,7 +2,7 @@ type: llm
 provider: litellm_llm
 timeout: 120
 models:
-- model: gpt-4o-mini
+- model: gpt-4o-mini-2024-07-18
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -11,7 +11,7 @@ models:
     max_tokens: 4096
     response_format:
       type: json_object
-- model: gpt-4o
+- model: gpt-4o-2024-08-06
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -89,58 +89,58 @@ pipes:
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: historical_question_retrieval
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_answer
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: sql_explanation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_regeneration
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: relationship_recommendation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: chart_generation
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: chart_adjustment
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: intent_classification
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
     embedder: openai_embedder.text-embedding-3-large
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
   - name: sql_executor
     engine: wren_ui
   - name: preprocess_sql_data
-    llm: litellm_llm.gpt-4o-mini
+    llm: litellm_llm.gpt-4o-mini-2024-07-18
 
 ---
 settings:

--- a/wren-launcher/utils/docker.go
+++ b/wren-launcher/utils/docker.go
@@ -30,6 +30,11 @@ const (
 	AI_SERVICE_CONFIG_URL   string = "https://raw.githubusercontent.com/Canner/WrenAI/" + WREN_PRODUCT_VERSION + "/docker/config.example.yaml"
 )
 
+var generationModelToModelName = map[string]string{
+	"gpt-4o-mini": "gpt-4o-mini-2024-07-18",
+	"gpt-4o":      "gpt-4o-2024-08-06",
+}
+
 func replaceEnvFileContent(content string, projectDir string, openaiApiKey string, openAIGenerationModel string, hostPort int, aiPort int, userUUID string, telemetryEnabled bool) string {
 	// replace PROJECT_DIR
 	reg := regexp.MustCompile(`PROJECT_DIR=(.*)`)
@@ -152,7 +157,7 @@ func PrepareConfigFileForOpenAI(projectDir string, generationModel string) error
 
 	// replace the generation model in config.yaml
 	config := string(content)
-	config = strings.ReplaceAll(config, "litellm_llm.gpt-4o-mini", "litellm_llm."+generationModel)
+	config = strings.ReplaceAll(config, "litellm_llm.gpt-4o-mini-2024-07-18", "litellm_llm."+generationModelToModelName[generationModel])
 
 	// write back to config.yaml
 	err = os.WriteFile(configPath, []byte(config), 0644)


### PR DESCRIPTION
According to OpenAI docs, in production applications, it is a best practice to use dated model snapshot IDs instead of aliases, which may change periodically.

ref: https://platform.openai.com/docs/models#current-model-aliases