### PR TITLE
feat(wren-ui): Enhance save as view for follow-up questions

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -243,6 +243,7 @@ export type CreateThreadResponseInput = {
 
 export type CreateViewInput = {
   name: Scalars['String'];
+  rephrasedQuestion: Scalars['String'];
   responseId: Scalars['Int'];
 };
 

--- a/wren-ui/src/apollo/server/resolvers/modelResolver.ts
+++ b/wren-ui/src/apollo/server/resolvers/modelResolver.ts
@@ -802,7 +802,7 @@ export class ModelResolver {
 
   // create view from sql of a response
   public async createView(_root: any, args: any, ctx: IContext) {
-    const { name: displayName, responseId } = args.data;
+    const { name: displayName, responseId, rephrasedQuestion } = args.data;
 
     // validate view name
     const validateResult = await this.validateViewName(displayName, ctx);
@@ -842,7 +842,7 @@ export class ModelResolver {
 
       // properties from the thread response
       responseId, // helpful for mapping back to the thread response
-      question: response.question,
+      question: rephrasedQuestion,
     };
 
     const eventName = TelemetryEvent.HOME_CREATE_VIEW;

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -436,6 +436,7 @@ export const typeDefs = gql`
   input CreateViewInput {
     name: String!
     responseId: Int!
+    rephrasedQuestion: String!
   }
 
   input ValidateViewInput {

--- a/wren-ui/src/components/modals/SaveAsViewModal.tsx
+++ b/wren-ui/src/components/modals/SaveAsViewModal.tsx
@@ -10,10 +10,11 @@ const { Text } = Typography;
 type Props = ModalAction<{ sql: string }> & {
   loading?: boolean;
   defaultValue: { sql: string; responseId: number };
+  payload: { rephrasedQuestion: string };
 };
 
 export default function SaveAsViewModal(props: Props) {
-  const { visible, loading, onSubmit, onClose, defaultValue } = props;
+  const { visible, loading, onSubmit, onClose, defaultValue, payload } = props;
   const [form] = Form.useForm();
   const [validateViewMutation] = useValidateViewMutation({
     fetchPolicy: 'no-cache',
@@ -23,7 +24,11 @@ export default function SaveAsViewModal(props: Props) {
     form
       .validateFields()
       .then(async (values) => {
-        await onSubmit({ responseId: defaultValue.responseId, ...values });
+        await onSubmit({
+          responseId: defaultValue.responseId,
+          ...payload,
+          ...values,
+        });
         onClose();
       })
       .catch(console.error);

--- a/wren-ui/src/components/pages/home/promptThread/index.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/index.tsx
@@ -57,6 +57,7 @@ const AnswerResultTemplate: React.FC<
       {index > 0 && <Divider />}
       <AnswerResult
         motion={motion}
+        isOpeningQuestion={index === 0}
         isLastThreadResponse={isLastThreadResponse}
         onInitPreviewDone={onInitPreviewDone}
         threadResponse={threadResponse}

--- a/wren-ui/src/components/pages/home/promptThread/store.tsx
+++ b/wren-ui/src/components/pages/home/promptThread/store.tsx
@@ -21,7 +21,10 @@ export type IPromptThreadStore = {
     onFixSQLStatement?: (responseId: number, sql: string) => Promise<void>;
     fixStatementLoading?: boolean;
   };
-  onOpenSaveAsViewModal: (data: { sql: string; responseId: number }) => void;
+  onOpenSaveAsViewModal: (
+    data: { sql: string; responseId: number },
+    payload: { rephrasedQuestion: string },
+  ) => void;
   onSelectRecommendedQuestion: ({
     question,
     sql,


### PR DESCRIPTION
## Description
This PR enhances when saving query results as Views. For follow-up questions, we will use the rephrased question (AI-rewritten question).

## Implementation
The implementation uses client-side decision-making, where the frontend determines whether it's an opening question and passes the corresponding question text (original or rephrased) to the backend via GraphQL mutation.

### Improve Question Handling Logic When Creating Views

#### Changes

**Core Changes:**
- Added `rephrasedQuestion` parameter to `CreateViewInput` to allow frontend to explicitly specify the question text to save
- Modified `createView` resolver to use the passed `rephrasedQuestion` instead of directly using `response.question`

**Frontend Logic Optimization:**
- Added `isOpeningQuestion` prop to `AnswerResult` component to determine if it's an opening question
- Implemented smart question selection logic:
  - **Opening Question**: Uses original question text
  - **Follow-up Question**: Uses rephrased question text (includes full context)
- Updated `SaveAsViewModal` to receive and pass through the `rephrasedQuestion` parameter

#### Technical Details

**Modified Files:**
1. `wren-ui/src/apollo/server/schema.ts` - GraphQL schema definition
2. `wren-ui/src/apollo/server/resolvers/modelResolver.ts` - Resolver implementation
3. `wren-ui/src/apollo/client/graphql/__types__.ts` - TypeScript type definitions
4. `wren-ui/src/components/pages/home/promptThread/AnswerResult.tsx` - Main logic implementation
5. `wren-ui/src/components/pages/home/promptThread/index.tsx` - Props passing
6. `wren-ui/src/components/pages/home/promptThread/store.tsx` - Store type definitions
7. `wren-ui/src/components/modals/SaveAsViewModal.tsx` - Modal component update

## Screenshots or Recordings
### Opening Question (First thread response) -> (save as view with question)
<img width="1919" height="965" alt="截圖 2025-10-21 上午10 43 54" src="https://github.com/user-attachments/assets/7655f8a3-f39d-4166-aa55-7f25aee6ae34" />


<img width="1919" height="965" alt="截圖 2025-10-21 上午10 45 16" src="https://github.com/user-attachments/assets/e2eab2cf-2d4e-43d2-9ef7-ab41bea46ee1" />

### Follow-up Question WITH rephrased Question -> (save as view with rephrased question)
<img width="1919" height="965" alt="截圖 2025-10-21 上午10 47 16" src="https://github.com/user-attachments/assets/ff1bee12-44b4-48da-ac4b-c87ca511c46b" />

<img width="1919" height="965" alt="截圖 2025-10-21 上午10 50 21" src="https://github.com/user-attachments/assets/14d783e9-3d15-4c61-8f4c-4daee7c36ba6" />


#### Testing
Recommended test scenarios:
1. Create a View from an opening question and verify it uses the original question text
2. Create a View from a follow-up question and verify it uses the rephrased question text
3. Verify that the created View stores the correct question text in the database

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rephrased question support: When saving views from conversation results, the system now captures and uses rephrased versions of opening questions, providing improved clarity and better context for saved queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->