### PR TITLE
feat(wren-ui): Support SQL formatting in FixSQL modal

### DIFF
--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -712,9 +712,9 @@ export class AskingResolver {
     sql: (parent: ThreadResponse, _args: any, _ctx: IContext) => {
       if (parent.breakdownDetail && parent.breakdownDetail.steps) {
         // construct sql from breakdownDetail
-        return format(constructCteSql(parent.breakdownDetail.steps));
+        return safeFormatSQL(constructCteSql(parent.breakdownDetail.steps));
       }
-      return parent.sql ? format(parent.sql) : null;
+      return parent.sql ? safeFormatSQL(parent.sql) : null;
     },
     askingTask: async (parent: ThreadResponse, _args: any, ctx: IContext) => {
       if (parent.adjustment) {
@@ -755,13 +755,13 @@ export class AskingResolver {
 
   public getDetailStepNestedResolver = () => ({
     sql: (parent: DetailStep, _args: any, _ctx: IContext) => {
-      return format(parent.sql);
+      return safeFormatSQL(parent.sql);
     },
   });
 
   public getResultCandidateNestedResolver = () => ({
     sql: (parent: any, _args: any, _ctx: IContext) => {
-      return format(parent.sql);
+      return safeFormatSQL(parent.sql);
     },
     view: async (parent: any, _args: any, ctx: IContext) => {
       const viewId = parent.view?.id;

--- a/wren-ui/src/apollo/server/resolvers/askingResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/askingResolver.ts
@@ -15,7 +15,7 @@ import {
 import { reduce } from 'lodash';
 import { IContext } from '../types';
 import { getLogger } from '@server/utils';
-import { format } from 'sql-formatter';
+import { safeFormatSQL } from '@server/utils/sqlFormat';
 import {
   AskingDetailTaskInput,
   constructCteSql,
@@ -555,7 +555,9 @@ export class AskingResolver {
       error: adjustmentTask?.error,
       sql: adjustmentTask?.response?.[0]?.sql,
       traceId: adjustmentTask?.traceId,
-      invalidSql: adjustmentTask?.invalidSql,
+      invalidSql: adjustmentTask?.invalidSql
+        ? safeFormatSQL(adjustmentTask.invalidSql)
+        : null,
     };
   }
 
@@ -744,7 +746,9 @@ export class AskingResolver {
         error: adjustmentTask?.error,
         sql: adjustmentTask?.response?.[0]?.sql,
         traceId: adjustmentTask?.traceId,
-        invalidSql: adjustmentTask?.invalidSql,
+        invalidSql: adjustmentTask?.invalidSql
+          ? safeFormatSQL(adjustmentTask.invalidSql)
+          : null,
       };
     },
   });
@@ -812,7 +816,9 @@ export class AskingResolver {
       intentReasoning: askingTask.intentReasoning,
       sqlGenerationReasoning: askingTask.sqlGenerationReasoning,
       retrievedTables: askingTask.retrievedTables,
-      invalidSql: askingTask.invalidSql ? format(askingTask.invalidSql) : null,
+      invalidSql: askingTask.invalidSql
+        ? safeFormatSQL(askingTask.invalidSql)
+        : null,
       traceId: askingTask.traceId,
     };
   }

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -15,7 +15,7 @@ import {
 } from '../types';
 import { getLogger, transformInvalidColumnName } from '@server/utils';
 import { DeployResponse } from '../services/deployService';
-import { format } from 'sql-formatter';
+import { safeFormatSQL } from '@server/utils/sqlFormat';
 import { isEmpty, isNil } from 'lodash';
 import { replaceAllowableSyntax, validateDisplayName } from '../utils/regex';
 import { Model, ModelColumn } from '../repositories';
@@ -821,7 +821,7 @@ export class ModelResolver {
     }
 
     // construct cte sql and format it
-    const statement = format(response.sql);
+    const statement = safeFormatSQL(response.sql);
 
     // describe columns
     const { columns } = await ctx.queryService.describeStatement(statement, {
@@ -988,7 +988,7 @@ export class ModelResolver {
       });
     }
     const language = project.type === DataSourceName.MSSQL ? 'tsql' : undefined;
-    return format(nativeSql, { language });
+    return safeFormatSQL(nativeSql, { language });
   }
 
   public async updateViewMetadata(

--- a/wren-ui/src/apollo/server/resolvers/sqlPairResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/sqlPairResolver.ts
@@ -3,7 +3,7 @@ import { SqlPair } from '@server/repositories';
 import * as Errors from '@server/utils/error';
 import { TelemetryEvent, TrackTelemetry } from '@server/telemetry/telemetry';
 import { DialectSQL, WrenSQL } from '@server/models/adaptor';
-import { format } from 'sql-formatter';
+import { safeFormatSQL } from '@server/utils/sqlFormat';
 
 export class SqlPairResolver {
   constructor() {
@@ -111,7 +111,7 @@ export class SqlPairResolver {
         manifest,
       },
     );
-    return format(wrenSQL, { language: 'postgresql' }) as WrenSQL;
+    return safeFormatSQL(wrenSQL, { language: 'postgresql' }) as WrenSQL;
   }
 
   private async validateSql(sql: string, ctx: IContext) {

--- a/wren-ui/src/apollo/server/services/askingService.ts
+++ b/wren-ui/src/apollo/server/services/askingService.ts
@@ -20,7 +20,7 @@ import {
 } from '../repositories/threadResponseRepository';
 import { getLogger } from '@server/utils';
 import { isEmpty, isNil } from 'lodash';
-import { format } from 'sql-formatter';
+import { safeFormatSQL } from '@server/utils/sqlFormat';
 import {
   PostHogTelemetry,
   TelemetryEvent,
@@ -975,7 +975,7 @@ export class AskingService implements IAskingService {
     const deployment = await this.deployService.getLastDeployment(project.id);
     const mdl = deployment.manifest;
     const steps = response?.breakdownDetail?.steps;
-    const sql = format(constructCteSql(steps, stepIndex));
+    const sql = safeFormatSQL(constructCteSql(steps, stepIndex));
     const eventName = TelemetryEvent.HOME_PREVIEW_ANSWER;
     try {
       const data = (await this.queryService.preview(sql, {

--- a/wren-ui/src/apollo/server/utils/sqlFormat.ts
+++ b/wren-ui/src/apollo/server/utils/sqlFormat.ts
@@ -1,0 +1,22 @@
+import { format, FormatOptionsWithLanguage } from 'sql-formatter';
+import { getLogger } from './logger';
+
+const logger = getLogger('SQL Format');
+
+export function safeFormatSQL(
+  sql: string,
+  options?: FormatOptionsWithLanguage,
+): string {
+  try {
+    return format(sql, options);
+  } catch (err) {
+    try {
+      logger.debug(`Fallback to Trino dialect for SQL formatting...`);
+      // Try using Trino as the fallback dialect
+      return format(sql, { ...options, language: 'trino' });
+    } catch (_fallbackError) {
+      logger.error(`Failed to format SQL: ${err.message}`);
+      return sql;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Support SQL formatting in FixSQL modal

## Solution
- Handle invalid SQL formatting on the backend
  - [x] Adjustment Task
  - [x] Asking Task
- Other, replace with safe format SQL for preventing parsed error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Reduced errors when displaying SQL previews and breakdowns; invalid or partial SQL is now shown safely without crashing.
  - Improved reliability of SQL formatting across ask flows, models, and SQL pairs.

- Refactor
  - Consolidated SQL formatting behind a single, resilient formatter for consistent results throughout the app.
  - Standardized SQL output for better readability, with smarter fallback behavior to handle edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->