### PR TITLE
fix(wren-ui): fix error handling

### DIFF
--- a/wren-ui/src/components/modals/AdjustSQLModal.tsx
+++ b/wren-ui/src/components/modals/AdjustSQLModal.tsx
@@ -28,9 +28,8 @@ export default function AdjustSQLModal(props: Props) {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [showPreview, setShowPreview] = useState<boolean>(false);
 
-  const [previewSqlMutation, previewSqlResult] = usePreviewSqlMutation({
-    onError: (error) => console.error(error),
-  });
+  // Handle errors via try/catch blocks rather than onError callback
+  const [previewSqlMutation, previewSqlResult] = usePreviewSqlMutation();
 
   const sqlValue = Form.useWatch('sql', form);
 

--- a/wren-ui/src/components/modals/FixSQLModal.tsx
+++ b/wren-ui/src/components/modals/FixSQLModal.tsx
@@ -18,9 +18,9 @@ export function FixSQLModal(props: Props) {
   const [previewLoading, setPreviewLoading] = useState(false);
   const [form] = Form.useForm();
 
-  const [previewSqlMutation, previewSqlResult] = usePreviewSqlMutation({
-    onError: (error) => console.error(error),
-  });
+  // Handle errors via try/catch blocks rather than onError callback
+  const [previewSqlMutation, previewSqlResult] = usePreviewSqlMutation();
+
   const error = useMemo(() => {
     if (!previewSqlResult.error) return null;
     const graphQLError = parseGraphQLError(previewSqlResult.error);

--- a/wren-ui/src/components/modals/ImportDataSourceSQLModal.tsx
+++ b/wren-ui/src/components/modals/ImportDataSourceSQLModal.tsx
@@ -38,10 +38,10 @@ export default function ImportDataSourceSQLModal(props: Props) {
   const { visible, defaultValue, onSubmit, onClose } = props;
   const name = getDataSourceName(defaultValue?.dataSource) || 'data source';
 
+  // Handle errors via try/catch blocks rather than onError callback
   const [substituteDialectSQL, modelSubstitudeResult] =
-    useModelSubstituteMutation({
-      onError: (error) => console.error(error),
-    });
+    useModelSubstituteMutation();
+
   const error = useMemo(
     () =>
       modelSubstitudeResult.error

--- a/wren-ui/src/components/modals/QuestionSQLPairModal.tsx
+++ b/wren-ui/src/components/modals/QuestionSQLPairModal.tsx
@@ -84,9 +84,8 @@ export default function QuestionSQLPairModal(props: Props) {
   const [generatingQuestion, setGeneratingQuestion] = useState<boolean>(false);
   const [showPreview, setShowPreview] = useState<boolean>(false);
 
-  const [previewSqlMutation, previewSqlResult] = usePreviewSqlMutation({
-    onError: (error) => console.error(error),
-  });
+  // Handle errors via try/catch blocks rather than onError callback
+  const [previewSqlMutation, previewSqlResult] = usePreviewSqlMutation();
 
   const [generateQuestionMutation] = useGenerateQuestionMutation({
     onError: (error) => console.error(error),


### PR DESCRIPTION
## Issue
Fix validate SQL has no effect

## Description

The error is already handled in a try-catch block with console.error,  so we need to remove the onError callback for the API to avoid being intercepted by Apollo's onError callback

- `AdjustSQLModal`
- `FixSQLModal` 
- `ImportDataSourceSQLModal`
- `QuestionSQLPairModal` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed direct console error logging from several modals when previewing or substituting SQL. Error handling and display within the UI remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->