### PR TITLE
chore(wren-ui): add disable grammarly extension attribute

### DIFF
--- a/wren-ui/src/components/pages/home/prompt/index.tsx
+++ b/wren-ui/src/components/pages/home/prompt/index.tsx
@@ -202,6 +202,8 @@ export default forwardRef<Attributes, Props>(function Prompt(props, ref) {
     <PromptStyle className="d-flex align-end bg-gray-2 p-3 border border-gray-3 rounded">
       <Input.TextArea
         ref={$promptInput}
+        // disable grammarly
+        data-gramm="false"
         size="large"
         autoSize
         placeholder="Ask to explore your data"


### PR DESCRIPTION
## Description
Grammarly continuously checks content when users access the Home page.
This issue occurs on the website but does not happen in the local environment.
As a temporary workaround, we have disabled Grammarly integration for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled Grammarly grammar checking in the text input area to improve user experience and prevent potential interference with text input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->