### PR TITLE
chore(wren-ai-service): minor updates

### DIFF
--- a/wren-ai-service/demo/run_sql.py
+++ b/wren-ai-service/demo/run_sql.py
@@ -66,7 +66,7 @@ def main():
                     sql=command,
                     dataset_type=data_source,
                     manifest=mdl_json,
-                    limit=10,
+                    limit=50,
                 )
                 print(f"\nExecution result:\n{df.to_string()}\n")
             except Exception as e:

--- a/wren-ai-service/src/config.py
+++ b/wren-ai-service/src/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     table_column_retrieval_size: int = Field(default=100)
     allow_using_db_schemas_without_pruning: bool = Field(default=False)
 
+    # generation config
+    allow_sql_generation_reasoning: bool = Field(default=True)
+
     # service config
     query_cache_ttl: int = Field(default=3600)  # unit: seconds
     query_cache_maxsize: int = Field(

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -121,6 +121,7 @@ def create_service_container(
                     **pipe_components["sql_summary"],
                 ),
             },
+            allow_sql_generation_reasoning=settings.allow_sql_generation_reasoning,
             **query_cache,
         ),
         chart_service=ChartService(

--- a/wren-ai-service/src/pipelines/generation/sql_generation.py
+++ b/wren-ai-service/src/pipelines/generation/sql_generation.py
@@ -46,8 +46,10 @@ SQL:
 User's Question: {{ query }}
 Current Time: {{ current_time }}
 
+{% if sql_generation_reasoning %}
 ### REASONING PLAN ###
 {{ sql_generation_reasoning }}
+{% endif %}
 
 Let's think step by step.
 """
@@ -58,8 +60,8 @@ Let's think step by step.
 def prompt(
     query: str,
     documents: List[str],
-    sql_generation_reasoning: str,
     prompt_builder: PromptBuilder,
+    sql_generation_reasoning: str | None = None,
     configuration: Configuration | None = None,
     sql_samples: List[Dict] | None = None,
     has_calculated_field: bool = False,
@@ -138,7 +140,7 @@ class SQLGeneration(BasicPipeline):
         self,
         query: str,
         contexts: List[str],
-        sql_generation_reasoning: str,
+        sql_generation_reasoning: str | None = None,
         configuration: Configuration = Configuration(),
         sql_samples: List[Dict] | None = None,
         project_id: str | None = None,

--- a/wren-ai-service/src/pipelines/generation/sql_generation_reasoning.py
+++ b/wren-ai-service/src/pipelines/generation/sql_generation_reasoning.py
@@ -25,6 +25,8 @@ You are a helpful data analyst who is great at thinking deeply and reasoning abo
 2. Give a step by step reasoning plan in order to answer user's question.
 3. The reasoning plan should be in the language same as the language user provided in the input.
 4. Make sure to consider the current time provided in the input if the user's question is related to the date/time.
+5. Don't include SQL in the reasoning plan.
+6. Each step in the reasoning plan must start with a number, and a reasoning for the step.
 
 ### FINAL ANSWER FORMAT ###
 The final answer must be a reasoning plan in JSON format:

--- a/wren-ai-service/src/pipelines/generation/utils/sql.py
+++ b/wren-ai-service/src/pipelines/generation/utils/sql.py
@@ -224,7 +224,6 @@ TEXT_TO_SQL_RULES = """
 - If the user asks for a specific date, please give the date range in SQL query
     - example: "What is the total revenue for the month of 2024-11-01?"
     - answer: "SELECT SUM(r.PriceSum) FROM Revenue r WHERE CAST(r.PurchaseTimestamp AS TIMESTAMP WITH TIME ZONE) >= CAST('2024-11-01 00:00:00' AS TIMESTAMP WITH TIME ZONE) AND CAST(r.PurchaseTimestamp AS TIMESTAMP WITH TIME ZONE) < CAST('2024-11-02 00:00:00' AS TIMESTAMP WITH TIME ZONE)"
-- ALWAYS ADD "timestamp" to the front of the timestamp literal, ex. "timestamp '2024-02-20 12:00:00'"
 - USE THE VIEW TO SIMPLIFY THE QUERY.
 - DON'T MISUSE THE VIEW NAME. THE ACTUAL NAME IS FOLLOWING THE CREATE VIEW STATEMENT.
 - MUST USE the value of alias from the comment section of the corresponding table or column in the DATABASE SCHEMA section for the column/table alias.


### PR DESCRIPTION
- refine sql generation reasoning prompt
- refine text to sql prompt
- add allow_sql_generation_reasoning to config.yaml, default: True

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the default SQL query result limit to return up to 50 results.
  - Introduced a configurable option to enable SQL generation reasoning, with an optional structured reasoning plan in prompts.

- **Improvements**
  - Enhanced processing robustness and error handling for SQL generation outputs.
  - Refined the formatting of the reasoning steps to provide clearer, step-by-step insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->