### PR TITLE
feat(wren-ui): use intent reasoning instead of hard code string for misleading query

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -27,6 +27,7 @@ export type AskingTask = {
   __typename?: 'AskingTask';
   candidates: Array<ResultCandidate>;
   error?: Maybe<Error>;
+  intentReasoning?: Maybe<Scalars['String']>;
   status: AskingTaskStatus;
   type?: Maybe<AskingTaskType>;
 };

--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -25,7 +25,7 @@ export type AskingTaskQueryVariables = Types.Exact<{
 }>;
 
 
-export type AskingTaskQuery = { __typename?: 'Query', askingTask: { __typename?: 'AskingTask', status: Types.AskingTaskStatus, type?: Types.AskingTaskType | null, candidates: Array<{ __typename?: 'ResultCandidate', sql: string, type: Types.ResultCandidateType, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null }>, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } };
+export type AskingTaskQuery = { __typename?: 'Query', askingTask: { __typename?: 'AskingTask', status: Types.AskingTaskStatus, type?: Types.AskingTaskType | null, intentReasoning?: string | null, candidates: Array<{ __typename?: 'ResultCandidate', sql: string, type: Types.ResultCandidateType, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null }>, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } };
 
 export type ThreadsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -318,6 +318,7 @@ export const AskingTaskDocument = gql`
     error {
       ...CommonError
     }
+    intentReasoning
   }
 }
     ${CommonErrorFragmentDoc}`;

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -128,6 +128,7 @@ export const ASKING_TASK = gql`
       error {
         ...CommonError
       }
+      intentReasoning
     }
   }
   ${COMMON_ERROR}

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -507,7 +507,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
   }
 
   private transformAskResult(body: any): AskResult {
-    const { type } = body;
+    const { type, intent_reasoning } = body;
     const { status, error } = this.transformStatusAndError(body);
     const candidates = (body?.response || []).map((candidate: any) => ({
       type: candidate?.type?.toUpperCase() as AskCandidateType,
@@ -520,6 +520,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
       status: status as AskResultStatus,
       error,
       response: candidates,
+      intentReasoning: intent_reasoning,
     };
   }
 

--- a/wren-ui/src/apollo/server/models/adaptor.ts
+++ b/wren-ui/src/apollo/server/models/adaptor.ts
@@ -119,7 +119,9 @@ export type AskResult = AskResponse<
     viewId?: number | null;
   }>,
   AskResultStatus
->;
+> & {
+  intentReasoning?: string;
+};
 
 export enum RecommendationQuestionStatus {
   GENERATING = 'GENERATING',

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -44,6 +44,7 @@ export interface AskingTask {
     sql: string;
   }>;
   error: WrenAIError | null;
+  intentReasoning?: string;
 }
 
 // DetailedThread is a type that represents a detailed thread, which is a thread with responses.
@@ -224,6 +225,7 @@ export class AskingResolver {
       status: askResult.status,
       error: askResult.error,
       candidates,
+      intentReasoning: askResult.intentReasoning,
     };
   }
 

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -583,6 +583,7 @@ export const typeDefs = gql`
     type: AskingTaskType
     error: Error
     candidates: [ResultCandidate!]!
+    intentReasoning: String
   }
 
   input InstantRecommendedQuestionsInput {

--- a/wren-ui/src/components/pages/home/prompt/Result.tsx
+++ b/wren-ui/src/components/pages/home/prompt/Result.tsx
@@ -40,6 +40,7 @@ interface Props {
     candidates: AskingTask['candidates'];
     askingStreamTask: string;
     recommendedQuestions: RecommendedQuestionsTask;
+    intentReasoning: string;
   };
   error?: any;
   onSelectResult: (payload: { sql: string; viewId: number | null }) => void;
@@ -117,7 +118,9 @@ const makeProcessingError =
             Close
           </Button>
         </div>
-        <div className="gray-7">{config.description || message}</div>
+        <div className="gray-7">
+          {config.description || data.intentReasoning || message}
+        </div>
         {hasStacktrace && (
           <ErrorCollapse className="mt-2" message={stacktrace.join('\n')} />
         )}
@@ -243,8 +246,6 @@ const GeneralAnswer = (props: Props) => {
 const MisleadingQuery = makeProcessingError({
   icon: <WarningOutlined className="mr-2 text-lg gold-6" />,
   title: 'Clarification needed',
-  description:
-    "Could you please provide more details or specify the information you're seeking?",
 });
 
 const getGeneralAnswerStateComponent = (state: PROCESS_STATE) => {

--- a/wren-ui/src/components/pages/home/prompt/index.tsx
+++ b/wren-ui/src/components/pages/home/prompt/index.tsx
@@ -105,6 +105,7 @@ export default forwardRef<Attributes, Props>(function Prompt(props, ref) {
       candidates: askingTask?.candidates || [], // for text to sql answer, only one candidate
       askingStreamTask, // for general answer
       recommendedQuestions, // guiding user to ask
+      intentReasoning: askingTask?.intentReasoning || '',
     }),
     [data],
   );


### PR DESCRIPTION


## Description
 - Change templated response “Could you please provide more details or specify the information you're seeking?” to the text AI service provided.

![image](https://github.com/user-attachments/assets/1e2038de-21d2-4aee-a6c0-017f73711163)

## AI API

   ```js
       // GET /v1/asks/{query_id}/result
       {
	    "status": "understanding|searching|generating|finished|failed|stopped",
	    "response": [Result],
	    "intent_reasoning": <string|optional>
	    "error": <Error|optional>
       }
   ```
   ↓ example response
   ```json
       {
          "status": "finished",
          "rephrased_question": "What is the current number of people sleeping at 2025-01-23 15:07:29?",
          "intent_reasoning": "The question about 'people sleeping' is unrelated to the database schema.",
          "type": "MISLEADING_QUERY",
          "response": null,
          "error": null
       }
   ```

## UI screenshots
![截圖 2025-01-23 下午6 43 35](https://github.com/user-attachments/assets/e4c11f58-1dd2-422b-a4d3-4ae3e054096c)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `intentReasoning` field to provide additional context about task intent across multiple system components
	- Enhanced error handling with more detailed reasoning information

- **Improvements**
	- Expanded GraphQL schema and query responses to include intent reasoning
	- Updated data models to support new intent reasoning property

<!-- end of auto-generated comment: release notes by coderabbit.ai -->