### PR TITLE
chore(wren-ui): add sharp library when building image

### DIFF
--- a/wren-ui/Dockerfile
+++ b/wren-ui/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 RUN yarn install --immutable
+RUN yarn add sharp
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Description
Fixing error when deploying wren-ui on k8s, [ref](https://nextjs.org/docs/messages/sharp-missing-in-production)
```
[2025-01-15T02:22:59.568] [DEBUG] ProjectService - Creating project...
[2025-01-15T02:22:59.573] [DEBUG] DataSourceResolver - Project created.
[2025-01-15T02:22:59.573] [DEBUG] DataSourceResolver - Dashboard init...
[2025-01-15T02:22:59.577] [DEBUG] DataSourceResolver - Dashboard created.
[2025-01-15T02:23:13.592] [DEBUG] ModelService - start update primary keys
[2025-01-15T02:23:13.621] [DEBUG] ModelService - start batch update model description
[2025-01-15T02:23:13.626] [DEBUG] ModelService - start batch update column description
[2025-01-15T02:23:13.974] [DEBUG] DeployService - Deploying model, hash: a7947ac33ce7268dd7d3b996fd52d278854401de
[2025-01-15T02:23:13.982] [DEBUG] WrenAIAdaptor - Got error when deploying to wren AI, hash: a7947ac33ce7268dd7d3b996fd52d278854401de. Error: connect ECONNREFUSED 2001:cafe:42:1::a60d:5555
⨯ Error: 'sharp' is required to be installed in standalone mode for the image optimization to function correctly. Read more at: https://nextjs.org/docs/messages/sharp-missing-in-production
⨯ Error: 'sharp' is required to be installed in standalone mode for the image optimization to function correctly. Read more at: https://nextjs.org/docs/messages/sharp-missing-in-production
⨯ Error: 'sharp' is required to be installed in standalone mode for the image optimization to function correctly. Read more at: https://nextjs.org/docs/messages/sharp-missing-in-production
```

add sharp library when building image(only need this library on standalone environment)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker configuration to include the `sharp` package for image processing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->