### PR TITLE
fix(wren-ui): add loading to import data source SQL syntax modal

### DIFF
--- a/wren-ui/src/components/modals/ImportDataSourceSQLModal.tsx
+++ b/wren-ui/src/components/modals/ImportDataSourceSQLModal.tsx
@@ -10,9 +10,7 @@ import ErrorCollapse from '@/components/ErrorCollapse';
 import { useModelSubstituteMutation } from '@/apollo/client/graphql/sql.generated';
 import { DataSource, DataSourceName } from '@/apollo/client/graphql/__types__';
 
-type Props = ModalAction<{ dataSource: DATA_SOURCES }> & {
-  loading?: boolean;
-};
+type Props = ModalAction<{ dataSource: DATA_SOURCES }>;
 
 const Toolbar = (props) => {
   const { dataSource } = props;
@@ -37,7 +35,7 @@ export const isSupportSubstitute = (dataSource: DataSource) => {
 };
 
 export default function ImportDataSourceSQLModal(props: Props) {
-  const { visible, defaultValue, loading, onSubmit, onClose } = props;
+  const { visible, defaultValue, onSubmit, onClose } = props;
   const name = getDataSourceName(defaultValue?.dataSource) || 'data source';
 
   const [substituteDialectSQL, modelSubstitudeResult] =
@@ -73,6 +71,8 @@ export default function ImportDataSourceSQLModal(props: Props) {
       .catch(console.error);
   };
 
+  const loading = modelSubstitudeResult.loading;
+
   return (
     <Modal
       title={`Import from ${name} SQL`}
@@ -87,7 +87,6 @@ export default function ImportDataSourceSQLModal(props: Props) {
       visible={visible}
       width={600}
       cancelButtonProps={{ disabled: loading }}
-      okButtonProps={{ disabled: loading }}
       afterClose={() => reset()}
     >
       <Form form={form} layout="vertical">


### PR DESCRIPTION
## Description
Add loading to import data source SQL syntax when converting 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved loading state handling within the Import Data Source SQL modal for a more consistent user experience. The loading indicator is now managed internally, and the confirm button accurately reflects the loading status during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->