### PR TITLE
fix: correct return type annotations in DDLChunker methods

### DIFF
--- a/wren-ai-service/src/pipelines/indexing/db_schema.py
+++ b/wren-ai-service/src/pipelines/indexing/db_schema.py
@@ -123,7 +123,7 @@ class DDLChunker:
         models: List[Dict[str, Any]],
         relationships: List[Dict[str, Any]],
         column_batch_size: int,
-    ) -> List[str]:
+    ) -> List[Dict[str, str]]:
         def _model_command(model: Dict[str, Any]) -> dict:
             properties = model.get("properties", {})
 
@@ -228,7 +228,7 @@ class DDLChunker:
             + [_model_command(model)]
         ]
 
-    def _convert_views(self, views: List[Dict[str, Any]]) -> List[str]:
+    def _convert_views(self, views: List[Dict[str, Any]]) -> List[Dict[str, str]]:
         def _payload(view: Dict[str, Any]) -> dict:
             return {
                 "type": "VIEW",
@@ -243,7 +243,7 @@ class DDLChunker:
             {"name": view["name"], "payload": str(_payload(view))} for view in views
         ]
 
-    def _convert_metrics(self, metrics: List[Dict[str, Any]]) -> List[str]:
+    def _convert_metrics(self, metrics: List[Dict[str, Any]]) -> List[Dict[str, str]]:
         def _create_column(name: str, data_type: str, comment: str) -> dict:
             return {
                 "type": "COLUMN",


### PR DESCRIPTION
## Description
Fix incorrect return type annotations in `DDLChunker` class methods. These methods were annotated as returning `List[str]` but actually return `List[Dict[str, str]]`.

## Problem
The following methods have incorrect type annotations:
- `_convert_models_and_relationships()` 
- `_convert_views()`
- `_convert_metrics()`

All return dictionaries with "name" and "payload" keys, not strings.

## Evidence
In the `DDLChunker.run` method, the code accesses `chunk["payload"]`:
```python
for chunk in await self._get_ddl_commands(...):
    content = chunk["payload"]  # This proves chunk is a dict, not a string
```

## Solution
Update return type annotations from `List[str]` to `List[Dict[str, str]]`

## Testing
- Type checkers (mypy, pyright) will now correctly validate these methods
- No functional changes, only type annotation fixes