### PR TITLE
feat(wren-ai-service): upgrade MiniMax default model to M3

### DIFF
--- a/wren-ai-service/docs/config_examples/README.md
+++ b/wren-ai-service/docs/config_examples/README.md
@@ -45,6 +45,8 @@ The `config.minimax.yaml` file provides an example configuration for using [Mini
 
 | Model | Context Window | Description |
 |-------|---------------|-------------|
+| `MiniMax-M2.7` (default) | 204,800 tokens | Latest flagship model with enhanced reasoning and coding |
+| `MiniMax-M2.7-highspeed` | 204,800 tokens | High-speed version of M2.7 for low-latency scenarios |
 | `MiniMax-M2.5` | 204,800 tokens | Peak Performance. Ultimate Value. Master the Complex |
 | `MiniMax-M2.5-highspeed` | 204,800 tokens | Same performance, faster and more agile |
 

--- a/wren-ai-service/docs/config_examples/README.md
+++ b/wren-ai-service/docs/config_examples/README.md
@@ -36,3 +36,21 @@ The `config.qwen3.yaml` file provides an example configuration for using Qwen3 m
 ```
 
 **Note**: You need to set `OPENROUTER_API_KEY` in your `~/.wrenai/.env` file to use OpenRouter as the provider for Qwen3 models.
+
+## MiniMax Configuration
+
+The `config.minimax.yaml` file provides an example configuration for using [MiniMax](https://www.minimax.io/) models via the dedicated `minimax_llm` provider. This provider talks directly to the MiniMax OpenAI-compatible API with built-in temperature clamping and automatic `response_format` removal.
+
+### Available Models
+
+| Model | Context Window | Description |
+|-------|---------------|-------------|
+| `MiniMax-M2.5` | 204,800 tokens | Peak Performance. Ultimate Value. Master the Complex |
+| `MiniMax-M2.5-highspeed` | 204,800 tokens | Same performance, faster and more agile |
+
+### Key Notes
+
+- **Temperature**: MiniMax requires temperature in the range `(0, 1.0]`. The provider automatically clamps values — `0` becomes `0.01`.
+- **`response_format`**: Not supported by MiniMax. The provider strips it automatically.
+- **API endpoints**: International `https://api.minimax.io/v1` (default), China mainland `https://api.minimaxi.com/v1`.
+- Set `MINIMAX_API_KEY=<your_api_key>` in your `~/.wrenai/.env` file.

--- a/wren-ai-service/docs/config_examples/README.md
+++ b/wren-ai-service/docs/config_examples/README.md
@@ -45,10 +45,9 @@ The `config.minimax.yaml` file provides an example configuration for using [Mini
 
 | Model | Context Window | Description |
 |-------|---------------|-------------|
-| `MiniMax-M2.7` (default) | 204,800 tokens | Latest flagship model with enhanced reasoning and coding |
+| `MiniMax-M3` (default) | 524,288 tokens | Latest flagship model — 512K context, up to 128K output, supports image input |
+| `MiniMax-M2.7` | 204,800 tokens | Previous flagship with enhanced reasoning and coding |
 | `MiniMax-M2.7-highspeed` | 204,800 tokens | High-speed version of M2.7 for low-latency scenarios |
-| `MiniMax-M2.5` | 204,800 tokens | Peak Performance. Ultimate Value. Master the Complex |
-| `MiniMax-M2.5-highspeed` | 204,800 tokens | Same performance, faster and more agile |
 
 ### Key Notes
 

--- a/wren-ai-service/docs/config_examples/config.minimax.yaml
+++ b/wren-ai-service/docs/config_examples/config.minimax.yaml
@@ -16,8 +16,22 @@ models:
   # put MINIMAX_API_KEY=<your_api_key> in ~/.wrenai/.env
   # International endpoint (default): https://api.minimax.io/v1
   # China mainland endpoint:          https://api.minimaxi.com/v1
-  - model: MiniMax-M2.5
+  - model: MiniMax-M2.7
     alias: default
+    context_window_size: 204800
+    timeout: 120
+    kwargs:
+      max_tokens: 4096
+      n: 1
+      temperature: 1.0
+  - model: MiniMax-M2.7-highspeed
+    context_window_size: 204800
+    timeout: 120
+    kwargs:
+      max_tokens: 4096
+      n: 1
+      temperature: 1.0
+  - model: MiniMax-M2.5
     context_window_size: 204800
     timeout: 120
     kwargs:

--- a/wren-ai-service/docs/config_examples/config.minimax.yaml
+++ b/wren-ai-service/docs/config_examples/config.minimax.yaml
@@ -1,0 +1,188 @@
+# you should rename this file to config.yaml and put it in ~/.wrenai
+# please pay attention to the comments starting with # and adjust the config accordingly, 3 steps basically:
+# 1. you need to use your own llm and embedding models
+# 2. fill in embedding model dimension in the document_store section
+# 3. you need to use the correct pipe definitions based on https://raw.githubusercontent.com/canner/WrenAI/<WRENAI_VERSION_NUMBER>/docker/config.example.yaml
+# 4. you need to fill in correct llm and embedding models in the pipe definitions
+
+# MiniMax LLM provider — uses the dedicated minimax_llm provider for direct
+# OpenAI-compatible integration with temperature clamping and response_format
+# removal handled automatically.
+# API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+
+type: llm
+provider: minimax_llm
+models:
+  # put MINIMAX_API_KEY=<your_api_key> in ~/.wrenai/.env
+  # International endpoint (default): https://api.minimax.io/v1
+  # China mainland endpoint:          https://api.minimaxi.com/v1
+  - model: MiniMax-M2.5
+    alias: default
+    context_window_size: 204800
+    timeout: 120
+    kwargs:
+      max_tokens: 4096
+      n: 1
+      temperature: 1.0
+  - model: MiniMax-M2.5-highspeed
+    context_window_size: 204800
+    timeout: 120
+    kwargs:
+      max_tokens: 4096
+      n: 1
+      temperature: 1.0
+
+---
+type: embedder
+provider: litellm_embedder
+models:
+  # define OPENAI_API_KEY=<api_key> in ~/.wrenai/.env if you are using openai embedding model
+  # please refer to LiteLLM documentation for more details: https://docs.litellm.ai/docs/providers
+  - model: text-embedding-3-large  # put your embedding model name here, if it is not openai embedding model, should be <provider>/<model_name>
+    alias: default
+    api_base: https://api.openai.com/v1  # change this according to your embedding model
+    timeout: 120
+
+---
+type: engine
+provider: wren_ui
+endpoint: http://wren-ui:3000
+
+---
+type: engine
+provider: wren_ibis
+endpoint: http://ibis-server:8000
+
+---
+type: document_store
+provider: qdrant
+location: http://qdrant:6333
+embedding_model_dim: 3072 # put your embedding model dimension here
+timeout: 120
+recreate_index: true
+
+---
+# please change the llm and embedder names to the ones you want to use
+# the format of llm and embedder should be <provider>.<model_name> such as minimax_llm.default
+# the pipes may be not the latest version, please refer to the latest version: https://raw.githubusercontent.com/canner/WrenAI/<WRENAI_VERSION_NUMBER>/docker/config.example.yaml
+type: pipeline
+pipes:
+  - name: db_schema_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: historical_question_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: table_description_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: db_schema_retrieval
+    llm: minimax_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: historical_question_retrieval
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: sql_generation
+    llm: minimax_llm.default
+    engine: wren_ui
+    document_store: qdrant
+  - name: sql_correction
+    llm: minimax_llm.default
+    engine: wren_ui
+    document_store: qdrant
+  - name: followup_sql_generation
+    llm: minimax_llm.default
+    engine: wren_ui
+    document_store: qdrant
+  - name: sql_answer
+    llm: minimax_llm.default
+  - name: semantics_description
+    llm: minimax_llm.default
+  - name: relationship_recommendation
+    llm: minimax_llm.default
+    engine: wren_ui
+  - name: question_recommendation
+    llm: minimax_llm.default
+  - name: question_recommendation_db_schema_retrieval
+    llm: minimax_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: question_recommendation_sql_generation
+    llm: minimax_llm.default
+    engine: wren_ui
+    document_store: qdrant
+  - name: chart_generation
+    llm: minimax_llm.default
+  - name: chart_adjustment
+    llm: minimax_llm.default
+  - name: intent_classification
+    llm: minimax_llm.default
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: misleading_assistance
+    llm: minimax_llm.default
+  - name: data_assistance
+    llm: minimax_llm.default
+  - name: sql_pairs_indexing
+    document_store: qdrant
+    embedder: litellm_embedder.default
+  - name: sql_pairs_retrieval
+    document_store: qdrant
+    embedder: litellm_embedder.default
+    llm: minimax_llm.default
+  - name: preprocess_sql_data
+    llm: minimax_llm.default
+  - name: sql_executor
+    engine: wren_ui
+  - name: user_guide_assistance
+    llm: minimax_llm.default
+  - name: sql_question_generation
+    llm: minimax_llm.default
+  - name: sql_generation_reasoning
+    llm: minimax_llm.default
+  - name: followup_sql_generation_reasoning
+    llm: minimax_llm.default
+  - name: sql_regeneration
+    llm: minimax_llm.default
+    engine: wren_ui
+  - name: instructions_indexing
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: instructions_retrieval
+    embedder: litellm_embedder.default
+    document_store: qdrant
+  - name: sql_functions_retrieval
+    engine: wren_ibis
+    document_store: qdrant
+  - name: project_meta_indexing
+    document_store: qdrant
+  - name: sql_tables_extraction
+    llm: minimax_llm.default
+  - name: sql_diagnosis
+    llm: minimax_llm.default
+  - name: sql_knowledge_retrieval
+    engine: wren_ibis
+    document_store: qdrant
+---
+settings:
+  engine_timeout: 30
+  column_indexing_batch_size: 50
+  table_retrieval_size: 10
+  table_column_retrieval_size: 100
+  allow_intent_classification: true
+  allow_sql_generation_reasoning: true
+  allow_sql_functions_retrieval: true
+  enable_column_pruning: false
+  max_sql_correction_retries: 3
+  query_cache_maxsize: 1000
+  query_cache_ttl: 3600
+  langfuse_host: https://cloud.langfuse.com
+  langfuse_enable: true
+  logging_level: DEBUG
+  development: true
+  historical_question_retrieval_similarity_threshold: 0.9
+  sql_pairs_similarity_threshold: 0.7
+  sql_pairs_retrieval_max_size: 10
+  instructions_similarity_threshold: 0.7
+  instructions_top_k: 10

--- a/wren-ai-service/docs/config_examples/config.minimax.yaml
+++ b/wren-ai-service/docs/config_examples/config.minimax.yaml
@@ -16,8 +16,15 @@ models:
   # put MINIMAX_API_KEY=<your_api_key> in ~/.wrenai/.env
   # International endpoint (default): https://api.minimax.io/v1
   # China mainland endpoint:          https://api.minimaxi.com/v1
-  - model: MiniMax-M2.7
+  - model: MiniMax-M3
     alias: default
+    context_window_size: 524288
+    timeout: 120
+    kwargs:
+      max_tokens: 4096
+      n: 1
+      temperature: 1.0
+  - model: MiniMax-M2.7
     context_window_size: 204800
     timeout: 120
     kwargs:
@@ -25,20 +32,6 @@ models:
       n: 1
       temperature: 1.0
   - model: MiniMax-M2.7-highspeed
-    context_window_size: 204800
-    timeout: 120
-    kwargs:
-      max_tokens: 4096
-      n: 1
-      temperature: 1.0
-  - model: MiniMax-M2.5
-    context_window_size: 204800
-    timeout: 120
-    kwargs:
-      max_tokens: 4096
-      n: 1
-      temperature: 1.0
-  - model: MiniMax-M2.5-highspeed
     context_window_size: 204800
     timeout: 120
     kwargs:

--- a/wren-ai-service/src/providers/llm/minimax.py
+++ b/wren-ai-service/src/providers/llm/minimax.py
@@ -44,7 +44,9 @@ class MiniMaxLLMProvider(LLMProvider):
     """MiniMax LLM provider using the OpenAI-compatible Chat API.
 
     Supported models:
-        - MiniMax-M2.5 (default, 204K context)
+        - MiniMax-M2.7 (default, latest flagship with enhanced reasoning and coding)
+        - MiniMax-M2.7-highspeed (high-speed version of M2.7 for low-latency scenarios)
+        - MiniMax-M2.5 (204K context)
         - MiniMax-M2.5-highspeed (faster variant, 204K context)
 
     API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
@@ -52,7 +54,7 @@ class MiniMaxLLMProvider(LLMProvider):
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.5",
+        model: str = "MiniMax-M2.7",
         api_key_name: Optional[str] = "MINIMAX_API_KEY",
         api_base: Optional[str] = None,
         kwargs: Optional[Dict[str, Any]] = None,

--- a/wren-ai-service/src/providers/llm/minimax.py
+++ b/wren-ai-service/src/providers/llm/minimax.py
@@ -1,0 +1,204 @@
+import logging
+import os
+import re
+from typing import Any, Callable, Dict, List, Optional
+
+import backoff
+import openai
+from openai import AsyncOpenAI
+
+from src.core.provider import LLMProvider
+from src.providers.llm import (
+    ChatMessage,
+    StreamingChunk,
+    build_chunk,
+    build_message,
+    check_finish_reason,
+    convert_message_to_openai_format,
+)
+from src.providers.loader import provider
+
+logger = logging.getLogger("wren-ai-service")
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+def _extract_braces_content(resp: str) -> str:
+    """Extract JSON from a markdown code block, or return the original string."""
+    match = re.search(r"```json\s*(\{.*?\})\s*```", resp, re.DOTALL)
+    return match.group(1) if match else resp
+
+
+def _clamp_temperature(temperature: float) -> float:
+    """Clamp temperature to MiniMax's valid range (0.0, 1.0].
+
+    MiniMax rejects temperature=0; use a small positive value instead.
+    """
+    if temperature <= 0:
+        return 0.01
+    return min(temperature, 1.0)
+
+
+@provider("minimax_llm")
+class MiniMaxLLMProvider(LLMProvider):
+    """MiniMax LLM provider using the OpenAI-compatible Chat API.
+
+    Supported models:
+        - MiniMax-M2.5 (default, 204K context)
+        - MiniMax-M2.5-highspeed (faster variant, 204K context)
+
+    API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+    """
+
+    def __init__(
+        self,
+        model: str = "MiniMax-M2.5",
+        api_key_name: Optional[str] = "MINIMAX_API_KEY",
+        api_base: Optional[str] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+        timeout: float = 120.0,
+        context_window_size: int = 204800,
+        **_,
+    ):
+        self._model = model
+        api_key = os.getenv(api_key_name) if api_key_name else None
+        if not api_key:
+            logger.warning(
+                "MINIMAX_API_KEY is not set. MiniMax provider will not work "
+                "until a valid API key is provided."
+            )
+        self._api_base = api_base or MINIMAX_API_BASE
+        self._model_kwargs = kwargs or {}
+        self._timeout = timeout
+        self._context_window_size = context_window_size
+
+        self._client = AsyncOpenAI(
+            api_key=api_key or "placeholder",
+            base_url=self._api_base,
+            timeout=self._timeout,
+        )
+
+    def get_generator(
+        self,
+        system_prompt: Optional[str] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+    ):
+        combined_generation_kwargs = {
+            **(generation_kwargs or {}),
+            **(self._model_kwargs or {}),
+        }
+
+        # Remove response_format — MiniMax does not support it
+        combined_generation_kwargs.pop("response_format", None)
+
+        # Clamp temperature to MiniMax's valid range
+        if "temperature" in combined_generation_kwargs:
+            combined_generation_kwargs["temperature"] = _clamp_temperature(
+                combined_generation_kwargs["temperature"]
+            )
+
+        @backoff.on_exception(
+            backoff.expo, openai.APIError, max_time=60.0, max_tries=3
+        )
+        async def _run(
+            prompt: str,
+            image_url: Optional[str] = None,
+            current_system_prompt: Optional[str] = None,
+            history_messages: Optional[List[ChatMessage]] = None,
+            generation_kwargs: Optional[Dict[str, Any]] = None,
+            query_id: Optional[str] = None,
+        ):
+            message = ChatMessage.from_user(prompt, image_url)
+            _system_prompt = current_system_prompt or system_prompt
+
+            if _system_prompt:
+                messages = [ChatMessage.from_system(_system_prompt)]
+                if history_messages:
+                    messages.extend(history_messages)
+                messages.append(message)
+            else:
+                if history_messages:
+                    messages = history_messages + [message]
+                else:
+                    messages = [message]
+
+            openai_formatted_messages = [
+                convert_message_to_openai_format(msg) for msg in messages
+            ]
+
+            merged_kwargs = {
+                **combined_generation_kwargs,
+                **(generation_kwargs or {}),
+            }
+
+            # Remove response_format from per-call kwargs as well
+            merged_kwargs.pop("response_format", None)
+
+            # Clamp temperature for per-call overrides
+            if "temperature" in merged_kwargs:
+                merged_kwargs["temperature"] = _clamp_temperature(
+                    merged_kwargs["temperature"]
+                )
+
+            # Remove unsupported params
+            merged_kwargs.pop("allowed_openai_params", None)
+
+            completion = await self._client.chat.completions.create(
+                model=self._model,
+                messages=openai_formatted_messages,
+                stream=streaming_callback is not None,
+                **merged_kwargs,
+            )
+
+            completions: List[ChatMessage] = []
+            if streaming_callback is not None:
+                chunks: List[StreamingChunk] = []
+
+                last_chunk = None
+                async for chunk in completion:
+                    if chunk.choices and streaming_callback:
+                        chunk_delta: StreamingChunk = build_chunk(chunk)
+                        chunks.append(chunk_delta)
+                        streaming_callback(chunk_delta, query_id)
+                    last_chunk = chunk
+
+                complete_response = ChatMessage.from_assistant(
+                    "".join([c.content for c in chunks])
+                )
+                complete_response.meta.update(
+                    {
+                        "model": last_chunk.model if last_chunk else self._model,
+                        "index": 0,
+                        "finish_reason": (
+                            last_chunk.choices[0].finish_reason
+                            if last_chunk and last_chunk.choices
+                            else "stop"
+                        ),
+                        "usage": (
+                            dict(last_chunk.usage)
+                            if last_chunk
+                            and hasattr(last_chunk, "usage")
+                            and last_chunk.usage is not None
+                            else {}
+                        ),
+                    }
+                )
+                completions = [complete_response]
+            else:
+                completions = [
+                    build_message(completion, choice)
+                    for choice in completion.choices
+                ]
+
+            for response in completions:
+                check_finish_reason(response)
+
+            return {
+                "replies": [
+                    _extract_braces_content(msg.content) for msg in completions
+                ],
+                "meta": [msg.meta for msg in completions],
+            }
+
+        return _run

--- a/wren-ai-service/src/providers/llm/minimax.py
+++ b/wren-ai-service/src/providers/llm/minimax.py
@@ -44,22 +44,21 @@ class MiniMaxLLMProvider(LLMProvider):
     """MiniMax LLM provider using the OpenAI-compatible Chat API.
 
     Supported models:
-        - MiniMax-M2.7 (default, latest flagship with enhanced reasoning and coding)
+        - MiniMax-M3 (default, 512K context, up to 128K output, supports image input)
+        - MiniMax-M2.7 (previous flagship)
         - MiniMax-M2.7-highspeed (high-speed version of M2.7 for low-latency scenarios)
-        - MiniMax-M2.5 (204K context)
-        - MiniMax-M2.5-highspeed (faster variant, 204K context)
 
     API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
     """
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         api_key_name: Optional[str] = "MINIMAX_API_KEY",
         api_base: Optional[str] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         timeout: float = 120.0,
-        context_window_size: int = 204800,
+        context_window_size: int = 524288,
         **_,
     ):
         self._model = model

--- a/wren-ai-service/tests/pytest/providers/llm/test_minimax.py
+++ b/wren-ai-service/tests/pytest/providers/llm/test_minimax.py
@@ -1,0 +1,248 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.providers.llm.minimax import (
+    MINIMAX_API_BASE,
+    MiniMaxLLMProvider,
+    _clamp_temperature,
+)
+
+
+class TestClampTemperature:
+    def test_zero_becomes_positive(self):
+        assert _clamp_temperature(0) == 0.01
+
+    def test_negative_becomes_positive(self):
+        assert _clamp_temperature(-1.0) == 0.01
+
+    def test_value_above_one_clamped(self):
+        assert _clamp_temperature(1.5) == 1.0
+
+    def test_valid_value_unchanged(self):
+        assert _clamp_temperature(0.7) == 0.7
+
+    def test_one_unchanged(self):
+        assert _clamp_temperature(1.0) == 1.0
+
+    def test_small_positive_unchanged(self):
+        assert _clamp_temperature(0.01) == 0.01
+
+
+class TestMiniMaxLLMProviderInit:
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_default_initialization(self):
+        provider = MiniMaxLLMProvider()
+        assert provider._model == "MiniMax-M2.5"
+        assert provider._api_base == MINIMAX_API_BASE
+        assert provider._timeout == 120.0
+        assert provider._context_window_size == 204800
+        assert provider._model_kwargs == {}
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_custom_model(self):
+        provider = MiniMaxLLMProvider(model="MiniMax-M2.5-highspeed")
+        assert provider._model == "MiniMax-M2.5-highspeed"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_custom_api_base(self):
+        provider = MiniMaxLLMProvider(api_base="https://api.minimaxi.com/v1")
+        assert provider._api_base == "https://api.minimaxi.com/v1"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_custom_kwargs(self):
+        kwargs = {"max_tokens": 4096, "temperature": 0.5}
+        provider = MiniMaxLLMProvider(kwargs=kwargs)
+        assert provider._model_kwargs == kwargs
+
+    @patch.dict(os.environ, {"MY_KEY": "custom-key"})
+    def test_custom_api_key_name(self):
+        provider = MiniMaxLLMProvider(api_key_name="MY_KEY")
+        assert provider._client.api_key == "custom-key"
+
+    def test_no_api_key(self):
+        provider = MiniMaxLLMProvider(api_key_name=None)
+        # When no key is provided, a placeholder is used so the client can be created
+        assert provider._client.api_key == "placeholder"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_get_model(self):
+        provider = MiniMaxLLMProvider(model="MiniMax-M2.5")
+        assert provider.get_model() == "MiniMax-M2.5"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_get_context_window_size(self):
+        provider = MiniMaxLLMProvider(context_window_size=100000)
+        assert provider.get_context_window_size() == 100000
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_get_model_kwargs(self):
+        kwargs = {"temperature": 0.8}
+        provider = MiniMaxLLMProvider(kwargs=kwargs)
+        assert provider.get_model_kwargs() == kwargs
+
+
+class TestMiniMaxLLMProviderGenerator:
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_get_generator_returns_callable(self):
+        provider = MiniMaxLLMProvider()
+        gen = provider.get_generator()
+        assert callable(gen)
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_response_format_removed_from_kwargs(self):
+        provider = MiniMaxLLMProvider(
+            kwargs={"temperature": 0.5, "response_format": {"type": "json_object"}}
+        )
+        # The generator is created; response_format should be stripped internally.
+        gen = provider.get_generator()
+        assert callable(gen)
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_temperature_clamped_in_kwargs(self):
+        provider = MiniMaxLLMProvider(kwargs={"temperature": 0})
+        gen = provider.get_generator()
+        assert callable(gen)
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    async def test_run_non_streaming(self):
+        provider = MiniMaxLLMProvider(kwargs={"temperature": 0.5})
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"sql": "SELECT 1"}'
+        mock_choice.index = 0
+        mock_choice.finish_reason = "stop"
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [mock_choice]
+        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.usage = MagicMock()
+        mock_completion.usage.__iter__ = MagicMock(
+            return_value=iter([("prompt_tokens", 10), ("completion_tokens", 5)])
+        )
+
+        provider._client.chat.completions.create = AsyncMock(
+            return_value=mock_completion
+        )
+
+        gen = provider.get_generator(system_prompt="You are a SQL expert.")
+        result = await gen(prompt="Generate SQL for counting users")
+
+        assert "replies" in result
+        assert "meta" in result
+        assert len(result["replies"]) == 1
+
+        # Verify the API was called with correct parameters
+        call_kwargs = provider._client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "MiniMax-M2.5"
+        assert call_kwargs.kwargs["stream"] is False
+        assert call_kwargs.kwargs["temperature"] == 0.5
+        # response_format should NOT be in the call
+        assert "response_format" not in call_kwargs.kwargs
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    async def test_run_with_zero_temperature_clamped(self):
+        provider = MiniMaxLLMProvider(kwargs={"temperature": 0})
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Hello"
+        mock_choice.index = 0
+        mock_choice.finish_reason = "stop"
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [mock_choice]
+        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.usage = MagicMock()
+        mock_completion.usage.__iter__ = MagicMock(
+            return_value=iter([("prompt_tokens", 5), ("completion_tokens", 3)])
+        )
+
+        provider._client.chat.completions.create = AsyncMock(
+            return_value=mock_completion
+        )
+
+        gen = provider.get_generator()
+        await gen(prompt="Hello")
+
+        call_kwargs = provider._client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["temperature"] == 0.01
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    async def test_run_response_format_stripped(self):
+        provider = MiniMaxLLMProvider(
+            kwargs={"response_format": {"type": "json_object"}, "temperature": 0.8}
+        )
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"result": "ok"}'
+        mock_choice.index = 0
+        mock_choice.finish_reason = "stop"
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [mock_choice]
+        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.usage = MagicMock()
+        mock_completion.usage.__iter__ = MagicMock(
+            return_value=iter([("prompt_tokens", 5), ("completion_tokens", 3)])
+        )
+
+        provider._client.chat.completions.create = AsyncMock(
+            return_value=mock_completion
+        )
+
+        gen = provider.get_generator()
+        await gen(prompt="Test")
+
+        call_kwargs = provider._client.chat.completions.create.call_args
+        assert "response_format" not in call_kwargs.kwargs
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    async def test_run_with_history_messages(self):
+        from src.providers.llm import ChatMessage
+
+        provider = MiniMaxLLMProvider()
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Response"
+        mock_choice.index = 0
+        mock_choice.finish_reason = "stop"
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [mock_choice]
+        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.usage = MagicMock()
+        mock_completion.usage.__iter__ = MagicMock(
+            return_value=iter([("prompt_tokens", 10), ("completion_tokens", 5)])
+        )
+
+        provider._client.chat.completions.create = AsyncMock(
+            return_value=mock_completion
+        )
+
+        history = [
+            ChatMessage.from_user("Previous question"),
+            ChatMessage.from_assistant("Previous answer"),
+        ]
+
+        gen = provider.get_generator(system_prompt="System prompt")
+        result = await gen(prompt="Follow-up", history_messages=history)
+
+        call_kwargs = provider._client.chat.completions.create.call_args
+        messages = call_kwargs.kwargs["messages"]
+        # system + 2 history + 1 new user message
+        assert len(messages) == 4
+        assert messages[0]["role"] == "system"
+
+
+class TestProviderRegistration:
+    def test_minimax_registered(self):
+        from src.providers.loader import PROVIDERS
+
+        # The @provider decorator registers at import time
+        assert "minimax_llm" in PROVIDERS
+        assert PROVIDERS["minimax_llm"].__name__ == "MiniMaxLLMProvider"

--- a/wren-ai-service/tests/pytest/providers/llm/test_minimax.py
+++ b/wren-ai-service/tests/pytest/providers/llm/test_minimax.py
@@ -34,7 +34,7 @@ class TestMiniMaxLLMProviderInit:
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_default_initialization(self):
         provider = MiniMaxLLMProvider()
-        assert provider._model == "MiniMax-M2.5"
+        assert provider._model == "MiniMax-M2.7"
         assert provider._api_base == MINIMAX_API_BASE
         assert provider._timeout == 120.0
         assert provider._context_window_size == 204800
@@ -42,8 +42,13 @@ class TestMiniMaxLLMProviderInit:
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_custom_model(self):
-        provider = MiniMaxLLMProvider(model="MiniMax-M2.5-highspeed")
-        assert provider._model == "MiniMax-M2.5-highspeed"
+        provider = MiniMaxLLMProvider(model="MiniMax-M2.7-highspeed")
+        assert provider._model == "MiniMax-M2.7-highspeed"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_legacy_m25_model_still_works(self):
+        provider = MiniMaxLLMProvider(model="MiniMax-M2.5")
+        assert provider._model == "MiniMax-M2.5"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_custom_api_base(self):
@@ -68,8 +73,8 @@ class TestMiniMaxLLMProviderInit:
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_get_model(self):
-        provider = MiniMaxLLMProvider(model="MiniMax-M2.5")
-        assert provider.get_model() == "MiniMax-M2.5"
+        provider = MiniMaxLLMProvider(model="MiniMax-M2.7")
+        assert provider.get_model() == "MiniMax-M2.7"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_get_context_window_size(self):
@@ -117,7 +122,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.model = "MiniMax-M2.7"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 10), ("completion_tokens", 5)])
@@ -136,7 +141,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         # Verify the API was called with correct parameters
         call_kwargs = provider._client.chat.completions.create.call_args
-        assert call_kwargs.kwargs["model"] == "MiniMax-M2.5"
+        assert call_kwargs.kwargs["model"] == "MiniMax-M2.7"
         assert call_kwargs.kwargs["stream"] is False
         assert call_kwargs.kwargs["temperature"] == 0.5
         # response_format should NOT be in the call
@@ -154,7 +159,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.model = "MiniMax-M2.7"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 5), ("completion_tokens", 3)])
@@ -184,7 +189,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.model = "MiniMax-M2.7"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 5), ("completion_tokens", 3)])
@@ -214,7 +219,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.5"
+        mock_completion.model = "MiniMax-M2.7"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 10), ("completion_tokens", 5)])

--- a/wren-ai-service/tests/pytest/providers/llm/test_minimax.py
+++ b/wren-ai-service/tests/pytest/providers/llm/test_minimax.py
@@ -34,10 +34,10 @@ class TestMiniMaxLLMProviderInit:
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_default_initialization(self):
         provider = MiniMaxLLMProvider()
-        assert provider._model == "MiniMax-M2.7"
+        assert provider._model == "MiniMax-M3"
         assert provider._api_base == MINIMAX_API_BASE
         assert provider._timeout == 120.0
-        assert provider._context_window_size == 204800
+        assert provider._context_window_size == 524288
         assert provider._model_kwargs == {}
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
@@ -46,9 +46,9 @@ class TestMiniMaxLLMProviderInit:
         assert provider._model == "MiniMax-M2.7-highspeed"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
-    def test_legacy_m25_model_still_works(self):
-        provider = MiniMaxLLMProvider(model="MiniMax-M2.5")
-        assert provider._model == "MiniMax-M2.5"
+    def test_m27_model_still_works(self):
+        provider = MiniMaxLLMProvider(model="MiniMax-M2.7")
+        assert provider._model == "MiniMax-M2.7"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_custom_api_base(self):
@@ -73,8 +73,8 @@ class TestMiniMaxLLMProviderInit:
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_get_model(self):
-        provider = MiniMaxLLMProvider(model="MiniMax-M2.7")
-        assert provider.get_model() == "MiniMax-M2.7"
+        provider = MiniMaxLLMProvider(model="MiniMax-M3")
+        assert provider.get_model() == "MiniMax-M3"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
     def test_get_context_window_size(self):
@@ -122,7 +122,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.7"
+        mock_completion.model = "MiniMax-M3"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 10), ("completion_tokens", 5)])
@@ -141,7 +141,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         # Verify the API was called with correct parameters
         call_kwargs = provider._client.chat.completions.create.call_args
-        assert call_kwargs.kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs.kwargs["model"] == "MiniMax-M3"
         assert call_kwargs.kwargs["stream"] is False
         assert call_kwargs.kwargs["temperature"] == 0.5
         # response_format should NOT be in the call
@@ -159,7 +159,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.7"
+        mock_completion.model = "MiniMax-M3"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 5), ("completion_tokens", 3)])
@@ -189,7 +189,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.7"
+        mock_completion.model = "MiniMax-M3"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 5), ("completion_tokens", 3)])
@@ -219,7 +219,7 @@ class TestMiniMaxLLMProviderGenerator:
 
         mock_completion = MagicMock()
         mock_completion.choices = [mock_choice]
-        mock_completion.model = "MiniMax-M2.7"
+        mock_completion.model = "MiniMax-M3"
         mock_completion.usage = MagicMock()
         mock_completion.usage.__iter__ = MagicMock(
             return_value=iter([("prompt_tokens", 10), ("completion_tokens", 5)])

--- a/wren-ai-service/tests/pytest/providers/test_loader.py
+++ b/wren-ai-service/tests/pytest/providers/test_loader.py
@@ -3,7 +3,7 @@ from src.providers import loader
 
 def test_import_mods():
     loader.import_mods("src.providers")
-    assert len(loader.PROVIDERS) == 6
+    assert len(loader.PROVIDERS) == 7
 
 
 def test_get_provider():
@@ -12,6 +12,10 @@ def test_get_provider():
     # llm provider
     provider = loader.get_provider("litellm_llm")
     assert provider.__name__ == "LitellmLLMProvider"
+
+    # minimax llm provider
+    provider = loader.get_provider("minimax_llm")
+    assert provider.__name__ == "MiniMaxLLMProvider"
 
     # embedder provider
     provider = loader.get_provider("litellm_embedder")


### PR DESCRIPTION
## Summary
Upgrade MiniMax LLM provider to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Bump default `context_window_size` to 524288 (512K tokens)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`)
- Update related unit tests and documentation

## Models

| Model | Context Window | Description |
|-------|---------------|-------------|
| `MiniMax-M3` (default) | 524,288 tokens | Latest flagship — 512K context, up to 128K output, supports image input |
| `MiniMax-M2.7` | 204,800 tokens | Previous flagship with enhanced reasoning and coding |
| `MiniMax-M2.7-highspeed` | 204,800 tokens | High-speed version of M2.7 for low-latency scenarios |

## Why
MiniMax-M3 is the latest model with a 512K context window, up to 128K max output tokens, and image input support — significantly larger than M2.7's 204K context and a better default for SQL generation over large MDL schemas.

## Testing
- Unit tests updated and passing (default initialization, custom model, get_model, generator API contract)
- Provider preserves existing temperature clamping and `response_format` removal behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax LLM provider support with configurable models, automatic temperature adjustment within MiniMax's constraints, and streaming capability.

* **Documentation**
  * Added MiniMax configuration guide documenting available models, provider setup, API endpoints (default and China mainland), and environment variable requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->