### PR TITLE
chore(wren-ai-service): Introduce Model Aliases for Simplified Pipeline Configuration

### DIFF
--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -54,6 +54,7 @@ data:
     timeout: 120
     models:
     - model: gpt-4o-mini-2024-07-18
+      alias: default
       api_base: https://api.openai.com/v1
       api_key_name: LLM_OPENAI_API_KEY
       kwargs:
@@ -83,6 +84,7 @@ data:
     provider: litellm_embedder
     models:
     - model: text-embedding-3-large
+      alias: default
       api_base: https://api.openai.com/v1
       api_key_name: EMBEDDER_OPENAI_API_KEY
       timeout: 120
@@ -103,81 +105,81 @@ data:
     type: pipeline
     pipes:
       - name: db_schema_indexing
-        embedder: litellm_embedder.text-embedding-3-large
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: historical_question_indexing
-        embedder: litellm_embedder.text-embedding-3-large
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: table_description_indexing
-        embedder: litellm_embedder.text-embedding-3-large
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: db_schema_retrieval
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
-        embedder: litellm_embedder.text-embedding-3-large
+        llm: litellm_llm.default
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: historical_question_retrieval
-        embedder: litellm_embedder.text-embedding-3-large
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: sql_generation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: sql_correction
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: followup_sql_generation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: sql_summary
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_answer
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_breakdown
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: sql_expansion
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: semantics_description
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: relationship_recommendation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: question_recommendation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: question_recommendation_db_schema_retrieval
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
-        embedder: litellm_embedder.text-embedding-3-large
+        llm: litellm_llm.default
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: question_recommendation_sql_generation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
       - name: intent_classification
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
-        embedder: litellm_embedder.text-embedding-3-large
+        llm: litellm_llm.default
+        embedder: litellm_embedder.default
         document_store: qdrant
       - name: data_assistance
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_pairs_indexing
         document_store: qdrant
-        embedder: litellm_embedder.text-embedding-3-large
+        embedder: litellm_embedder.default
       - name: sql_pairs_retrieval
         document_store: qdrant
-        embedder: litellm_embedder.text-embedding-3-large
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        embedder: litellm_embedder.default
+        llm: litellm_llm.default
       - name: preprocess_sql_data
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_executor
         engine: wren_ui
       - name: chart_generation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: chart_adjustment
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_question_generation
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_generation_reasoning
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
       - name: sql_regeneration
-        llm: litellm_llm.gpt-4o-mini-2024-07-18
+        llm: litellm_llm.default
         engine: wren_ui
 
     ---

--- a/docker/config.example.yaml
+++ b/docker/config.example.yaml
@@ -3,6 +3,7 @@ provider: litellm_llm
 timeout: 120
 models:
 - model: gpt-4o-mini-2024-07-18
+  alias: default
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -34,6 +35,7 @@ type: embedder
 provider: litellm_embedder
 models:
 - model: text-embedding-3-large
+  alias: default
   api_base: https://api.openai.com/v1
   api_key_name: EMBEDDER_OPENAI_API_KEY
   timeout: 120
@@ -55,81 +57,81 @@ recreate_index: true
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_breakdown
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: intent_classification
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_question_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
 
 ---

--- a/wren-ai-service/docs/config_examples/config.azure.yaml
+++ b/wren-ai-service/docs/config_examples/config.azure.yaml
@@ -7,27 +7,28 @@
 type: llm
 provider: litellm_llm
 models:
-# put AZURE_API_KEY=<your_api_key> in ~/.wrenai/.env
-- model: azure/gpt-4     # Your Azure deployment name, put 'azure/' before deployment name
-  api_base: https://endpoint.openai.azure.com  # Replace with your custom Azure endpoint
-  api_version: 2024-02-15-preview
-  timeout: 120
-  kwargs:
-    temperature: 0
-    n: 1
-    seed: 0
-    max_tokens: 4096
-    
+  # put AZURE_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - model: azure/gpt-4 # Your Azure deployment name, put 'azure/' before deployment name
+    alias: default
+    api_base: https://endpoint.openai.azure.com # Replace with your custom Azure endpoint
+    api_version: 2024-02-15-preview
+    timeout: 120
+    kwargs:
+      temperature: 0
+      n: 1
+      seed: 0
+      max_tokens: 4096
 
 ---
 type: embedder
