### PR TITLE
feat(wren-ai-service): Add SQL Correction Service and API Endpoints

### DIFF
--- a/wren-ai-service/src/globals.py
+++ b/wren-ai-service/src/globals.py
@@ -27,6 +27,7 @@ class ServiceContainer:
     sql_pairs_service: services.SqlPairsService
     sql_question_service: services.SqlQuestionService
     instructions_service: services.InstructionsService
+    sql_correction_service: services.SqlCorrectionService
 
 
 @dataclass
@@ -254,6 +255,15 @@ def create_service_container(
                 "instructions_indexing": indexing.Instructions(
                     **pipe_components["instructions_indexing"],
                 )
+            },
+            **query_cache,
+        ),
+        sql_correction_service=services.SqlCorrectionService(
+            pipelines={
+                "sql_correction": generation.SQLCorrection(
+                    **pipe_components["sql_correction"],
+                    engine_timeout=settings.engine_timeout,
+                ),
             },
             **query_cache,
         ),

--- a/wren-ai-service/src/web/v1/routers/__init__.py
+++ b/wren-ai-service/src/web/v1/routers/__init__.py
@@ -11,6 +11,7 @@ from src.web.v1.routers import (
     semantics_description,
     semantics_preparation,
     sql_answers,
+    sql_corrections,
     sql_expansions,
     sql_pairs,
     sql_question,
@@ -30,3 +31,4 @@ router.include_router(chart_adjustment.router)
 router.include_router(sql_pairs.router)
 router.include_router(sql_question.router)
 router.include_router(instructions.router)
+router.include_router(sql_corrections.router)

--- a/wren-ai-service/src/web/v1/routers/sql_corrections.py
+++ b/wren-ai-service/src/web/v1/routers/sql_corrections.py
@@ -26,13 +26,8 @@ Endpoints:
    - Initiates SQL correction process for invalid SQL queries
    - Request body: PostRequest
      {
-       "contexts": [Document],                  # List of context documents
-       "invalid_generation_results": [          # List of invalid SQL generation results
-         {
-           "sql": "SELECT * FROM table",        # Invalid SQL statement
-           "error": "Error message"             # Error message
-         }
-       ],
+       "sql": "SELECT * FROM table",        # Invalid SQL statement
+       "error": "Error message"             # Error message
        "project_id": "project-id"              # Optional project ID
      }
    - Response: PostResponse
@@ -69,9 +64,8 @@ Results are cached with a TTL defined in the service configuration.
 
 
 class PostRequest(BaseModel):
-    # todo: check the contexts
-    contexts: list[dict]
-    invalid_generation_results: list[dict[str, str]]
+    sql: str
+    error: str
     project_id: Optional[str] = None
 
 

--- a/wren-ai-service/src/web/v1/routers/sql_corrections.py
+++ b/wren-ai-service/src/web/v1/routers/sql_corrections.py
@@ -1,0 +1,126 @@
+import uuid
+from dataclasses import asdict
+from typing import Dict, List, Literal, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+from haystack import Document
+from pydantic import BaseModel
+
+from src.globals import (
+    ServiceContainer,
+    ServiceMetadata,
+    get_service_container,
+    get_service_metadata,
+)
+from src.web.v1.services import SqlCorrectionService
+
+router = APIRouter()
+
+
+"""
+SQL Correction Router
+
+This router handles endpoints related to correcting invalid SQL queries.
+
+Endpoints:
+1. POST /sql-correction
+   - Initiates SQL correction process for invalid SQL queries
+   - Request body: PostRequest
+     {
+       "contexts": [Document],                  # List of context documents
+       "invalid_generation_results": [          # List of invalid SQL generation results
+         {
+           "sql": "SELECT * FROM table",        # Invalid SQL statement
+           "error": "Error message"             # Error message
+         }
+       ],
+       "project_id": "project-id"              # Optional project ID
+     }
+   - Response: PostResponse
+     {
+       "event_id": "unique-uuid"               # Unique identifier for tracking correction
+     }
+
+2. GET /sql-correction/{event_id}
+   - Retrieves status and results of SQL correction process
+   - Path parameter: event_id (str)
+   - Response: GetResponse
+     {
+       "event_id": "unique-uuid",              # Unique identifier
+       "status": "correcting" | "finished" | "failed",
+       "response": {},                         # Correction results (when status is "finished")
+       "error": {                              # Present only if status is "failed"
+         "code": "OTHERS",
+         "message": "Error description"
+       },
+       "trace_id": "trace-id"                  # Optional trace ID for debugging
+     }
+
+The SQL correction is an asynchronous process. The POST endpoint initiates the operation
+and returns immediately with an event_id. The GET endpoint can then be used to check the
+status and retrieve the results.
+
+Usage:
+1. Send a POST request to start the correction process
+2. Use the returned event_id to poll the GET endpoint until status is "finished" or "failed"
+
+Note: The actual processing is performed in the background using FastAPI's BackgroundTasks.
+Results are cached with a TTL defined in the service configuration.
+"""
+
+
+class PostRequest(BaseModel):
+    # todo: check the contexts
+    contexts: List[Document]
+    invalid_generation_results: List[Dict[str, str]]
+    project_id: Optional[str] = None
+
+
+class PostResponse(BaseModel):
+    event_id: str
+
+
+@router.post("/sql-correction")
+async def correct(
+    request: PostRequest,
+    background_tasks: BackgroundTasks,
+    service_container: ServiceContainer = Depends(get_service_container),
+    service_metadata: ServiceMetadata = Depends(get_service_metadata),
+) -> PostResponse:
+    event_id = str(uuid.uuid4())
+    service = service_container.sql_correction_service
+    service[event_id] = SqlCorrectionService.Event(id=event_id, status="correcting")
+
+    correction_request = SqlCorrectionService.CorrectionRequest(
+        id=event_id, **request.model_dump()
+    )
+
+    background_tasks.add_task(
+        service.correct,
+        correction_request,
+        service_metadata=asdict(service_metadata),
+    )
+    return PostResponse(event_id=event_id)
+
+
+class GetResponse(BaseModel):
+    event_id: str
+    status: Literal["correcting", "finished", "failed"]
+    response: Optional[Dict] = None
+    error: Optional[dict] = None
+    trace_id: Optional[str] = None
+
+
+@router.get("/sql-correction/{event_id}")
+async def get(
+    event_id: str,
+    container: ServiceContainer = Depends(get_service_container),
+) -> GetResponse:
+    event: SqlCorrectionService.Event = container.sql_correction_service[event_id]
+    return GetResponse(
+        event_id=event.id,
+        status=event.status,
+        response=event.response,
+        error=event.error and event.error.model_dump(),
+        trace_id=event.trace_id,
+    )

--- a/wren-ai-service/src/web/v1/routers/sql_corrections.py
+++ b/wren-ai-service/src/web/v1/routers/sql_corrections.py
@@ -42,7 +42,7 @@ Endpoints:
      {
        "event_id": "unique-uuid",              # Unique identifier
        "status": "correcting" | "finished" | "failed",
-       "response": {},                         # Correction results (when status is "finished")
+       "response": "corrected-sql",            # Correction results (when status is "finished")
        "error": {                              # Present only if status is "failed"
          "code": "OTHERS",
          "message": "Error description"
@@ -99,7 +99,7 @@ async def correct(
 class GetResponse(BaseModel):
     event_id: str
     status: Literal["correcting", "finished", "failed"]
-    response: Optional[dict] = None
+    response: Optional[str] = None
     error: Optional[dict] = None
     trace_id: Optional[str] = None
 

--- a/wren-ai-service/src/web/v1/services/__init__.py
+++ b/wren-ai-service/src/web/v1/services/__init__.py
@@ -69,6 +69,7 @@ from .relationship_recommendation import RelationshipRecommendation  # noqa: E40
 from .semantics_description import SemanticsDescription  # noqa: E402
 from .semantics_preparation import SemanticsPreparationService  # noqa: E402
 from .sql_answer import SqlAnswerService  # noqa: E402
+from .sql_corrections import SqlCorrectionService  # noqa: E402
 from .sql_expansion import SqlExpansionService  # noqa: E402
 from .sql_pairs import SqlPairsService  # noqa: E402
 from .sql_question import SqlQuestionService  # noqa: E402
@@ -83,6 +84,7 @@ __all__ = [
     "SemanticsDescription",
     "SemanticsPreparationService",
     "SqlAnswerService",
+    "SqlCorrectionService",
     "SqlExpansionService",
     "SqlPairsService",
     "SqlQuestionService",

--- a/wren-ai-service/src/web/v1/services/instructions.py
+++ b/wren-ai-service/src/web/v1/services/instructions.py
@@ -51,7 +51,7 @@ class InstructionsService:
         self._cache[id] = self.Event(
             event_id=id,
             status="failed",
-            error=self.Event.Error(code=code, message=error_message),
+            error=self.Error(code=code, message=error_message),
             trace_id=trace_id,
         )
         logger.error(error_message)
@@ -151,7 +151,7 @@ class InstructionsService:
             return self.Event(
                 event_id=event_id,
                 status="failed",
-                error=self.Event.Error(code="OTHERS", message=message),
+                error=self.Error(code="OTHERS", message=message),
             )
 
         return response

--- a/wren-ai-service/src/web/v1/services/sql_corrections.py
+++ b/wren-ai-service/src/web/v1/services/sql_corrections.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Dict, List, Literal, Optional
+from typing import Literal, Optional
 
 from cachetools import TTLCache
-from haystack import Document
 from langfuse.decorators import observe
 from pydantic import BaseModel
 
@@ -21,18 +20,18 @@ class SqlCorrectionService:
     class Event(BaseModel, MetadataTraceable):
         event_id: str
         status: Literal["correcting", "finished", "failed"] = "correcting"
-        response: Optional[Dict] = None
+        response: Optional[dict] = None
         error: Optional["SqlCorrectionService.Error"] = None
         trace_id: Optional[str] = None
 
     def __init__(
         self,
-        pipelines: Dict[str, BasicPipeline],
+        pipelines: dict[str, BasicPipeline],
         maxsize: int = 1_000_000,
         ttl: int = 120,
     ):
         self._pipelines = pipelines
-        self._cache: Dict[str, self.Event] = TTLCache(maxsize=maxsize, ttl=ttl)
+        self._cache: dict[str, self.Event] = TTLCache(maxsize=maxsize, ttl=ttl)
 
     def _handle_exception(
         self,
@@ -51,8 +50,8 @@ class SqlCorrectionService:
 
     class CorrectionRequest(BaseModel):
         event_id: str
-        contexts: List[Document]
-        invalid_generation_results: List[Dict[str, str]]
+        contexts: list[dict]
+        invalid_generation_results: list[dict[str, str]]
         project_id: Optional[str] = None
 
     @observe(name="SQL Correction")

--- a/wren-ai-service/src/web/v1/services/sql_corrections.py
+++ b/wren-ai-service/src/web/v1/services/sql_corrections.py
@@ -50,8 +50,8 @@ class SqlCorrectionService:
 
     class CorrectionRequest(BaseModel):
         event_id: str
-        contexts: list[dict]
-        invalid_generation_results: list[dict[str, str]]
+        sql: str
+        error: str
         project_id: Optional[str] = None
 
     @observe(name="SQL Correction")
@@ -65,11 +65,14 @@ class SqlCorrectionService:
         trace_id = kwargs.get("trace_id")
 
         try:
-            # todo: modify the contexts
-            # todo: check the result format
+            _invalid = {
+                "sql": request.sql,
+                "error": request.error,
+            }
+
             result = await self._pipelines["sql_correction"].run(
-                contexts=request.contexts,
-                invalid_generation_results=request.invalid_generation_results,
+                contexts=[],
+                invalid_generation_results=[_invalid],
                 project_id=request.project_id,
             )
 

--- a/wren-ai-service/src/web/v1/services/sql_corrections.py
+++ b/wren-ai-service/src/web/v1/services/sql_corrections.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Dict, List, Literal, Optional
+
+from cachetools import TTLCache
+from haystack import Document
+from langfuse.decorators import observe
+from pydantic import BaseModel
+
+from src.core.pipeline import BasicPipeline
+from src.utils import trace_metadata
+from src.web.v1.services import MetadataTraceable
+
+logger = logging.getLogger("wren-ai-service")
+
+
+class SqlCorrectionService:
+    class Event(BaseModel, MetadataTraceable):
+        class Error(BaseModel):
+            code: Literal["OTHERS"]
+            message: str
+
+        id: str
+        status: Literal["correcting", "finished", "failed"] = "correcting"
+        response: Optional[Dict] = None
+        error: Optional[Error] = None
+        trace_id: Optional[str] = None
+
+    def __init__(
+        self,
+        pipelines: Dict[str, BasicPipeline],
+        maxsize: int = 1_000_000,
+        ttl: int = 120,
+    ):
+        self._pipelines = pipelines
+        self._cache: Dict[str, self.Event] = TTLCache(maxsize=maxsize, ttl=ttl)
+
+    def _handle_exception(
+        self,
+        id: str,
+        error_message: str,
+        code: str = "OTHERS",
+        trace_id: Optional[str] = None,
+    ):
+        self._cache[id] = self.Event(
+            id=id,
+            status="failed",
+            error=self.Event.Error(code=code, message=error_message),
+            trace_id=trace_id,
+        )
+        logger.error(error_message)
+
+    class CorrectionRequest(BaseModel):
+        id: str
+        contexts: List[Document]
+        invalid_generation_results: List[Dict[str, str]]
+        project_id: Optional[str] = None
+
+    @observe(name="SQL Correction")
+    @trace_metadata
+    async def correct(
+        self,
+        request: CorrectionRequest,
+        **kwargs,
+    ):
+        logger.info(f"Request {request.id}: SQL Correction process is running...")
+        trace_id = kwargs.get("trace_id")
+
+        try:
+            # todo: modify the contexts
+            # todo: check the result format
+            result = await self._pipelines["sql_correction"].run(
+                contexts=request.contexts,
+                invalid_generation_results=request.invalid_generation_results,
+                project_id=request.project_id,
+            )
+
+            self._cache[request.id] = self.Event(
+                id=request.id,
+                status="finished",
+                trace_id=trace_id,
+                response=result,
+            )
+
+        except Exception as e:
+            self._handle_exception(
+                request.id,
+                f"An error occurred during SQL correction: {str(e)}",
+                trace_id=trace_id,
+            )
+
+        return self._cache[request.id].with_metadata()
+
+    def __getitem__(self, id: str) -> Event:
+        response = self._cache.get(id)
+
+        if response is None:
+            message = f"SQL Correction Event with ID '{id}' not found."
+            logger.exception(message)
+            return self.Event(
+                id=id,
+                status="failed",
+                error=self.Event.Error(code="OTHERS", message=message),
+            )
+
+        return response
+
+    def __setitem__(self, id: str, value: Event):
+        self._cache[id] = value


### PR DESCRIPTION
This PR introduces a new SQL Correction Service that helps users fix invalid SQL queries through a dedicated API endpoint.

Key changes:
- Added new `SqlCorrectionService` with background task processing
- Implemented `/sql-corrections` endpoints for POST and GET operations
- Integrated service with existing container and router infrastructure
- Added error handling and caching mechanisms

The service accepts invalid SQL queries with error messages and returns corrected SQL statements through an asynchronous process. Users can track the correction status using the provided event ID.

Endpoints:
- POST `/sql-corrections`: Submit invalid SQL for correction
- GET `/sql-corrections/{event_id}`: Check correction status and results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new SQL correction capability that lets users submit SQL queries with errors for automatic correction.
	- Users now receive a unique event ID upon submission, enabling them to track the status and results of their correction requests through dedicated endpoints.
	- Added a new service for managing SQL correction requests, enhancing error management and event tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->