### PR TITLE
feat(wren-ui): Use rephrasedQuestion for asking a question answer

### DIFF
--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -299,7 +299,12 @@ export default function AnswerResult(props: Props) {
                 className="mr-2"
                 onClick={() =>
                   onOpenSaveToKnowledgeModal(
-                    { question, sql },
+                    {
+                      question:
+                        threadResponse?.askingTask?.rephrasedQuestion ||
+                        question,
+                      sql,
+                    },
                     { isCreateMode: true },
                   )
                 }


### PR DESCRIPTION
## Description
- Use rephrasedQuestion first
  - For asking a question/follow-up question, will use 'rephrasedQuestion' as the initial value for the question of the Add Question-SQL pair Modal
  - For clicking a Recommended question in a thread page, will use ‘question’ as the initial value for the question of the Add Question-SQL pair Modal