### PR TITLE
fix(wren-ui): allow to adjust the answer if generating a text answer fails

### DIFF
--- a/wren-ui/src/components/diagram/CustomDropdown.tsx
+++ b/wren-ui/src/components/diagram/CustomDropdown.tsx
@@ -315,6 +315,7 @@ export const AdjustAnswerDropdown = makeDropdown(
       {
         label: 'Adjust SQL',
         icon: <CodeFilled className="text-base" />,
+        disabled: !data.sql,
         key: 'adjust-sql',
         onClick: () =>
           onMoreClick({

--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -159,15 +159,42 @@ export default function TextBasedAnswer(props: AnswerResultProps) {
     }
   };
 
+  const adjustAnswerDropdown = (
+    <AdjustAnswerDropdown
+      onMoreClick={onMoreClick}
+      data={adjustAnswerDropdownData}
+      onDropdownVisibleChange={adjustResultsDropdown.onVisibleChange}
+    >
+      <Button
+        className="px-0"
+        type="link"
+        size="small"
+        icon={<EditOutlined />}
+        onClick={(event) => event.stopPropagation()}
+      >
+        Adjust the answer
+        <CaretDownOutlined
+          className="ml-1"
+          rotate={adjustResultsDropdown.visible ? 180 : 0}
+        />
+      </Button>
+    </AdjustAnswerDropdown>
+  );
+
   if (error) {
     return (
-      <Alert
-        className="m-6"
-        message={error.shortMessage}
-        description={error.message}
-        type="error"
-        showIcon
-      />
+      <>
+        <div className="py-4 px-6">
+          <div className="text-right">{adjustAnswerDropdown}</div>
+          <Alert
+            className="mt-4 mb-2"
+            message={error.shortMessage}
+            description={error.message}
+            type="error"
+            showIcon
+          />
+        </div>
+      </>
     );
   }
 
@@ -179,27 +206,7 @@ export default function TextBasedAnswer(props: AnswerResultProps) {
       title={false}
     >
       <div className="text-md gray-10 py-4 px-6">
-        <div className="text-right mb-4">
-          <AdjustAnswerDropdown
-            onMoreClick={onMoreClick}
-            data={adjustAnswerDropdownData}
-            onDropdownVisibleChange={adjustResultsDropdown.onVisibleChange}
-          >
-            <Button
-              className="px-0"
-              type="link"
-              size="small"
-              icon={<EditOutlined />}
-              onClick={(event) => event.stopPropagation()}
-            >
-              Adjust the answer
-              <CaretDownOutlined
-                className="ml-1"
-                rotate={adjustResultsDropdown.visible ? 180 : 0}
-              />
-            </Button>
-          </AdjustAnswerDropdown>
-        </div>
+        <div className="text-right mb-4">{adjustAnswerDropdown}</div>
         <MarkdownBlock content={textAnswer} />
         {isStreaming && <LoadingOutlined className="geekblue-6" spin />}
         {status === ThreadResponseAnswerStatus.INTERRUPTED && (


### PR DESCRIPTION
## Description
 - allow to adjust the answer if generating a text answer fails

## UI (example)

![截圖 2025-04-02 下午5 37 22](https://github.com/user-attachments/assets/cf8c47dd-99a5-4eb4-8cb1-3c80b1213004)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The answer adjustment control has been enhanced to appear uniformly in both regular and error scenarios, ensuring a consistent and seamless user experience. Users can now modify their answers easily even when an error alert is present. This improvement provides clearer guidance and easier interaction across different states.
  - The 'Adjust SQL' dropdown item is now conditionally disabled based on the presence of SQL data, improving user control and interface responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->