### PR TITLE
fix(wren-ui): transform temporal value for chart displaying in safari

### DIFF
--- a/wren-ui/src/components/chart/handler.ts
+++ b/wren-ui/src/components/chart/handler.ts
@@ -449,7 +449,7 @@ export default class ChartSpecHandler {
     // Safari not support if containing "YYYY-MM-DD HH:mm:ss.SSS UTC+00:00"
     // so we remove the UTC+00:00 for compatibility
     if (strValue.includes('UTC')) {
-      return strValue.replace(/\s+UTC[+-][0-9]+(:?[0-9]+)?/, '');
+      return strValue.replace(/\s+UTC[+-][0-9]+(:[0-9]+)?/, '');
     }
     return strValue;
   }

--- a/wren-ui/src/components/chart/handler.ts
+++ b/wren-ui/src/components/chart/handler.ts
@@ -449,7 +449,7 @@ export default class ChartSpecHandler {
     // Safari not support if containing "YYYY-MM-DD HH:mm:ss.SSS UTC+00:00"
     // so we remove the UTC+00:00 for compatibility
     if (strValue.includes('UTC')) {
-      return strValue.replace(/\s+UTC\+[0-9]+(:?[0-9]+)?/, '');
+      return strValue.replace(/\s+UTC[+-][0-9]+(:?[0-9]+)?/, '');
     }
     return strValue;
   }


### PR DESCRIPTION
## Description
This PR converts the preview result value to a string to ensure proper date rendering in Safari. It also removes the `UTC+00:00` suffix if the value contains a timestamp like `2018-10-01 08:00:00.000000 UTC+08:00`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Safari by removing the "UTC+00:00" timezone suffix from temporal data values.

- **Refactor**
  - Enhanced chart data processing to better handle temporal values on the x and y axes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->