### PR TITLE
chore(wren-ai-service): multi arch build

### DIFF
--- a/.github/workflows/ai-service-release-image.yaml
+++ b/.github/workflows/ai-service-release-image.yaml
@@ -7,15 +7,34 @@ on:
         description: Docker image tag name (Optional)
         type: string
 
+env:
+  WREN_AI_SERVICE_IMAGE: ghcr.io/canner/wren-ai-service
+
 defaults:
   run:
     working-directory: wren-ai-service
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag-preparation.outputs.TAG_NAME }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: linux_arm64_runner
+            platform: linux/arm64
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare tag name
         id: tag-preparation
         run: |
@@ -25,28 +44,62 @@ jobs:
             tag_name=commit-$(git log -1 --pretty=%h)
           fi
           echo "TAG_NAME=$tag_name" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Prepare platform
+        run: |
+          platform=${{ matrix.arch.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.arch.platform }}
+          labels: ${{ env.WREN_AI_SERVICE_IMAGE }}
+          context: ./wren-ai-service
+          file: ./wren-ai-service/docker/Dockerfile
+          outputs: type=image,name=${{ env.WREN_AI_SERVICE_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs: [ build-image ]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.WREN_AI_SERVICE_IMAGE }}
+          tags: |
+            ${{ needs.build-image.outputs.tag_name }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/canner/wren-ai-service
-          tags: |
-            type=raw,${{ env.TAG_NAME }}
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          context: ./wren-ai-service
-          file: ./wren-ai-service/docker/Dockerfile
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.WREN_AI_SERVICE_IMAGE }}@sha256:%s ' *) \
+            $TAGS

--- a/.github/workflows/ai-service-release-image.yaml
+++ b/.github/workflows/ai-service-release-image.yaml
@@ -43,7 +43,7 @@ jobs:
           else
             tag_name=commit-$(git log -1 --pretty=%h)
           fi
-          echo "TAG_NAME=$tag_name" >> $GITHUB_ENV
+          echo "TAG_NAME=$tag_name" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Prepare platform

--- a/.github/workflows/ai-service-release-nightly-image.yaml
+++ b/.github/workflows/ai-service-release-nightly-image.yaml
@@ -6,43 +6,95 @@ on:
     paths:
       - 'wren-ai-service/**'
 
+env:
+  WREN_AI_SERVICE_IMAGE: ghcr.io/canner/wren-ai-service
+
 defaults:
   run:
     working-directory: wren-ai-service
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag-preparation.outputs.TAG_NAME }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: linux_arm64_runner
+            platform: linux/arm64
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare tag name
-        id: tag-preparation
-        run: |
-          tag_name=main-$(git log -1 --pretty=%h)
-          echo "TAG_NAME=$tag_name" >> $GITHUB_OUTPUT
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare tag name
+        id: tag-preparation
+        run: |
+          tag_name=main-$(git log -1 --pretty=%h)
+          echo "TAG_NAME=$tag_name" >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Prepare platform
+        run: |
+          platform=${{ matrix.arch.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.arch.platform }}
+          labels: ${{ env.WREN_AI_SERVICE_IMAGE }}
+          context: ./wren-ai-service
+          file: ./wren-ai-service/docker/Dockerfile
+          outputs: type=image,name=${{ env.WREN_AI_SERVICE_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs: [ build-image ]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/canner/wren-ai-service
+          images: ${{ env.WREN_AI_SERVICE_IMAGE }}
           tags: |
-            type=raw,${{ env.TAG_NAME }}
-            type=raw,nightly
-      - name: Build and push
-        uses: docker/build-push-action@v6
+            ${{ needs.build-image.outputs.tag_name }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          context: ./wren-ai-service
-          file: ./wren-ai-service/docker/Dockerfile
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.WREN_AI_SERVICE_IMAGE }}@sha256:%s ' *) \
+            $TAGS

--- a/.github/workflows/ai-service-release-stable-image.yaml
+++ b/.github/workflows/ai-service-release-stable-image.yaml
@@ -8,6 +8,9 @@ on:
         type: string
         required: true
 
+env:
+  WREN_AI_SERVICE_IMAGE: ghcr.io/canner/wren-ai-service
+
 defaults:
   run:
     working-directory: wren-ai-service
@@ -78,34 +81,83 @@ jobs:
           git push origin "release/ai-service/$version"
   build-image:
     needs: upgrade-ai-service-version
-    runs-on: ubuntu-latest
+    outputs:
+      tag_name: latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: linux_arm64_runner
+            platform: linux/arm64
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Prepare platform
+        run: |
+          platform=${{ matrix.arch.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.arch.platform }}
+          labels: ${{ env.WREN_AI_SERVICE_IMAGE }}
+          context: ./wren-ai-service
+          file: ./wren-ai-service/docker/Dockerfile
+          outputs: type=image,name=${{ env.WREN_AI_SERVICE_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs: [ build-image ]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/canner/wren-ai-service
+          images: ${{ env.WREN_AI_SERVICE_IMAGE }}
           tags: |
-            type=raw,${{ github.event.inputs.version }}
-            type=raw,latest
-      - name: Build and push
-        uses: docker/build-push-action@v6
+            ${{ needs.build-image.outputs.tag_name }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          context: ./wren-ai-service
-          file: ./wren-ai-service/docker/Dockerfile
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.WREN_AI_SERVICE_IMAGE }}@sha256:%s ' *) \
+            $TAGS


### PR DESCRIPTION
tested using release build, build time is shortened from 8-9 minutes to 2-3 minutes

https://github.com/Canner/WrenAI/actions/runs/12838438473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
	- Enhanced GitHub Actions workflows for AI service image releases.
	- Added multi-architecture support for Docker image builds (AMD64 and ARM64).
	- Improved image management with new manifest list creation process.
	- Introduced new environment variable `WREN_AI_SERVICE_IMAGE` for flexible image naming.
	- Added new job for digest handling and organization in the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->