-provider: litellm_embedder  
+provider: litellm_embedder
 models:
-# put AZURE_API_KEY=<your_api_key> in ~/.wrenai/.env
-- model: azure/text-embedding-ada-002  # Your Azure deployment name, put 'azure/' before deployment name
-  api_base: https://endpoint.openai.azure.com  # Replace with your custom Azure endpoint
-  api_version: 2023-05-15
-  timeout: 300
+  # put AZURE_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - model: azure/text-embedding-ada-002 # Your Azure deployment name, put 'azure/' before deployment name
+    alias: default
+    api_base: https://endpoint.openai.azure.com # Replace with your custom Azure endpoint
+    api_version: 2023-05-15
+    timeout: 300
 
 ---
 type: engine
@@ -37,8 +38,8 @@ endpoint: http://wren-ui:3000
 ---
 type: document_store
 provider: qdrant
-location: http://qdrant:6333  # Donot set the QDRANT_API_KEY if you are using the qdrant from docker
-embedding_model_dim: 1536  # Must match model dimension from embedder
+location: http://qdrant:6333 # Donot set the QDRANT_API_KEY if you are using the qdrant from docker
+embedding_model_dim: 1536 # Must match model dimension from embedder
 timeout: 120
 recreate_index: true
 
@@ -49,87 +50,87 @@ recreate_index: true
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.azure/text-embedding-ada-002
-    document_store: qdrant  # Match document_store name
-    llm: litellm_llm.azure/gpt-4
+    embedder: litellm_embedder.default
+    document_store: qdrant # Match document_store name
+    llm: litellm_llm.default
   - name: historical_question_indexing
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.azure/gpt-4
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: intent_classification
-    llm: litellm_llm.azure/gpt-4
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: sql_pairs_preparation
     document_store: qdrant
-    embedder: litellm_embedder.azure/text-embedding-ada-002
-    llm: litellm_llm.azure/gpt-4
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.azure/text-embedding-ada-002
-    llm: litellm_llm.azure/gpt-4
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    embedder: litellm_embedder.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.azure/gpt-4
-    embedder: litellm_embedder.azure/text-embedding-ada-002
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.azure/gpt-4
+    llm: litellm_llm.default
     engine: wren_ui
 
 ---

--- a/wren-ai-service/docs/config_examples/config.deepseek.yaml
+++ b/wren-ai-service/docs/config_examples/config.deepseek.yaml
@@ -7,41 +7,43 @@
 type: llm
 provider: litellm_llm
 models:
-# put DEEPSEEK_API_KEY=<your_api_key> in ~/.wrenai/.env
-- api_base: https://api.deepseek.com/v1
-  model: deepseek/deepseek-reasoner
-  timeout: 120
-  kwargs:
-    n: 1
-    temperature: 0
-    response_format:
-      type: text
-- api_base: https://api.deepseek.com/v1
-  model: deepseek/deepseek-chat
-  timeout: 120
-  kwargs:
-    n: 1
-    temperature: 0
-    response_format:
-      type: text
-- api_base: https://api.deepseek.com/v1
-  model: deepseek/deepseek-coder
-  timeout: 120
-  kwargs:
-    n: 1
-    temperature: 0
-    response_format:
-      type: json_object
+  # put DEEPSEEK_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - api_base: https://api.deepseek.com/v1
+    model: deepseek/deepseek-reasoner
+    alias: default
+    timeout: 120
+    kwargs:
+      n: 1
+      temperature: 0
+      response_format:
+        type: text
+  - api_base: https://api.deepseek.com/v1
+    model: deepseek/deepseek-chat
+    timeout: 120
+    kwargs:
+      n: 1
+      temperature: 0
+      response_format:
+        type: text
+  - api_base: https://api.deepseek.com/v1
+    model: deepseek/deepseek-coder
+    timeout: 120
+    kwargs:
+      n: 1
+      temperature: 0
+      response_format:
+        type: json_object
 
 ---
 type: embedder
 provider: litellm_embedder
 models:
