### PR TITLE
fix(wren-ai-service): Update SQL Analysis API to v2 and Spec

### DIFF
--- a/wren-ai-service/eval/utils.py
+++ b/wren-ai-service/eval/utils.py
@@ -163,7 +163,7 @@ async def get_contexts_from_sql(
 
         async with aiohttp.request(
             "GET",
-            f"{api_endpoint}/v1/analysis/sql",
+            f"{api_endpoint}/v2/analysis/sql",
             json={
                 "sql": quoted_sql,
                 "manifest": mdl_json,

--- a/wren-ai-service/eval/utils.py
+++ b/wren-ai-service/eval/utils.py
@@ -161,12 +161,14 @@ async def get_contexts_from_sql(
         quoted_sql, no_error = add_quotes(sql)
         assert no_error, f"Error in quoting SQL: {sql}"
 
+        manifest_str = base64.b64encode(orjson.dumps(mdl_json)).decode()
+
         async with aiohttp.request(
             "GET",
             f"{api_endpoint}/v2/analysis/sql",
             json={
                 "sql": quoted_sql,
-                "manifest": mdl_json,
+                "manifestStr": manifest_str,
             },
             timeout=aiohttp.ClientTimeout(total=timeout),
         ) as response:

--- a/wren-ai-service/tests/pytest/eval/test_metrics.py
+++ b/wren-ai-service/tests/pytest/eval/test_metrics.py
@@ -47,7 +47,7 @@ def mocker():
 def _success_analysis_sql(m, engine_config, repeat=1):
     for _ in range(repeat):
         m.get(
-            f"{engine_config['api_endpoint']}/v1/analysis/sql",
+            f"{engine_config['api_endpoint']}/v2/analysis/sql",
             payload=[
                 {
                     "selectItems": [


### PR DESCRIPTION
This PR updates the `get_contexts_from_sql` function in the `wren-ai-service/eval/utils.py` file to enhance the way SQL analysis requests are made to the API. The key changes include:

1. **API Endpoint Update**: The API endpoint has been updated from `/v1/analysis/sql` to `/v2/analysis/sql`. This change is likely to accommodate new features or improvements in the API.

2. **Manifest Encoding**: The `manifest` parameter, previously sent as a JSON object, is now encoded as a base64 string (`manifestStr`). This change ensures that the manifest data is safely transmitted over the network, potentially avoiding issues with special characters or data integrity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated SQL analysis API endpoint to v2.
	- Modified manifest data transmission by base64 encoding.

- **Refactor**
	- Improved API interaction method for SQL analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->