### PR TITLE
chore(wren-ai-service): allow ignore sql generation reasoning in api

### DIFF
--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -232,8 +232,10 @@ class AskService:
         table_names = []
         error_message = None
         invalid_sql = None
-        if ask_request.ignore_sql_generation_reasoning:
-            self._allow_sql_generation_reasoning = False
+        allow_sql_generation_reasoning = (
+            self._allow_sql_generation_reasoning
+            and not ask_request.ignore_sql_generation_reasoning
+        )
 
         try:
             user_query = ask_request.query
@@ -431,7 +433,7 @@ class AskService:
             if (
                 not self._is_stopped(query_id, self._ask_results)
                 and not api_results
-                and self._allow_sql_generation_reasoning
+                and allow_sql_generation_reasoning
             ):
                 self._ask_results[query_id] = AskResultResponse(
                     status="planning",

--- a/wren-ai-service/src/web/v1/services/ask.py
+++ b/wren-ai-service/src/web/v1/services/ask.py
@@ -30,6 +30,7 @@ class AskRequest(BaseModel):
     thread_id: Optional[str] = None
     histories: Optional[list[AskHistory]] = Field(default_factory=list)
     configurations: Optional[Configuration] = Configuration()
+    ignore_sql_generation_reasoning: Optional[bool] = False
 
     @property
     def query_id(self) -> str:
@@ -231,6 +232,8 @@ class AskService:
         table_names = []
         error_message = None
         invalid_sql = None
+        if ask_request.ignore_sql_generation_reasoning:
+            self._allow_sql_generation_reasoning = False
 
         try:
             user_query = ask_request.query


### PR DESCRIPTION
simply define `ignore_sql_generation_reasoning` as `true` in `/v1/asks` api request. The default value of this field is `false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional setting to ignore SQL generation reasoning in requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->