### PR TITLE
feat(wren-ai-service): Add Instructions Support to Evaluation Dataset and Prediction Parameters

### DIFF
--- a/wren-ai-service/eval/__init__.py
+++ b/wren-ai-service/eval/__init__.py
@@ -11,6 +11,7 @@ class EvalSettings(Settings):
     config_path: str = "eval/config.yaml"
     openai_api_key: SecretStr = Field(alias="OPENAI_API_KEY")
     allow_sql_samples: bool = True
+    allow_instructions: bool = True
     db_path_for_duckdb: str = ""
 
     # BigQuery

--- a/wren-ai-service/eval/evaluation.py
+++ b/wren-ai-service/eval/evaluation.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
 
     dataset = parse_toml(meta["evaluation_dataset"])
     metrics = pipelines.metrics_initiator(
-        meta["pipeline"], dataset, pipe_components, args.semantics
+        meta["pipeline"], dataset, pipe_components, args.semantics, settings
     )
 
     evaluator = Evaluator(**metrics)

--- a/wren-ai-service/eval/pipelines.py
+++ b/wren-ai-service/eval/pipelines.py
@@ -508,8 +508,13 @@ def metrics_initiator(
     dataset: dict,
     pipe_components: dict[str, PipelineComponent],
     enable_semantics_comparison: bool = True,
+    settings: EvalSettings = EvalSettings(),
 ) -> dict:
-    engine_info = engine_config(dataset["mdl"], pipe_components)
+    engine_info = engine_config(
+        dataset["mdl"],
+        pipe_components,
+        settings.db_path_for_duckdb,
+    )
     component = pipe_components["evaluation"]
     match pipeline:
         case "retrieval":

--- a/wren-ai-service/eval/preparation.py
+++ b/wren-ai-service/eval/preparation.py
@@ -1,6 +1,7 @@
 """
 This file aims to prepare spider 1.0 or bird eval dataset for text-to-sql eval purpose
 """
+
 import argparse
 import asyncio
 import os
@@ -428,6 +429,19 @@ if __name__ == "__main__":
 
             # ignore empty context
             if context:
+                previous_ground_truths = get_next_few_items_circular(
+                    values["ground_truth"], i
+                )
+                sql_pairs = [
+                    {
+                        "question": ground_truth["question"],
+                        "sql": ground_truth["sql"],
+                    }
+                    for ground_truth in previous_ground_truths
+                ]
+
+                instructions = [ground_truth.get("evidence", "")]
+
                 candidate_eval_dataset.append(
                     {
                         "categories": [],
@@ -437,9 +451,8 @@ if __name__ == "__main__":
                         "document": get_documents_given_contexts(
                             [context], values["mdl"]
                         ),
-                        "samples": get_next_few_items_circular(
-                            values["ground_truth"], i
-                        ),
+                        "samples": sql_pairs,
+                        "instructions": instructions,
                     }
                 )
             # else:

--- a/wren-ai-service/eval/utils.py
+++ b/wren-ai-service/eval/utils.py
@@ -231,6 +231,7 @@ def engine_config(
             "mdl_json": mdl,
             "api_endpoint": engine._endpoint,
             "timeout": 10,
+            "data_source": "duckdb",
         }
 
     return {


### PR DESCRIPTION
This PR introduces instruction handling capabilities to the evaluation framework with three main changes:

1. Added instructions field to evaluation dataset preparation:
   - Extracts evidence as instructions from ground truth data
   - Restructures SQL pairs format for better clarity
   - Maintains backward compatibility with existing dataset structure

2. Enhanced prediction parameters to include instructions:
   - Added instructions field to prediction parameter set
   - Modified SQL pairs format to separate question and SQL components

3. Added configuration flags for feature control:
   - Introduced `allow_instructions` flag alongside existing `allow_sql_samples`
   - Enables granular control over which features are active during evaluation

Related PR: https://github.com/Canner/WrenAI/pull/1376