### PR TITLE
fix(wren-ui): adjust chart properties show correctly

### DIFF
--- a/wren-ui/src/components/chart/properties/BasicProperties.tsx
+++ b/wren-ui/src/components/chart/properties/BasicProperties.tsx
@@ -25,7 +25,7 @@ export function ChartTypeProperty(props: {
   const { options } = props;
   return (
     <Form.Item className="mb-0" label="Chart type" name="chartType">
-      <Select size="small" options={options} />
+      <Select size="small" options={options} placeholder="Select chart type" />
     </Form.Item>
   );
 }
@@ -38,12 +38,12 @@ export function AxisProperty(props: {
     <Row gutter={16}>
       <Col span={12}>
         <Form.Item className="mb-0" label="X-axis" name="xAxis">
-          <Select size="small" options={options} />
+          <Select size="small" options={options} placeholder="Select x-axis" />
         </Form.Item>
       </Col>
       <Col span={12}>
         <Form.Item className="mb-0" label="Y-axis" name="yAxis">
-          <Select size="small" options={options} />
+          <Select size="small" options={options} placeholder="Select y-axis" />
         </Form.Item>
       </Col>
     </Row>
@@ -53,6 +53,7 @@ export function AxisProperty(props: {
 export interface PropertiesProps {
   columns: { name: string; type: string }[];
   titleMap: Record<string, string>;
+  onChartTypeChange: (chartType: ChartType) => void;
 }
 
 export default function BasicProperties(props: PropertiesProps) {

--- a/wren-ui/src/components/chart/properties/DonutProperties.tsx
+++ b/wren-ui/src/components/chart/properties/DonutProperties.tsx
@@ -18,14 +18,22 @@ export default function DonutProperties(props: PropertiesProps) {
         </Col>
         <Col span={12}>
           <Form.Item className="mb-0" label="Category" name="color">
-            <Select size="small" options={columnOptions} />
+            <Select
+              size="small"
+              options={columnOptions}
+              placeholder="Select category"
+            />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={12}>
           <Form.Item className="mb-0" label="Value" name="theta">
-            <Select size="small" options={columnOptions} />
+            <Select
+              size="small"
+              options={columnOptions}
+              placeholder="Select value"
+            />
           </Form.Item>
         </Col>
         <Col span={12}></Col>

--- a/wren-ui/src/components/chart/properties/GroupedBarProperties.tsx
+++ b/wren-ui/src/components/chart/properties/GroupedBarProperties.tsx
@@ -19,7 +19,11 @@ export default function GroupedBarProperties(props: PropertiesProps) {
         </Col>
         <Col span={12}>
           <Form.Item className="mb-0" label="Sub-category" name="xOffset">
-            <Select size="small" options={columnOptions} />
+            <Select
+              size="small"
+              options={columnOptions}
+              placeholder="Select sub-category"
+            />
           </Form.Item>
         </Col>
       </Row>

--- a/wren-ui/src/components/chart/properties/LineProperties.tsx
+++ b/wren-ui/src/components/chart/properties/LineProperties.tsx
@@ -19,7 +19,11 @@ export default function LineProperties(props: PropertiesProps) {
         </Col>
         <Col span={12}>
           <Form.Item className="mb-0" label="Line groups" name="color">
-            <Select size="small" options={columnOptions} />
+            <Select
+              size="small"
+              options={columnOptions}
+              placeholder="Select line groups"
+            />
           </Form.Item>
         </Col>
       </Row>

--- a/wren-ui/src/components/chart/properties/StackedBarProperties.tsx
+++ b/wren-ui/src/components/chart/properties/StackedBarProperties.tsx
@@ -19,7 +19,11 @@ export default function StackedBarProperties(props: PropertiesProps) {
         </Col>
         <Col span={12}>
           <Form.Item className="mb-0" label="Stack groups" name="color">
-            <Select size="small" options={columnOptions} />
+            <Select
+              size="small"
+              options={columnOptions}
+              placeholder="Select stack groups"
+            />
           </Form.Item>
         </Col>
       </Row>

--- a/wren-ui/src/components/pages/home/promptThread/ChartAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/ChartAnswer.tsx
@@ -19,7 +19,6 @@ import {
 import { usePreviewDataMutation } from '@/apollo/client/graphql/home.generated';
 import { isEmpty, isEqual } from 'lodash';
 import {
-  convertToChartType,
   getChartSpecFieldTitleMap,
   getChartSpecOptionValues,
 } from '@/components/chart/handler';
@@ -95,6 +94,7 @@ export default function ChartAnswer(props: Props) {
   const [newValues, setNewValues] = useState(null);
 
   const [form] = Form.useForm();
+  const chartType = Form.useWatch('chartType', form);
   const { chartDetail } = threadResponse;
   const { error, status, adjustment } = chartDetail || {};
 
@@ -118,16 +118,6 @@ export default function ChartAnswer(props: Props) {
     return chartDetail.chartSchema;
   }, [chartDetail]);
 
-  const chartType = useMemo(() => {
-    if (!chartDetail?.chartSchema?.mark) return null;
-    const mark = chartDetail.chartSchema?.mark;
-    const encoding = chartDetail.chartSchema?.encoding;
-    return convertToChartType(
-      typeof mark === 'string' ? mark : mark.type,
-      encoding,
-    );
-  }, [chartSpec]);
-
   const chartOptionValues = useMemo(() => {
     return getChartSpecOptionValues(chartSpec);
   }, [chartSpec]);
@@ -141,7 +131,7 @@ export default function ChartAnswer(props: Props) {
   }, [chartOptionValues]);
 
   const isAdjusted = useMemo(() => {
-    return newValues !== null ? !isEqual(chartOptionValues, newValues) : false;
+    return newValues !== null && !isEqual(chartOptionValues, newValues);
   }, [chartOptionValues, newValues]);
 
   const dataValues = useMemo(() => {
@@ -162,7 +152,7 @@ export default function ChartAnswer(props: Props) {
   const loading =
     previewDataResult.loading || !getIsChartFinished(status) || regenerating;
 
-  const DynamicProperties = getDynamicProperties(chartType);
+  const DynamicProperties = getDynamicProperties(chartType as ChartType);
 
   const onFormChange = () => {
     setNewValues(form.getFieldsValue());


### PR DESCRIPTION
## Description
Show the adjust chart properties correctly

<img width="747" alt="image" src="https://github.com/user-attachments/assets/e11f1f18-d901-474b-b112-57fe9a524cac" />
<img width="745" alt="image" src="https://github.com/user-attachments/assets/b9a76b21-dccf-4bed-b27b-661a2f320cd5" />
<img width="743" alt="image" src="https://github.com/user-attachments/assets/8410d925-4cd8-4876-9cb8-bf26938535e4" />
<img width="741" alt="image" src="https://github.com/user-attachments/assets/64e0c85b-1ed9-41ef-b98f-d05f16a0e288" />
<img width="740" alt="image" src="https://github.com/user-attachments/assets/23436e37-a20a-4f64-876c-36bf7e3f8165" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **User Interface Improvements**
	- Added placeholder text to chart configuration dropdowns for better user guidance
	- Enhanced chart type selection and configuration options

- **Chart Configuration**
	- Improved chart type change handling
	- Added more descriptive selection prompts for chart-specific properties

- **Technical Enhancements**
	- Simplified chart type determination logic
	- Improved type safety in chart configuration components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->