### PR TITLE
Add OAuth2 support to IbisTrinoConnection

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
@@ -53,6 +53,7 @@ export interface IbisTrinoConnectionInfo {
   schema: string;
   user: string;
   password: string;
+  auth?: OAuth2Authentication;
 }
 
 export interface IbisSnowflakeConnectionInfo {
@@ -61,6 +62,12 @@ export interface IbisSnowflakeConnectionInfo {
   account: string;
   database: string;
   schema: string;
+}
+
+export interface OAuth2Authentication {
+  clientId: string;
+  clientSecret: string;
+  tokenUrl: string;
 }
 
 export type IbisConnectionInfo =

--- a/wren-ui/src/components/pages/setup/dataSources/TrinoProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/TrinoProperties.tsx
@@ -89,6 +89,42 @@ export default function TrinoProperties({ mode }: Props) {
       >
         <Input.Password placeholder="Input password" />
       </Form.Item>
+      <Form.Item
+        label="OAuth2 Client ID"
+        name="clientId"
+        rules={[
+          {
+            required: false,
+            message: ERROR_TEXTS.CONNECTION.CLIENT_ID.REQUIRED,
+          },
+        ]}
+      >
+        <Input placeholder="OAuth2 Client ID" />
+      </Form.Item>
+      <Form.Item
+        label="OAuth2 Client Secret"
+        name="clientSecret"
+        rules={[
+          {
+            required: false,
+            message: ERROR_TEXTS.CONNECTION.CLIENT_SECRET.REQUIRED,
+          },
+        ]}
+      >
+        <Input.Password placeholder="OAuth2 Client Secret" />
+      </Form.Item>
+      <Form.Item
+        label="OAuth2 Token URL"
+        name="tokenUrl"
+        rules={[
+          {
+            required: false,
+            message: ERROR_TEXTS.CONNECTION.TOKEN_URL.REQUIRED,
+          },
+        ]}
+      >
+        <Input placeholder="OAuth2 Token URL" />
+      </Form.Item>
       <Form.Item label="Use SSL" name="ssl" valuePropName="checked">
         <Switch />
       </Form.Item>


### PR DESCRIPTION
Add support for OAuth2 authentication in IbisTrinoConnection.

* Add `OAuth2Authentication` interface to handle OAuth2 authentication in `wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts`.
* Update `IbisTrinoConnectionInfo` interface to include optional `auth` field for OAuth2 authentication.
* Add fields for OAuth2 client ID, client secret, and token URL in `TrinoProperties` component in `wren-ui/src/components/pages/setup/dataSources/TrinoProperties.tsx`.
* Update form submission logic to include OAuth2 fields in `TrinoProperties` component.

