### PR TITLE
fix(wren-ui): change to responses length to trigger scrolling bottom

### DIFF
--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useMemo, useRef } from 'react';
 import { Divider } from 'antd';
 import styled from 'styled-components';
+import { nextTick } from '@/utils/time';
 import usePromptThreadStore from './store';
 import AnswerResult from './AnswerResult';
 import { makeIterable, IterableComponent } from '@/utils/iteration';
@@ -102,8 +103,10 @@ export default function PromptThread() {
     const isLastResponseFinished =
       getIsFinished(lastResponse?.askingTask?.status) ||
       getAnswerIsFinished(lastResponse?.answerDetail?.status);
-    triggerScrollToBottom(isLastResponseFinished ? 'auto' : 'smooth');
-  }, [responses]);
+    nextTick().then(() => {
+      triggerScrollToBottom(isLastResponseFinished ? 'auto' : 'smooth');
+    });
+  }, [responses.length]);
 
   const onInitPreviewDone = () => {
     triggerScrollToBottom();


### PR DESCRIPTION
## Description
Since the response content dynamically updates during task processing, refine the watcher to monitor content length and automatically scroll to the bottom when new content is appended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced auto-scroll behavior on the homepage so that the view consistently moves to display the most recent responses after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->