### PR TITLE
docs: add Qwen3 think/no_think config example (#1636)

### DIFF
--- a/wren-ai-service/docs/config_examples/README.md
+++ b/wren-ai-service/docs/config_examples/README.md
@@ -3,3 +3,36 @@
 Since these config files are examples, so **please carefully read the file and comments inside**. Try to understand the purpose of each section and parameter, **don't simply copy and paste the content of these config files into your own config file. It will not work.** For more detailed information to the configurations, please [read this file](../configuration.md).
 
 We also definitely welcome your contribution to add config files for other LLM providers.
+
+## Qwen3 Think and No_Think Configuration
+
+The `config.qwen3.yaml` file provides an example configuration for using Qwen3 models with their unique thinking and non-thinking capabilities. Qwen3 models support two modes:
+
+### Thinking Mode
+- Use `/think` in your prompts to enable step-by-step reasoning
+- Optimized with `temperature=0.6`, `top_p=0.95`, `top_k=20`
+- Best for complex problems requiring detailed reasoning
+- Uses the `qwen3-thinking` alias in the pipeline configuration
+
+### Non-Thinking Mode  
+- Use `/no_think` in your prompts for direct, fast responses
+- Optimized with `temperature=0.7`, `top_p=0.8`, `top_k=20`
+- Best for simple queries and general conversation
+- Uses the `qwen3-fast` alias in the pipeline configuration
+
+### Available Models
+- `qwen/qwen3-30b-a3b`: 30B parameter MoE model (3.3B activated)
+- `qwen/qwen3-32b`: 32B parameter dense model
+- `qwen/qwen3-8b`: 8B parameter dense model
+- `qwen/qwen3-14b`: 14B parameter dense model
+
+### Usage Examples
+```
+# Enable thinking for complex reasoning
+"Explain the mathematical proof for the Pythagorean theorem /think"
+
+# Use fast mode for simple queries  
+"What is the capital of France? /no_think"
+```
+
+**Note**: You need to set `OPENROUTER_API_KEY` in your `~/.wrenai/.env` file to use OpenRouter as the provider for Qwen3 models.

--- a/wren-ai-service/docs/config_examples/config.qwen3.yaml
+++ b/wren-ai-service/docs/config_examples/config.qwen3.yaml
@@ -1,0 +1,204 @@
+# you should rename this file to config.yaml and put it in ~/.wrenai
+# please pay attention to the comments starting with # and adjust the config accordingly, 3 steps basically:
+# 1. you need to use your own llm and embedding models
+# 2. fill in embedding model dimension in the document_store section
+# 3. you need to use the correct pipe definitions based on https://raw.githubusercontent.com/canner/WrenAI/<WRENAI_VERSION_NUMBER>/docker/config.example.yaml
+# 4. you need to fill in correct llm and embedding models in the pipe definitions
+
+type: llm
+provider: litellm_llm
+models:
+  # put OPENROUTER_API_KEY=<your_api_key> in ~/.wrenai/.env
+  # Qwen3 models support thinking and non-thinking modes
+  # Use /think and /no_think in prompts to control reasoning behavior
+  - api_base: https://openrouter.ai/api/v1
+    model: openrouter/qwen/qwen3-30b-a3b
+    alias: default
+    timeout: 600
+    kwargs:
+      n: 1
+      temperature: 0.6  # Recommended for thinking mode
+      top_p: 0.95
+      top_k: 20
+      response_format:
+        type: text
+  - api_base: https://openrouter.ai/api/v1
+    model: openrouter/qwen/qwen3-30b-a3b
+    alias: qwen3-thinking
+    timeout: 600
+    kwargs:
+      n: 1
+      temperature: 0.6  # Optimized for thinking mode
+      top_p: 0.95
+      top_k: 20
+      response_format:
+        type: text
+  - api_base: https://openrouter.ai/api/v1
+    model: openrouter/qwen/qwen3-30b-a3b
+    alias: qwen3-fast
+    timeout: 600
+    kwargs:
+      n: 1
+      temperature: 0.7  # Optimized for non-thinking mode
+      top_p: 0.8
+      top_k: 20
+      response_format:
+        type: text
+  - api_base: https://openrouter.ai/api/v1
+    model: openrouter/qwen/qwen3-32b
+    alias: qwen3-32b
+    timeout: 600
+    kwargs:
+      n: 1
+      temperature: 0.6
+      top_p: 0.95
+      top_k: 20
+      response_format:
+        type: json_object
+
+---
+type: embedder
+provider: litellm_embedder
+models:
+  # define OPENAI_API_KEY=<api_key> in ~/.wrenai/.env if you are using openai embedding model
+  # please refer to LiteLLM documentation for more details: https://docs.litellm.ai/docs/providers
+  - model: text-embedding-3-large  # put your embedding model name here, if it is not openai embedding model, should be <provider>/<model_name>
+    alias: default
+    api_base: https://api.openai.com/v1  # change this according to your embedding model
+    timeout: 120
+
+---
+type: engine
+provider: wren_ui
+endpoint: http://wren-ui:3000
+
+---
+type: engine
+provider: wren_ibis
+endpoint: http://wren-ibis:8000
+
+---
+type: document_store
+provider: qdrant
+location: http://qdrant:6333
+embedding_model_dim: 3072 # put your embedding model dimension here
+timeout: 120
+recreate_index: true
+
+---
+# please change the llm and embedder names to the ones you want to use
+# the format of llm and embedder should be <provider>.<model_name> such as litellm_llm.gpt-4o-2024-08-06
+# the pipes may be not the latest version, please refer to the latest version: https://raw.githubusercontent.com/canner/WrenAI/<WRENAI_VERSION_NUMBER>/docker/config.example.yaml
+type: pipeline
+pipes:
+  - name: db_schema_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: historical_question_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: table_description_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: db_schema_retrieval
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: historical_question_retrieval
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: sql_generation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: sql_correction
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: followup_sql_generation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: sql_answer
+    llm: litellm_llm.qwen3-fast
+  - name: semantics_description
+    llm: litellm_llm.default
+  - name: relationship_recommendation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: question_recommendation
+    llm: litellm_llm.default
+  - name: question_recommendation_db_schema_retrieval
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: question_recommendation_sql_generation
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: chart_generation
+    llm: litellm_llm.default
+  - name: chart_adjustment
+    llm: litellm_llm.default
+  - name: intent_classification
+    llm: litellm_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: misleading_assistance
+    llm: litellm_llm.default
+  - name: data_assistance
+    llm: litellm_llm.qwen3-fast
+  - name: sql_pairs_indexing
+    document_store: qdrant
+    embedder: litellm_embedder.default
+  - name: sql_pairs_retrieval
+    document_store: qdrant
+    embedder: litellm_embedder.default
+    llm: litellm_llm.default
+  - name: preprocess_sql_data
+    llm: litellm_llm.default
+  - name: sql_executor
+    engine: wren_ui
+  - name: user_guide_assistance
+    llm: litellm_llm.default
+  - name: sql_question_generation
+    llm: litellm_llm.default
+  - name: sql_generation_reasoning
+    llm: litellm_llm.qwen3-thinking
+  - name: followup_sql_generation_reasoning
+    llm: litellm_llm.qwen3-thinking
+  - name: sql_regeneration
+    llm: litellm_llm.default
+    engine: wren_ui
+  - name: instructions_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: instructions_retrieval
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: sql_functions_retrieval
+    engine: wren_ibis
+    document_store: qdrant
+  - name: project_meta_indexing
+    document_store: qdrant
+  - name: sql_tables_extraction
+    llm: litellm_llm.default
+
+---
+settings:
+  engine_timeout: 30
+  column_indexing_batch_size: 50
+  table_retrieval_size: 10
+  table_column_retrieval_size: 100
+  allow_intent_classification: true
+  allow_sql_generation_reasoning: true
+  allow_sql_functions_retrieval: true
+  enable_column_pruning: false
+  max_sql_correction_retries: 3
+  query_cache_maxsize: 1000
+  query_cache_ttl: 3600
+  langfuse_host: https://cloud.langfuse.com
+  langfuse_enable: true
+  logging_level: DEBUG
+  development: true
+  historical_question_retrieval_similarity_threshold: 0.9
+  sql_pairs_similarity_threshold: 0.7
+  sql_pairs_retrieval_max_size: 10
+  instructions_similarity_threshold: 0.7
+  instructions_top_k: 10


### PR DESCRIPTION
This PR adds a new configuration example (`config.qwen3.yaml`) under docs/config_examples for the Qwen3 “think” and “no_think” endpoints. It mirrors the existing DeepSeek example, swapping in the correct `api_base` and model names.
Closes Canner/WrenAI#1636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions for using Qwen3 models in both Thinking and Non-Thinking modes, including usage examples and model descriptions.
  - Documented the requirement to set the `OPENROUTER_API_KEY` environment variable for OpenRouter integration.

- **New Features**
  - Introduced a comprehensive example YAML configuration for WrenAI, showcasing customizable model, pipeline, and runtime settings, including support for Qwen3 model variants and multiple task-specific pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->