### PR TITLE
feat(wren-ui): Adjust SQL toolbar for View SQL

### DIFF
--- a/wren-ui/src/components/code/BaseCodeBlock.tsx
+++ b/wren-ui/src/components/code/BaseCodeBlock.tsx
@@ -14,6 +14,7 @@ export interface BaseProps {
   maxHeight?: string;
   showLineNumbers?: boolean;
   backgroundColor?: string;
+  onCopy?: () => void;
 }
 
 const getBlockStyles = (props: {
@@ -114,6 +115,7 @@ export const createCodeBlock = (HighlightRules: any) => {
       loading,
       showLineNumbers,
       backgroundColor,
+      onCopy,
     } = props;
     const { ace } = window as any;
     const { Tokenizer } = ace.require('ace/tokenizer');
@@ -174,6 +176,7 @@ export const createCodeBlock = (HighlightRules: any) => {
             {copyable && (
               <CopyText
                 copyable={{
+                  onCopy,
                   icon: [
                     <Button
                       key="copy-icon"

--- a/wren-ui/src/components/pages/home/promptThread/ViewSQLTabContent.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/ViewSQLTabContent.tsx
@@ -2,7 +2,16 @@ import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useEffect } from 'react';
 import styled from 'styled-components';
-import { Button, Divider, Empty, Space, Switch, Typography } from 'antd';
+import {
+  Alert,
+  Button,
+  Divider,
+  Empty,
+  message,
+  Space,
+  Switch,
+  Typography,
+} from 'antd';
 import CheckOutlined from '@ant-design/icons/CheckOutlined';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import CodeFilled from '@ant-design/icons/CodeFilled';
@@ -10,6 +19,7 @@ import { BinocularsIcon } from '@/utils/icons';
 import { nextTick } from '@/utils/time';
 import useNativeSQL from '@/hooks/useNativeSQL';
 import { DATA_SOURCE_OPTIONS } from '@/components/pages/setup/utils';
+import { Logo } from '@/components/Logo';
 import { Props as AnswerResultProps } from '@/components/pages/home/promptThread/AnswerResult';
 import usePromptThreadStore from '@/components/pages/home/promptThread/store';
 import PreviewData from '@/components/dataPreview/PreviewData';
@@ -78,12 +88,49 @@ export default function ViewSQLTabContent(props: AnswerResultProps) {
     checked && fetchNativeSQL({ variables: { responseId: id } });
   };
 
+  const onCopy = () => {
+    if (!nativeSQLResult.nativeSQLMode) {
+      message.success(
+        <>
+          You copied Wren SQL. This dialect is for the Wren Engine and may not
+          run directly on your database.
+          {hasNativeSQL && (
+            <>
+              {' '}
+              Click “<b>Show original SQL</b>” to get the executable version.
+            </>
+          )}
+        </>,
+      );
+    }
+  };
+
   return (
     <div className="text-md gray-10 p-6 pb-4">
+      <Alert
+        banner
+        className="mb-3 adm-alert-info"
+        message={
+          <>
+            You’re viewing Wren SQL by default. If you want to run this query on
+            your own database, click “Show original SQL” to get the exact
+            syntax.
+            <Typography.Link
+              className="underline ml-1"
+              href="https://docs.getwren.ai/oss/guide/home/wren_sql"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more about Wren SQL
+            </Typography.Link>
+          </>
+        }
+        type="info"
+      />
       <StyledPre className="p-0 mb-3">
-        <StyledToolBar className="d-flex justify-space-between text-family-base">
+        <StyledToolBar className="d-flex align-center justify-space-between text-family-base">
           <div>
-            {nativeSQLResult.nativeSQLMode && (
+            {nativeSQLResult.nativeSQLMode ? (
               <>
                 <Image
                   className="mr-2"
@@ -96,23 +143,33 @@ export default function ViewSQLTabContent(props: AnswerResultProps) {
                   {DATA_SOURCE_OPTIONS[dataSourceType].label}
                 </Text>
               </>
+            ) : (
+              <span className="d-flex align-center gx-2">
+                <Logo size={18} />
+                <Text className="gray-8 text-medium text-sm">Wren SQL</Text>
+              </span>
             )}
           </div>
           <Space split={<Divider type="vertical" className="m-0" />}>
             {showNativeSQL && (
-              <label className="d-flex align-center cursor-pointer">
+              <div
+                className="d-flex align-center cursor-pointer"
+                onClick={() =>
+                  onChangeNativeSQL(!nativeSQLResult.nativeSQLMode)
+                }
+              >
                 <Switch
                   checkedChildren={<CheckOutlined />}
                   unCheckedChildren={<CloseOutlined />}
                   className="mr-2"
                   size="small"
-                  onChange={onChangeNativeSQL}
+                  checked={nativeSQLResult.nativeSQLMode}
                   loading={nativeSQLResult.loading}
                 />
                 <Text className="gray-8 text-medium text-base">
                   Show original SQL
                 </Text>
-              </label>
+              </div>
             )}
             <Button
               type="link"
@@ -132,6 +189,7 @@ export default function ViewSQLTabContent(props: AnswerResultProps) {
           maxHeight="300"
           loading={nativeSQLResult.loading}
           copyable
+          onCopy={onCopy}
         />
       </StyledPre>
       <div className="mt-6">


### PR DESCRIPTION
## Description
 - Adjust SQL toolbar for View SQL
   - Info message: You’re viewing Wren SQL by default. If you want to run this query on your own database, click “Show original SQL” to get the exact syntax. Learn more about Wren SQL
   - toast message: You copied Wren SQL. This dialect is for the Wren Engine and may not run directly on your database. Click “**Show original SQL**” to get the executable version.

## Tasks
 - Show info message top of SQL toolbar
 - Show 'Wren SQL' & logo for SQL toolbar as default
 - Show toast message when copy Wren SQL statement
 - Fix trigger 2 times toggle button issue

## Ref UI

### Own data source (E.g., PG)
![截圖 2025-05-07 上午11 19 49](https://github.com/user-attachments/assets/4198d9f8-1cd6-49f8-b560-e1c182c76432)
![截圖 2025-05-07 上午11 19 52](https://github.com/user-attachments/assets/7c673fe4-3e96-4c6a-ac90-b858fde61206)
![截圖 2025-05-07 上午11 52 03](https://github.com/user-attachments/assets/a077ca4c-134d-4762-b964-deb674c3d991)


### Sample dataset
![截圖 2025-05-07 上午10 57 53](https://github.com/user-attachments/assets/b5380129-6517-4ffc-89e4-e076342ea201)

![截圖 2025-05-07 上午10 57 57](https://github.com/user-attachments/assets/e82ecfa1-25f0-4d6d-a858-f33ed99e3f07)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an informational alert in the SQL view to clarify when Wren SQL is being displayed, including a link to documentation.
  - The copy button for SQL code now triggers a message when copying Wren SQL, warning users it may not run directly on their database and suggesting to switch to original SQL if needed.

- **Improvements**
  - The position of the copy button in code blocks now adjusts dynamically if a vertical scrollbar is present for better usability.
  - The toggle for switching between Wren SQL and original SQL has improved interaction and layout for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->