### PR TITLE
fix(wren-ui): show text based answer preview data error

### DIFF
--- a/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/TextBasedAnswer.tsx
@@ -116,6 +116,7 @@ export default function TextBasedAnswer(props: AnswerResultProps) {
   const [previewData, previewDataResult] = usePreviewDataMutation({
     onError: (error) => console.error(error),
   });
+  const hasPreviewData = !!previewDataResult.data?.previewData;
 
   const onPreviewData = async () => {
     await previewData({ variables: { where: { responseId: id } } });
@@ -242,22 +243,19 @@ export default function TextBasedAnswer(props: AnswerResultProps) {
               View results
             </Button>
 
-            {previewDataResult?.data?.previewData && (
-              <div
-                className="mt-2 mb-3"
-                data-guideid="text-answer-preview-data"
-              >
+            <div className="mt-2 mb-3" data-guideid="text-answer-preview-data">
+              {hasPreviewData && (
                 <Text type="secondary" className="text-sm">
                   Considering the limit of the context window, we retrieve up to
                   500 rows of results to generate the answer.
                 </Text>
-                <PreviewData
-                  error={previewDataResult.error}
-                  loading={previewDataResult.loading}
-                  previewData={previewDataResult?.data?.previewData}
-                />
-              </div>
-            )}
+              )}
+              <PreviewData
+                error={previewDataResult.error}
+                loading={previewDataResult.loading}
+                previewData={previewDataResult?.data?.previewData}
+              />
+            </div>
           </div>
         ) : (
           <>


### PR DESCRIPTION
## Description
This PR addresses a text answer preview issue where the preview data section was not properly displayed when data was available. The fix ensures that the preview data section is always rendered, but the explanatory text is conditionally shown based on whether preview data exists.

## Implementation 
The implementation follows a conditional rendering approach where:

- **Always Render**: The preview data container and `PreviewData` component are always rendered to maintain consistent layout
- **Conditional Display**: The explanatory text is only shown when `hasPreviewData` is true
- **State Management**: Introduced a `hasPreviewData` variable to avoid repeated property access and improve readability

## Actual Changes

### Text Answer Preview Enhancement
- **Fixed Preview Data Display**: Modified `TextBasedAnswer.tsx` to always render the preview data section
- **Conditional UI Elements**: Added conditional rendering for explanatory text based on data availability
- **Improved State Handling**: Introduced `hasPreviewData` variable for cleaner conditional logic
- **Layout Consistency**: Ensured the preview data section maintains consistent spacing and structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview section now consistently displayed, reducing layout shifts when no data is available.
  * Explanatory text shows only when relevant preview data exists, preventing confusing messages.

* **Refactor**
  * Streamlined conditional rendering by always mounting the preview container and component, improving UI stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->