### PR TITLE
fix(wren-ui): allow process state transition skipped when understanding

### DIFF
--- a/wren-ui/src/components/pages/home/prompt/Result.tsx
+++ b/wren-ui/src/components/pages/home/prompt/Result.tsx
@@ -257,7 +257,10 @@ const getDefaultStateComponent = (state: PROCESS_STATE) => {
   return (
     {
       [PROCESS_STATE.UNDERSTANDING]: Understanding,
+      // Polling AI status for every 1 second might skip the searching state.
       [PROCESS_STATE.SEARCHING]: IntentionFinished,
+      [PROCESS_STATE.PLANNING]: IntentionFinished,
+      [PROCESS_STATE.GENERATING]: IntentionFinished,
       // The finished status will respond by AI directly if viewId found, so we need to handle with intention finished.
       [PROCESS_STATE.FINISHED]: IntentionFinished,
       [PROCESS_STATE.FAILED]: Failed,

--- a/wren-ui/src/hooks/useAskProcessState.tsx
+++ b/wren-ui/src/hooks/useAskProcessState.tsx
@@ -91,7 +91,13 @@ export class ProcessStateMachine {
       prev: [],
     },
     [PROCESS_STATE.UNDERSTANDING]: {
-      next: [PROCESS_STATE.SEARCHING],
+      // probably skipped status if polling delay longer than AI processing time
+      // so need to allow all possible statuses
+      next: [
+        PROCESS_STATE.SEARCHING,
+        PROCESS_STATE.PLANNING,
+        PROCESS_STATE.GENERATING,
+      ],
       prev: [PROCESS_STATE.IDLE],
     },
     [PROCESS_STATE.SEARCHING]: {


### PR DESCRIPTION
## Description
allow process state transition skipped when understanding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved process state management now delivers a consistent and unified view for users during various stages of processing.
  - Expanded transitions between processing stages enhance responsiveness, ensuring a smoother interface regardless of processing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->