### PR TITLE
fix(wren-ai-service): The DeepSeek response may not be a valid JSON format.

### DIFF
--- a/wren-ai-service/src/providers/llm/litellm.py
+++ b/wren-ai-service/src/providers/llm/litellm.py
@@ -16,7 +16,7 @@ from src.providers.llm import (
     connect_chunks,
 )
 from src.providers.loader import provider
-from src.utils import remove_trailing_slash
+from src.utils import remove_trailing_slash, extract_braces_content
 
 
 @provider("litellm_llm")
@@ -113,7 +113,7 @@ class LitellmLLMProvider(LLMProvider):
                 check_finish_reason(response)
 
             return {
-                "replies": [message.content for message in completions],
+                "replies": [extract_braces_content(message.content) for message in completions],
                 "meta": [message.meta for message in completions],
             }
 

--- a/wren-ai-service/src/utils.py
+++ b/wren-ai-service/src/utils.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import re
 from pathlib import Path
 
 import requests
@@ -187,3 +188,11 @@ def fetch_wren_ai_docs(doc_endpoint: str, is_oss: bool) -> list[dict]:
             )
 
     return results
+
+def extract_braces_content(resp: str) -> str:
+    """
+    Extracts JSON content enclosed in a markdown code block that starts with ```json.
+    Returns the JSON string including braces, or the original string if no match is found.
+    """
+    match = re.search(r'```json\s*(\{.*?\})\s*```', resp, re.DOTALL)
+    return match.group(1) if match else resp


### PR DESCRIPTION
When testing WrenAI with DeepSeek, I encountered a JSON formatting exception. After installing Langfuse, I noticed that DeepSeek frequently returns responses in JSON_OBJECT format with extra characters - specifically starting with \`\`\`json and ending with \`\`\`. To accommodate this behavior, we need to implement substring extraction based on curly brace positions to ensure successful JSON parsing.
Additionally, I observed that historical issues #1354  contain a similar problem.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced response formatting by extracting and returning only the content within curly braces in AI-generated replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->