### PR TITLE
feat(wren-launcher): support MySQL and Postgres data source for dbt-tool

### DIFF
--- a/wren-launcher/commands/dbt/README.md
+++ b/wren-launcher/commands/dbt/README.md
@@ -1,3 +1,17 @@
+# Requirement for DBT project
+This part outlines some requirements for the target dbt project:
+- Ensure the DBT project is qualified and generates the required files:
+  - `catalog.json`
+  - `manifest.json`
+  Execute the following commands:
+	```
+	dbt build
+	dbt docs generate
+	```
+- Prepare the profile of the dbt project for the connection info of your database.
+  - `profiles.yml`
+
+
 # How to Support a New Data Source
 
 This document outlines the steps required to add support for a new data source to the dbt project converter.

--- a/wren-launcher/commands/dbt/converter.go
+++ b/wren-launcher/commands/dbt/converter.go
@@ -154,6 +154,18 @@ func ConvertDbtProjectCore(opts ConvertOptions) (*ConvertResult, error) {
 						"format": typedDS.Format,
 					},
 				}
+			case *WrenMysqlDataSource:
+				wrenDataSource = map[string]interface{}{
+					"type": "mysql",
+					"properties": map[string]interface{}{
+						"host":     typedDS.Host,
+						"port":     typedDS.Port,
+						"database": typedDS.Database,
+						"user":     typedDS.User,
+						"password": typedDS.Password,
+						"sslMode":  typedDS.SslMode,
+					},
+				}
 			default:
 				pterm.Warning.Printf("Warning: Unsupported data source type: %s\n", ds.GetType())
 				wrenDataSource = map[string]interface{}{

--- a/wren-launcher/commands/dbt/data_source.go
+++ b/wren-launcher/commands/dbt/data_source.go
@@ -17,6 +17,7 @@ const (
 	timestampType = "timestamp"
 	doubleType    = "double"
 	booleanType   = "boolean"
+	postgresType  = "postgres"
 )
 
 // Constants for SQL data types
@@ -74,7 +75,7 @@ func FromDbtProfiles(profiles *DbtProfiles) ([]DataSource, error) {
 // convertConnectionToDataSource converts connection to corresponding DataSource based on connection type
 func convertConnectionToDataSource(conn DbtConnection, dbtHomePath, profileName, outputName string) (DataSource, error) {
 	switch strings.ToLower(conn.Type) {
-	case "postgres", "postgresql":
+	case postgresType, "postgresql":
 		return convertToPostgresDataSource(conn)
 	case "duckdb":
 		return convertToLocalFileDataSource(conn, dbtHomePath)
@@ -231,7 +232,7 @@ type WrenPostgresDataSource struct {
 
 // GetType implements DataSource interface
 func (ds *WrenPostgresDataSource) GetType() string {
-	return "postgres"
+	return postgresType
 }
 
 // Validate implements DataSource interface
@@ -309,7 +310,7 @@ func (ds *WrenMysqlDataSource) MapType(sourceType string) string {
 	case "CHAR":
 		return "char"
 	case "VARCHAR":
-		return "varchar"
+		return varcharType
 	case "TEXT", "TINYTEXT", "MEDIUMTEXT", "LONGTEXT", "ENUM", "SET":
 		return "text"
 	case "BIT", "TINYINT":
@@ -444,7 +445,7 @@ func (d *DefaultDataSource) MapType(sourceType string) string {
 	case "integer", "int", "bigint", "int64":
 		return "integer"
 	case "varchar", "text", "string", "char":
-		return "varchar"
+		return varcharType
 	case "timestamp", "datetime", "date":
 		return "timestamp"
 	case "double", "float", "decimal", "numeric":

--- a/wren-launcher/commands/dbt/data_source.go
+++ b/wren-launcher/commands/dbt/data_source.go
@@ -160,17 +160,18 @@ func convertToMysqlDataSource(conn DbtConnection) (*WrenMysqlDataSource, error) 
 	if conn.SslDisable {
 		sslMode = "DISABLED"
 	}
+	port := strconv.Itoa(conn.Port)
+	if conn.Port == 0 {
+		port = "3306"
+	}
+
 	ds := &WrenMysqlDataSource{
 		Host:     conn.Host,
-		Port:     strconv.Itoa(conn.Port),
+		Port:     port,
 		Database: conn.Database,
 		User:     conn.User,
 		Password: conn.Password,
 		SslMode:  sslMode,
-	}
-
-	if ds.Port == "" {
-		ds.Port = "3306" // Default MySQL port
 	}
 
 	return ds, nil

--- a/wren-launcher/commands/dbt/data_source.go
+++ b/wren-launcher/commands/dbt/data_source.go
@@ -98,17 +98,17 @@ func convertToPostgresDataSource(conn DbtConnection) (*WrenPostgresDataSource, e
 	}
 
 	pterm.Info.Printf("Converting Postgres data source: %s:%d/%s\n", conn.Host, conn.Port, dbName)
+	port := strconv.Itoa(conn.Port)
+	if conn.Port == 0 {
+		port = "5432"
+	}
+
 	ds := &WrenPostgresDataSource{
 		Host:     conn.Host,
-		Port:     strconv.Itoa(conn.Port),
+		Port:     port,
 		Database: dbName,
 		User:     conn.User,
 		Password: conn.Password,
-	}
-
-	// If no port is specified, use PostgreSQL default port
-	if ds.Port == "" {
-		ds.Port = "5432"
 	}
 
 	return ds, nil

--- a/wren-launcher/commands/dbt/data_source.go
+++ b/wren-launcher/commands/dbt/data_source.go
@@ -87,10 +87,17 @@ func convertConnectionToDataSource(conn DbtConnection, dbtHomePath, profileName,
 
 // convertToPostgresDataSource converts to PostgreSQL data source
 func convertToPostgresDataSource(conn DbtConnection) (*WrenPostgresDataSource, error) {
+	// For PostgreSQL, prefer dbname over database field
+	dbName := conn.DbName
+	if dbName == "" {
+		dbName = conn.Database
+	}
+
+	pterm.Info.Printf("Converting Postgres data source: %s:%d/%s\n", conn.Host, conn.Port, dbName)
 	ds := &WrenPostgresDataSource{
 		Host:     conn.Host,
 		Port:     conn.Port,
-		Database: conn.Database,
+		Database: dbName,
 		User:     conn.User,
 		Password: conn.Password,
 	}

--- a/wren-launcher/commands/dbt/data_source_test.go
+++ b/wren-launcher/commands/dbt/data_source_test.go
@@ -21,7 +21,7 @@ func validatePostgresDataSource(t *testing.T, ds *WrenPostgresDataSource, expect
 		t.Errorf("Expected host '%s', got '%s'", testHost, ds.Host)
 	}
 	if ds.Port != "5432" {
-		t.Errorf("Expected port 5432, got %d", ds.Port)
+		t.Errorf("Expected port 5432, got %s", ds.Port)
 	}
 	if ds.Database != expectedDB {
 		t.Errorf("Expected database '%s', got '%s'", expectedDB, ds.Database)

--- a/wren-launcher/commands/dbt/profiles.go
+++ b/wren-launcher/commands/dbt/profiles.go
@@ -34,6 +34,8 @@ type DbtConnection struct {
 	SearchPath string `yaml:"search_path,omitempty" json:"search_path,omitempty"` // Postgres
 	SSLMode    string `yaml:"sslmode,omitempty" json:"sslmode,omitempty"`         // Postgres
 
+	SslDisable bool `yaml:"ssl_disable,omitempty" json:"ssl_disable,omitempty"` // MySQL
+
 	Path string `yaml:"path,omitempty" json:"path,omitempty"` // DuckDB
 	// Flexible additional properties
 	Additional map[string]interface{} `yaml:",inline" json:"additional,omitempty"`

--- a/wren-launcher/commands/dbt/profiles.go
+++ b/wren-launcher/commands/dbt/profiles.go
@@ -19,6 +19,7 @@ type DbtConnection struct {
 	Port     int    `yaml:"port,omitempty" json:"port,omitempty"`
 	User     string `yaml:"user,omitempty" json:"user,omitempty"`
 	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+	DbName   string `yaml:"dbname,omitempty" json:"dbname,omitempty"` // Postgres
 	Database string `yaml:"database,omitempty" json:"database,omitempty"`
 	Schema   string `yaml:"schema,omitempty" json:"schema,omitempty"`
 	// Additional fields for different database types

--- a/wren-launcher/commands/dbt/profiles_analyzer.go
+++ b/wren-launcher/commands/dbt/profiles_analyzer.go
@@ -148,7 +148,7 @@ func parseConnection(connectionMap map[string]interface{}) (*DbtConnection, erro
 		"type": true, "host": true, "port": true, "user": true, "password": true,
 		"database": true, "dbname": true, "schema": true, "project": true, "dataset": true,
 		"keyfile": true, "account": true, "warehouse": true, "role": true,
-		"keepalive": true, "search_path": true, "sslmode": true, "path": true,
+		"keepalive": true, "search_path": true, "sslmode": true, "path": true, "ssl_disable": true,
 	}
 
 	for key, value := range connectionMap {

--- a/wren-launcher/commands/dbt/profiles_analyzer.go
+++ b/wren-launcher/commands/dbt/profiles_analyzer.go
@@ -141,6 +141,7 @@ func parseConnection(connectionMap map[string]interface{}) (*DbtConnection, erro
 	connection.SearchPath = getString("search_path")
 	connection.SSLMode = getString("sslmode")
 	connection.Path = getString("path")
+	connection.SslDisable = getBool("ssl_disable") // MySQL specific
 
 	// Store any additional fields that weren't mapped
 	knownFields := map[string]bool{

--- a/wren-launcher/commands/dbt/profiles_analyzer.go
+++ b/wren-launcher/commands/dbt/profiles_analyzer.go
@@ -127,6 +127,7 @@ func parseConnection(connectionMap map[string]interface{}) (*DbtConnection, erro
 	connection.User = getString("user")
 	connection.Password = getString("password")
 	connection.Database = getString("database")
+	connection.DbName = getString("dbname") // PostgreSQL specific
 	connection.Schema = getString("schema")
 
 	// Extract database-specific fields
@@ -144,7 +145,7 @@ func parseConnection(connectionMap map[string]interface{}) (*DbtConnection, erro
 	// Store any additional fields that weren't mapped
 	knownFields := map[string]bool{
 		"type": true, "host": true, "port": true, "user": true, "password": true,
-		"database": true, "schema": true, "project": true, "dataset": true,
+		"database": true, "dbname": true, "schema": true, "project": true, "dataset": true,
 		"keyfile": true, "account": true, "warehouse": true, "role": true,
 		"keepalive": true, "search_path": true, "sslmode": true, "path": true,
 	}


### PR DESCRIPTION
# Description
- Fix the connection info mapping for Postgres
- Add type mapping for Postgres 
- Add the connection info mapping for MySQL
- Add type mapping for MySQL

The type mapping tables follows [the logic of wren eninge](https://github.com/Canner/wren-engine/blob/68b8153f20a04a8a1c0ba85f4c3aacbcd38b4c04/ibis-server/app/model/metadata/postgres.py#L225)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MySQL data sources in DBT project conversion and explicit PostgreSQL database-name support.

* **Bug Fixes**
  * Improved validation and port handling for PostgreSQL and MySQL connection configurations.

* **Documentation**
  * Added DBT project requirements (which JSON outputs and profile configuration are needed).

* **Tests**
  * Added and updated tests covering MySQL validation and PostgreSQL database-name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->