### PR TITLE
feat(wren-ui): Support editable chart titles in dashboard item

### DIFF
--- a/wren-ui/migrations/20250510000001_alter_dashboard_item_table.js
+++ b/wren-ui/migrations/20250510000001_alter_dashboard_item_table.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('dashboard_item', (table) => {
+    table
+      .string('display_name')
+      .comment('Display name of the dashboard item')
+      .nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('dashboard_item', (table) => {
+    table.dropColumn('display_name');
+  });
+};

--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -189,6 +189,7 @@ export type DashboardItem = {
   __typename?: 'DashboardItem';
   dashboardId: Scalars['Int'];
   detail: DashboardItemDetail;
+  displayName?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   layout: DashboardItemLayout;
   type: DashboardItemType;
@@ -611,6 +612,7 @@ export type Mutation = {
   triggerDataSourceDetection: Scalars['Boolean'];
   updateCalculatedField: Scalars['JSON'];
   updateCurrentProject: Scalars['Boolean'];
+  updateDashboardItem: DashboardItem;
   updateDashboardItemLayouts: Array<DashboardItem>;
   updateDataSource: DataSource;
   updateInstruction: Instruction;
@@ -852,6 +854,12 @@ export type MutationUpdateCalculatedFieldArgs = {
 
 export type MutationUpdateCurrentProjectArgs = {
   data: UpdateCurrentProjectInput;
+};
+
+
+export type MutationUpdateDashboardItemArgs = {
+  data: UpdateDashboardItemInput;
+  where: DashboardItemWhereInput;
 };
 
 
@@ -1341,6 +1349,10 @@ export type UpdateColumnMetadataInput = {
 
 export type UpdateCurrentProjectInput = {
   language: ProjectLanguage;
+};
+
+export type UpdateDashboardItemInput = {
+  displayName: Scalars['String'];
 };
 
 export type UpdateDashboardItemLayoutsInput = {

--- a/wren-ui/src/apollo/client/graphql/dashboard.generated.ts
+++ b/wren-ui/src/apollo/client/graphql/dashboard.generated.ts
@@ -3,26 +3,34 @@ import * as Types from './__types__';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type CommonDashboardItemFragment = { __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } };
+export type CommonDashboardItemFragment = { __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, displayName?: string | null, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } };
 
 export type DashboardItemsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type DashboardItemsQuery = { __typename?: 'Query', dashboardItems: Array<{ __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } }> };
+export type DashboardItemsQuery = { __typename?: 'Query', dashboardItems: Array<{ __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, displayName?: string | null, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } }> };
 
 export type CreateDashboardItemMutationVariables = Types.Exact<{
   data: Types.CreateDashboardItemInput;
 }>;
 
 
-export type CreateDashboardItemMutation = { __typename?: 'Mutation', createDashboardItem: { __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } } };
+export type CreateDashboardItemMutation = { __typename?: 'Mutation', createDashboardItem: { __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, displayName?: string | null, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } } };
+
+export type UpdateDashboardItemMutationVariables = Types.Exact<{
+  where: Types.DashboardItemWhereInput;
+  data: Types.UpdateDashboardItemInput;
+}>;
+
+
+export type UpdateDashboardItemMutation = { __typename?: 'Mutation', updateDashboardItem: { __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, displayName?: string | null, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } } };
 
 export type UpdateDashboardItemLayoutsMutationVariables = Types.Exact<{
   data: Types.UpdateDashboardItemLayoutsInput;
 }>;
 
 
