### PR TITLE
fix(wren-ui): Remove line chart color properties reset & adjust config

### DIFF
--- a/wren-ui/src/components/chart/handler.ts
+++ b/wren-ui/src/components/chart/handler.ts
@@ -111,7 +111,7 @@ const config: Config = {
   legend: {
     symbolLimit: 15,
     columns: 1,
-    labelFontSize: 12,
+    labelFontSize: 10,
     labelColor: COLOR.GRAY_8,
     titleColor: COLOR.GRAY_9,
     titleFontSize: 14,
@@ -119,8 +119,12 @@ const config: Config = {
   range: {
     category: colorScheme,
     ordinal: colorScheme,
+    diverging: colorScheme,
+    symbol: colorScheme,
+    heatmap: colorScheme,
+    ramp: colorScheme,
   },
-  point: { size: 60 },
+  point: { size: 60, color: DEFAULT_COLOR },
 };
 
 export default class ChartSpecHandler {
@@ -151,7 +155,7 @@ export default class ChartSpecHandler {
     // default options
     this.options = {
       width: isNil(options?.width) ? 'container' : options.width,
-      height: isNil(options?.height) ? 280 : options.height,
+      height: isNil(options?.height) ? 320 : options.height,
       stack: isNil(options?.stack) ? 'zero' : options.stack,
       point: isNil(options?.point) ? true : options.point,
       donutInner: isNil(options?.donutInner) ? 60 : options.donutInner,
@@ -295,7 +299,7 @@ export default class ChartSpecHandler {
     }
 
     // basic color properties
-    let colorProperties = {
+    const colorProperties = {
       title,
       field: category?.field,
       type: category?.type,
@@ -303,11 +307,6 @@ export default class ChartSpecHandler {
         range: colorScheme,
       },
     } as any;
-    if (this.mark.type === MarkType.LINE) {
-      colorProperties = {
-        value: DEFAULT_COLOR,
-      };
-    }
 
     this.encoding.color = {
       ...colorProperties,


### PR DESCRIPTION
## Description
The color field & type properties are replaced in the line chart condition, which needs to be removed to keep the settings

- Before 
<img width="745" alt="image" src="https://github.com/user-attachments/assets/a8d8ea07-4262-4341-a090-3f96e2b2ac28" />

- After
<img width="751" alt="image" src="https://github.com/user-attachments/assets/104cf8d9-c2f4-40a7-9cc7-22f02d27b63c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced chart configuration with new properties for range options, including `diverging`, `symbol`, `heatmap`, and `ramp`.
	- Introduced a default color setting for chart points.

- **Improvements**
	- Reduced legend font size for better readability.
	- Increased default chart height for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->