### PR TITLE
fix(wren-ai-service): respect user response_format override in intent_classification pipeline

### DIFF
--- a/wren-ai-service/src/pipelines/generation/intent_classification.py
+++ b/wren-ai-service/src/pipelines/generation/intent_classification.py
@@ -346,6 +346,16 @@ class IntentClassification(BasicPipeline):
         table_column_retrieval_size: Optional[int] = 100,
         **kwargs,
     ):
+        # User config must fully override defaults (e.g. response_format for non-OpenAI providers)
+        user_kwargs = llm_provider.get_model_kwargs() or {}
+        model_kwargs = dict(INTENT_CLASSIFICAION_MODEL_KWARGS)
+        if "response_format" in user_kwargs:
+            model_kwargs.pop("response_format", None)
+        model_kwargs.update(user_kwargs)
+
+        if model_kwargs.get("response_format") is None:
+            logger.info("Structured output disabled for intent classification")
+
         self._components = {
             "embedder": embedder_provider.get_text_embedder(),
             "table_retriever": document_store_provider.get_retriever(
@@ -358,7 +368,7 @@ class IntentClassification(BasicPipeline):
             ),
             "generator": llm_provider.get_generator(
                 system_prompt=intent_classification_system_prompt,
-                generation_kwargs=INTENT_CLASSIFICAION_MODEL_KWARGS,
+                generation_kwargs=model_kwargs,
             ),
             "generator_name": llm_provider.get_model(),
             "prompt_builder": PromptBuilder(


### PR DESCRIPTION
### Summary

This PR fixes an issue where the intent_classification pipeline always injects
OpenAI-only structured output defaults (`json_schema`), even when users
override `response_format` in config.

### Details

Qwen-compatible API servers do not support OpenAI structured output and
disconnect when receiving unsupported parameters. The current merge logic
overwrites user-provided kwargs, making it impossible to disable structured
output.

This change ensures user configuration fully overrides defaults, allowing
non-OpenAI providers to function correctly.

### Impact

- Fixes Qwen / LiteLLM compatibility
- Respects config precedence
- Preserves backward compatibility for OpenAI users

Closes #2113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Intent classification configuration now supports user and provider-supplied model parameters. Custom settings take priority over hard-coded defaults, enabling more granular control over intent classification behavior. Response format handling has been improved to prevent conflicts between custom and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->