### PR TITLE
fix(wren-ui): prevent stuck on text-based answer loading if when query data error

### DIFF
--- a/wren-ui/src/apollo/server/backgrounds/textBasedAnswerBackgroundTracker.ts
+++ b/wren-ui/src/apollo/server/backgrounds/textBasedAnswerBackgroundTracker.ts
@@ -76,12 +76,25 @@ export class TextBasedAnswerBackgroundTracker {
             project.id,
           );
           const mdl = deployment.manifest;
-          const data = (await this.queryService.preview(threadResponse.sql, {
-            project,
-            manifest: mdl,
-            modelingOnly: false,
-            limit: 500,
-          })) as PreviewDataResponse;
+          let data: PreviewDataResponse;
+          try {
+            data = (await this.queryService.preview(threadResponse.sql, {
+              project,
+              manifest: mdl,
+              modelingOnly: false,
+              limit: 500,
+            })) as PreviewDataResponse;
+          } catch (error) {
+            logger.error(`Error when query sql data: ${error}`);
+            await this.threadResponseRepository.updateOne(threadResponse.id, {
+              answerDetail: {
+                ...threadResponse.answerDetail,
+                status: ThreadResponseAnswerStatus.FAILED,
+                error: error?.extensions || error,
+              },
+            });
+            throw error;
+          }
 
           // request AI service
           const response = await this.wrenAIAdaptor.createTextBasedAnswer({

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -44,7 +44,8 @@ const getThreadResponseIsFinished = (threadResponse: ThreadResponse) => {
   let isBreakdownFinished = null;
   let isChartFinished = null;
 
-  if (answerDetail?.queryId) {
+  // answerDetail status can be FAILED before getting queryId from Wren AI adapter
+  if (answerDetail?.queryId || answerDetail?.status) {
     isAnswerFinished = getAnswerIsFinished(answerDetail?.status);
   }
   if (breakdownDetail?.queryId) {


### PR DESCRIPTION
## Description 
This PR improves error handling by displaying a text-based error message when a query to Ibis/Engine Service fails, before making a request to Wren AI Service. This prevents the UI from getting stuck on loading.
(Sync from SaaS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during data retrieval, ensuring that issues are logged and processed more reliably.
	- Refined the logic for determining when an answer has completed processing, enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->