-# define OPENAI_API_KEY=<api_key> in ~/.wrenai/.env if you are using openai embedding model
-# please refer to LiteLLM documentation for more details: https://docs.litellm.ai/docs/providers
-- model: text-embedding-3-large  # put your embedding model name here, if it is not openai embedding model, should be <provider>/<model_name>
-  api_base: https://api.openai.com/v1  # change this according to your embedding model
-  timeout: 120
+  # define OPENAI_API_KEY=<api_key> in ~/.wrenai/.env if you are using openai embedding model
+  # please refer to LiteLLM documentation for more details: https://docs.litellm.ai/docs/providers
+  - model: text-embedding-3-large # put your embedding model name here, if it is not openai embedding model, should be <provider>/<model_name>
+    alias: default
+    api_base: https://api.openai.com/v1 # change this according to your embedding model
+    timeout: 120
 
 ---
 type: engine
@@ -52,7 +54,7 @@ endpoint: http://wren-ui:3000
 type: document_store
 provider: qdrant
 location: http://qdrant:6333
-embedding_model_dim: 3072  # put your embedding model dimension here
+embedding_model_dim: 3072 # put your embedding model dimension here
 timeout: 120
 recreate_index: true
 
@@ -63,82 +65,82 @@ recreate_index: true
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.deepseek/deepseek-coder
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.deepseek/deepseek-chat
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.deepseek/deepseek-coder
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: intent_classification
-    llm: litellm_llm.deepseek/deepseek-coder
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.deepseek/deepseek-chat
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
-    llm: litellm_llm.deepseek/deepseek-coder
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.deepseek/deepseek-reasoner
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.deepseek/deepseek-coder
+    llm: litellm_llm.default
     engine: wren_ui
 
 ---
@@ -146,7 +148,7 @@ settings:
   column_indexing_batch_size: 50
   table_retrieval_size: 10
   table_column_retrieval_size: 100
-  allow_using_db_schemas_without_pruning: false  # if you want to use db schemas without pruning, set this to true. It will be faster
+  allow_using_db_schemas_without_pruning: false # if you want to use db schemas without pruning, set this to true. It will be faster
   query_cache_maxsize: 1000
   query_cache_ttl: 3600
   langfuse_host: https://cloud.langfuse.com

--- a/wren-ai-service/docs/config_examples/config.google_ai_studio.yaml
+++ b/wren-ai-service/docs/config_examples/config.google_ai_studio.yaml
@@ -8,29 +8,31 @@
 type: llm
 provider: litellm_llm
 models:
-# put GEMINI_API_KEY=<your_api_key> in ~/.wrenai/.env
-- model: gemini/gemini-2.0-flash-exp  # gemini/<gemini_model_name>
-  timeout: 120
-  kwargs:
-    n: 1
-    temperature: 0
-- model: gemini/gemini-2.0-flash-exp  # gemini/<gemini_model_name>
-  alias: gemini-llm-for-chart
-  timeout: 120
-  kwargs:
-    n: 1
-    temperature: 0
-    response_format:
-      type: json_object
+  # put GEMINI_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - model: gemini/gemini-2.0-flash-exp # gemini/<gemini_model_name>
+    alias: default
+    timeout: 120
+    kwargs:
+      n: 1
+      temperature: 0
+  - model: gemini/gemini-2.0-flash-exp # gemini/<gemini_model_name>
+    alias: gemini-llm-for-chart
+    timeout: 120
+    kwargs:
+      n: 1
+      temperature: 0
+      response_format:
+        type: json_object
 
 ---
 type: embedder
 provider: litellm_embedder
 models:
-# put GEMINI_API_KEY=<your_api_key> in ~/.wrenai/.env
-- model: gemini/text-embedding-004  # gemini/<gemini_model_name>
-  api_base: https://generativelanguage.googleapis.com/v1beta/openai  # change this according to your embedding model
-  timeout: 120
+  # put GEMINI_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - model: gemini/text-embedding-004 # gemini/<gemini_model_name>
+    alias: default
+    api_base: https://generativelanguage.googleapis.com/v1beta/openai # change this according to your embedding model
+    timeout: 120
 
 ---
 type: engine
@@ -41,7 +43,7 @@ endpoint: http://wren-ui:3000
 type: document_store
 provider: qdrant
 location: http://qdrant:6333