-export type UpdateDashboardItemLayoutsMutation = { __typename?: 'Mutation', updateDashboardItemLayouts: Array<{ __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } }> };
+export type UpdateDashboardItemLayoutsMutation = { __typename?: 'Mutation', updateDashboardItemLayouts: Array<{ __typename?: 'DashboardItem', id: number, dashboardId: number, type: Types.DashboardItemType, displayName?: string | null, layout: { __typename?: 'DashboardItemLayout', x: number, y: number, w: number, h: number }, detail: { __typename?: 'DashboardItemDetail', sql: string, chartSchema?: any | null } }> };
 
 export type DeleteDashboardItemMutationVariables = Types.Exact<{
   where: Types.DashboardItemWhereInput;
@@ -53,6 +61,7 @@ export const CommonDashboardItemFragmentDoc = gql`
     sql
     chartSchema
   }
+  displayName
 }
     `;
 export const DashboardItemsDocument = gql`
@@ -122,6 +131,40 @@ export function useCreateDashboardItemMutation(baseOptions?: Apollo.MutationHook
 export type CreateDashboardItemMutationHookResult = ReturnType<typeof useCreateDashboardItemMutation>;
 export type CreateDashboardItemMutationResult = Apollo.MutationResult<CreateDashboardItemMutation>;
 export type CreateDashboardItemMutationOptions = Apollo.BaseMutationOptions<CreateDashboardItemMutation, CreateDashboardItemMutationVariables>;
+export const UpdateDashboardItemDocument = gql`
+    mutation UpdateDashboardItem($where: DashboardItemWhereInput!, $data: UpdateDashboardItemInput!) {
+  updateDashboardItem(where: $where, data: $data) {
+    ...CommonDashboardItem
+  }
+}
+    ${CommonDashboardItemFragmentDoc}`;
+export type UpdateDashboardItemMutationFn = Apollo.MutationFunction<UpdateDashboardItemMutation, UpdateDashboardItemMutationVariables>;
+
+/**
+ * __useUpdateDashboardItemMutation__
+ *
+ * To run a mutation, you first call `useUpdateDashboardItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateDashboardItemMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateDashboardItemMutation, { data, loading, error }] = useUpdateDashboardItemMutation({
+ *   variables: {
+ *      where: // value for 'where'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateDashboardItemMutation(baseOptions?: Apollo.MutationHookOptions<UpdateDashboardItemMutation, UpdateDashboardItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateDashboardItemMutation, UpdateDashboardItemMutationVariables>(UpdateDashboardItemDocument, options);
+      }
+export type UpdateDashboardItemMutationHookResult = ReturnType<typeof useUpdateDashboardItemMutation>;
+export type UpdateDashboardItemMutationResult = Apollo.MutationResult<UpdateDashboardItemMutation>;
+export type UpdateDashboardItemMutationOptions = Apollo.BaseMutationOptions<UpdateDashboardItemMutation, UpdateDashboardItemMutationVariables>;
 export const UpdateDashboardItemLayoutsDocument = gql`
     mutation UpdateDashboardItemLayouts($data: UpdateDashboardItemLayoutsInput!) {
   updateDashboardItemLayouts(data: $data) {

--- a/wren-ui/src/apollo/client/graphql/dashboard.ts
+++ b/wren-ui/src/apollo/client/graphql/dashboard.ts
@@ -15,6 +15,7 @@ export const COMMON_DASHBOARD_ITEM = gql`
       sql
       chartSchema
     }
+    displayName
   }
 `;
 
@@ -30,6 +31,18 @@ export const DASHBOARD_ITEMS = gql`
 export const CREATE_DASHBOARD_ITEM = gql`
   mutation CreateDashboardItem($data: CreateDashboardItemInput!) {
     createDashboardItem(data: $data) {
+      ...CommonDashboardItem
+    }
+  }
+  ${COMMON_DASHBOARD_ITEM}
+`;
+
+export const UPDATE_DASHBOARD_ITEM = gql`
+  mutation UpdateDashboardItem(
+    $where: DashboardItemWhereInput!
+    $data: UpdateDashboardItemInput!
+  ) {
+    updateDashboardItem(where: $where, data: $data) {
       ...CommonDashboardItem
     }
   }

--- a/wren-ui/src/apollo/server/repositories/dashboardItemRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/dashboardItemRepository.ts
@@ -39,6 +39,7 @@ export interface DashboardItem {
   type: DashboardItemType;
   layout: DashboardItemLayout;
   detail: DashboardItemDetail;
+  displayName?: string;
 }
 
 export interface IDashboardItemRepository

--- a/wren-ui/src/apollo/server/resolvers.ts
+++ b/wren-ui/src/apollo/server/resolvers.ts
@@ -154,6 +154,7 @@ const resolvers = {
     // Dashboard
     updateDashboardItemLayouts: dashboardResolver.updateDashboardItemLayouts,
     createDashboardItem: dashboardResolver.createDashboardItem,
+    updateDashboardItem: dashboardResolver.updateDashboardItem,
     deleteDashboardItem: dashboardResolver.deleteDashboardItem,
     previewItemSQL: dashboardResolver.previewItemSQL,
 

--- a/wren-ui/src/apollo/server/resolvers/dashboardResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/dashboardResolver.ts
@@ -15,6 +15,7 @@ export class DashboardResolver {
   constructor() {
     this.getDashboardItems = this.getDashboardItems.bind(this);
     this.createDashboardItem = this.createDashboardItem.bind(this);
+    this.updateDashboardItem = this.updateDashboardItem.bind(this);
     this.deleteDashboardItem = this.deleteDashboardItem.bind(this);
     this.updateDashboardItemLayouts =
       this.updateDashboardItemLayouts.bind(this);
@@ -60,6 +61,20 @@ export class DashboardResolver {
       sql: response.sql,
       chartSchema: response.chartDetail?.chartSchema,
     });
+  }
+
+  public async updateDashboardItem(
+    _root: any,
+    args: { where: { id: number }; data: { displayName: string } },
+    ctx: IContext,
+  ): Promise<DashboardItem> {
+    const { id } = args.where;
+    const { displayName } = args.data;
+    const item = await ctx.dashboardService.getDashboardItem(id);
+    if (!item) {
+      throw new Error(`Dashboard item not found. id: ${id}`);
+    }
+    return await ctx.dashboardService.updateDashboardItem(id, { displayName });
   }
 
   public async deleteDashboardItem(

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -862,6 +862,10 @@ export const typeDefs = gql`
     responseId: Int!
   }
 
