### PR TITLE
fix(wren-ui): cannot switch authentication method for Redshift connector

### DIFF
--- a/wren-ui/src/components/pages/setup/dataSources/RedshiftProperties.tsx
+++ b/wren-ui/src/components/pages/setup/dataSources/RedshiftProperties.tsx
@@ -182,16 +182,18 @@ export default function RedshiftProperties(props: Props) {
   ) as REDSHIFT_AUTH_METHOD;
 
   useEffect(() => {
-    if (isEditMode) {
-      if (redshiftType && initialRedshiftTypeRef.current === null) {
-        initialRedshiftTypeRef.current = redshiftType;
-      }
-    } else {
+    if (!isEditMode) {
       form.setFieldsValue({
         redshiftType: REDSHIFT_AUTH_METHOD.redshift,
       });
     }
-  }, [isEditMode, form, redshiftType]);
+  }, [isEditMode, form]);
+
+  useEffect(() => {
+    if (isEditMode && redshiftType && initialRedshiftTypeRef.current === null) {
+      initialRedshiftTypeRef.current = redshiftType;
+    }
+  }, [isEditMode, redshiftType]);
 
   const getIsEditModeForComponent = (componentType: REDSHIFT_AUTH_METHOD) => {
     if (!isEditMode) return false;


### PR DESCRIPTION
## Description
Fix cannot switch authentication method for Redshift connector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the reliability of form initialization for Redshift data sources, ensuring default values and initial states are set more accurately depending on edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->