-embedding_model_dim: 768  # put your embedding model dimension here
+embedding_model_dim: 768 # put your embedding model dimension here
 timeout: 120
 recreate_index: true
 
@@ -52,82 +54,82 @@ recreate_index: true
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.gemini/text-embedding-004
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.gemini/text-embedding-004
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.gemini/text-embedding-004
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
-    embedder: litellm_embedder.gemini/text-embedding-004
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.gemini/text-embedding-004
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
-    embedder: litellm_embedder.gemini/text-embedding-004
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
   - name: chart_generation
     llm: litellm_llm.gemini-llm-for-chart
   - name: chart_adjustment
     llm: litellm_llm.gemini-llm-for-chart
   - name: intent_classification
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
-    embedder: litellm_embedder.gemini/text-embedding-004
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.gemini/text-embedding-004
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.gemini/text-embedding-004
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.gemini/gemini-2.0-flash-exp
+    llm: litellm_llm.default
     engine: wren_ui
 
 ---
@@ -135,7 +137,7 @@ settings:
   column_indexing_batch_size: 50
   table_retrieval_size: 10
   table_column_retrieval_size: 100
-  allow_using_db_schemas_without_pruning: false  # if you want to use db schemas without pruning, set this to true. It will be faster
+  allow_using_db_schemas_without_pruning: false # if you want to use db schemas without pruning, set this to true. It will be faster
   query_cache_maxsize: 1000
   query_cache_ttl: 3600
   langfuse_host: https://cloud.langfuse.com

--- a/wren-ai-service/docs/config_examples/config.groq.yaml
+++ b/wren-ai-service/docs/config_examples/config.groq.yaml
@@ -7,23 +7,25 @@
 type: llm
 provider: litellm_llm
 models:
-# put GROQ_API_KEY=<your_api_key> in ~/.wrenai/.env
-- api_base: https://api.groq.com/openai/v1
-  model: groq/llama-3.3-70b-specdec  # groq/<ollama_model_name>
-  timeout: 120
-  kwargs:
-    n: 1
-    temperature: 0
+  # put GROQ_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - api_base: https://api.groq.com/openai/v1
+    model: groq/llama-3.3-70b-specdec # groq/<ollama_model_name>
+    alias: default
+    timeout: 120
+    kwargs:
+      n: 1
+      temperature: 0
 
 ---
 type: embedder
 provider: litellm_embedder
 models:
-# define OPENAI_API_KEY=<api_key> in ~/.wrenai/.env if you are using openai embedding model
-# please refer to LiteLLM documentation for more details: https://docs.litellm.ai/docs/providers
-- model: text-embedding-3-large  # put your embedding model name here, if it is not openai embedding model, should be <provider>/<model_name>
-  api_base: https://api.openai.com/v1  # change this according to your embedding model
-  timeout: 120
+  # define OPENAI_API_KEY=<api_key> in ~/.wrenai/.env if you are using openai embedding model
+  # please refer to LiteLLM documentation for more details: https://docs.litellm.ai/docs/providers
+  - model: text-embedding-3-large # put your embedding model name here, if it is not openai embedding model, should be <provider>/<model_name>
+    alias: default
+    api_base: https://api.openai.com/v1 # change this according to your embedding model
+    timeout: 120
 
 ---
 type: engine
@@ -34,7 +36,7 @@ endpoint: http://wren-ui:3000
 type: document_store
 provider: qdrant
 location: http://qdrant:6333
-embedding_model_dim: 3072  # put your embedding model dimension here
+embedding_model_dim: 3072 # put your embedding model dimension here
 timeout: 120
 recreate_index: true
 
@@ -45,82 +47,82 @@ recreate_index: true
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: intent_classification
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.groq/llama-3.3-70b-specdec
+    llm: litellm_llm.default
     engine: wren_ui
 
 ---
@@ -128,7 +130,7 @@ settings:
   column_indexing_batch_size: 50
   table_retrieval_size: 10
   table_column_retrieval_size: 100
-  allow_using_db_schemas_without_pruning: false  # if you want to use db schemas without pruning, set this to true. It will be faster
+  allow_using_db_schemas_without_pruning: false # if you want to use db schemas without pruning, set this to true. It will be faster
   query_cache_maxsize: 1000
   query_cache_ttl: 3600
   langfuse_host: https://cloud.langfuse.com

