### PR TITLE
feat(wren-ui): remove unnecessary sql column of thread table

### DIFF
--- a/wren-ui/migrations/20241226135712_remove_thread_sql.js
+++ b/wren-ui/migrations/20241226135712_remove_thread_sql.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  // drop foreign key constraint before altering column type to prevent data loss
+  await knex.schema.alterTable('thread_response', (table) => {
+    table.dropForeign('thread_id');
+  });
+  await knex.schema.alterTable('thread', (table) => {
+    table.dropColumn('sql');
+  });
+  await knex.schema.alterTable('thread_response', (table) => {
+    table.foreign('thread_id').references('thread.id').onDelete('CASCADE');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable('thread', (table) => {
+    table.text('sql').nullable();
+  });
+};

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -257,8 +257,6 @@ export type DetailedThread = {
   __typename?: 'DetailedThread';
   id: Scalars['Int'];
   responses: Array<ThreadResponse>;
-  /** @deprecated Doesn't seem to be reasonable to put a sql in a thread */
-  sql: Scalars['String'];
 };
 
 export type Diagram = {
@@ -997,8 +995,6 @@ export type Task = {
 export type Thread = {
   __typename?: 'Thread';
   id: Scalars['Int'];
-  /** @deprecated Doesn't seem to be reasonable to put a sql in a thread */
-  sql: Scalars['String'];
   summary: Scalars['String'];
 };
 

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -37,7 +37,7 @@ export type ThreadQueryVariables = Types.Exact<{
 }>;
 
 
-export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, sql: string, responses: Array<{ __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, chartDetail?: { __typename?: 'ThreadResponseChartDetail', queryId?: string | null, status: Types.ChartTaskStatus, description?: string | null, chartSchema?: any | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null }> } };
+export type ThreadQuery = { __typename?: 'Query', thread: { __typename?: 'DetailedThread', id: number, responses: Array<{ __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql: string, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, chartDetail?: { __typename?: 'ThreadResponseChartDetail', queryId?: string | null, status: Types.ChartTaskStatus, description?: string | null, chartSchema?: any | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null }> } };
 
 export type ThreadResponseQueryVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
@@ -65,7 +65,7 @@ export type CreateThreadMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateThreadMutation = { __typename?: 'Mutation', createThread: { __typename?: 'Thread', id: number, sql: string } };
+export type CreateThreadMutation = { __typename?: 'Mutation', createThread: { __typename?: 'Thread', id: number } };
 
 export type CreateThreadResponseMutationVariables = Types.Exact<{
   threadId: Types.Scalars['Int'];
@@ -81,7 +81,7 @@ export type UpdateThreadMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateThreadMutation = { __typename?: 'Mutation', updateThread: { __typename?: 'Thread', id: number, sql: string, summary: string } };
+export type UpdateThreadMutation = { __typename?: 'Mutation', updateThread: { __typename?: 'Thread', id: number, summary: string } };
 
 export type DeleteThreadMutationVariables = Types.Exact<{
   where: Types.ThreadUniqueWhereInput;
@@ -386,7 +386,6 @@ export const ThreadDocument = gql`
     query Thread($threadId: Int!) {
   thread(threadId: $threadId) {
     id
-    sql
     responses {
       ...CommonResponse
     }
@@ -524,7 +523,6 @@ export const CreateThreadDocument = gql`
     mutation CreateThread($data: CreateThreadInput!) {
   createThread(data: $data) {
     id
-    sql
   }
 }
     `;
@@ -592,7 +590,6 @@ export const UpdateThreadDocument = gql`
     mutation UpdateThread($where: ThreadUniqueWhereInput!, $data: UpdateThreadInput!) {
   updateThread(where: $where, data: $data) {
     id
-    sql
     summary
   }
 }

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -144,7 +144,6 @@ export const THREAD = gql`
   query Thread($threadId: Int!) {
     thread(threadId: $threadId) {
       id
-      sql
       responses {
         ...CommonResponse
       }
@@ -180,7 +179,6 @@ export const CREATE_THREAD = gql`
   mutation CreateThread($data: CreateThreadInput!) {
     createThread(data: $data) {
       id
-      sql
     }
   }
 `;
@@ -204,7 +202,6 @@ export const UPDATE_THREAD = gql`
   ) {
     updateThread(where: $where, data: $data) {
       id
-      sql
       summary
     }
   }

--- a/wren-ui/src/apollo/server/repositories/threadRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/threadRepository.ts
@@ -17,7 +17,6 @@ export interface ThreadRecommendationQuestionResult {
 export interface Thread {
   id: number; // ID
   projectId: number; // Reference to project.id
-  sql: string; // SQL
   summary: string; // Thread summary
 
   // recommend question

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -700,20 +700,12 @@ export const typeDefs = gql`
   # Thread only consists of basic information of a thread
   type Thread {
     id: Int!
-    sql: String!
-      @deprecated(
-        reason: "Doesn't seem to be reasonable to put a sql in a thread"
-      )
     summary: String!
   }
 
   # Detailed thread consists of thread and thread responses
   type DetailedThread {
     id: Int!
-    sql: String!
-      @deprecated(
-        reason: "Doesn't seem to be reasonable to put a sql in a thread"
-      )
     responses: [ThreadResponse!]!
   }
 

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -575,7 +575,6 @@ export class AskingService implements IAskingService {
     const { id } = await this.projectService.getCurrentProject();
     const thread = await this.threadRepository.createOne({
       projectId: id,
-      sql: input.sql,
       summary: input.question,
     });
 
@@ -969,8 +968,6 @@ export class AskingService implements IAskingService {
     const { id } = await this.projectService.getCurrentProject();
     const thread = await this.threadRepository.createOne({
       projectId: id,
-      // todo: remove sql from thread
-      sql: view.statement,
       summary: input.question,
     });
 


### PR DESCRIPTION
## Description
The sql column in the thread table is no longer in use, so we will remove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined thread data structure by removing the `sql` field from various types and operations.
  
- **Bug Fixes**
	- Adjusted GraphQL queries and mutations to ensure they no longer reference the deprecated `sql` field.

- **Refactor**
	- Updated methods in the `AskingService` to eliminate SQL handling during thread creation.

- **Documentation**
	- Enhanced clarity in thread representation by removing unnecessary SQL fields from the schema and types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->