### PR TITLE
chore(wren-ui): Make password field optional in MySQL connection form

### DIFF
--- a/wren-ui/src/components/pages/setup/dataSources/MySQLProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/MySQLProperties.tsx
@@ -66,13 +66,6 @@ export default function MySQLProperties(props: Props) {
       <Form.Item
         label="Password"
         name="password"
-        required
-        rules={[
-          {
-            required: true,
-            message: ERROR_TEXTS.CONNECTION.PASSWORD.REQUIRED,
-          },
-        ]}
       >
         <Input.Password placeholder="input password" />
       </Form.Item>


### PR DESCRIPTION
## Description
This PR removed the required attribute and associated validation rules from the password field in the MySQL connection form.
Fix #1088 

## Context
The following Docker Compose configuration is used to spin up a local MySQL 5.7 instance for testing:
```yaml
version: '3.3'

services:
  db:
    image: mysql:5.7
    restart: always
    environment:
      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
      MYSQL_DATABASE: testdb
      MYSQL_USER: user
      MYSQL_PASSWORD: user
      # MYSQL_ROOT_PASSWORD: root
    ports:
      - '3306:3306'
    volumes:
      - my-db:/var/lib/mysql

volumes:
  my-db:

```

## Recordings
Screen recordings have been created below to demonstrate and verify that:
- `root` can connect without providing a password.
- `user` cannot connect without a password, and receives an access denied error unless the correct password is provided.

https://github.com/user-attachments/assets/03c6db85-2cb9-4687-acef-913b4f56444f

https://github.com/user-attachments/assets/a3be25d7-ee47-43a5-9c22-680f3b45e2ea





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Made the password field optional in the MySQL data source setup form, allowing users to leave it blank if desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->