### PR TITLE
fix(wren-ui): fix multi line chart type to dashbord item type

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -178,6 +178,7 @@ export enum DashboardItemType {
   BAR = 'BAR',
   GROUPED_BAR = 'GROUPED_BAR',
   LINE = 'LINE',
+  MULTI_LINE = 'MULTI_LINE',
   NUMBER = 'NUMBER',
   PIE = 'PIE',
   STACKED_BAR = 'STACKED_BAR',

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -799,6 +799,7 @@ export const typeDefs = gql`
     BAR
     PIE
     LINE
+    MULTI_LINE
     AREA
     GROUPED_BAR
     STACKED_BAR


### PR DESCRIPTION
## Description
Fix add multi line chart to dashboard cause failed 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new dashboard item type `MULTI_LINE` to support additional visualization options for dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->