--- a/wren-ai-service/docs/config_examples/config.ollama.yaml
+++ b/wren-ai-service/docs/config_examples/config.ollama.yaml
@@ -7,11 +7,9 @@
 type: llm
 provider: litellm_llm
 models:
-  # put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
-  - api_base: http://host.docker.internal:11434/v1 # change this to your ollama host, api_base should be <ollama_url>/v1
-    model: openai/phi4:14b # openai/<ollama_model_name>
+  - api_base: http://host.docker.internal:11434 # change this to your ollama host, api_base should be <ollama_url>/v1
+    model: ollama_chat/phi4:14b # openai/<ollama_model_name>
     alias: default
-    api_key_name: OPENAI_API_KEY
     timeout: 600
     kwargs:
       n: 1
@@ -21,11 +19,9 @@ models:
 type: embedder
 provider: litellm_embedder
 models:
-  # put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
-  - model: openai/nomic-embed-text # put your ollama embedder model name here, openai/<ollama_model_name>
+  - model: ollama/nomic-embed-text # put your ollama embedder model name here, openai/<ollama_model_name>
     alias: default
-    api_base: http://host.docker.internal:11434/v1 # change this to your ollama host, api_base should be <ollama_url>/v1
-    api_key_name: OPENAI_API_KEY
+    api_base: http://host.docker.internal:11434 # change this to your ollama host, api_base should be <ollama_url>/v1
     timeout: 600
 
 ---

--- a/wren-ai-service/docs/config_examples/config.ollama.yaml
+++ b/wren-ai-service/docs/config_examples/config.ollama.yaml
@@ -7,8 +7,8 @@
 type: llm
 provider: litellm_llm
 models:
-  - api_base: http://host.docker.internal:11434 # change this to your ollama host, api_base should be <ollama_url>/v1
-    model: ollama_chat/phi4:14b # openai/<ollama_model_name>
+  - api_base: http://host.docker.internal:11434 # change this to your ollama host, api_base should be <ollama_url>
+    model: ollama_chat/phi4:14b # ollama_chat/<ollama_model_name>
     alias: default
     timeout: 600
     kwargs:
@@ -19,9 +19,9 @@ models:
 type: embedder
 provider: litellm_embedder
 models:
-  - model: ollama/nomic-embed-text # put your ollama embedder model name here, openai/<ollama_model_name>
+  - model: ollama/nomic-embed-text # put your ollama embedder model name here, ollama/<ollama_model_name>
     alias: default
-    api_base: http://host.docker.internal:11434 # change this to your ollama host, api_base should be <ollama_url>/v1
+    api_base: http://host.docker.internal:11434 # change this to your ollama host, api_base should be <ollama_url>
     timeout: 600
 
 ---

--- a/wren-ai-service/docs/config_examples/config.ollama.yaml
+++ b/wren-ai-service/docs/config_examples/config.ollama.yaml
@@ -7,24 +7,26 @@
 type: llm
 provider: litellm_llm
 models:
-# put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
-- api_base: http://host.docker.internal:11434/v1  # change this to your ollama host, api_base should be <ollama_url>/v1
-  model: openai/phi4:14b  # openai/<ollama_model_name>
-  api_key_name: OPENAI_API_KEY
-  timeout: 600
-  kwargs:
-    n: 1
-    temperature: 0
+  # put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
+  - api_base: http://host.docker.internal:11434/v1 # change this to your ollama host, api_base should be <ollama_url>/v1
+    model: openai/phi4:14b # openai/<ollama_model_name>
+    alias: default
+    api_key_name: OPENAI_API_KEY
+    timeout: 600
+    kwargs:
+      n: 1
+      temperature: 0
 
 ---
 type: embedder
 provider: litellm_embedder
 models:
