### PR TITLE
feat(wren-ai-service): Add trace ID propagation across service responses

### DIFF
--- a/wren-ai-service/src/utils.py
+++ b/wren-ai-service/src/utils.py
@@ -123,7 +123,9 @@ def trace_metadata(func):
 
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
-        results = await func(*args, **kwargs)
+        trace_id = langfuse_context.get_current_trace_id()
+
+        results = await func(*args, **kwargs, trace_id=trace_id)
 
         addition = {}
         if isinstance(results, dict):

--- a/wren-ai-service/src/web/v1/routers/question_recommendation.py
+++ b/wren-ai-service/src/web/v1/routers/question_recommendation.py
@@ -122,6 +122,7 @@ class GetResponse(BaseModel):
     status: Literal["generating", "finished", "failed"]
     response: Optional[dict]
     error: Optional[dict]
+    trace_id: Optional[str] = None
 
 
 @router.get(
@@ -147,4 +148,5 @@ async def get(
         status=resource.status,
         response=_formatter(resource.response),
         error=resource.error and resource.error.model_dump(),
+        trace_id=resource.trace_id,
     )

--- a/wren-ai-service/src/web/v1/routers/relationship_recommendation.py
+++ b/wren-ai-service/src/web/v1/routers/relationship_recommendation.py
@@ -107,7 +107,7 @@ class GetResponse(BaseModel):
     status: Literal["generating", "finished", "failed"]
     response: Optional[dict]
     error: Optional[dict]
-
+    trace_id: Optional[str] = None
 
 @router.get(
     "/relationship-recommendations/{id}",
@@ -124,4 +124,5 @@ async def get(
         status=resource.status,
         response=resource.response,
         error=resource.error and resource.error.model_dump(),
+        trace_id=resource.trace_id,
     )

--- a/wren-ai-service/src/web/v1/routers/semantics_description.py
+++ b/wren-ai-service/src/web/v1/routers/semantics_description.py
@@ -128,6 +128,7 @@ class GetResponse(BaseModel):
     status: Literal["generating", "finished", "failed"]
     response: Optional[list[dict]]
     error: Optional[dict]
+    trace_id: Optional[str] = None
 
 
 @router.get(
@@ -164,4 +165,5 @@ async def get(
         status=resource.status,
         response=resource.response and _formatter(resource.response),
         error=resource.error and resource.error.model_dump(),
+        trace_id=resource.trace_id,
     )

--- a/wren-ai-service/src/web/v1/routers/sql_pairs.py
+++ b/wren-ai-service/src/web/v1/routers/sql_pairs.py
@@ -153,7 +153,7 @@ async def get(
 ) -> GetResponse:
     event: SqlPairsService.Event = container.sql_pairs_service[event_id]
     return GetResponse(
-        id=event.id,
+        event_id=event.id,
         status=event.status,
         error=event.error and event.error.model_dump(),
         trace_id=event.trace_id,

--- a/wren-ai-service/src/web/v1/routers/sql_pairs.py
+++ b/wren-ai-service/src/web/v1/routers/sql_pairs.py
@@ -143,6 +143,7 @@ class GetResponse(BaseModel):
     event_id: str
     status: Literal["indexing", "deleting", "finished", "failed"]
     error: Optional[dict]
+    trace_id: Optional[str]
 
 
 @router.get("/sql-pairs/{event_id}")
@@ -152,7 +153,8 @@ async def get(
 ) -> GetResponse:
     event: SqlPairsService.Event = container.sql_pairs_service[event_id]
     return GetResponse(
-        event_id=event.id,
+        id=event.id,
         status=event.status,
         error=event.error and event.error.model_dump(),
+        trace_id=event.trace_id,
     )

--- a/wren-ai-service/src/web/v1/services/sql_pairs.py
+++ b/wren-ai-service/src/web/v1/services/sql_pairs.py
@@ -43,7 +43,7 @@ class SqlPairsService:
         self._cache[id] = self.Event(
             id=id,
             status="failed",
-            error=self.Resource.Error(code=code, message=error_message),
+            error=self.Event.Error(code=code, message=error_message),
             trace_id=trace_id,
         )
         logger.error(error_message)

--- a/wren-ai-service/src/web/v1/services/sql_question.py
+++ b/wren-ai-service/src/web/v1/services/sql_question.py
@@ -45,7 +45,7 @@ class SqlQuestionResultResponse(BaseModel):
     status: Literal["generating", "succeeded", "failed"]
     error: Optional[SqlQuestionError] = None
     questions: Optional[list[str]] = None
-
+    trace_id: Optional[str] = None
 
 class SqlQuestionService:
     def __init__(
@@ -66,6 +66,7 @@ class SqlQuestionService:
         sql_question_request: SqlQuestionRequest,
         **kwargs,
     ):
+        trace_id = kwargs.get("trace_id")
         results = {
             "sql_question_result": {},
             "metadata": {
@@ -79,6 +80,7 @@ class SqlQuestionService:
 
             self._sql_question_results[query_id] = SqlQuestionResultResponse(
                 status="generating",
+                trace_id=trace_id,
             )
 
             sql_questions_result = (
@@ -91,6 +93,7 @@ class SqlQuestionService:
             self._sql_question_results[query_id] = SqlQuestionResultResponse(
                 status="succeeded",
                 questions=sql_questions_result,
+                trace_id=trace_id,
             )
 
             results["sql_question_result"] = sql_questions_result
@@ -106,6 +109,7 @@ class SqlQuestionService:
                     code="OTHERS",
                     message=str(e),
                 ),
+                trace_id=trace_id,
             )
 
             results["metadata"]["error_type"] = "OTHERS"


### PR DESCRIPTION
### Changes
- Added `trace_id` field to response models across multiple services to enable end-to-end tracing
- Modified `trace_metadata` decorator to pass trace ID through function calls
- Updated service handlers to propagate trace IDs through the request lifecycle

### Impact
This change improves observability by allowing requests to be traced across different services and components. The trace ID is now consistently propagated through the entire request lifecycle, making it easier to debug and monitor request flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced multiple API endpoints to include an optional trace identifier in responses, improving visibility and aiding in debugging and request tracking.
	- The new trace ID field is now available across various operations, providing additional context for both successful outcomes and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->