### PR TITLE
chore(wren-launcher): minor-updates (ai-env-changed)

### DIFF
--- a/deployment/kustomizations/base/cm.yaml
+++ b/deployment/kustomizations/base/cm.yaml
@@ -72,24 +72,6 @@ data:
         n: 1
         seed: 0
         temperature: 0
-    - model: gpt-4o-mini-2024-07-18
-      kwargs:
-        temperature: 0
-        n: 1
-        seed: 0
-        max_tokens: 4096
-    - model: gpt-4o-2024-08-06
-      kwargs:
-        temperature: 0
-        n: 1
-        seed: 0
-        max_tokens: 4096
-    - model: o3-mini-2025-01-31
-      kwargs:
-        n: 1
-        seed: 0
-        max_completion_tokens: 4096
-        reasoning_effort: low
 
     ---
     type: embedder

--- a/docker/config.example.yaml
+++ b/docker/config.example.yaml
@@ -21,26 +21,6 @@ models:
       n: 1
       seed: 0
       temperature: 0
-  - model: gpt-4o-mini-2024-07-18
-    kwargs:
-      temperature: 0
-      n: 1
-      # for better consistency of llm response, refer: https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed
-      seed: 0
-      max_tokens: 4096
-  - model: gpt-4o-2024-08-06
-    kwargs:
-      temperature: 0
-      n: 1
-      # for better consistency of llm response, refer: https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed
-      seed: 0
-      max_tokens: 4096
-  - model: o3-mini-2025-01-31
-    kwargs:
-      n: 1
-      seed: 0
-      max_completion_tokens: 4096
-      reasoning_effort: low
 
 ---
 type: embedder

--- a/wren-ai-service/tools/config/config.example.yaml
+++ b/wren-ai-service/tools/config/config.example.yaml
@@ -21,26 +21,6 @@ models:
       n: 1
       seed: 0
       temperature: 0
-  - model: gpt-4o-mini-2024-07-18
-    kwargs:
-      temperature: 0
-      n: 1
-      # for better consistency of llm response, refer: https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed
-      seed: 0
-      max_tokens: 4096
-  - model: gpt-4o-2024-08-06
-    kwargs:
-      temperature: 0
-      n: 1
-      # for better consistency of llm response, refer: https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed
-      seed: 0
-      max_tokens: 4096
-  - model: o3-mini-2025-01-31
-    kwargs:
-      n: 1
-      seed: 0
-      max_completion_tokens: 4096
-      reasoning_effort: low
 
 ---
 type: embedder

--- a/wren-ai-service/tools/config/config.full.yaml
+++ b/wren-ai-service/tools/config/config.full.yaml
@@ -21,26 +21,6 @@ models:
       n: 1
       seed: 0
       temperature: 0
-  - model: gpt-4o-mini-2024-07-18
-    kwargs:
-      temperature: 0
-      n: 1
-      # for better consistency of llm response
-      seed: 0
-      max_tokens: 4096
-  - model: gpt-4o-2024-08-06
-    kwargs:
-      temperature: 0
-      n: 1
-      # for better consistency of llm response
-      seed: 0
-      max_tokens: 4096
-  - model: o3-mini-2025-01-31
-    kwargs:
-      n: 1
-      seed: 0
-      max_completion_tokens: 4096
-      reasoning_effort: low
 
 ---
 type: embedder

--- a/wren-launcher/Makefile
+++ b/wren-launcher/Makefile
@@ -2,10 +2,12 @@ BINARY_NAME=wren-launcher
 
 build:
 	env GOARCH=amd64 GOOS=darwin CGO_ENABLED=1 go build -o dist/${BINARY_NAME}-darwin main.go
+	env GOARCH=arm64 GOOS=darwin CGO_ENABLED=1 go build -o dist/${BINARY_NAME}-darwin-arm64 main.go
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o dist/${BINARY_NAME}-linux main.go
 	env GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build -o dist/${BINARY_NAME}-windows.exe main.go
-	cd ./dist; chmod +x ${BINARY_NAME}-darwin && chmod +x ${BINARY_NAME}-linux \
+	cd ./dist; chmod +x ${BINARY_NAME}-darwin && chmod +x ${BINARY_NAME}-darwin-arm64 && chmod +x ${BINARY_NAME}-linux \
 	&& tar zcvf ${BINARY_NAME}-darwin.tar.gz ${BINARY_NAME}-darwin \
