### PR TITLE
Feat(wren-ui): add Turkish (TR) language support

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -1127,6 +1127,7 @@ export enum ProjectLanguage {
   NL = 'NL',
   PT = 'PT',
   RU = 'RU',
+  TR = 'TR',
   ZH_CN = 'ZH_CN',
   ZH_TW = 'ZH_TW'
 }

--- a/wren-ui/src/apollo/server/models/adaptor.ts
+++ b/wren-ui/src/apollo/server/models/adaptor.ts
@@ -44,6 +44,7 @@ export enum WrenAILanguage {
   FA_IR = 'Persian',
   AR = 'Arabic',
   NL = 'Dutch',
+  TR = 'Turkish'
 }
 
 export interface DeployData {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -130,7 +130,8 @@ export const typeDefs = gql`
     IT
     FA_IR
     AR
-    NL
+    NL,
+    TR
   }
 
   type DataSource {

--- a/wren-ui/src/utils/language.ts
+++ b/wren-ui/src/utils/language.ts
@@ -16,4 +16,5 @@ export const getLanguageText = (language: ProjectLanguage) =>
     [ProjectLanguage.FA_IR]: 'Persian',
     [ProjectLanguage.AR]: 'Arabic',
     [ProjectLanguage.NL]: 'Dutch',
+    [ProjectLanguage.TR]: 'Turkish'
   })[language] || language;


### PR DESCRIPTION
This commit adds Turkish (TR) language support across the wren-ui project.

Changes include:
- Added TR = 'TR' to ProjectLanguage enum in __types__.ts
- Added TR = 'Turkish' to WrenAILanguage enum in adaptor.ts
- Added TR to GraphQL ProjectLanguage enum in schema.ts
- Mapped ProjectLanguage.TR to 'Turkish' in getLanguageText (language.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Turkish language support is now available as a selectable language option in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->