### PR TITLE
chore(wren-ui): upgrade tar-fs to 2.1.3

### DIFF
--- a/wren-ui/package.json
+++ b/wren-ui/package.json
@@ -96,7 +96,8 @@
   },
   "resolutions": {
     "ws": "8.17.1",
-    "axios": "1.8.4"
+    "axios": "1.8.4",
+    "tar-fs": "2.1.3"
   },
   "_moduleAliases": {
     "@server": "src/apollo/server"

--- a/wren-ui/yarn.lock
+++ b/wren-ui/yarn.lock
@@ -14400,15 +14400,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^2.0.0":
-  version: 2.1.2
-  resolution: "tar-fs@npm:2.1.2"
+"tar-fs@npm:2.1.3":
+  version: 2.1.3
+  resolution: "tar-fs@npm:2.1.3"
   dependencies:
     chownr: "npm:^1.1.1"
     mkdirp-classic: "npm:^0.5.2"
     pump: "npm:^3.0.0"
     tar-stream: "npm:^2.1.4"
-  checksum: 10c0/9c704bd4a53be7565caf34ed001d1428532457fe3546d8fc1233f0f0882c3d2403f8602e8046e0b0adeb31fe95336572a69fb28851a391523126b697537670fc
+  checksum: 10c0/472ee0c3c862605165163113ab6924f411c07506a1fb24c51a1a80085f0d4d381d86d2fd6b189236c8d932d1cd97b69cce35016767ceb658a35f7584fe77f305
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
upgrade tar-fs to 2.1.3
fix security dependency: https://github.com/Canner/WrenAI/security/dependabot/82