### PR TITLE
fix: add missing quotes around column names in relation conditions

### DIFF
--- a/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
+++ b/wren-ui/src/apollo/server/mdl/mdlBuilder.ts
@@ -430,7 +430,7 @@ export class MDLBuilder implements IMDLBuilder {
     //TODO phase2: implement the expression for relation condition
     const { fromColumnName, toColumnName, fromModelName, toModelName } =
       relation;
-    return `"${fromModelName}".${fromColumnName} = "${toModelName}".${toColumnName}`;
+    return `"${fromModelName}"."${fromColumnName}" = "${toModelName}"."${toColumnName}"`;
   }
 
   private buildTableReference(model: Model): TableReference | null {


### PR DESCRIPTION
The getRelationCondition method was not properly quoting column names in SQL conditions, which could cause issues with column names that contain spaces or special characters. This commit adds double quotes around column names to match the existing pattern used for model names.