### PR TITLE
CI: add latest tag to ui image

### DIFF
--- a/.github/workflows/ui-release-image-stable.yaml
+++ b/.github/workflows/ui-release-image-stable.yaml
@@ -87,8 +87,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         working-directory: /tmp/digests
+        # tag with input version and latest
         run: |
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}') --tag latest
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.WREN_UI_IMAGE }}@sha256:%s ' *) \
             $TAGS


### PR DESCRIPTION
add latest tag to ui image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our UI release process so that the stable image is now automatically labeled as "latest" alongside its version tag.
  - This update simplifies deployment by ensuring end users always access the most current, production-ready UI release while improving overall release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->