### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,5 +15,18 @@
       "Bash(ls:*)",
       "Bash(wc:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary\n\nAdds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`.\n\nCloses #2163\n\n---\n_Disclosure: I am the author and maintainer of `block-no-verify`._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and development configuration to include a pre-execution hook for command-line tool usage. This enhances the development workflow without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->