-# put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
-- model: openai/nomic-embed-text  # put your ollama embedder model name here, openai/<ollama_model_name>
-  api_base: http://host.docker.internal:11434/v1  # change this to your ollama host, api_base should be <ollama_url>/v1
-  api_key_name: OPENAI_API_KEY
-  timeout: 600
+  # put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
+  - model: openai/nomic-embed-text # put your ollama embedder model name here, openai/<ollama_model_name>
+    alias: default
+    api_base: http://host.docker.internal:11434/v1 # change this to your ollama host, api_base should be <ollama_url>/v1
+    api_key_name: OPENAI_API_KEY
+    timeout: 600
 
 ---
 type: engine
@@ -35,7 +37,7 @@ endpoint: http://wren-ui:3000
 type: document_store
 provider: qdrant
 location: http://qdrant:6333
-embedding_model_dim: 768  # put your embedding model dimension here
+embedding_model_dim: 768 # put your embedding model dimension here
 timeout: 120
 recreate_index: true
 
@@ -46,90 +48,90 @@ recreate_index: true
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.openai/nomic-embed-text
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.openai/nomic-embed-text
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.openai/nomic-embed-text
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.openai/phi4:14b
-    embedder: litellm_embedder.openai/nomic-embed-text
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.openai/nomic-embed-text
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_breakdown
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.openai/phi4:14b
-    embedder: litellm_embedder.openai/nomic-embed-text
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: intent_classification
-    llm: litellm_llm.openai/phi4:14b
-    embedder: litellm_embedder.openai/nomic-embed-text
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.openai/nomic-embed-text
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.openai/nomic-embed-text
-    llm: litellm_llm.openai/phi4:14b
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.openai/phi4:14b
+    llm: litellm_llm.default
     engine: wren_ui
-  
+
 ---
 settings:
   column_indexing_batch_size: 50
   table_retrieval_size: 10
   table_column_retrieval_size: 100
-  allow_using_db_schemas_without_pruning: false  # if you want to use db schemas without pruning, set this to true. It will be faster
+  allow_using_db_schemas_without_pruning: false # if you want to use db schemas without pruning, set this to true. It will be faster
   query_cache_maxsize: 1000
   query_cache_ttl: 3600
   langfuse_host: https://cloud.langfuse.com

--- a/wren-ai-service/docs/config_examples/config.ollama.yaml
+++ b/wren-ai-service/docs/config_examples/config.ollama.yaml
@@ -10,6 +10,7 @@ models:
 # put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
 - api_base: http://host.docker.internal:11434/v1  # change this to your ollama host, api_base should be <ollama_url>/v1
   model: openai/phi4:14b  # openai/<ollama_model_name>
+  api_key_name: OPENAI_API_KEY
   timeout: 600
   kwargs:
     n: 1
@@ -22,6 +23,7 @@ models:
 # put OPENAI_API_KEY=<random_string> in ~/.wrenai/.env
 - model: openai/nomic-embed-text  # put your ollama embedder model name here, openai/<ollama_model_name>
   api_base: http://host.docker.internal:11434/v1  # change this to your ollama host, api_base should be <ollama_url>/v1
+  api_key_name: OPENAI_API_KEY
   timeout: 600
 
 ---

--- a/wren-ai-service/tools/config/config.example.yaml
+++ b/wren-ai-service/tools/config/config.example.yaml
@@ -3,6 +3,7 @@ provider: litellm_llm
 timeout: 120
 models:
 - model: gpt-4o-mini-2024-07-18
+  alias: default
   api_base: https://api.openai.com/v1
   api_key_name: LLM_OPENAI_API_KEY
   kwargs:
@@ -34,6 +35,7 @@ type: embedder
 provider: litellm_embedder
 models:
   - model: text-embedding-3-large
+    alias: default
     api_base: https://api.openai.com/v1
     api_key_name: EMBEDDER_OPENAI_API_KEY
     timeout: 120
@@ -69,84 +71,84 @@ recreate_index: false
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_breakdown
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: intent_classification
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: evaluation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
 
 ---
 settings:

--- a/wren-ai-service/tools/config/config.full.yaml
+++ b/wren-ai-service/tools/config/config.full.yaml
@@ -2,41 +2,43 @@ type: llm
 provider: litellm_llm
 timeout: 120
 models:
