### PR TITLE
fix(wren-ui): DuckDb image path case-sensitive & adjust retrieving models text

### DIFF
--- a/wren-ui/src/components/pages/home/preparation/step/Retrieving.tsx
+++ b/wren-ui/src/components/pages/home/preparation/step/Retrieving.tsx
@@ -21,12 +21,12 @@ export default function Retrieving(props: Props) {
 
   const title = isAdjustment
     ? 'User-selected models applied'
-    : 'Retrieving related models';
+    : 'Retrieving top 10 model candidates';
 
   const modelDescription = isAdjustment ? (
     <>{tables.length} models applied</>
   ) : (
-    <>{tables.length} models found</>
+    <>Top {tables.length} model candidates identified</>
   );
 
   return (

--- a/wren-ui/src/utils/dataSourceType.ts
+++ b/wren-ui/src/utils/dataSourceType.ts
@@ -21,7 +21,7 @@ export const getDataSourceImage = (dataSource: DATA_SOURCES | string) => {
     case DATA_SOURCES.CLICK_HOUSE:
       return '/images/dataSource/clickhouse.svg';
     case DATA_SOURCES.DUCKDB:
-      return '/images/dataSource/duckdb.svg';
+      return '/images/dataSource/duckDb.svg';
     case DATA_SOURCES.TRINO:
       return '/images/dataSource/trino.svg';
     case DATA_SOURCES.SNOWFLAKE:


### PR DESCRIPTION
### Description
- Fix incorrect file path from SaaS sync: rename `duckdb.svg` to `duckDb.svg` to prevent image load issues on case-sensitive file systems.
   <img width="1610" alt="image" src="https://github.com/user-attachments/assets/4510f958-a3eb-48bf-9133-b1d79719272e" />

- Adjust reasoning retrieving models text
  <img width="837" alt="image" src="https://github.com/user-attachments/assets/fee0cbc5-c20a-4e6e-8a58-b67106c135c8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated UI text to provide more specific descriptions when retrieving model candidates.
  - Adjusted image path for DuckDB data source to ensure correct icon display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->