### PR TITLE
chore(wren-ai-service)：add open router config example

### DIFF
--- a/wren-ai-service/docs/config_examples/config.open_router.yaml
+++ b/wren-ai-service/docs/config_examples/config.open_router.yaml
@@ -1,0 +1,158 @@
+# you should rename this file to config.yaml and put it in ~/.wrenai
+# please pay attention to the comments starting with # and adjust the config accordingly, 3 steps basically:
+# 1. you need to use your own llm and embedding models
+# 2. fill in embedding model dimension in the document_store section
+# 3. you need to use the correct pipe definitions based on https://raw.githubusercontent.com/canner/WrenAI/<WRENAI_VERSION_NUMBER>/docker/config.example.yaml
+# 4. you need to fill in correct llm and embedding models in the pipe definitions
+
+type: llm
+provider: litellm_llm
+timeout: 120
+models:
+  # put OPENROUTER_API_KEY=<your_api_key> in ~/.wrenai/.env
+  - api_base: https://openrouter.ai/api/v1
+    model: openrouter/anthropic/claude-3.7-sonnet
+    alias: default
+    timeout: 600
+    kwargs:
+      n: 1
+      temperature: 0
+
+---
+type: embedder
+provider: litellm_embedder
+models:
+  # put GEMINI_API_KEY=<your_api_key> in ~/.wrenai/.env
+  # openrouter embedding model is not supported yet, so you can use gemini embedding model as a workaround
+  - model: gemini/text-embedding-004
+    alias: default
+    timeout: 120
+
+---
+type: engine
+provider: wren_ui
+endpoint: http://wren-ui:3000
+
+---
+type: engine
+provider: wren_ibis
+endpoint: http://wren-ibis:8000
+
+---
+type: document_store
+provider: qdrant
+location: http://qdrant:6333
+embedding_model_dim: 768  # put your embedding model dimension here
+timeout: 120
+recreate_index: true
+
+---
+type: pipeline
+pipes:
+  - name: db_schema_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: historical_question_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: table_description_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: db_schema_retrieval
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: historical_question_retrieval
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: sql_generation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: sql_correction
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: followup_sql_generation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: sql_answer
+    llm: litellm_llm.default
+  - name: semantics_description
+    llm: litellm_llm.default
+  - name: relationship_recommendation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: question_recommendation
+    llm: litellm_llm.default
+  - name: question_recommendation_db_schema_retrieval
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: question_recommendation_sql_generation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: intent_classification
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: misleading_assistance
+    llm: litellm_llm.default
+  - name: data_assistance
+    llm: litellm_llm.default
+  - name: sql_pairs_indexing
+    document_store: qdrant
+    embedder: litellm_embedder.default
+  - name: sql_pairs_retrieval
+    document_store: qdrant
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
+  - name: preprocess_sql_data
+    llm: litellm_llm.default
+  - name: sql_executor
+    engine: wren_ui
+  - name: user_guide_assistance
+    llm: litellm_llm.default
+  - name: chart_generation
+    llm: litellm_llm.default
+  - name: chart_adjustment
+    llm: litellm_llm.default
+  - name: sql_question_generation
+    llm: litellm_llm.default
+  - name: sql_generation_reasoning
+    llm: litellm_llm.default
+  - name: followup_sql_generation_reasoning
+    llm: litellm_llm.default
+  - name: sql_regeneration
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: instructions_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: instructions_retrieval
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: sql_functions_retrieval
+    engine: wren_ibis
+    document_store: qdrant
+  - name: project_meta_indexing
+    document_store: qdrant
+
+---
+settings:
+  engine_timeout: 30
+  column_indexing_batch_size: 50
+  table_retrieval_size: 10
+  table_column_retrieval_size: 100
+  allow_intent_classification: true
+  allow_sql_generation_reasoning: true
+  enable_column_pruning: false
+  query_cache_maxsize: 1000
+  query_cache_ttl: 3600
+  langfuse_host: https://cloud.langfuse.com
+  langfuse_enable: true
+  logging_level: DEBUG
+  development: false
+  historical_question_retrieval_similarity_threshold: 0.9
+  sql_pairs_similarity_threshold: 0.7
+  sql_pairs_retrieval_max_size: 10
+  instructions_similarity_threshold: 0.7
+  instructions_top_k: 10


### PR DESCRIPTION
Add new open router config example for supporting open router api key in WrenAI.
[open router ](https://openrouter.ai/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive example configuration file for integrating language models, embedding models, engines, document stores, and pipelines.
  - Included detailed comments to guide customization, API key setup, and adjustment of operational parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->