### PR TITLE
fix(wren-ui): Calculated fields in model preview Issue & improvements

### DIFF
--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -21,6 +21,7 @@ import { replaceAllowableSyntax, validateDisplayName } from '../utils/regex';
 import { Model, ModelColumn } from '../repositories';
 import {
   findColumnsToUpdate,
+  getPreviewColumnsStr,
   handleNestedColumns,
   replaceInvalidReferenceName,
   updateModelPrimaryKey,
@@ -890,7 +891,10 @@ export class ModelResolver {
     }
     const project = await ctx.projectService.getCurrentProject();
     const { manifest } = await ctx.mdlService.makeCurrentModelMDL();
-    const sql = `select * from "${model.referenceName}"`;
+    const modelColumns = await ctx.modelColumnRepository.findColumnsByModelIds([
+      model.id,
+    ]);
+    const sql = `select ${getPreviewColumnsStr(modelColumns)} from "${model.referenceName}"`;
 
     const data = (await ctx.queryService.preview(sql, {
       project,

--- a/wren-ui/src/apollo/server/utils/model.ts
+++ b/wren-ui/src/apollo/server/utils/model.ts
@@ -6,6 +6,12 @@ import {
 import { replaceAllowableSyntax } from './regex';
 import { CompactColumn } from '@server/services/metadataService';
 
+export function getPreviewColumnsStr(modelColumns: ModelColumn[]) {
+  if (modelColumns.length === 0) return '*';
+  const columns = modelColumns.map((column) => `"${column.sourceColumnName}"`);
+  return columns.join(',');
+}
+
 export function transformInvalidColumnName(columnName: string) {
   let referenceName = replaceAllowableSyntax(columnName);
   // If the reference name does not start with a letter, add a prefix

--- a/wren-ui/src/components/selectors/lineageSelector/index.tsx
+++ b/wren-ui/src/components/selectors/lineageSelector/index.tsx
@@ -106,7 +106,9 @@ export const getLineageOptions = (data: {
   const convertor = (field) => {
     const value = compactObject(getFieldValue(field));
     const isRelationship = field.nodeType === NODE_TYPE.RELATION;
-
+    // check if source model's calculated field
+    const isSourceModelCalculatedField =
+      isSourceModel && field.nodeType === NODE_TYPE.CALCULATED_FIELD;
     // check if user select aggregation functions, then the source model fields cannot be selected
     const isSourceModelFieldsWithAggregation =
       aggregations.includes(expression) && isSourceModel && !isRelationship;
@@ -133,6 +135,7 @@ export const getLineageOptions = (data: {
     const disabled =
       isSourceModelFieldsWithAggregation ||
       isRelationshipWithoutPrimaryKey ||
+      isSourceModelCalculatedField ||
       isInUsedRelationship ||
       isInvalidType;
 
@@ -143,6 +146,8 @@ export const getLineageOptions = (data: {
     } else if (isRelationshipWithoutPrimaryKey) {
       title =
         'Please set a primary key within this model to use it in a calculated field.';
+    } else if (isSourceModelCalculatedField) {
+      title = 'Calculated field from the source model is not supported.';
     } else if (isInUsedRelationship) {
       title = 'This relationship is in use.';
     } else if (isInvalidType) {

--- a/wren-ui/src/utils/columnType.tsx
+++ b/wren-ui/src/utils/columnType.tsx
@@ -26,6 +26,7 @@ export const getColumnTypeIcon = (payload: { type: string }, attrs?: any) => {
       return <TextIcon {...attrs} />;
 
     case COLUMN_TYPE.BYTEA:
+    case COLUMN_TYPE.VARBINARY:
       return <BinaryIcon {...attrs} />;
 
     case COLUMN_TYPE.UUID:
@@ -39,6 +40,7 @@ export const getColumnTypeIcon = (payload: { type: string }, attrs?: any) => {
     case COLUMN_TYPE.INTEGER:
     case COLUMN_TYPE.INT8:
     case COLUMN_TYPE.BIGINT:
+    case COLUMN_TYPE.INT64:
     case COLUMN_TYPE.NUMERIC:
     case COLUMN_TYPE.DECIMAL:
     case COLUMN_TYPE.FLOAT4:

--- a/wren-ui/src/utils/enum/columnType.ts
+++ b/wren-ui/src/utils/enum/columnType.ts
@@ -17,6 +17,8 @@ export enum COLUMN_TYPE {
   INT8 = 'INT8',
   BIGINT = 'BIGINT', // alias for INT8
 
+  INT64 = 'INT64',
+
   NUMERIC = 'NUMERIC',
   DECIMAL = 'DECIMAL',
 
@@ -53,6 +55,7 @@ export enum COLUMN_TYPE {
 
   // Binary Data Types
   BYTEA = 'BYTEA',
+  VARBINARY = 'VARBINARY',
 
   // UUID Type
   UUID = 'UUID',

--- a/wren-ui/src/utils/validator/calculatedFieldValidator.ts
+++ b/wren-ui/src/utils/validator/calculatedFieldValidator.ts
@@ -55,6 +55,7 @@ export const checkNumberFunctionAllowType = makeCheckAllowType(mathFunctions, [
   COLUMN_TYPE.INTEGER,
   COLUMN_TYPE.INT8,
   COLUMN_TYPE.BIGINT,
+  COLUMN_TYPE.INT64,
   COLUMN_TYPE.NUMERIC,
   COLUMN_TYPE.DECIMAL,
   COLUMN_TYPE.FLOAT4,


### PR DESCRIPTION
## Description
This PR addresses an issue where some calculated fields (CFs) fail to display in the model preview.

## Root Cause:
The engine requires all columns, including calculated fields, to be explicitly listed in the query when previewing a model. Using a wildcard (*) does not include calculated fields in the result.

## Solution:
Update the model preview query to explicitly list all columns and calculated fields, ensuring accurate previews. 
For example:
```
SELECT "col"..., "cf"... FROM "model"
```

## Additional context
- Add functionality to disable calculated fields in the same model
- Add some column types