### PR TITLE
feat(wren-ui): Integrate adjust SQL API

### DIFF
--- a/wren-ui/src/apollo/client/graphql/home.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/home.generated.ts
@@ -174,13 +174,6 @@ export type GenerateThreadRecommendationQuestionsMutationVariables = Types.Exact
 
 export type GenerateThreadRecommendationQuestionsMutation = { __typename?: 'Mutation', generateThreadRecommendationQuestions: boolean };
 
-export type GenerateThreadResponseBreakdownMutationVariables = Types.Exact<{
-  responseId: Types.Scalars['Int'];
-}>;
-
-
-export type GenerateThreadResponseBreakdownMutation = { __typename?: 'Mutation', generateThreadResponseBreakdown: { __typename?: 'ThreadResponse', id: number, threadId: number, question: string, sql?: string | null, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, breakdownDetail?: { __typename?: 'ThreadResponseBreakdownDetail', queryId?: string | null, status: Types.AskingTaskStatus, description?: string | null, steps?: Array<{ __typename?: 'DetailStep', summary: string, sql: string, cteName?: string | null }> | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, answerDetail?: { __typename?: 'ThreadResponseAnswerDetail', queryId?: string | null, status?: Types.ThreadResponseAnswerStatus | null, content?: string | null, numRowsUsedInLLM?: number | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, chartDetail?: { __typename?: 'ThreadResponseChartDetail', queryId?: string | null, status: Types.ChartTaskStatus, description?: string | null, chartType?: Types.ChartType | null, chartSchema?: any | null, adjustment?: boolean | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, askingTask?: { __typename?: 'AskingTask', status: Types.AskingTaskStatus, type?: Types.AskingTaskType | null, rephrasedQuestion?: string | null, intentReasoning?: string | null, sqlGenerationReasoning?: string | null, retrievedTables?: Array<string> | null, invalidSql?: string | null, traceId?: string | null, queryId?: string | null, candidates: Array<{ __typename?: 'ResultCandidate', sql: string, type: Types.ResultCandidateType, view?: { __typename?: 'ViewInfo', id: number, name: string, statement: string, displayName: string } | null, sqlPair?: { __typename?: 'SqlPair', id: number, question: string, sql: string, projectId: number } | null }>, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null, adjustment?: { __typename?: 'ThreadResponseAdjustment', type: Types.ThreadResponseAdjustmentType, payload?: any | null } | null, adjustmentTask?: { __typename?: 'AdjustmentTask', queryId?: string | null, status?: Types.AskingTaskStatus | null, sql?: string | null, traceId?: string | null, error?: { __typename?: 'Error', code?: string | null, shortMessage?: string | null, message?: string | null, stacktrace?: Array<string | null> | null } | null } | null } };
-
 export type GenerateThreadResponseAnswerMutationVariables = Types.Exact<{
   responseId: Types.Scalars['Int'];
 }>;
@@ -1130,39 +1123,6 @@ export function useGenerateThreadRecommendationQuestionsMutation(baseOptions?: A
 export type GenerateThreadRecommendationQuestionsMutationHookResult = ReturnType<typeof useGenerateThreadRecommendationQuestionsMutation>;
 export type GenerateThreadRecommendationQuestionsMutationResult = Apollo.MutationResult<GenerateThreadRecommendationQuestionsMutation>;
 export type GenerateThreadRecommendationQuestionsMutationOptions = Apollo.BaseMutationOptions<GenerateThreadRecommendationQuestionsMutation, GenerateThreadRecommendationQuestionsMutationVariables>;
-export const GenerateThreadResponseBreakdownDocument = gql`
-    mutation GenerateThreadResponseBreakdown($responseId: Int!) {
-  generateThreadResponseBreakdown(responseId: $responseId) {
-    ...CommonResponse
-  }
-}
-    ${CommonResponseFragmentDoc}`;
-export type GenerateThreadResponseBreakdownMutationFn = Apollo.MutationFunction<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>;
-
-/**
- * __useGenerateThreadResponseBreakdownMutation__
- *
- * To run a mutation, you first call `useGenerateThreadResponseBreakdownMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useGenerateThreadResponseBreakdownMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [generateThreadResponseBreakdownMutation, { data, loading, error }] = useGenerateThreadResponseBreakdownMutation({
- *   variables: {
- *      responseId: // value for 'responseId'
- *   },
- * });
- */
-export function useGenerateThreadResponseBreakdownMutation(baseOptions?: Apollo.MutationHookOptions<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>(GenerateThreadResponseBreakdownDocument, options);
-      }
-export type GenerateThreadResponseBreakdownMutationHookResult = ReturnType<typeof useGenerateThreadResponseBreakdownMutation>;
-export type GenerateThreadResponseBreakdownMutationResult = Apollo.MutationResult<GenerateThreadResponseBreakdownMutation>;
-export type GenerateThreadResponseBreakdownMutationOptions = Apollo.BaseMutationOptions<GenerateThreadResponseBreakdownMutation, GenerateThreadResponseBreakdownMutationVariables>;
 export const GenerateThreadResponseAnswerDocument = gql`
     mutation GenerateThreadResponseAnswer($responseId: Int!) {
   generateThreadResponseAnswer(responseId: $responseId) {

--- a/wren-ui/src/apollo/client/graphql/home.ts
+++ b/wren-ui/src/apollo/client/graphql/home.ts
@@ -356,16 +356,6 @@ export const GENERATE_THREAD_RECOMMENDATION_QUESTIONS = gql`
   }
 `;
 
-export const GENERATE_THREAD_RESPONSE_BREAKDOWN = gql`
-  mutation GenerateThreadResponseBreakdown($responseId: Int!) {
-    generateThreadResponseBreakdown(responseId: $responseId) {
-      ...CommonResponse
-    }
-  }
-
-  ${COMMON_RESPONSE}
-`;
-
 export const GENERATE_THREAD_RESPONSE_ANSWER = gql`
   mutation GenerateThreadResponseAnswer($responseId: Int!) {
     generateThreadResponseAnswer(responseId: $responseId) {

--- a/wren-ui/src/components/modals/AdjustSQLModal.tsx
+++ b/wren-ui/src/components/modals/AdjustSQLModal.tsx
@@ -9,7 +9,12 @@ import ErrorCollapse from '@/components/ErrorCollapse';
 import PreviewData from '@/components/dataPreview/PreviewData';
 import { usePreviewSqlMutation } from '@/apollo/client/graphql/sql.generated';
 
-type Props = ModalAction<{ sql: string }> & {
+interface AdjustSQLFormValues {
+  responseId: number;
+  sql: string;
+}
+
+type Props = ModalAction<AdjustSQLFormValues, AdjustSQLFormValues> & {
   loading?: boolean;
 };
 
@@ -91,7 +96,10 @@ export default function AdjustSQLModal(props: Props) {
       .then(async (values) => {
         try {
           await onValidateSQL();
-          await onSubmit(values);
+          await onSubmit({
+            responseId: defaultValue?.responseId,
+            sql: values.sql,
+          });
           onClose();
         } catch (error) {
           handleError(error);

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -190,7 +190,6 @@ export default function AnswerResult(props: Props) {
     onOpenSaveAsViewModal,
     onGenerateThreadRecommendedQuestions,
     onGenerateTextBasedAnswer,
-    onGenerateBreakdownAnswer,
     onGenerateChartAnswer,
     onOpenSaveToKnowledgeModal,
     // recommend questions
@@ -259,13 +258,6 @@ export default function AnswerResult(props: Props) {
   ]);
 
   const onTabClick = (activeKey: string) => {
-    if (
-      activeKey === ANSWER_TAB_KEYS.VIEW_SQL &&
-      !threadResponse.breakdownDetail
-    ) {
-      onGenerateBreakdownAnswer(id);
-    }
-
     if (activeKey === ANSWER_TAB_KEYS.CHART && !threadResponse.chartDetail) {
       onGenerateChartAnswer(id);
     }

--- a/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx
@@ -28,9 +28,16 @@ import {
   ThreadResponse,
   ThreadResponseAnswerDetail,
   ThreadResponseAnswerStatus,
+  ThreadResponseAdjustment,
+  ThreadResponseAdjustmentType,
 } from '@/apollo/client/graphql/__types__';
 
 const { Title, Text } = Typography;
+
+const adjustmentType = {
+  [ThreadResponseAdjustmentType.APPLY_SQL]: 'User-provided SQL applied',
+  [ThreadResponseAdjustmentType.REASONING]: 'Reasoning steps adjusted',
+};
 
 const knowledgeTooltip = (
   <>
@@ -147,15 +154,10 @@ const renderRecommendedQuestions = (
   );
 };
 
-const AdjustmentInformation = () => {
-  // TODO: use real data
-  const adjustment = {
-    type: 'ADJUST_SQL',
-  };
-  const adjustmentType = {
-    ADJUST_SQL: 'User-provided SQL applied',
-    ADJUST_REASONING_STEPS: 'Reasoning steps adjusted',
-  };
+const AdjustmentInformation = (props: {
+  adjustment: ThreadResponseAdjustment;
+}) => {
+  const { adjustment } = props;
 
   return (
     <div className="rounded bg-gray-3 gray-6 py-2 px-3 mb-2">
@@ -208,14 +210,14 @@ export default function AnswerResult(props: Props) {
     question,
     sql,
     view,
+    adjustment,
   } = threadResponse;
 
   const resultStyle = isLastThreadResponse
     ? { minHeight: 'calc(100vh - (194px))' }
     : null;
 
-  // TODO: use real data
-  const isAdjustment = false;
+  const isAdjustment = !!adjustment;
 
   const recommendedQuestionProps = getRecommendedQuestionProps(
     recommendedQuestions,
@@ -270,7 +272,7 @@ export default function AnswerResult(props: Props) {
 
   return (
     <div style={resultStyle} data-jsid="answerResult">
-      {isAdjustment && <AdjustmentInformation />}
+      {isAdjustment && <AdjustmentInformation adjustment={adjustment} />}
       <QuestionTitle className="mb-4" question={question} />
       <Preparation
         className="mb-3"

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -155,7 +155,7 @@ export default function TextBasedAnswer(props: AnswerResultProps) {
         sqlGenerationReasoning: data.sqlGenerationReasoning,
       });
     } else if (type === MORE_ACTION.ADJUST_SQL) {
-      onOpenAdjustSQLModal({ sql: data.sql });
+      onOpenAdjustSQLModal({ responseId: id, sql: data.sql });
     }
   };
 

--- a/wren-ui/src/components/pages/home/promptThread/ViewSQLTabContent.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/ViewSQLTabContent.tsx
@@ -120,7 +120,7 @@ export default function ViewSQLTabContent(props: AnswerResultProps) {
               data-ph-capture-attribute-name="view_sql_copy_sql"
               icon={<CodeFilled />}
               size="small"
-              onClick={() => onOpenAdjustSQLModal({ sql })}
+              onClick={() => onOpenAdjustSQLModal({ sql, responseId: id })}
             >
               Adjust SQL
             </Button>

--- a/wren-ui/src/components/pages/home/promptThread/store.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/store.tsx
@@ -41,7 +41,7 @@ export type IPromptThreadStore = {
     retrievedTables: string[];
     sqlGenerationReasoning: string;
   }) => void;
-  onOpenAdjustSQLModal: (data: { sql: string }) => void;
+  onOpenAdjustSQLModal: (data: { responseId: number; sql: string }) => void;
 };
 
 // Register store provider

--- a/wren-ui/src/components/pages/home/promptThread/store.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/store.tsx
@@ -27,7 +27,6 @@ export type IPromptThreadStore = {
   }: SelectQuestionProps) => Promise<void>;
   onGenerateThreadRecommendedQuestions: () => Promise<void>;
   onGenerateTextBasedAnswer: (responseId: number) => Promise<void>;
-  onGenerateBreakdownAnswer: (responseId: number) => Promise<void>;
   onGenerateChartAnswer: (responseId: number) => Promise<void>;
   onAdjustChartAnswer: (
     responseId: number,

--- a/wren-ui/src/hooks/useAdjustAnswer.tsx
+++ b/wren-ui/src/hooks/useAdjustAnswer.tsx
@@ -115,9 +115,18 @@ export default function useAdjustAnswer(threadId?: number) {
   };
 
   const onAdjustSQL = async (responseId: number, sql: string) => {
-    await adjustThreadResponse({
+    const response = await adjustThreadResponse({
       variables: { responseId, data: { sql } },
     });
+
+    // update thread cache
+    const nextThreadResponse = response.data?.adjustThreadResponse;
+    handleUpdateThreadCache(
+      threadId,
+      nextThreadResponse,
+      threadResponseResult.client,
+    );
+
     // It won't have adjusmentTask, no need to fetch
   };
 

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -37,7 +37,6 @@ import {
   useGenerateThreadRecommendationQuestionsMutation,
   useGetThreadRecommendationQuestionsLazyQuery,
   useGenerateThreadResponseAnswerMutation,
-  useGenerateThreadResponseBreakdownMutation,
   useGenerateThreadResponseChartMutation,
   useAdjustThreadResponseChartMutation,
 } from '@/apollo/client/graphql/home.generated';
@@ -57,25 +56,18 @@ const getThreadResponseIsFinished = (threadResponse: ThreadResponse) => {
 
   // false make it keep polling when the text based answer is default needed.
   let isAnswerFinished = isBreakdownOnly ? null : false;
-  let isBreakdownFinished = null;
   let isChartFinished = null;
 
   // answerDetail status can be FAILED before getting queryId from Wren AI adapter
   if (answerDetail?.queryId || answerDetail?.status) {
     isAnswerFinished = getAnswerIsFinished(answerDetail?.status);
   }
-  if (breakdownDetail?.queryId) {
-    isBreakdownFinished = getIsFinished(breakdownDetail?.status);
-  }
+
   if (chartDetail?.queryId) {
     isChartFinished = getIsChartFinished(chartDetail?.status);
   }
   // if equal false, it means it has task & the task is not finished
-  return (
-    isAnswerFinished !== false &&
-    isBreakdownFinished !== false &&
-    isChartFinished !== false
-  );
+  return isAnswerFinished !== false && isChartFinished !== false;
 };
 
 export default function HomeThread() {
@@ -156,9 +148,6 @@ export default function HomeThread() {
   const [generateThreadResponseAnswer] =
     useGenerateThreadResponseAnswerMutation();
 
-  const [generateThreadResponseBreakdown] =
-    useGenerateThreadResponseBreakdownMutation();
-
   const [generateThreadResponseChart] =
     useGenerateThreadResponseChartMutation();
   const [adjustThreadResponseChart] = useAdjustThreadResponseChartMutation();
@@ -192,13 +181,6 @@ export default function HomeThread() {
 
   const onGenerateThreadResponseAnswer = async (responseId: number) => {
     await generateThreadResponseAnswer({ variables: { responseId } });
-    fetchThreadResponse({ variables: { responseId } });
-  };
-
-  const onGenerateThreadResponseBreakdown = async (responseId: number) => {
-    await generateThreadResponseBreakdown({
-      variables: { responseId },
-    });
     fetchThreadResponse({ variables: { responseId } });
   };
 
@@ -331,7 +313,6 @@ export default function HomeThread() {
     onSelectRecommendedQuestion: onCreateResponse,
     onGenerateThreadRecommendedQuestions: onGenerateThreadRecommendedQuestions,
     onGenerateTextBasedAnswer: onGenerateThreadResponseAnswer,
-    onGenerateBreakdownAnswer: onGenerateThreadResponseBreakdown,
     onGenerateChartAnswer: onGenerateThreadResponseChart,
     onAdjustChartAnswer: onAdjustThreadResponseChart,
     onOpenSaveToKnowledgeModal: questionSqlPairModal.openModal,

--- a/wren-ui/src/pages/home/[id].tsx
+++ b/wren-ui/src/pages/home/[id].tsx
@@ -366,10 +366,10 @@ export default function HomeThread() {
       <AdjustSQLModal
         {...adjustSqlModal.state}
         onClose={adjustSqlModal.closeModal}
-        loading={false}
-        onSubmit={async (data) => {
-          console.log('adjust sql:', data);
-        }}
+        loading={adjustAnswer.loading}
+        onSubmit={async (values) =>
+          await adjustAnswer.onAdjustSQL(values.responseId, values.sql)
+        }
       />
     </SiderLayout>
   );

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -129,11 +129,11 @@ class GenerateThreadResponseAnswerErrorHandler extends ErrorHandler {
   }
 }
 
-class GenerateThreadResponseBreakdownErrorHandler extends ErrorHandler {
+class AdjustThreadResponseErrorHandler extends ErrorHandler {
   public getErrorMessage(error: GraphQLError) {
     switch (error.extensions?.code) {
       default:
-        return 'Failed to generate thread response breakdown SQL answer.';
+        return 'Failed to adjust thread response answer.';
     }
   }
 }
@@ -376,8 +376,8 @@ errorHandlers.set(
   new GenerateThreadResponseAnswerErrorHandler(),
 );
 errorHandlers.set(
-  'GenerateThreadResponseBreakdown',
-  new GenerateThreadResponseBreakdownErrorHandler(),
+  'AdjustThreadResponse',
+  new AdjustThreadResponseErrorHandler(),
 );
 
 errorHandlers.set('CreateView', new CreateViewErrorHandler());


### PR DESCRIPTION
This pull request includes several changes to the `wren-ui` project, primarily focused on adding support for SQL adjustments and removing the breakdown answer generation functionality. The most important changes include updating the `AdjustSQLModal` component to handle `responseId`, modifying the `AnswerResult` component to display adjustment information, and updating the `useAdjustAnswer` hook to fetch thread responses after SQL adjustments.

## Tasks
 - Integrate adjust thread response SQL API
 - Remove breakdown answer generation