+	&& tar zcvf ${BINARY_NAME}-darwin-arm64.tar.gz ${BINARY_NAME}-darwin-arm64 \
 	&& tar zcvf ${BINARY_NAME}-linux.tar.gz ${BINARY_NAME}-linux \
 	&& zip ${BINARY_NAME}-windows.zip ${BINARY_NAME}-windows.exe
 

--- a/wren-launcher/Makefile
+++ b/wren-launcher/Makefile
@@ -4,11 +4,13 @@ build:
 	env GOARCH=amd64 GOOS=darwin CGO_ENABLED=1 go build -o dist/${BINARY_NAME}-darwin main.go
 	env GOARCH=arm64 GOOS=darwin CGO_ENABLED=1 go build -o dist/${BINARY_NAME}-darwin-arm64 main.go
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o dist/${BINARY_NAME}-linux main.go
+	env GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build -o dist/${BINARY_NAME}-linux-arm64 main.go
 	env GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build -o dist/${BINARY_NAME}-windows.exe main.go
-	cd ./dist; chmod +x ${BINARY_NAME}-darwin && chmod +x ${BINARY_NAME}-darwin-arm64 && chmod +x ${BINARY_NAME}-linux \
+	cd ./dist; chmod +x ${BINARY_NAME}-darwin && chmod +x ${BINARY_NAME}-darwin-arm64 && chmod +x ${BINARY_NAME}-linux && chmod +x ${BINARY_NAME}-linux-arm64 \
 	&& tar zcvf ${BINARY_NAME}-darwin.tar.gz ${BINARY_NAME}-darwin \
 	&& tar zcvf ${BINARY_NAME}-darwin-arm64.tar.gz ${BINARY_NAME}-darwin-arm64 \
 	&& tar zcvf ${BINARY_NAME}-linux.tar.gz ${BINARY_NAME}-linux \
+	&& tar zcvf ${BINARY_NAME}-linux-arm64.tar.gz ${BINARY_NAME}-linux-arm64 \
 	&& zip ${BINARY_NAME}-windows.zip ${BINARY_NAME}-windows.exe
 
 clean:

--- a/wren-launcher/commands/launch.go
+++ b/wren-launcher/commands/launch.go
@@ -48,7 +48,7 @@ func evaluateTelemetryPreferences() (bool, error) {
 
 func askForLLMProvider() (string, error) {
 	// let users know we're asking for a LLM provider
-	pterm.Warning.Println("We highly recommend using OpenAI models with Wren AI, especailly the latest models.")
+	pterm.Warning.Println("We highly recommend using OpenAI models with Wren AI, especially the latest models.")
 	pterm.Warning.Println("These models have been extensively tested to ensure optimal performance and compatibility.")
 	pterm.Warning.Println("While it is technically possible to integrate other AI models, please note that they have not been fully tested with our system.")
 	pterm.Warning.Println("Therefore, using alternative models is at your own risk and may result in unexpected behavior or suboptimal performance.")

--- a/wren-launcher/commands/launch.go
+++ b/wren-launcher/commands/launch.go
@@ -108,7 +108,7 @@ func askForGenerationModel() (string, error) {
 
 	prompt := promptui.Select{
 		Label: "Select an OpenAI's generation model",
-		Items: []string{"gpt-4.1-nano", "gpt-4.1-mini", "gpt-4.1", "gpt-4o-mini", "gpt-4o", "o3-mini"},
+		Items: []string{"gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"},
 	}
 
 	_, result, err := prompt.Run()
@@ -309,12 +309,9 @@ func getOpenaiGenerationModel() (string, bool) {
 		// validate if input args is a valid generation model
 		pterm.Info.Println("OpenAI generation model is provided")
 		validModels := map[string]bool{
-			"gpt-4.1-nano": true,
-			"gpt-4.1-mini": true,
 			"gpt-4.1":      true,
-			"gpt-4o-mini":   true,
-			"gpt-4o":        true,
-			"o3-mini":       true,
+			"gpt-4.1-mini": true,
+			"gpt-4.1-nano": true,
 		}
 		if !validModels[openaiGenerationModel] {
 			pterm.Error.Println("Invalid generation model", openaiGenerationModel)

--- a/wren-launcher/commands/launch.go
+++ b/wren-launcher/commands/launch.go
@@ -48,7 +48,7 @@ func evaluateTelemetryPreferences() (bool, error) {
 
 func askForLLMProvider() (string, error) {
 	// let users know we're asking for a LLM provider
-	pterm.Warning.Println("We highly recommend using OpenAI GPT-4o or GPT-4o-mini with Wren AI.")
+	pterm.Warning.Println("We highly recommend using OpenAI models with Wren AI, especailly the latest models.")
 	pterm.Warning.Println("These models have been extensively tested to ensure optimal performance and compatibility.")
 	pterm.Warning.Println("While it is technically possible to integrate other AI models, please note that they have not been fully tested with our system.")
 	pterm.Warning.Println("Therefore, using alternative models is at your own risk and may result in unexpected behavior or suboptimal performance.")
@@ -232,7 +232,16 @@ func Launch() {
 	uiPort := utils.FindAvailablePort(3000)
 	aiPort := utils.FindAvailablePort(5555)
 
-	err = utils.PrepareDockerFiles(openaiApiKey, openaiGenerationModel, uiPort, aiPort, projectDir, telemetryEnabled, llmProvider)
+	err = utils.PrepareDockerFiles(
+		openaiApiKey,
+		openaiGenerationModel,
+		uiPort,
+		aiPort,
+		projectDir,
+		telemetryEnabled,
+		llmProvider,
+		platform,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/wren-launcher/config/config.go
+++ b/wren-launcher/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"runtime"
 )
 
 // private variable within the config package
@@ -19,7 +20,7 @@ func InitFlags() {
 	flag.StringVar(&openaiAPIKey, "openai-api-key", "", "The OPENAI API key")
 	flag.StringVar(&openaiGenerationModel, "openai-generation-model", "", "The OPENAI generation model, valid values are: gpt-4o-mini, gpt-4o")
 	flag.BoolVar(&experimentalEngineRustVersion, "experimental-engine-rust-version", true, "Use the experimental Rust version of the Wren Engine")
-	flag.StringVar(&platform, "platform", "linux/amd64", "The platform to use, valid values are: linux/amd64, linux/arm64")
+	flag.StringVar(&platform, "platform", GetPlatform(), "The platform to use, valid values are: linux/amd64, linux/arm64")
 }
 
 func IsExperimentalEngineRustVersion() bool {
@@ -27,7 +28,22 @@ func IsExperimentalEngineRustVersion() bool {
 }
 
 func GetPlatform() string {
-	return platform
+	switch runtime.GOOS {
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			return "linux/arm64"
+		}
+		return "linux/amd64"
+	case "linux":
+		if runtime.GOARCH == "arm64" {
+			return "linux/arm64"
+		}
+		return "linux/amd64"
+	case "windows":
+		return "linux/amd64"  // Windows typically uses amd64
+	default:
+		return "linux/amd64"  // Default to amd64 for unknown platforms
+	}
 }
 
 // IsTelemetryDisabled exposes the state of the telemetry flag

--- a/wren-launcher/config/config.go
+++ b/wren-launcher/config/config.go
@@ -18,7 +18,7 @@ func InitFlags() {
 	flag.BoolVar(&disableTelemetry, "disable-telemetry", false, "Disable telemetry if set to true")
 	flag.StringVar(&llmProvider, "llm-provider", "", "The LLM provider to use, valid values are: openai, custom")
 	flag.StringVar(&openaiAPIKey, "openai-api-key", "", "The OPENAI API key")
-	flag.StringVar(&openaiGenerationModel, "openai-generation-model", "", "The OPENAI generation model, valid values are: gpt-4o-mini, gpt-4o")
+	flag.StringVar(&openaiGenerationModel, "openai-generation-model", "", "The OPENAI generation model, valid values are: gpt-4.1, gpt-4.1-mini, gpt-4.1-nano")
 	flag.BoolVar(&experimentalEngineRustVersion, "experimental-engine-rust-version", true, "Use the experimental Rust version of the Wren Engine")
 	flag.StringVar(&platform, "platform", GetPlatform(), "The platform to use, valid values are: linux/amd64, linux/arm64")
 }

--- a/wren-launcher/utils/docker.go
+++ b/wren-launcher/utils/docker.go
@@ -39,10 +39,14 @@ var generationModelToModelName = map[string]string{
 	"gpt-4o":       "gpt-4o-2024-08-06",
 }
 
-func replaceEnvFileContent(content string, projectDir string, openaiApiKey string, openAIGenerationModel string, hostPort int, aiPort int, userUUID string, telemetryEnabled bool) string {
+func replaceEnvFileContent(content string, projectDir string, openaiApiKey string, openAIGenerationModel string, hostPort int, aiPort int, userUUID string, telemetryEnabled bool, platform string) string {
+	// replace PLATFORM
+	reg := regexp.MustCompile(`PLATFORM=(.*)`)
+	str := reg.ReplaceAllString(content, "PLATFORM="+platform)
+
 	// replace PROJECT_DIR
-	reg := regexp.MustCompile(`PROJECT_DIR=(.*)`)
-	str := reg.ReplaceAllString(content, "PROJECT_DIR="+projectDir)
+	reg = regexp.MustCompile(`PROJECT_DIR=(.*)`)
+	str = reg.ReplaceAllString(str, "PROJECT_DIR="+projectDir)
 
 	// replace SHOULD_FORCE_DEPLOY
 	reg = regexp.MustCompile(`SHOULD_FORCE_DEPLOY=(.*)`)
@@ -76,10 +80,6 @@ func replaceEnvFileContent(content string, projectDir string, openaiApiKey strin
 	// replace EXPERIMENTAL_ENGINE_RUST_VERSION
 	reg = regexp.MustCompile(`EXPERIMENTAL_ENGINE_RUST_VERSION=(.*)`)
 	str = reg.ReplaceAllString(str, "EXPERIMENTAL_ENGINE_RUST_VERSION="+fmt.Sprintf("%t", config.IsExperimentalEngineRustVersion()))
-
-	// replace PLATFORM
-	reg = regexp.MustCompile(`PLATFORM=(.*)`)
-	str = reg.ReplaceAllString(str, "PLATFORM="+fmt.Sprintf("%s", config.GetPlatform()))
 
 	return str
 }
@@ -237,7 +237,7 @@ func mergeEnvContent(newEnvFile string, envFileContent string) (string, error) {
 	return envFileContent, nil
 }
 
-func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostPort int, aiPort int, projectDir string, telemetryEnabled bool, llmProvider string) error {
+func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostPort int, aiPort int, projectDir string, telemetryEnabled bool, llmProvider string, platform string) error {
 	// download docker-compose file
 	composeFile := path.Join(projectDir, "docker-compose.yaml")
 	pterm.Info.Println("Downloading docker-compose file to", composeFile)
@@ -276,6 +276,7 @@ func PrepareDockerFiles(openaiApiKey string, openaiGenerationModel string, hostP
 			aiPort,
 			userUUID,
 			telemetryEnabled,
+			platform,
 		)
 		newEnvFile := getEnvFilePath(projectDir)
 

--- a/wren-launcher/utils/docker.go
+++ b/wren-launcher/utils/docker.go
@@ -154,7 +154,10 @@ func PrepareConfigFileForOpenAI(projectDir string, generationModel string) error
 
 	// replace the generation model in config.yaml
 	config := string(content)
-	config = strings.ReplaceAll(config, "litellm_llm.default", "litellm_llm."+generationModelToModelName[generationModel])
+	// gpt-4.1-nano is the default model, so we don't need to replace it
+	if generationModel != "gpt-4.1-nano" {
+		config = strings.ReplaceAll(config, "litellm_llm.default", "litellm_llm."+generationModelToModelName[generationModel])
+	}
 
 	// replace allow_using_db_schemas_without_pruning setting
 	// enable this feature since OpenAI models have sufficient context window size to handle full schema

--- a/wren-launcher/utils/docker.go
+++ b/wren-launcher/utils/docker.go
@@ -31,12 +31,9 @@ const (
 )
 
 var generationModelToModelName = map[string]string{
-	"gpt-4.1-nano": "gpt-4.1-nano-2025-04-14",
-	"gpt-4.1-mini": "gpt-4.1-mini-2025-04-14",
 	"gpt-4.1":      "gpt-4.1-2025-04-14",
-	"gpt-4o-mini":  "gpt-4o-mini-2024-07-18",
-	"o3-mini":      "o3-mini-2025-01-31",
-	"gpt-4o":       "gpt-4o-2024-08-06",
+	"gpt-4.1-mini": "gpt-4.1-mini-2025-04-14",
+	"gpt-4.1-nano": "gpt-4.1-nano-2025-04-14",
 }
 
 func replaceEnvFileContent(content string, projectDir string, openaiApiKey string, openAIGenerationModel string, hostPort int, aiPort int, userUUID string, telemetryEnabled bool, platform string) string {


### PR DESCRIPTION
- allow using darwin-arm64 and linux-arm64 launcher app
- auto detect docker image platform(linux/amd64 or linux/arm64)
- remove old openai models
- fix the issue of choosing default openai model: gpt-4.1-nano

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for building and distributing binaries for macOS and Linux ARM64 architectures.
  - Platform detection is now dynamic, automatically selecting the appropriate architecture based on your system.

- **Improvements**
  - Environment configuration now more accurately reflects the system platform.
  - Updated warning messages to recommend the latest OpenAI models more broadly.
  - Streamlined available OpenAI model options to focus on the latest versions.
  - Simplified LLM model configurations by removing deprecated models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->