### PR TITLE
chore(wren-ai-service): minor updates

### DIFF
--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -368,7 +368,6 @@ class AskService:
                         contexts=documents,
                         invalid_generation_results=failed_dry_run_results,
                         project_id=ask_request.project_id,
-                        generation_reasoning=sql_generation_reasoning,
                     )
 
                     if valid_generation_results := sql_correction_results[

--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -424,8 +424,6 @@ class AskService:
                     code="OTHERS",
                     message=str(e),
                 ),
-                rephrased_question=rephrased_question,
-                intent_reasoning=intent_reasoning,
             )
 
             results["metadata"]["error_type"] = "OTHERS"

--- a/wren-ai-service/tests/pytest/test_usecases.py
+++ b/wren-ai-service/tests/pytest/test_usecases.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
         os.makedirs("outputs")
 
     with open(
-        f"outputs/final_results_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json",
+        f"outputs/usecases_final_results_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.yaml",
         "w",
     ) as f:
-        json.dump(final_results, f, indent=2)
+        yaml.safe_dump(final_results, f, sort_keys=False, allow_unicode=True)


### PR DESCRIPTION
- add generation_reasoning as output in ask pipeline
- write usecase test results in yaml instead of json for better readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `generation_reasoning` field to AI service response, providing more detailed feedback about SQL generation process.
- **Chores**
  - Updated test output to use YAML format instead of JSON for result storage.
  - Enhanced SQL string formatting in results for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->