### PR TITLE
Allow custom timeout via env-vars

### DIFF
--- a/wren-ai-service/entrypoint.sh
+++ b/wren-ai-service/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 INTERVAL=1
-TIMEOUT=60
+TIMEOUT=${LAUNCH_TIMEOUT:-60}
 
 # Wait for qdrant to be responsive
 echo "Waiting for qdrant to start..."


### PR DESCRIPTION
Too many this kind of message in my console, just wanna specify a longer time.

```
Timeout: wren-ai-service did not start within 60 seconds
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization flexibility: Service startup now supports a configurable timeout duration, allowing users to adjust the waiting period for responsiveness via an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->