### PR TITLE
feat(wren-ai-service): Add a few properties in Prediction Result for Evaluation

### DIFF
--- a/wren-ai-service/eval/metrics/accuracy.py
+++ b/wren-ai-service/eval/metrics/accuracy.py
@@ -7,6 +7,7 @@ import pandas as pd
 from deepeval.evaluate import TestResult
 from deepeval.metrics import BaseMetric
 from deepeval.test_case import LLMTestCase
+from deprecated import deprecated
 
 from eval.utils import get_data_from_wren_engine, get_openai_client
 
@@ -170,6 +171,9 @@ class AccuracyMetric(BaseMetric):
         return "Accuracy(column-based)"
 
 
+@deprecated(
+    reason="We don't generate multiple candidates for Text to SQL task, so don't need this metric"
+)
 class AccuracyMultiCandidateMetric(BaseMetric):
     def __init__(self):
         self.threshold = 0

--- a/wren-ai-service/eval/pipelines.py
+++ b/wren-ai-service/eval/pipelines.py
@@ -15,7 +15,6 @@ sys.path.append(f"{Path().parent.resolve()}")
 from eval import EvalSettings
 from eval.metrics import (
     AccuracyMetric,
-    AccuracyMultiCandidateMetric,
     AnswerRelevancyMetric,
     ContextualPrecisionMetric,
     ContextualRecallMetric,
@@ -289,7 +288,7 @@ class GenerationPipeline(Eval):
                 ExactMatchAccuracy(),
                 ExecutionAccuracy(),
             ],
-            "post_metrics": [AccuracyMultiCandidateMetric()],
+            "post_metrics": [],
         }
 
 
@@ -388,7 +387,7 @@ class AskPipeline(Eval):
                 ExactMatchAccuracy(),
                 ExecutionAccuracy(),
             ],
-            "post_metrics": [AccuracyMultiCandidateMetric()],
+            "post_metrics": [],
         }
 
 

--- a/wren-ai-service/eval/pipelines.py
+++ b/wren-ai-service/eval/pipelines.py
@@ -2,6 +2,7 @@ import asyncio
 import re
 import sys
 from abc import abstractmethod
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Literal
 
@@ -135,6 +136,7 @@ class Eval:
             "samples": query.get("samples", []),
             "type": "execution",
             "reasoning": "",
+            "elapsed_time": 0,
         }
 
         langfuse_context.update_current_trace(
@@ -143,7 +145,11 @@ class Eval:
             metadata=trace_metadata(self._meta, type=prediction["type"]),
         )
 
-        return await self._process(prediction, **query)
+        start_time = datetime.now()
+        returned = await self._process(prediction, **query)
+        returned["elapsed_time"] = (datetime.now() - start_time).total_seconds()
+
+        return returned
 
     @observe(capture_input=False)
     async def flat(self, prediction: dict, **kwargs) -> dict:

--- a/wren-ai-service/eval/pipelines.py
+++ b/wren-ai-service/eval/pipelines.py
@@ -39,7 +39,7 @@ def deploy_model(mdl: str, pipes: list) -> None:
     asyncio.run(wrapper())
 
 
-def extract_units(docs: list) -> list:
+def extract_units(docs: list[dict]) -> list:
     def parse_ddl(ddl: str) -> list:
         """
         Parses a DDL statement and returns a list of column definitions in the format table_name.column_name, excluding foreign keys.
@@ -81,7 +81,7 @@ def extract_units(docs: list) -> list:
 
     columns = []
     for doc in docs:
-        columns.extend(parse_ddl(doc))
+        columns.extend(parse_ddl(doc.get("table_ddl", "")))
     return columns
 
 
@@ -114,8 +114,7 @@ class Eval:
         return [prediction for batch in batches for prediction in batch]
 
     @abstractmethod
-    def _process(self, prediction: dict, **_) -> dict:
-        ...
+    def _process(self, prediction: dict, **_) -> dict: ...
 
     async def _flat(self, prediction: dict, **_) -> dict:
         """

--- a/wren-ai-service/eval/pipelines.py
+++ b/wren-ai-service/eval/pipelines.py
@@ -118,7 +118,7 @@ class Eval:
 
     async def _flat(self, prediction: dict, **_) -> dict:
         """
-        No operation function to be overridden by subclasses,if needed.
+        No operation function to be overridden by subclasses if needed.
         """
         return prediction
 
@@ -134,6 +134,7 @@ class Eval:
             "context": query["context"],
             "samples": query.get("samples", []),
             "type": "execution",
+            "reasoning": "",
         }
 
         langfuse_context.update_current_trace(
@@ -146,6 +147,12 @@ class Eval:
 
     @observe(capture_input=False)
     async def flat(self, prediction: dict, **kwargs) -> dict:
+        """
+        This method changes the trace type to 'shallow' to handle cases where a trace has multiple actual outputs.
+        The flattening mechanism was historically used to get individual scores for evaluation when a single trace
+        produced multiple outputs. While currently maintained for backwards compatibility, this functionality may
+        be removed in the future if no longer needed.
+        """
         prediction["source_trace_id"] = prediction["trace_id"]
         prediction["source_trace_url"] = prediction["trace_url"]
         prediction["trace_id"] = langfuse_context.get_current_trace_id()

--- a/wren-ai-service/eval/prediction.py
+++ b/wren-ai-service/eval/prediction.py
@@ -105,6 +105,7 @@ if __name__ == "__main__":
     dataset = parse_toml(path)
 
     settings = EvalSettings()
+    # todo: refactor this
     _mdl = base64.b64encode(orjson.dumps(dataset["mdl"])).decode("utf-8")
     if "spider_" in path:
         settings.datasource = "duckdb"


### PR DESCRIPTION
This PR introduces several improvements and cleanups to the SQL generation pipeline:

### Key Changes
- Deprecated `AccuracyMultiCandidateMetric` as it's no longer needed for Text to SQL tasks
- Added SQL reasoning step in `AskPipeline` with dedicated `SQLGenerationReasoning` component
- Added timing metrics to track elapsed time for predictions
- Improved type hints and documentation

### Technical Details
1. Pipeline Enhancements:
   - Added elapsed time tracking for predictions
   - Integrated SQL reasoning step before generation
   - Removed unused multi-candidate metric from pipelines

2. Code Quality:
   - Added type hints for `extract_units` function parameters
   - Improved error handling for DDL parsing
   - Enhanced documentation for the `flat` method
   - Added proper handling of table_ddl in document processing

3. Performance Tracking:
   - Added elapsed_time field to prediction outputs
   - Improved trace metadata handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Evaluation output now includes processing duration for improved performance visibility.
  - Enhanced SQL reasoning functionality provides additional insights in SQL generation tasks.

- **Refactor**
  - Deprecated the multi-candidate accuracy metric to streamline performance measurements.
  - Improved data source handling with refined encoding for more robust configuration.
  - Updated method signatures for better clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->