### PR TITLE
fix(wren-ui): delete semantics when reseting project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ wren-ai-service/tools/dev/etc/**
 .deepeval-cache.json
 .deepeval_telemtry.txt
 docker/config.yaml
+docker/docker-compose-local.yaml
 
 # python
 .python-version

--- a/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/wrenAIAdaptor.ts
@@ -48,6 +48,7 @@ const getAIServiceError = (error: any) => {
 
 export interface IWrenAIAdaptor {
   deploy(deployData: DeployData): Promise<WrenAIDeployResponse>;
+  delete(projectId: number): Promise<void>;
 
   /**
    * Ask AI service a question.
@@ -126,6 +127,31 @@ export class WrenAIAdaptor implements IWrenAIAdaptor {
   constructor({ wrenAIBaseEndpoint }: { wrenAIBaseEndpoint: string }) {
     this.wrenAIBaseEndpoint = wrenAIBaseEndpoint;
   }
+
+  public async delete(projectId: number): Promise<void> {
+    try {
+      if (!projectId) {
+        throw new Error('Project ID is required');
+      }
+      const url = `${this.wrenAIBaseEndpoint}/v1/semantics`;
+      const response = await axios.delete(url, {
+        params: {
+          project_id: projectId.toString(),
+        },
+      });
+
+      if (response.status === 200) {
+        logger.info(`Wren AI: Deleted semantics for project ${projectId}`);
+      } else {
+        throw new Error(`Failed to delete semantics. ${response.data?.error}`);
+      }
+    } catch (error: any) {
+      throw new Error(
+        `Wren AI: Failed to delete semantics: ${getAIServiceError(error)}`,
+      );
+    }
+  }
+
   public async deploySqlPair(
     projectId: number,
     sqlPair: Partial<SqlPair>,

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -130,6 +130,7 @@ export class ProjectResolver {
       await ctx.modelService.deleteAllViewsByProjectId(id);
       await ctx.modelService.deleteAllModelsByProjectId(id);
       await ctx.projectService.deleteProject(id);
+      await ctx.wrenAIAdaptor.delete(id);
 
       // telemetry
       ctx.telemetry.sendEvent(eventName, {


### PR DESCRIPTION
delete semantics when reseting project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version control settings to exclude a local Docker configuration file.

- **New Features**
  - Enhanced project reset operations with an additional deletion process for associated semantic data, ensuring a more thorough cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->