### PR TITLE
feat(wren-ai-service): Implement Chat History Management with Max History Limit

### DIFF
--- a/wren-ai-service/src/config.py
+++ b/wren-ai-service/src/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     # generation config
     allow_intent_classification: bool = Field(default=True)
     allow_sql_generation_reasoning: bool = Field(default=True)
+    max_histories: int = Field(default=10)
 
     # engine config
     engine_timeout: float = Field(default=30.0)

--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -117,6 +117,7 @@ def create_service_container(
             },
             allow_intent_classification=settings.allow_intent_classification,
             allow_sql_generation_reasoning=settings.allow_sql_generation_reasoning,
+            max_histories=settings.max_histories,
             **query_cache,
         ),
         chart_service=services.ChartService(

--- a/wren-ai-service/src/pipelines/generation/data_assistance.py
+++ b/wren-ai-service/src/pipelines/generation/data_assistance.py
@@ -53,15 +53,9 @@ def prompt(
     db_schemas: list[str],
     language: str,
     prompt_builder: PromptBuilder,
-    history: Optional[AskHistory] = None,
+    histories: Optional[list[AskHistory]] = None,
 ) -> dict:
-    if history:
-        previous_query_summaries = [
-            step.summary for step in history.steps if step.summary
-        ]
-    else:
-        previous_query_summaries = []
-
+    previous_query_summaries = [history.question for history in histories]
     query = "\n".join(previous_query_summaries) + "\n" + query
 
     return prompt_builder.run(
@@ -106,9 +100,9 @@ class DataAssistance(BasicPipeline):
 
     def _streaming_callback(self, chunk, query_id):
         if query_id not in self._user_queues:
-            self._user_queues[
-                query_id
-            ] = asyncio.Queue()  # Create a new queue for the user if it doesn't exist
+            self._user_queues[query_id] = (
+                asyncio.Queue()
+            )  # Create a new queue for the user if it doesn't exist
         # Put the chunk content into the user's queue
         asyncio.create_task(self._user_queues[query_id].put(chunk.content))
         if chunk.meta.get("finish_reason"):
@@ -119,9 +113,9 @@ class DataAssistance(BasicPipeline):
             return await self._user_queues[query_id].get()
 
         if query_id not in self._user_queues:
-            self._user_queues[
-                query_id
-            ] = asyncio.Queue()  # Ensure the user's queue exists
+            self._user_queues[query_id] = (
+                asyncio.Queue()
+            )  # Ensure the user's queue exists
         while True:
             try:
                 # Wait for an item from the user's queue
@@ -146,7 +140,7 @@ class DataAssistance(BasicPipeline):
         db_schemas: list[str],
         language: str,
         query_id: Optional[str] = None,
-        history: Optional[AskHistory] = None,
+        histories: Optional[list[AskHistory]] = None,
     ):
         logger.info("Data Assistance pipeline is running...")
         return await self._pipe.execute(
@@ -156,7 +150,7 @@ class DataAssistance(BasicPipeline):
                 "db_schemas": db_schemas,
                 "language": language,
                 "query_id": query_id or "",
-                "history": history,
+                "histories": histories,
                 **self._components,
             },
         )

--- a/wren-ai-service/src/pipelines/generation/followup_sql_generation.py
+++ b/wren-ai-service/src/pipelines/generation/followup_sql_generation.py
@@ -48,11 +48,11 @@ SQL:
 {% endif %}
 
 ### CONTEXT ###
-Previous SQL Summary:
-{% for summary in previous_query_summaries %}
-    {{ summary }}
+Previous Queries:
+{% for history in histories %}
+    {{ history.question }}
+    {{ history.sql }}
 {% endfor %}
-Previous SQL Query: {{ history.sql }}
 
 ### QUESTION ###
 User's Follow-up Question: {{ query }}
@@ -71,20 +71,20 @@ def prompt(
     query: str,
     documents: List[str],
     sql_generation_reasoning: str,
-    history: AskHistory,
+    histories: list[AskHistory],
     configuration: Configuration,
     prompt_builder: PromptBuilder,
     sql_samples: List[Dict] | None = None,
     has_calculated_field: bool = False,
     has_metric: bool = False,
 ) -> dict:
-    previous_query_summaries = [step.summary for step in history.steps if step.summary]
+    previous_query_summaries = [history.question for history in histories]
 
     return prompt_builder.run(
         query=query,
         documents=documents,
         sql_generation_reasoning=sql_generation_reasoning,
-        history=history,
+        histories=histories,
         previous_query_summaries=previous_query_summaries,
         instructions=construct_instructions(
             configuration,
@@ -152,7 +152,7 @@ class FollowUpSQLGeneration(BasicPipeline):
         query: str,
         contexts: List[str],
         sql_generation_reasoning: str,
-        history: AskHistory,
+        histories: list[AskHistory],
         configuration: Configuration = Configuration(),
         sql_samples: List[Dict] | None = None,
         project_id: str | None = None,
@@ -166,7 +166,7 @@ class FollowUpSQLGeneration(BasicPipeline):
                 "query": query,
                 "documents": contexts,
                 "sql_generation_reasoning": sql_generation_reasoning,
-                "history": history,
+                "histories": histories,
                 "project_id": project_id,
                 "configuration": configuration,
                 "sql_samples": sql_samples,

--- a/wren-ai-service/src/pipelines/generation/intent_classification.py
+++ b/wren-ai-service/src/pipelines/generation/intent_classification.py
@@ -103,7 +103,11 @@ intent_classification_user_prompt_template = """
 
 ### INPUT ###
 {% if query_history %}
-User's previous SQLs: {{ query_history }}
+User's previous SQLs:
+{% for history in query_history %}
+{{ history.question }}
+{{ history.sql }}
+{% endfor %}
 {% endif %}
 User's question: {{query}}
 Current Time: {{ current_time }}
@@ -222,14 +226,14 @@ def prompt(
     query: str,
     construct_db_schemas: list[str],
     prompt_builder: PromptBuilder,
-    history: Optional[AskHistory] = None,
+    histories: Optional[list[AskHistory]] = None,
     configuration: Configuration | None = None,
 ) -> dict:
     return prompt_builder.run(
         query=query,
         language=configuration.language,
         db_schemas=construct_db_schemas,
-        query_history=history.sql if history else [],
+        query_history=histories,
         current_time=configuration.show_current_time(),
     )
 
@@ -316,7 +320,7 @@ class IntentClassification(BasicPipeline):
         self,
         query: str,
         id: Optional[str] = None,
-        history: Optional[AskHistory] = None,
+        histories: Optional[list[AskHistory]] = None,
         configuration: Configuration = Configuration(),
     ):
         logger.info("Intent Classification pipeline is running...")
@@ -325,7 +329,7 @@ class IntentClassification(BasicPipeline):
             inputs={
                 "query": query,
                 "id": id or "",
-                "history": history,
+                "histories": histories,
                 "configuration": configuration,
                 **self._components,
             },

--- a/wren-ai-service/src/pipelines/retrieval/retrieval.py
+++ b/wren-ai-service/src/pipelines/retrieval/retrieval.py
@@ -292,7 +292,7 @@ def prompt(
     construct_db_schemas: list[dict],
     prompt_builder: PromptBuilder,
     check_using_db_schemas_without_pruning: dict,
-    history: Optional[AskHistory] = None,
+    histories: Optional[list[AskHistory]] = None,
 ) -> dict:
     if not check_using_db_schemas_without_pruning["db_schemas"]:
         logger.info(
@@ -303,12 +303,7 @@ def prompt(
             for construct_db_schema in construct_db_schemas
         ]
 
-        if history:
-            previous_query_summaries = [
-                step.summary for step in history.steps if step.summary
-            ]
-        else:
-            previous_query_summaries = []
+        previous_query_summaries = [history.question for history in histories]
 
         query = "\n".join(previous_query_summaries) + "\n" + query
         return prompt_builder.run(question=query, db_schemas=db_schemas)
@@ -482,7 +477,7 @@ class Retrieval(BasicPipeline):
         query: str = "",
         tables: Optional[list[str]] = None,
         id: Optional[str] = None,
-        history: Optional[AskHistory] = None,
+        histories: Optional[list[AskHistory]] = None,
     ):
         logger.info("Ask Retrieval pipeline is running...")
         return await self._pipe.execute(
@@ -491,7 +486,7 @@ class Retrieval(BasicPipeline):
                 "query": query,
                 "tables": tables,
                 "id": id or "",
-                "history": history,
+                "histories": histories,
                 **self._components,
                 **self._configs,
             },

--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -165,6 +165,7 @@ class AskService:
         pipelines: Dict[str, BasicPipeline],
         allow_intent_classification: bool = True,
         allow_sql_generation_reasoning: bool = True,
+        max_histories: int = 10,
         maxsize: int = 1_000_000,
         ttl: int = 120,
     ):
@@ -177,6 +178,7 @@ class AskService:
         )
         self._allow_sql_generation_reasoning = allow_sql_generation_reasoning
         self._allow_intent_classification = allow_intent_classification
+        self._max_histories = max_histories
 
     def _is_stopped(self, query_id: str, container: dict):
         if (
@@ -204,7 +206,7 @@ class AskService:
         }
 
         query_id = ask_request.query_id
-        histories = ask_request.histories[:10]
+        histories = ask_request.histories[: self._max_histories]
         rephrased_question = None
         intent_reasoning = None
         sql_generation_reasoning = None


### PR DESCRIPTION
## Changes
This PR introduces improvements to the chat history management system by implementing a maximum history limit and restructuring how chat histories are handled.

### Key Updates:
1. Added `max_histories` configuration setting (default: 10) to limit the number of stored chat histories
2. Refactored history handling from single `AskHistory` to list-based `histories` approach
3. Simplified `AskHistory` model by removing `steps` and keeping essential fields (sql, question)
4. Updated prompt templates to better handle multiple history entries

### Technical Details:
- Added `max_histories` field to Settings class with a default value of 10
- Modified service container to pass max_histories configuration
- Updated pipeline interfaces (DataAssistance, IntentClassification, Retrieval, FollowUpSQLGeneration) to handle list of histories
- Enhanced prompt templates to display previous queries and their corresponding SQL statements
- Implemented history truncation in AskService to respect max_histories limit

### Impact
- Better memory management by limiting chat history size
- Improved context handling for follow-up questions
- More structured and maintainable history tracking

### Testing
Please ensure to test:
- Chat history limitation works as expected
- Follow-up questions work correctly with multiple history entries
- Prompt generation with various history scenarios