### PR TITLE
chore(wren-ai-service): correct wren_ibis endpoint in config examples

### DIFF
--- a/wren-ai-service/docs/config_examples/config.anthropic.yaml
+++ b/wren-ai-service/docs/config_examples/config.anthropic.yaml
@@ -35,7 +35,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.azure.yaml
+++ b/wren-ai-service/docs/config_examples/config.azure.yaml
@@ -40,7 +40,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.deepseek.yaml
+++ b/wren-ai-service/docs/config_examples/config.deepseek.yaml
@@ -55,7 +55,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.google_ai_studio.yaml
+++ b/wren-ai-service/docs/config_examples/config.google_ai_studio.yaml
@@ -41,7 +41,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.grok.yaml
+++ b/wren-ai-service/docs/config_examples/config.grok.yaml
@@ -37,7 +37,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.groq.yaml
+++ b/wren-ai-service/docs/config_examples/config.groq.yaml
@@ -36,7 +36,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.lm_studio.yaml
+++ b/wren-ai-service/docs/config_examples/config.lm_studio.yaml
@@ -35,7 +35,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.ollama.yaml
+++ b/wren-ai-service/docs/config_examples/config.ollama.yaml
@@ -33,7 +33,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.open_router.yaml
+++ b/wren-ai-service/docs/config_examples/config.open_router.yaml
@@ -36,7 +36,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store

--- a/wren-ai-service/docs/config_examples/config.qwen3.yaml
+++ b/wren-ai-service/docs/config_examples/config.qwen3.yaml
@@ -75,7 +75,7 @@ endpoint: http://wren-ui:3000
 ---
 type: engine
 provider: wren_ibis
-endpoint: http://wren-ibis:8000
+endpoint: http://ibis-server:8000
 
 ---
 type: document_store


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration examples to use a new endpoint URL for the "wren_ibis" engine provider. No other changes were made to the configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->