### PR TITLE
feat(wren-ui): Support connect to Oracle with dsn

### DIFF
--- a/wren-ui/src/apollo/server/dataSource.ts
+++ b/wren-ui/src/apollo/server/dataSource.ts
@@ -134,15 +134,27 @@ const dataSource = {
 
   // Oracle
   [DataSourceName.ORACLE]: {
-    sensitiveProps: ['password'],
+    sensitiveProps: ['password', 'dsn'],
     toIbisConnectionInfo(connectionInfo) {
       const decryptedConnectionInfo = decryptConnectionInfo(
         DataSourceName.ORACLE,
         connectionInfo,
       );
-      const { host, port, database, user, password } =
+      const { host, port, database, user, password, dsn } =
         decryptedConnectionInfo as ORACLE_CONNECTION_INFO;
-      return { host, port, database, user, password };
+      return Object.entries({
+        host,
+        port,
+        database,
+        user,
+        password,
+        dsn,
+      }).reduce((acc, [key, value]) => {
+        if (value !== undefined || value !== '') {
+          acc[key] = value;
+        }
+        return acc;
+      }, {});
     },
   } as IDataSourceConnectionInfo<
     ORACLE_CONNECTION_INFO,

--- a/wren-ui/src/apollo/server/repositories/projectRepository.ts
+++ b/wren-ui/src/apollo/server/repositories/projectRepository.ts
@@ -33,11 +33,12 @@ export interface MYSQL_CONNECTION_INFO {
 }
 
 export interface ORACLE_CONNECTION_INFO {
-  host: string;
-  port: number;
   user: string;
   password: string;
-  database: string;
+  host?: string;
+  port?: number;
+  database?: string;
+  dsn?: string;
 }
 
 export interface MS_SQL_CONNECTION_INFO {

--- a/wren-ui/src/components/pages/setup/dataSources/OracleProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/OracleProperties.tsx
@@ -28,11 +28,15 @@ export default function OracleProperties(props: Props) {
       <Form.Item
         label="Host"
         name="host"
-        required
         rules={[
           {
-            required: true,
-            validator: hostValidator,
+            required: false,
+            validator: (_, value) => {
+              if (value) {
+                return hostValidator(_, value);
+              }
+              return Promise.resolve();
+            },
           },
         ]}
       >
@@ -41,10 +45,8 @@ export default function OracleProperties(props: Props) {
       <Form.Item
         label="Port"
         name="port"
-        required
         rules={[
           {
-            required: true,
             message: ERROR_TEXTS.CONNECTION.PORT.REQUIRED,
           },
         ]}
@@ -79,15 +81,20 @@ export default function OracleProperties(props: Props) {
       <Form.Item
         label="Database name"
         name="database"
-        required
         rules={[
           {
-            required: true,
             message: ERROR_TEXTS.CONNECTION.DATABASE.REQUIRED,
           },
         ]}
       >
         <Input placeholder="Oracle database name" disabled={isEditMode} />
+      </Form.Item>
+      <Form.Item
+        label="DSN"
+        name="dsn"
+        tooltip="Oracle Data Source Name (DSN) - Alternative to host/port/database configuration"
+      >
+        <Input placeholder="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host)(PORT=port))(CONNECT_DATA=(SERVICE_NAME=service)))" />
       </Form.Item>
     </>
   );


### PR DESCRIPTION
Support connect to Oracle with dsn
DSN example:
1. Easy Connect String (Oracle 10g+): `{host}:{port}/{database}`
2. TNS (Oracle Native Format): 
```
(DESCRIPTION=
  (ADDRESS=(PROTOCOL=TCP)(HOST=your-host)(PORT=your-port))
  (CONNECT_DATA=
    (SERVICE_NAME=your-database)
  )
)
```