+  input UpdateDashboardItemInput {
+    displayName: String!
+  }
+
   input ItemLayoutInput {
     itemId: Int!
     x: Int!
@@ -901,6 +905,7 @@ export const typeDefs = gql`
     type: DashboardItemType!
     layout: DashboardItemLayout!
     detail: DashboardItemDetail!
+    displayName: String
   }
 
   type SqlPair {
@@ -1127,6 +1132,10 @@ export const typeDefs = gql`
       data: UpdateDashboardItemLayoutsInput!
     ): [DashboardItem!]!
     createDashboardItem(data: CreateDashboardItemInput!): DashboardItem!
+    updateDashboardItem(
+      where: DashboardItemWhereInput!
+      data: UpdateDashboardItemInput!
+    ): DashboardItem!
     deleteDashboardItem(where: DashboardItemWhereInput!): Boolean!
     previewItemSQL(data: PreviewItemSQLInput!): JSON!
 

--- a/wren-ui/src/apollo/server/services/dashboardService.ts
+++ b/wren-ui/src/apollo/server/services/dashboardService.ts
@@ -20,6 +20,10 @@ export interface CreateDashboardItemInput {
   chartSchema: DashboardItemDetail['chartSchema'];
 }
 
+export interface UpdateDashboardItemInput {
+  displayName: string;
+}
+
 export type UpdateDashboardItemLayouts = (DashboardItemLayout & {
   itemId: number;
 })[];
@@ -30,6 +34,10 @@ export interface IDashboardService {
   getDashboardItem(dashboardItemId: number): Promise<DashboardItem>;
   getDashboardItems(dashboardId: number): Promise<DashboardItem[]>;
   createDashboardItem(input: CreateDashboardItemInput): Promise<DashboardItem>;
+  updateDashboardItem(
+    dashboardItemId: number,
+    input: UpdateDashboardItemInput,
+  ): Promise<DashboardItem>;
   deleteDashboardItem(dashboardItemId: number): Promise<boolean>;
   updateDashboardItemLayouts(
     layouts: UpdateDashboardItemLayouts,
@@ -111,6 +119,15 @@ export class DashboardService implements IDashboardService {
         chartSchema: input.chartSchema,
       },
       layout,
+    });
+  }
+
+  public async updateDashboardItem(
+    dashboardItemId: number,
+    input: UpdateDashboardItemInput,
+  ): Promise<DashboardItem> {
+    return await this.dashboardItemRepository.updateOne(dashboardItemId, {
+      displayName: input.displayName,
     });
   }
 