-- model: gpt-4o-mini-2024-07-18
-  api_base: https://api.openai.com/v1
-  api_key_name: LLM_OPENAI_API_KEY
-  kwargs:
-    temperature: 0
-    n: 1
-    # for better consistency of llm response
-    seed: 0
-    max_tokens: 4096
-- model: gpt-4o-2024-08-06
-  api_base: https://api.openai.com/v1
-  api_key_name: LLM_OPENAI_API_KEY
-  kwargs:
-    temperature: 0
-    n: 1
-    # for better consistency of llm response
-    seed: 0
-    max_tokens: 4096
-- model: o3-mini-2025-01-31
-  api_base: https://api.openai.com/v1
-  api_key_name: LLM_OPENAI_API_KEY
-  kwargs:
-    n: 1
-    seed: 0
-    max_completion_tokens: 4096
-    reasoning_effort: low
+  - model: gpt-4o-mini-2024-07-18
+    alias: default
+    api_base: https://api.openai.com/v1
+    api_key_name: LLM_OPENAI_API_KEY
+    kwargs:
+      temperature: 0
+      n: 1
+      # for better consistency of llm response
+      seed: 0
+      max_tokens: 4096
+  - model: gpt-4o-2024-08-06
+    api_base: https://api.openai.com/v1
+    api_key_name: LLM_OPENAI_API_KEY
+    kwargs:
+      temperature: 0
+      n: 1
+      # for better consistency of llm response
+      seed: 0
+      max_tokens: 4096
+  - model: o3-mini-2025-01-31
+    api_base: https://api.openai.com/v1
+    api_key_name: LLM_OPENAI_API_KEY
+    kwargs:
+      n: 1
+      seed: 0
+      max_completion_tokens: 4096
+      reasoning_effort: low
 
 ---
 type: embedder
 provider: litellm_embedder
 models:
-- model: text-embedding-3-large
-  api_base: https://api.openai.com/v1
-  api_key_name: EMBEDDER_OPENAI_API_KEY
-  timeout: 120
+  - model: text-embedding-3-large
+    alias: default
+    api_base: https://api.openai.com/v1
+    api_key_name: EMBEDDER_OPENAI_API_KEY
+    timeout: 120
 
 ---
 type: engine
@@ -69,84 +71,84 @@ recreate_index: false
 type: pipeline
 pipes:
   - name: db_schema_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: table_description_indexing
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: historical_question_retrieval
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_correction
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: followup_sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_summary
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_answer
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_breakdown
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: sql_expansion
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: semantics_description
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: relationship_recommendation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: question_recommendation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: question_recommendation_db_schema_retrieval
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: question_recommendation_sql_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: chart_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: chart_adjustment
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: intent_classification
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
-    embedder: litellm_embedder.text-embedding-3-large
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
     document_store: qdrant
   - name: data_assistance
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_pairs_indexing
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
+    embedder: litellm_embedder.default
   - name: sql_pairs_retrieval
     document_store: qdrant
-    embedder: litellm_embedder.text-embedding-3-large
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
   - name: preprocess_sql_data
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_executor
     engine: wren_ui
   - name: sql_question_generation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_generation_reasoning
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
   - name: sql_regeneration
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
     engine: wren_ui
   - name: evaluation
-    llm: litellm_llm.gpt-4o-mini-2024-07-18
+    llm: litellm_llm.default
 
 ---
 settings:


### PR DESCRIPTION
This PR add a model alias to simplify and standardize model references across pipeline configurations. The changes include:

- Added 'alias: default' to LLM and embedder model configurations
- Updated all pipeline configurations to use the new alias reference system
- Replaced explicit model names with '.default' references in all pipeline configurations
- Applied changes consistently across deployment, docker, and Azure configurations
- Modified prefix to `ollama_chat` to ensure the json schema output in ollama example config

Benefits:
- Simplified model reference management
- Easier model swapping without updating multiple pipeline references
- Reduced configuration maintenance overhead
- More consistent configuration across different environments

The changes maintain full functionality while making the configuration more maintainable and flexible for future updates.

Reference:
- https://github.com/BerriAI/litellm/issues/6353
- https://docs.litellm.ai/docs/providers/ollama#json-schema-support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated configuration examples to standardize model references with a new alias field, enhancing maintainability.
	- Restructured model definitions for clarity, ensuring consistent usage of the default alias across configurations.
	- The overall configuration structure and existing settings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->