### PR TITLE
feat(wren-ui): Support MySQL ssl

### DIFF
--- a/wren-ui/src/apollo/server/dataSource.ts
+++ b/wren-ui/src/apollo/server/dataSource.ts
@@ -123,9 +123,16 @@ const dataSource = {
         DataSourceName.MYSQL,
         connectionInfo,
       );
-      const { host, port, database, user, password } =
+      const { host, port, database, user, password, ssl } =
         decryptedConnectionInfo as MYSQL_CONNECTION_INFO;
-      return { host, port, database, user, password };
+      return {
+        host,
+        port,
+        database,
+        user,
+        password,
+        sslMode: ssl ? 'ENABLED' : 'DISABLED',
+      };
     },
   } as IDataSourceConnectionInfo<
     MYSQL_CONNECTION_INFO,

--- a/wren-ui/src/apollo/server/repositories/projectRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/projectRepository.ts
@@ -30,6 +30,7 @@ export interface MYSQL_CONNECTION_INFO {
   user: string;
   password: string;
   database: string;
+  ssl: boolean;
 }
 
 export interface ORACLE_CONNECTION_INFO {

--- a/wren-ui/src/components/pages/setup/dataSources/MySQLProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/MySQLProperties.tsx
@@ -1,4 +1,4 @@
-import { Form, Input } from 'antd';
+import { Form, Input, Switch } from 'antd';
 import { ERROR_TEXTS } from '@/utils/error';
 import { FORM_MODE } from '@/utils/enum';
 import { hostValidator } from '@/utils/validator';
@@ -88,6 +88,9 @@ export default function MySQLProperties(props: Props) {
         ]}
       >
         <Input placeholder="MySQL database name" disabled={isEditMode} />
+      </Form.Item>
+      <Form.Item label="Use SSL" name="ssl" valuePropName="checked">
+        <Switch />
       </Form.Item>
     </>
   );


### PR DESCRIPTION
## Description
In this PR, we support SSL mode for MySQL data source.
The CA mode is not supported currently.

## Issue related
#1024 

<img width="718" alt="image" src="https://github.com/user-attachments/assets/0504c2ec-3a43-4720-ab60-6335dc4ab5a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option in the MySQL data source setup to enable or disable SSL via a toggle switch.

- **Enhancements**
	- MySQL connection information now explicitly indicates whether SSL is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->