### PR TITLE
feat(wren-ui): support records data source version

### DIFF
--- a/wren-ui/migrations/20250510000002_add_version_to_project.js
+++ b/wren-ui/migrations/20250510000002_add_version_to_project.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('project', (table) => {
+    table
+      .string('version')
+      .nullable()
+      .comment('data source version information');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('project', (table) => {
+    table.dropColumn('version');
+  });
+};

--- a/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
@@ -156,6 +156,10 @@ export interface IIbisAdaptor {
       schema?: string;
     },
   ) => Promise<WrenSQL>;
+  getVersion: (
+    dataSource: DataSourceName,
+    connectionInfo: WREN_AI_CONNECTION_INFO,
+  ) => Promise<string>;
 }
 
 export interface IbisResponse {
@@ -402,6 +406,28 @@ export class IbisAdaptor implements IIbisAdaptor {
         'Error running model substitution with ibis server',
         this.modelSubstituteErrorMessageBuilder,
       );
+    }
+  }
+
+  public async getVersion(
+    dataSource: DataSourceName,
+    connectionInfo: WREN_AI_CONNECTION_INFO,
+  ): Promise<string> {
+    connectionInfo = this.updateConnectionInfo(connectionInfo);
+    const ibisConnectionInfo = toIbisConnectionInfo(dataSource, connectionInfo);
+    const body = {
+      connectionInfo: ibisConnectionInfo,
+    };
+    try {
+      logger.debug(`Getting version from ibis`);
+      const res: AxiosResponse<string> = await axios.post(
+        `${this.ibisServerEndpoint}/${this.getIbisApiVersion(IBIS_API_TYPE.METADATA)}/connector/${dataSourceUrlMap[dataSource]}/metadata/version`,
+        body,
+      );
+      return res.data;
+    } catch (e) {
+      logger.debug(`Get version error: ${e.response?.data || e.message}`);
+      this.throwError(e, 'Error getting version from ibis server');
     }
   }
 

--- a/wren-ui/src/apollo/server/repositories/projectRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/projectRepository.ts
@@ -92,6 +92,7 @@ export interface RecommendationQuestionResult {
 export interface Project {
   id: number; // ID
   type: DataSourceName; // Project datasource type. ex: bigquery, mysql, postgresql, mongodb, etc
+  version: string; // Project datasource version
   displayName: string; // Project display name
   catalog: string; // Catalog name
   schema: string; // Schema name

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -221,6 +221,13 @@ export class ModelResolver {
     ctx: IContext,
   ): Promise<DeployResponse> {
     const project = await ctx.projectService.getCurrentProject();
+    if (!project.version && project.type !== DataSourceName.DUCKDB) {
+      const version =
+        await ctx.projectService.getProjectDataSourceVersion(project);
+      await ctx.projectService.updateProject(project.id, {
+        version,
+      });
+    }
     const { manifest } = await ctx.mdlService.makeCurrentModelMDL();
     const deployRes = await ctx.deployService.deploy(
       manifest,

--- a/wren-ui/src/apollo/server/resolvers/projectResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/projectResolver.ts
@@ -297,6 +297,11 @@ export class ProjectResolver {
       } else {
         // handle other data source
         await ctx.projectService.getProjectDataSourceTables(project);
+        const version =
+          await ctx.projectService.getProjectDataSourceVersion(project);
+        await ctx.projectService.updateProject(project.id, {
+          version,
+        });
         logger.debug(`Data source tables fetched`);
       }
       // telemetry

--- a/wren-ui/src/apollo/server/services/metadataService.ts
+++ b/wren-ui/src/apollo/server/services/metadataService.ts
@@ -48,6 +48,7 @@ export interface RecommendConstraint {
 export interface IDataSourceMetadataService {
   listTables(project: Project): Promise<CompactTable[]>;
   listConstraints(project: Project): Promise<RecommendConstraint[]>;
+  getVersion(project: Project): Promise<string>;
 }
 
 export class DataSourceMetadataService implements IDataSourceMetadataService {
@@ -82,5 +83,10 @@ export class DataSourceMetadataService implements IDataSourceMetadataService {
       return [];
     }
     return await this.ibisAdaptor.getConstraints(dataSource, connectionInfo);
+  }
+
+  public async getVersion(project: Project): Promise<string> {
+    const { type: dataSource, connectionInfo } = project;
+    return await this.ibisAdaptor.getVersion(dataSource, connectionInfo);
   }
 }

--- a/wren-ui/src/apollo/server/services/projectService.ts
+++ b/wren-ui/src/apollo/server/services/projectService.ts
@@ -43,11 +43,19 @@ export interface ProjectRecommendationQuestionsResult {
 }
 export interface IProjectService {
   createProject: (projectData: ProjectData) => Promise<Project>;
+  updateProject: (
+    projectId: number,
+    projectData: Partial<Project>,
+  ) => Promise<Project>;
   getGeneralConnectionInfo: (project: Project) => Record<string, any>;
   getProjectDataSourceTables: (
     project?: Project,
     projectId?: number,
   ) => Promise<CompactTable[]>;
+  getProjectDataSourceVersion: (
+    project?: Project,
+    projectId?: number,
+  ) => Promise<string>;
   getProjectSuggestedConstraint: (
     project?: Project,
     projectId?: number,
@@ -95,6 +103,24 @@ export class ProjectService implements IProjectService {
         telemetry,
         wrenAIAdaptor,
       });
+  }
+  public async updateProject(
+    projectId: number,
+    projectData: Partial<Project>,
+  ): Promise<Project> {
+    return await this.projectRepository.updateOne(projectId, projectData);
+  }
+
+  public async getProjectDataSourceVersion(
+    project?: Project,
+    projectId?: number,
+  ): Promise<string> {
+    const usedProject = project
+      ? project
+      : projectId
+        ? await this.getProjectById(projectId)
+        : await this.getCurrentProject();
+    return await this.metadataService.getVersion(usedProject);
   }
 
   public async generateProjectRecommendationQuestions(): Promise<void> {


### PR DESCRIPTION
## Description
This PR adds data source version tracking functionality to projects. Here's a summary of the changes:

## Technical Notes:
Version tracking is skipped for DuckDB data sources
Maintained backward compatibility with existing projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Projects now store and display the version information of their connected data source.
  - The application automatically retrieves and updates the data source version when saving a new data source or deploying a project (excluding DuckDB).
- **Bug Fixes**
  - Improved error handling and logging when retrieving data source version information.
- **Tests**
  - Added tests to ensure accurate retrieval and error handling for data source version fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->