### PR TITLE
chore(workflows): remove latest tag

### DIFF
--- a/.github/workflows/ui-release-image-stable.yaml
+++ b/.github/workflows/ui-release-image-stable.yaml
@@ -89,7 +89,7 @@ jobs:
         working-directory: /tmp/digests
         # tag with input version and latest
         run: |
-          TAGS=$(echo "${{ steps.meta.outputs.tags }} --tag latest" | awk '{printf "--tag %s ", $0}') 
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.WREN_UI_IMAGE }}@sha256:%s ' *) \
             $TAGS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow for image tagging during release. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->