--- a/wren-ui/src/components/EditableWrapper.tsx
+++ b/wren-ui/src/components/EditableWrapper.tsx
@@ -9,7 +9,7 @@ interface Props {
   dataIndex: string;
   record: any;
   rules?: any[];
-  handleSave: (id: string, value: { [key: string]: string }) => void;
+  handleSave: (id: string | number, value: { [key: string]: string }) => void;
 }
 
 const EditableStyle = styled.div`
@@ -40,6 +40,8 @@ export default function EditableWrapper(props: Props) {
   const { children, dataIndex, record, rules, handleSave } = props;
 
   const [editing, setEditing] = useState(false);
+  const textRef = useRef<HTMLDivElement>(null);
+  const inputWidth = useRef(0);
   const inputRef = useRef<InputRef>(null);
   const form = useContext(EditableContext);
   const dataIndexKey = Array.isArray(dataIndex)
@@ -51,6 +53,7 @@ export default function EditableWrapper(props: Props) {
   }, [editing]);
 
   const toggleEdit = () => {
+    if (textRef.current) inputWidth.current = textRef.current.clientWidth;
     setEditing(!editing);
     const value = get(record, dataIndexKey);
     form.setFieldsValue({ [dataIndexKey]: value });
@@ -69,10 +72,17 @@ export default function EditableWrapper(props: Props) {
 
   const childNode = editing ? (
     <Form.Item style={{ margin: 0 }} name={dataIndexKey} rules={rules}>
-      <Input size="small" ref={inputRef} onPressEnter={save} onBlur={save} />
+      <Input
+        size="small"
+        ref={inputRef}
+        onPressEnter={save}
+        onBlur={save}
+        style={{ width: inputWidth.current }}
+      />
     </Form.Item>
   ) : (
     <div
+      ref={textRef}
       className="editable-cell-value-wrap"
       style={{ paddingRight: 24 }}
       onClick={toggleEdit}

--- a/wren-ui/src/components/EllipsisWrapper.tsx
+++ b/wren-ui/src/components/EllipsisWrapper.tsx
@@ -53,7 +53,7 @@ export default function EllipsisWrapper(props: Props) {
   useEffect(() => {
     if (ref.current && !hasWidth) {
       const cellWidth = ref.current.clientWidth;
-      setWidth(cellWidth);
+      cellWidth === 0 ? setWidth('auto') : setWidth(cellWidth);
     }
 
     // Reset state when unmount

--- a/wren-ui/src/utils/errorHandler.tsx
+++ b/wren-ui/src/utils/errorHandler.tsx
@@ -285,6 +285,15 @@ class CreateDashboardItemErrorHandler extends ErrorHandler {
   }
 }
 
+class UpdateDashboardItemErrorHandler extends ErrorHandler {
+  public getErrorMessage(error: GraphQLError) {
+    switch (error.extensions?.code) {
+      default:
+        return 'Failed to update dashboard item.';
+    }
+  }
+}
+
 class UpdateDashboardItemLayoutsErrorHandler extends ErrorHandler {
   public getErrorMessage(error: GraphQLError) {
     switch (error.extensions?.code) {
@@ -414,6 +423,7 @@ errorHandlers.set('ResolveSchemaChange', new ResolveSchemaChangeErrorHandler());
 
 // Dashboard
 errorHandlers.set('CreateDashboardItem', new CreateDashboardItemErrorHandler());
+errorHandlers.set('UpdateDashboardItem', new UpdateDashboardItemErrorHandler());
 errorHandlers.set(
   'UpdateDashboardItemLayouts',
   new UpdateDashboardItemLayoutsErrorHandler(),


### PR DESCRIPTION
## Description
This PR adds support for editable chart titles in dashboard items.

## Screenshots
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/7508ab53-9ff5-4825-bb3b-55a438bebc74" />

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/8024dc9c-a422-41c6-8bb5-8fa8cf311c9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for setting and updating a display name for dashboard items.
  - Introduced inline editing for pinned dashboard item titles, allowing users to update titles directly from the dashboard.
- **Bug Fixes**
  - Improved editable input fields so their width matches the displayed text when editing.
  - Adjusted logic to ensure element width is set to 'auto' if the measured width is zero.
- **Chores**
  - Enhanced error handling for dashboard item updates with clear error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->