### PR TITLE
Update Qdrant: set field_schema to KEYWORD & add encoding="utf-8" for file opening

### DIFF
--- a/wren-ai-service/eval/preparation.py
+++ b/wren-ai-service/eval/preparation.py
@@ -89,7 +89,7 @@ def get_database_names(path: Path):
 
 
 def get_tables_by_db(path: Path, key: str):
-    with open(path, "rb") as f:
+    with open(path, "rb",encoding="utf-8") as f:
         json_data = orjson.loads(f.read())
 
     return {item[key]: item for item in json_data}
@@ -210,7 +210,7 @@ def build_mdl_relationships(tables_info):
 
 
 def get_ground_truths_by_db(path: Path, key: str):
-    with open(path, "rb") as f:
+    with open(path, "rb",encoding="utf-8") as f:
         json_data = orjson.loads(f.read())
 
     results = defaultdict(list)

--- a/wren-ai-service/src/pipelines/generation/chart_adjustment.py
+++ b/wren-ai-service/src/pipelines/generation/chart_adjustment.py
@@ -165,7 +165,7 @@ class ChartAdjustment(BasicPipeline):
             "post_processor": ChartGenerationPostProcessor(),
         }
 
-        with open("src/pipelines/generation/utils/vega-lite-schema-v5.json", "r") as f:
+        with open("src/pipelines/generation/utils/vega-lite-schema-v5.json", "r",encoding="utf-8") as f:
             _vega_schema = orjson.loads(f.read())
 
         self._configs = {

--- a/wren-ai-service/src/pipelines/generation/chart_generation.py
+++ b/wren-ai-service/src/pipelines/generation/chart_generation.py
@@ -138,7 +138,7 @@ class ChartGeneration(BasicPipeline):
             "post_processor": ChartGenerationPostProcessor(),
         }
 
-        with open("src/pipelines/generation/utils/vega-lite-schema-v5.json", "r") as f:
+        with open("src/pipelines/generation/utils/vega-lite-schema-v5.json", "r",encoding="utf-8") as f:
             _vega_schema = orjson.loads(f.read())
 
         self._configs = {

--- a/wren-ai-service/src/providers/document_store/qdrant.py
+++ b/wren-ai-service/src/providers/document_store/qdrant.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from typing import Any, Dict, List, Optional
-
+from qdrant_client.http import models
 import numpy as np
 import qdrant_client
 from haystack import Document, component
@@ -159,7 +159,8 @@ class AsyncQdrantDocumentStore(QdrantDocumentStore):
         # to improve the indexing performance
         # see https://qdrant.tech/documentation/guides/multiple-partitions/?q=mul#calibrate-performance
         self.client.create_payload_index(
-            collection_name=index, field_name="project_id", field_schema="keyword"
+            collection_name=index, field_name="project_id",
+              field_schema=models.PayloadSchemaType.KEYWORD,
         )
 
     async def _query_by_embedding(


### PR DESCRIPTION
This PR introduces two improvements:

1. In the Qdrant provider, the creation of the payload index for the "project_id" field has been updated to explicitly set the field schema using models.PayloadSchemaType.KEYWORD. This change ensures that the data type is correctly interpreted by Qdrant, leading to more reliable indexing and search operations.

2. In the chart generation pipeline, the JSON file loading has been updated to enforce encoding="utf-8". This ensures consistent behavior when reading configuration files across various environments.

Both improvements are aimed at enhancing compatibility and reliability of the document