### PR TITLE
fix(wren-ui): adjust manual cache refresh wording

### DIFF
--- a/wren-ui/src/components/pages/home/dashboardGrid/CacheSettingsDrawer.tsx
+++ b/wren-ui/src/components/pages/home/dashboardGrid/CacheSettingsDrawer.tsx
@@ -135,7 +135,7 @@ export const getScheduleText = (schedule: Schedule): string => {
       return `Cache refreshes on custom schedule`;
     }
     case FREQUENCY.NEVER: {
-      return 'Cache auto-refresh disabled';
+      return 'Cache refresh: manual only';
     }
     default: {
       return '';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the wording for manual cache refresh settings to display "Cache refresh: manual only" instead of "Cache auto-refresh disabled".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->