### PR TITLE
feat(wren-launcher) support MSSQL data source for dbt-tools

### DIFF
--- a/wren-launcher/commands/dbt/converter.go
+++ b/wren-launcher/commands/dbt/converter.go
@@ -154,6 +154,26 @@ func ConvertDbtProjectCore(opts ConvertOptions) (*ConvertResult, error) {
 						"password": typedDS.Password,
 					},
 				}
+			case *WrenMSSQLDataSource:
+				var host string
+				if opts.UsedByContainer {
+					host = handleLocalhostForContainer(typedDS.Host)
+				} else {
+					host = typedDS.Host
+				}
+				wrenDataSource = map[string]interface{}{
+					"type": "mssql",
+					"properties": map[string]interface{}{
+						"host":        host,
+						"port":        typedDS.Port,
+						"database":    typedDS.Database,
+						"user":        typedDS.User,
+						"password":    typedDS.Password,
+						"tds_version": typedDS.TdsVersion,
+						"driver":      typedDS.Driver,
+						"kwargs":      typedDS.Kwargs,
+					},
+				}
 			case *WrenLocalFileDataSource:
 				var url string
 				if opts.UsedByContainer {

--- a/wren-launcher/commands/dbt/data_source.go
+++ b/wren-launcher/commands/dbt/data_source.go
@@ -127,35 +127,6 @@ func convertToPostgresDataSource(conn DbtConnection) (*WrenPostgresDataSource, e
 		User:     conn.User,
 		Password: conn.Password,
 	}
-	// If no port is specified, use PostgreSQL default port
-	if ds.Port == 0 {
-		ds.Port = 5432
-	}
-
-	return ds, nil
-}
-
-func convertToMSSQLDataSource(conn DbtConnection) (*WrenMSSQLDataSource, error) {
-	port := strconv.Itoa(conn.Port)
-	if conn.Port == 0 {
-		port = "1433"
-	}
-
-	host := conn.Server
-	if host == "" {
-		host = conn.Host
-	}
-
-	ds := &WrenMSSQLDataSource{
-		Database:   conn.Database,
-		Host:       host,
-		Port:       port,
-		User:       conn.User,
-		Password:   conn.Password,
-		TdsVersion: "8.0",                           // the default tds version for Wren engine image
-		Driver:     "ODBC Driver 18 for SQL Server", // the driver used by Wren engine image
-		Kwargs:     map[string]interface{}{"TrustServerCertificate": "YES"},
-	}
 
 	return ds, nil
 }
@@ -465,11 +436,11 @@ func (ds *WrenMSSQLDataSource) Validate() error {
 func (ds *WrenMSSQLDataSource) MapType(sourceType string) string {
 	// This method is not used in WrenMSSQLDataSource, but required by DataSource interface
 	switch strings.ToLower(sourceType) {
-	case "char", "nchar":
+	case charType, "nchar":
 		return charType
 	case varcharType, "nvarchar":
 		return varcharType
-	case "text", "ntext":
+	case textType, "ntext":
 		return textType
 	case "bit", "tinyint":
 		return booleanType

--- a/wren-launcher/commands/dbt/data_source.go
+++ b/wren-launcher/commands/dbt/data_source.go
@@ -141,9 +141,14 @@ func convertToMSSQLDataSource(conn DbtConnection) (*WrenMSSQLDataSource, error) 
 		port = "1433"
 	}
 
+	host := conn.Server
+	if host == "" {
+		host = conn.Host
+	}
+
 	ds := &WrenMSSQLDataSource{
 		Database:   conn.Database,
-		Host:       conn.Server,
+		Host:       host,
 		Port:       port,
 		User:       conn.User,
 		Password:   conn.Password,

--- a/wren-launcher/commands/dbt/data_source_test.go
+++ b/wren-launcher/commands/dbt/data_source_test.go
@@ -826,3 +826,32 @@ func TestMapType(t *testing.T) {
 		})
 	}
 }
+
+// Validator interface for data sources
+type Validator interface {
+	Validate() error
+}
+
+// Helper function to test data source validation
+func testDataSourceValidation(t *testing.T, testName string, validDS Validator, invalidDSCases []struct {
+	name string
+	ds   Validator
+}) {
+	t.Helper()
+
+	t.Run(testName+" valid", func(t *testing.T) {
+		if err := validDS.Validate(); err != nil {
+			t.Errorf("Valid data source validation failed: %v", err)
+
+		}
+	})
+
+	for _, tt := range invalidDSCases {
+		t.Run(testName+" "+tt.name, func(t *testing.T) {
+			if err := tt.ds.Validate(); err == nil {
+				t.Errorf("Expected validation error for %s, but got none", tt.name)
+
+			}
+		})
+	}
+}

--- a/wren-launcher/commands/dbt/data_source_test.go
+++ b/wren-launcher/commands/dbt/data_source_test.go
@@ -220,6 +220,73 @@ func TestFromDbtProfiles_UnsupportedType(t *testing.T) {
 	}
 }
 
