### PR TITLE
fix: add fmt.Scanln for debugging missing error report

### DIFF
--- a/wren-launcher/commands/launch.go
+++ b/wren-launcher/commands/launch.go
@@ -375,6 +375,7 @@ func validateOpenaiApiKey(apiKey string) bool {
 	// insufficient credit balance error
 	if err != nil {
 		pterm.Error.Println("Invalid API key", err)
+		fmt.Scanln()
 		return true
 	}
 


### PR DESCRIPTION
This PR fixes issue #1537

Changes:
- Added fmt.Scanln for pause after error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling during API key validation. When an invalid key is detected, the launcher now pauses to allow user confirmation before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->