### PR TITLE
fix(wren-ui): fix graphql schema and reading optional property error

### DIFF
--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -943,9 +943,9 @@ export const typeDefs = gql`
   }
 
   type DashboardSchedule {
-    frequency: ScheduleFrequencyEnum!
-    hour: Int!
-    minute: Int!
+    frequency: ScheduleFrequencyEnum
+    hour: Int
+    minute: Int
     day: CacheScheduleDayEnum
     timezone: String
     cron: String
@@ -1015,7 +1015,7 @@ export const typeDefs = gql`
     description: String
     cacheEnabled: Boolean!
     nextScheduledAt: String
-    schedule: DashboardSchedule!
+    schedule: DashboardSchedule
     items: [DashboardItem!]!
   }
 

--- a/wren-ui/src/apollo/server/services/dashboardService.ts
+++ b/wren-ui/src/apollo/server/services/dashboardService.ts
@@ -417,7 +417,9 @@ export class DashboardService implements IDashboardService {
 
   protected validateScheduleInput(data: SetDashboardCacheData): void {
     const { schedule } = data;
-
+    if (!schedule) {
+      return;
+    }
     if (schedule.frequency === ScheduleFrequencyEnum.WEEKLY && !schedule.day) {
       throw new Error('Day of week is required for weekly schedule');
     }


### PR DESCRIPTION
## Description
1. Made frequency, hour, and minute fields optional in DashboardSchedule type by removing the ! non-null assertion
2. Made the schedule field optional in DetailedDashboard type
3. Added a null check in validateScheduleInput to skip validation when schedule is not provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved flexibility by allowing certain schedule-related fields to be optional in dashboard configurations.

- **Bug Fixes**
  - Enhanced schedule validation to handle cases where no schedule is provided, reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->