### PR TITLE
Fix: Correct provider name in config from openai to lm_studio

### DIFF
--- a/wren-ai-service/docs/config_examples/config.lm_studio.yaml
+++ b/wren-ai-service/docs/config_examples/config.lm_studio.yaml
@@ -10,7 +10,7 @@ provider: litellm_llm
 models:
   # put LM_STUDIO_API_KEY=<random_string> in ~/.wrenai/.env
   - api_base: http://host.docker.internal:1234/v1
-    model: openai/phi-4 # openai/<lm_studio_model_name>
+    model: lm_studio/phi-4 # lm_studio/<lm_studio_model_name>
     alias: default
     timeout: 600
     kwargs:
@@ -22,7 +22,7 @@ type: embedder
 provider: litellm_embedder
 models:
   # put LM_STUDIO_API_KEY=<random_string> in ~/.wrenai/.env
-  - model: openai/text-embedding-nomic-embed-text-v1.5 # put your lm_studio embedder model name here, openai/<lm_studio_model_name>
+  - model: lm_studio/text-embedding-nomic-embed-text-v1.5 # put your lm_studio embedder model name here, lm_studio/<lm_studio_model_name>
     alias: default
     api_base: http://host.docker.internal:1234/v1
     timeout: 600


### PR DESCRIPTION
PR Description
This PR fixes a typo in the config.lm_studio.yaml file where the provider was incorrectly set to openai instead of lm_studio. This caused local LLM services (such as LM Studio) to be unrecognized and unusable. Changes
Corrected the provider field from openai to lm_studio in the config file Ensured compatibility with local LLM services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration examples to use the "lm_studio/" model provider prefix instead of "openai/" for both language and embedding models. Comments were revised to match the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->