### PR TITLE
fix(wren-ui): adjust replacement regex for including UTC, UTC+0, UTC+00:00

### DIFF
--- a/wren-ui/src/components/chart/handler.ts
+++ b/wren-ui/src/components/chart/handler.ts
@@ -449,7 +449,7 @@ export default class ChartSpecHandler {
     // Safari not support if containing "YYYY-MM-DD HH:mm:ss.SSS UTC+00:00"
     // so we remove the UTC+00:00 for compatibility
     if (strValue.includes('UTC')) {
-      return strValue.replace(/\s+UTC[+-][0-9]+(:[0-9]+)?/, '');
+      return strValue.replace(/\s+UTC([+-][0-9]+)?(:[0-9]+)?/, '');
     }
     return strValue;
   }


### PR DESCRIPTION
## Description
Also replace `YYYY-MM-DD HH:mm:ss.SSS UTC` to `YYYY-MM-DD HH:mm:ss.SSS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Safari by enhancing the handling of UTC offset suffixes in temporal string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->