### PR TITLE
fix(wren-ui): Handle error with try/catch mutation shouldn't has onError

### DIFF
--- a/wren-ui/src/hooks/useAskPrompt.tsx
+++ b/wren-ui/src/hooks/useAskPrompt.tsx
@@ -160,10 +160,9 @@ const handleUpdateRerunAskingTaskCache = (
 export default function useAskPrompt(threadId?: number) {
   const [originalQuestion, setOriginalQuestion] = useState<string>('');
   const [threadQuestions, setThreadQuestions] = useState<string[]>([]);
+  // Handle errors via try/catch blocks rather than onError callback
   const [createAskingTask, createAskingTaskResult] =
-    useCreateAskingTaskMutation({
-      onError: (error) => console.error(error),
-    });
+    useCreateAskingTaskMutation();
   const [cancelAskingTask] = useCancelAskingTaskMutation({
     onError: (error) => console.error(error),
   });

--- a/wren-ui/src/hooks/useRecommendedQuestionsInstruction.tsx
+++ b/wren-ui/src/hooks/useRecommendedQuestionsInstruction.tsx
@@ -48,10 +48,9 @@ export default function useRecommendedQuestionsInstruction() {
       pollInterval: 2000,
     });
 
+  // Handle errors via try/catch blocks rather than onError callback
   const [generateProjectRecommendationQuestions] =
-    useGenerateProjectRecommendationQuestionsMutation({
-      onError: (error) => console.error(error),
-    });
+    useGenerateProjectRecommendationQuestionsMutation();
 
   const recommendedQuestionsTask = useMemo(
     () =>

--- a/wren-ui/src/hooks/useSetupModels.tsx
+++ b/wren-ui/src/hooks/useSetupModels.tsx
@@ -16,17 +16,20 @@ export default function useSetupModels() {
     onError: (error) => console.error(error),
   });
 
-  const [saveTablesMutation, { loading: submitting }] = useSaveTablesMutation({
-    onError: (error) => console.error(error),
-  });
+  // Handle errors via try/catch blocks rather than onError callback
+  const [saveTablesMutation, { loading: submitting }] = useSaveTablesMutation();
 
   const submitModels = async (tables: string[]) => {
-    await saveTablesMutation({
-      variables: {
-        data: { tables },
-      },
-    });
-    router.push(Path.OnboardingRelationships);
+    try {
+      await saveTablesMutation({
+        variables: {
+          data: { tables },
+        },
+      });
+      router.push(Path.OnboardingRelationships);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const onBack = () => {


### PR DESCRIPTION
## Description
This PR fixes an issue where GraphQL errors handled by onError were not reaching the try/catch block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated error handling in several features to use try/catch blocks instead of onError callbacks. This change does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->