### PR TITLE
fix(wren-ui): fix language for generate question for SQL pairs

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -511,7 +511,7 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
       const body = {
         sqls: input.sqls,
         project_id: input.projectId.toString(),
-        configuration: input.configurations,
+        configurations: input.configurations,
       };
 
       const res = await axios.post(

--- a/wren-ui/src/apollo/server/services/sqlPairService.ts
+++ b/wren-ui/src/apollo/server/services/sqlPairService.ts
@@ -4,6 +4,7 @@ import {
   QuestionsStatus,
   SqlPairResult,
   SqlPairStatus,
+  WrenAILanguage,
 } from '../models/adaptor';
 import { ISqlPairRepository, SqlPair } from '../repositories/sqlPairRepository';
 import { getLogger } from '@server/utils';
@@ -60,7 +61,7 @@ export class SqlPairService implements ISqlPairService {
   ): Promise<string[]> {
     try {
       const configurations = {
-        language: project.language,
+        language: WrenAILanguage[project.language] || WrenAILanguage.EN,
       };
 
       const { queryId } = await this.wrenAIAdaptor.generateQuestions({


### PR DESCRIPTION
## Description
- Correct the language configuration in `SqlPairService` to use `WrenAILanguage[project.language]`
- Correct **configurations** parameter name for post /v1/sql-questions API

## UI (manual testing)
![截圖 2025-03-24 下午3 28 02](https://github.com/user-attachments/assets/2c41ee05-796c-4705-a2f8-9afa3ddc4e84)
![截圖 2025-03-24 下午3 31 05](https://github.com/user-attachments/assets/96f8839d-fd36-4e15-92cf-ab716299fc3f)

![截圖 2025-03-24 下午3 28 09](https://github.com/user-attachments/assets/a9a1a3db-e9c4-4405-beea-bdccc50eff4c)

![截圖 2025-03-24 下午3 28 11](https://github.com/user-attachments/assets/68e8c766-85a7-4d61-8981-cdaea77eef94)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the configuration of automated question generation to ensure it reliably meets external expectations.
	- Enhanced language validation so that only supported language options are applied, ensuring smoother performance across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->