+func TestFromMssqlProfiles(t *testing.T) {
+	// Test MSSQL connection conversion
+	profiles := &DbtProfiles{
+		Profiles: map[string]DbtProfile{
+			"test_profile": {
+				Target: "dev",
+				Outputs: map[string]DbtConnection{
+					"dev": {
+						Type:     "sqlserver",
+						Server:   testHost,
+						Port:     1433,
+						Database: "test_db",
+						User:     testUser,
+						Password: testPassword,
+					},
+				},
+			},
+		},
+	}
+
+	dataSources, err := FromDbtProfiles(profiles)
+	if err != nil {
+		t.Fatalf("FromDbtProfiles failed: %v", err)
+	}
+
+	if len(dataSources) != 1 {
+		t.Fatalf("Expected 1 data source, got %d", len(dataSources))
+	}
+
+	ds, ok := dataSources[0].(*WrenMSSQLDataSource)
+	if !ok {
+		t.Fatalf("Expected WrenMSSQLDataSource, got %T", dataSources[0])
+	}
+
+	if ds.Host != testHost {
+		t.Errorf("Expected host '%s', got '%s'", testHost, ds.Host)
+	}
+
+	if ds.Port != "1433" {
+		t.Errorf("Expected port 1433, got %s", ds.Port)
+	}
+
+	if ds.Database != "test_db" {
+		t.Errorf("Expected database 'test_db', got '%s'", ds.Database)
+	}
+
+	if ds.User != testUser {
+		t.Errorf("Expected user '%s', got '%s'", testUser, ds.User)
+	}
+
+	if ds.Password != testPassword {
+		t.Errorf("Expected password '%s', got '%s'", testPassword, ds.Password)
+	}
+
+	if ds.TdsVersion != "8.0" {
+		t.Errorf("Expected TDS version '8.0', got '%s'", ds.TdsVersion)
+	}
+
+	if ds.Driver != "ODBC Driver 18 for SQL Server" {
+		t.Errorf("Expected driver 'ODBC Driver 18 for SQL Server', got '%s'", ds.Driver)
+	}
+
+	if ds.Kwargs["TrustServerCertificate"] != "YES" {
+		t.Errorf("Expected TrustServerCertificate 'YES', got '%s'", ds.Kwargs["TrustServerCertificate"])
+	}
+}
+
 func TestFromDbtProfiles_NilProfiles(t *testing.T) {
 	// Test nil profiles
 	_, err := FromDbtProfiles(nil)

--- a/wren-launcher/commands/dbt/profiles.go
+++ b/wren-launcher/commands/dbt/profiles.go
@@ -16,6 +16,7 @@ type DbtProfile struct {
 type DbtConnection struct {
 	Type     string `yaml:"type" json:"type"`
 	Host     string `yaml:"host,omitempty" json:"host,omitempty"`
+	Server   string `yaml:"server,omitempty" json:"server,omitempty"` // MSSQL
 	Port     int    `yaml:"port,omitempty" json:"port,omitempty"`
 	User     string `yaml:"user,omitempty" json:"user,omitempty"`
 	Password string `yaml:"password,omitempty" json:"password,omitempty"`

--- a/wren-launcher/commands/dbt/profiles_analyzer.go
+++ b/wren-launcher/commands/dbt/profiles_analyzer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
@@ -105,6 +106,12 @@ func parseConnection(connectionMap map[string]interface{}) (*DbtConnection, erro
 				return v
 			case float64:
 				return int(v)
+			case int64:
+				return int(v)
+			case string:
+				if i, err := strconv.Atoi(v); err == nil {
+					return i
+				}
 			}
 		}
 		return 0

--- a/wren-launcher/commands/dbt/profiles_analyzer.go
+++ b/wren-launcher/commands/dbt/profiles_analyzer.go
@@ -143,13 +143,14 @@ func parseConnection(connectionMap map[string]interface{}) (*DbtConnection, erro
 	connection.SSLMode = getString("sslmode")
 	connection.Path = getString("path")
 	connection.SslDisable = getBool("ssl_disable") // MySQL specific
+	connection.Server = getString("server")
 
 	// Store any additional fields that weren't mapped
 	knownFields := map[string]bool{
 		"type": true, "host": true, "port": true, "user": true, "password": true,
 		"database": true, "dbname": true, "schema": true, "project": true, "dataset": true,
 		"keyfile": true, "method": true, "account": true, "warehouse": true, "role": true,
-		"keepalive": true, "search_path": true, "sslmode": true, "path": true, "ssl_disable": true,
+		"keepalive": true, "search_path": true, "sslmode": true, "path": true, "server": true, "ssl_disable": true,
 	}
 
 	for key, value := range connectionMap {


### PR DESCRIPTION
- Reopen #1887 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added end-to-end support for Microsoft SQL Server (MSSQL) data sources in dbt profile conversion.
  * Recognizes “sqlserver” profiles and maps MSSQL-specific settings (server/host, port, database, user, password, TDS version, driver, and additional options).
  * Container-aware host handling improves reliability when running inside containers.
  * Enhanced profile parsing to accept the “server” field and more flexible numeric port values.

* Tests
  * Added comprehensive tests for MSSQL profile conversion and validation, including kwargs and TDS handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->