### PR TITLE
chore(wren-ui): return ibis error in error response

### DIFF
--- a/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
+++ b/wren-ui/src/apollo/server/adaptors/ibisAdaptor.ts
@@ -551,6 +551,8 @@ export class IbisAdaptor implements IIbisAdaptor {
       e.response?.data ||
       e.message ||
       defaultMessage;
+
+    const errorData = e.response?.data;
     throw Errors.create(Errors.GeneralErrorCodes.IBIS_SERVER_ERROR, {
       customMessage: errorMessageBuilder
         ? errorMessageBuilder(customMessage)
@@ -559,6 +561,7 @@ export class IbisAdaptor implements IIbisAdaptor {
       other: {
         correlationId: e.response?.headers['x-correlation-id'],
         processTime: e.response?.headers['x-process-time'],
+        ...errorData,
       },
     });
   }

--- a/wren-ui/src/apollo/server/utils/error.ts
+++ b/wren-ui/src/apollo/server/utils/error.ts
@@ -240,6 +240,7 @@ export const defaultApolloErrorHandler = (error: GraphQLError) => {
         message: error.message,
         shortMessage: shortMessages[code],
         stacktrace: error.extensions?.exception?.stacktrace,
+        other: error.extensions?.other,
       },
     };
   }


### PR DESCRIPTION
 return ibis error in graphql error response
previewSql example response: ibis response data will be attached under prop "other"
```
{
    "errors": [
        {
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "path": [
                "previewSql"
            ],
            "message": "Schema error: No field named c.c_nationkey1. Did you mean 'c.c_nationkey'?.",
            "extensions": {
                "code": "IBIS_SERVER_ERROR",
                "message": "Schema error: No field named c.c_nationkey1. Did you mean 'c.c_nationkey'?.",
                "shortMessage": "Data connection error",
                "stacktrace": [
                    "GraphQLError: Schema error: No field named c.c_nationkey1. Did you mean 'c.c_nationkey'?.",
                    "    at Module.create (webpack-internal:///(api)/./src/apollo/server/utils/error.ts:137:17)",
                    "    at IbisAdaptor.throwError (webpack-internal:///(api)/./src/apollo/server/adaptors/ibisAdaptor.ts:307:64)",
                    "    at IbisAdaptor.query (webpack-internal:///(api)/./src/apollo/server/adaptors/ibisAdaptor.ts:120:18)",
                    "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
                    "    at async QueryService.ibisQuery (webpack-internal:///(api)/./src/apollo/server/services/queryService.ts:108:25)",
                    "    at async QueryService.preview (webpack-internal:///(api)/./src/apollo/server/services/queryService.ts:48:24)",
                    "    at async ModelResolver.previewSql (webpack-internal:///(api)/./src/apollo/server/resolvers/modelResolver.ts:715:16)"
                ],
                "other": {
                    "correlationId": "6efebd8b-76c7-42cd-8f83-e1ed378cb5d2",
                    "processTime": "0.37810862495098263",
                    "errorCode": "INVALID_SQL",
                    "message": "Schema error: No field named c.c_nationkey1. Did you mean 'c.c_nationkey'?.",
                    "metadata": null,
                    "phase": "SQL_PLANNING",
                    "timestamp": "2025-09-02T04:12:19.541672"
                }
            }
        }
    ],
    "data": null
}
```