### PR TITLE
chore(wren-ai-service): allow regenerate sql using retrieved tables

### DIFF
--- a/wren-ai-service/src/web/v1/routers/ask.py
+++ b/wren-ai-service/src/web/v1/routers/ask.py
@@ -155,7 +155,7 @@ async def ask_feedback(
     service_container.ask_service._ask_feedback_results[
         query_id
     ] = AskFeedbackResultResponse(
-        status="understanding",
+        status="searching",
     )
 
     background_tasks.add_task(


### PR DESCRIPTION
`POST /v1/ask-feedbacks`: now users need to pass parameter `tables` (type: [string], which means table names) to regenerate sql.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a comma-separated text input for specifying table names, giving users direct control over SQL query regeneration.
  - Integrated database schema context into the SQL generation process for more accurate query outputs.
  - Enabled feedback requests to include specific table details for improved context.

- **Improvements**
  - Updated the feedback status indicator to display “searching” for clearer progress communication.
  - Enhanced document retrieval with improved filtering, leading to a more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->