### PR TITLE
feat(wren-ai-service): add context window size handling in LLMProvider and related components

### DIFF
--- a/wren-ai-service/src/core/provider.py
+++ b/wren-ai-service/src/core/provider.py
@@ -14,6 +14,9 @@ class LLMProvider(metaclass=ABCMeta):
     def get_model_kwargs(self):
         return self._model_kwargs
 
+    def get_context_window_size(self):
+        return self._context_window_size
+
 
 class EmbedderProvider(metaclass=ABCMeta):
     @abstractmethod

--- a/wren-ai-service/src/pipelines/retrieval/preprocess_sql_data.py
+++ b/wren-ai-service/src/pipelines/retrieval/preprocess_sql_data.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("wren-ai-service")
 def preprocess(
     sql_data: Dict,
     encoding: tiktoken.Encoding,
+    context_window_size: int,
 ) -> Dict:
     def reduce_data_size(data: list, reduction_step: int = 50) -> list:
         """Reduce the size of data by removing elements from the end.
@@ -48,8 +49,8 @@ def preprocess(
     _token_count = len(encoding.encode(str(sql_data)))
     num_rows_used_in_llm = len(sql_data.get("data", []))
     iteration = 0
-
-    while _token_count > 100_000:
+    
+    while _token_count > context_window_size:
         if iteration > 1000:
             """
             Avoid infinite loop
@@ -89,6 +90,7 @@ class PreprocessSqlData(BasicPipeline):
 
         self._configs = {
             "encoding": _encoding,
+            "context_window_size": llm_provider.get_context_window_size(),
         }
 
         super().__init__(Driver({}, sys.modules[__name__], adapter=base.DictResult()))

--- a/wren-ai-service/src/providers/__init__.py
+++ b/wren-ai-service/src/providers/__init__.py
@@ -34,7 +34,8 @@ def llm_processor(entry: dict) -> dict:
                     "n": 1,
                     "max_tokens": 4096,
                     "response_format": {"type": "json_object"}
-                }
+                },
+                "context_window_size": 200000
             }
         ],
         "api_base": "https://api.openai.com/v1"
@@ -52,6 +53,7 @@ def llm_processor(entry: dict) -> dict:
                 "max_tokens": 4096,
                 "response_format": {"type": "json_object"}
             },
+            "context_window_size": 200000,
             "api_base": "https://api.openai.com/v1"
         }
     }
@@ -70,12 +72,13 @@ def llm_processor(entry: dict) -> dict:
     for model in entry.get("models", []):
         model_name = f"{entry.get('provider')}.{model.get('alias', model.get('model'))}"
         model_additional_params = {
-            k: v for k, v in model.items() if k not in ["model", "kwargs", "alias"]
+            k: v for k, v in model.items() if k not in ["model", "kwargs", "alias", "context_window_size"]
         }
         returned[model_name] = {
             "provider": entry["provider"],
             "model": model["model"],
             "kwargs": model["kwargs"],
+            "context_window_size": model.get("context_window_size", 200000),
             **model_additional_params,
             **others,
         }

--- a/wren-ai-service/src/providers/llm/litellm.py
+++ b/wren-ai-service/src/providers/llm/litellm.py
@@ -31,6 +31,7 @@ class LitellmLLMProvider(LLMProvider):
         api_version: Optional[str] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         timeout: float = 120.0,
+        context_window_size: Optional[int] = 200000,
         **_,
     ):
         self._model = model
@@ -39,6 +40,7 @@ class LitellmLLMProvider(LLMProvider):
         self._api_version = api_version
         self._model_kwargs = kwargs
         self._timeout = timeout
+        self._context_window_size = context_window_size
 
     def get_generator(
         self,


### PR DESCRIPTION
This PR integrates the `context_window_size` parameter from `LLMProvider` into the token limit checking logic. This ensures that prompt + context do not exceed the model’s actual maximum context length.