### PR TITLE
fix(wren-ui): sql server ssl property default value replace with initial value

### DIFF
--- a/wren-ui/src/components/pages/setup/dataSources/SQLServerProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/SQLServerProperties.tsx
@@ -94,8 +94,9 @@ export default function SQLServerProperties(props: Props) {
         label="Enable Trust Server Certificate"
         name="trustServerCertificate"
         valuePropName="checked"
+        initialValue={true}
       >
-        <Switch defaultChecked />
+        <Switch />
       </Form.Item>
     </>
   );


### PR DESCRIPTION
## Description
This PR fixes the issue where the default value of SQL Server SSL properties does not work because Antd Form treats initialValue as the actual value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the default behavior of the "Enable Trust Server Certificate" option so it now initializes as enabled consistently, ensuring that the toggle accurately reflects its intended starting state for a clearer user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->