### PR TITLE
fix(wren-ui): resolve CVE-2026-25896 by upgrading fast-xml-parser to 4.5.4

### DIFF
--- a/wren-ui/package.json
+++ b/wren-ui/package.json
@@ -104,7 +104,8 @@
     "jws": "4.0.1",
     "tar": "7.5.7",
     "vega-selections": "6.1.2",
-    "vega-functions": "6.1.1"
+    "vega-functions": "6.1.1",
+    "fast-xml-parser": "4.5.4"
   },
   "_moduleAliases": {
     "@server": "src/apollo/server"

--- a/wren-ui/yarn.lock
+++ b/wren-ui/yarn.lock
@@ -7568,14 +7568,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.2.2":
-  version: 4.4.1
-  resolution: "fast-xml-parser@npm:4.4.1"
+"fast-xml-parser@npm:4.5.4":
+  version: 4.5.4
+  resolution: "fast-xml-parser@npm:4.5.4"
   dependencies:
     strnum: "npm:^1.0.5"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/7f334841fe41bfb0bf5d920904ccad09cefc4b5e61eaf4c225bf1e1bb69ee77ef2147d8942f783ee8249e154d1ca8a858e10bda78a5d78b8bed3f48dcee9bf33
+  checksum: 10c0/7989148650fc1fce988798b62467f7dee0fd5a7ad049373e00e65fbc68f689c119975d03da32c427f0a1f5aad01de2efbd783a48dcdaf3ca41817a8b161ad3e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert [#211](https://github.com/Canner/WrenAI/security/dependabot/211) (CVE-2026-25896, **critical**)
- Adds a yarn `resolutions` entry to force `fast-xml-parser` from `4.4.1` → `4.5.4`, fixing an entity encoding bypass via regex injection in DOCTYPE entity names
- The vulnerable package is a transitive dependency of `@google-cloud/storage@6.12.0`

## Test plan
- [x] `yarn install` succeeds without errors
- [x] `yarn why fast-xml-parser` confirms version `4.5.4`
- [x] CI passes (lint, type-check, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package dependency resolutions to ensure application stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->