### PR TITLE
chore(wren-ui): fix page size selector not working on SQL pairs table

### DIFF
--- a/wren-ui/src/pages/knowledge/question-sql-pairs.tsx
+++ b/wren-ui/src/pages/knowledge/question-sql-pairs.tsx
@@ -166,7 +166,9 @@ export default function ManageQuestionSQLPairs() {
           rowKey="id"
           pagination={{
             hideOnSinglePage: true,
-            pageSize: 10,
+            defaultPageSize: 10,
+            showSizeChanger: true,
+            pageSizeOptions: ['10', '20', '50', '100'],
             size: 'small',
           }}
           scroll={{ x: 1080 }}


### PR DESCRIPTION
## Problem
The page size dropdown on the SQL Pairs management page (`/knowledge/question-sql-pairs`) is visible but non-functional — selecting 20, 50, or 100 has no effect and the table always shows 10 rows.

<img width="354" height="282" alt="image" src="https://github.com/user-attachments/assets/787d1333-408c-4822-bc36-0e61442f59af" />

## Cause
`pageSize: 10` was hardcoded in the Ant Design `Table` pagination config, which overrides user selection on every render.

## Fix
Replace `pageSize` with `defaultPageSize` and explicitly enable `showSizeChanger` with `pageSizeOptions` so the dropdown works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable page size selector in table pagination, allowing users to display 10, 20, 50, or 100 items per page with a default of 10 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->