### PR TITLE
feat(wren-ui): add awsSecretKey to sensitive properties for redshift

### DIFF
--- a/wren-ui/src/apollo/server/services/projectService.ts
+++ b/wren-ui/src/apollo/server/services/projectService.ts
@@ -29,7 +29,11 @@ const config = getConfig();
 const logger = getLogger('ProjectService');
 logger.level = 'debug';
 
-const SENSITIVE_PROPERTY_NAME = new Set(['credentials', 'password']);
+const SENSITIVE_PROPERTY_NAME = new Set([
+  'credentials',
+  'password',
+  'awsSecretKey',
+]);
 export interface ProjectData {
   displayName: string;
   type: DataSourceName;

--- a/wren-ui/src/hooks/useSetupConnectionDataSource.tsx
+++ b/wren-ui/src/hooks/useSetupConnectionDataSource.tsx
@@ -80,6 +80,11 @@ export const transformFormToProperties = (
       properties?.password === PASSWORD_PLACEHOLDER
         ? undefined
         : properties?.password,
+
+    awsSecretKey:
+      properties?.awsSecretKey === PASSWORD_PLACEHOLDER
+        ? undefined
+        : properties?.awsSecretKey,
   };
 };
 
@@ -109,7 +114,9 @@ export const transformPropertiesToForm = (
         ? {
             password: properties?.password || PASSWORD_PLACEHOLDER,
           }
-        : {}),
+        : {
+            awsSecretKey: properties?.awsSecretKey || PASSWORD_PLACEHOLDER,
+          }),
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of sensitive information by ensuring that AWS secret keys are properly masked and excluded from general connection info.
  - Updated data source forms to consistently treat AWS secret keys like passwords, masking them and preventing accidental exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->