### PR TITLE
chore(wren-ui): upgrade lodash to 4.17.23 to fix CVE-2025-13465

### DIFF
--- a/wren-ui/package.json
+++ b/wren-ui/package.json
@@ -25,7 +25,7 @@
     "graphql": "^16.6.0",
     "graphql-type-json": "^0.3.2",
     "knex": "^3.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "log4js": "^6.9.1",
     "micro": "^9.4.1",
     "micro-cors": "^0.1.1",
@@ -105,7 +105,8 @@
     "tar": "7.5.7",
     "vega-selections": "6.1.2",
     "vega-functions": "6.1.1",
-    "fast-xml-parser": "4.5.4"
+    "fast-xml-parser": "4.5.4",
+    "lodash": "4.17.23"
   },
   "_moduleAliases": {
     "@server": "src/apollo/server"

--- a/wren-ui/yarn.lock
+++ b/wren-ui/yarn.lock
@@ -10088,10 +10088,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:~4.17.0":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+"lodash@npm:4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 
@@ -15970,7 +15970,7 @@ __metadata:
     knex: "npm:^3.1.0"
     less: "npm:^4.2.0"
     less-loader: "npm:^12.2.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     log4js: "npm:^6.9.1"
     micro: "npm:^9.4.1"
     micro-cors: "npm:^0.1.1"


### PR DESCRIPTION
## Summary
- Upgrades `lodash` from 4.17.21 to 4.17.23 to resolve prototype pollution vulnerability in `_.unset` and `_.omit`
- Adds `lodash` resolution to force all transitive dependencies to the patched version
- Fixes [Dependabot alert #174](https://github.com/Canner/WrenAI/security/dependabot/174) (CVE-2025-13465, GHSA-xxjr-mmjv-4gpg, medium severity)

## Test plan
- [x] `yarn install` succeeds, all lodash instances resolve to 4.17.23
- [x] `yarn check-types` shows no new errors (pre-existing vega-lite type errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lodash dependency from version 4.17.21 to 4.17.23 for improved stability and security.
  * Configured dependency resolution to ensure consistent library versioning across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->