### PR TITLE
chore(wren-ui): add github workflow PR tagger

### DIFF
--- a/.github/workflows/pr-tagger.yaml
+++ b/.github/workflows/pr-tagger.yaml
@@ -34,6 +34,17 @@ jobs:
             const changedFiles = '${{ steps.changed-files.outputs.all_changed_files }}'.split(' ');
             const labels = new Set();
 
+            // Define label colors
+            const labelColors = {
+              'wren-ui': 'f29513',        // Orange
+              'launcher': 'f29513',       // Orange (same as wren-ui)
+              'wren-ai-service': 'f29513', // Orange (same as wren-ui)
+              'deployment': '0075ca',     // Blue
+              'ai-env-changed': 'd73a4a',  // Red
+              'ui-env-changed': 'd73a4a'   // Red
+            };
+
+
             // Check for files in specific directories
             for (const file of changedFiles) {
               if (file.startsWith('wren-ui/src/')) {
@@ -93,6 +104,36 @@ jobs:
             }
 
             if (labels.size > 0) {
+              // Create or update labels with colors
+              for (const label of labels) {
+                try {
+                  // Try to create the label with color
+                  if (labelColors[label]) {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: label,
+                      color: labelColors[label]
+                    });
+                  }
+                } catch (error) {
+                  // Label already exists, update its color if needed
+                  if (labelColors[label]) {
+                    try {
+                      await github.rest.issues.updateLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        name: label,
+                        color: labelColors[label]
+                      });
+                    } catch (updateError) {
+                      console.log(`Could not update color for label ${label}: ${updateError.message}`);
+                    }
+                  }
+                }
+              }
+              
+              // Add labels to PR
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/pr-tagger.yaml
+++ b/.github/workflows/pr-tagger.yaml
@@ -7,6 +7,8 @@ on:
       - "wren-ui/src/**"
       - "deployment/**"
       - "wren-launcher/**"
+      - "wren-ai-service/**"
+      - "docker/**"
 
 jobs:
   tag-pr:
@@ -24,7 +26,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v35
 
-      - name: Tag PR based on changed files
+      - name: Tag PR based on changed files and title
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +42,53 @@ jobs:
                 labels.add('deployment');
               } else if (file.startsWith('wren-launcher/')) {
                 labels.add('launcher');
+              } else if (file.startsWith('wren-ai-service/')) {
+                labels.add('wren-ai-service');
+              } 
+              if (file.startsWith('docker/') && file.includes('.example')) {
+                labels.add('ai-env-changed'); 
+              }
+              if (file.startsWith('wren-ui/src/apollo/server/config.ts')) {
+                labels.add('ui-env-changed');
+              }
+            }
+
+            // Extract milestone from PR title
+            const prTitle = context.payload.pull_request.title;
+            const milestoneMatch = prTitle.match(/\(milestone:\s*([^)]+)\)/i);
+
+            if (milestoneMatch && milestoneMatch[1]) {
+              const milestone = milestoneMatch[1].trim();
+              if (milestone) {
+                labels.add(milestone);
+                console.log(`Found milestone in PR title: ${milestone}`);
+              }
+            }
+
+            // Append env changed label to PR title
+            if (labels.has('ai-env-changed')) {
+              // check if pr title contains "ai-env-changed"
+              if (!prTitle.includes('ai-env-changed')) {
+                const newTitle = `${prTitle} (ai-env-changed)`;
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  title: newTitle
+                });
+              }
+            }
+
+            if (labels.has('ui-env-changed')) {
+              // check if pr title contains "ui-env-changed"
+              if (!prTitle.includes('ui-env-changed')) {
+                const newTitle = `${prTitle} (ui-env-changed)`;
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  title: newTitle
+                });
               }
             }
 
@@ -53,5 +102,5 @@ jobs:
               
               console.log(`Added labels: ${Array.from(labels).join(', ')}`);
             } else {
-              console.log('No matching directories found in changed files');
+              console.log('No matching directories or milestone found');
             }

--- a/.github/workflows/pr-tagger.yaml
+++ b/.github/workflows/pr-tagger.yaml
@@ -1,0 +1,57 @@
+name: PR Tagger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "wren-ui/src/**"
+      - "deployment/**"
+      - "wren-launcher/**"
+
+jobs:
+  tag-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+
+      - name: Tag PR based on changed files
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const changedFiles = '${{ steps.changed-files.outputs.all_changed_files }}'.split(' ');
+            const labels = new Set();
+
+            // Check for files in specific directories
+            for (const file of changedFiles) {
+              if (file.startsWith('wren-ui/src/')) {
+                labels.add('wren-ui');
+              } else if (file.startsWith('deployment/')) {
+                labels.add('deployment');
+              } else if (file.startsWith('wren-launcher/')) {
+                labels.add('launcher');
+              }
+            }
+
+            if (labels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: Array.from(labels)
+              });
+              
+              console.log(`Added labels: ${Array.from(labels).join(', ')}`);
+            } else {
+              console.log('No matching directories found in changed files');
+            }


### PR DESCRIPTION
## Desciption
PR Tagging Logic Summary
🏷 Labeling based on changed files:
- If any file in wren-ui/src/ is changed → Add wren-ui label
- If any file in deployment/ is changed → Add deployment label
- If any file in wren-launcher/ is changed → Add launcher label
- If any file in wren-ai-service/ is changed → Add wren-ai-service label
- If any file in docker/ contains .example → Add ai-env-changed label
- If the file wren-ui/src/apollo/server/config.ts is changed → Add ui-env-changed label
- 
📌 Labeling based on PR title:
We can better identify the PR would be merged in what version.
- If PR title contains a milestone format (milestone: XYZ), then:
- Add XYZ as a label

📝 Updating PR Title with Environment Changes:
This can help us identify which commit has to update envs when deploying.
- If the ai-env-changed label is added but not present in the PR title, append (ai-env-changed) to the title
- If the ui-env-changed label is added but not present in the PR title, append (ui-env-changed) to the title

## Screenshot
<img width="1403" alt="image" src="https://github.com/user-attachments/assets/e3f5bf5c-e061-48d9-a8bd-e7ab8d8dd335" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automated labeling workflow that analyzes pull request changes and identifies milestones in titles to apply appropriate tags. This enhancement streamlines pull request organization and ensures that changes across various project areas are clearly categorized for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->