### PR TITLE
Feat(wren-ui): add Indonesian (ID) language support

### DIFF
--- a/wren-ui/src/apollo/client/graphql/__types__.ts
+++ b/wren-ui/src/apollo/client/graphql/__types__.ts
@@ -1128,6 +1128,7 @@ export enum ProjectLanguage {
   ES = 'ES',
   FA_IR = 'FA_IR',
   FR = 'FR',
+  ID = 'ID',
   IT = 'IT',
   JA = 'JA',
   KO = 'KO',

--- a/wren-ui/src/apollo/server/models/adaptor.ts
+++ b/wren-ui/src/apollo/server/models/adaptor.ts
@@ -46,6 +46,7 @@ export enum WrenAILanguage {
   NL = 'Dutch',
   AZ_AZ = 'Azerbaijani',
   TR = 'Turkish',
+  ID = 'Indonesian',
 }
 
 export interface DeployData {

--- a/wren-ui/src/apollo/server/schema.ts
+++ b/wren-ui/src/apollo/server/schema.ts
@@ -139,6 +139,7 @@ export const typeDefs = gql`
     NL
     AZ_AZ
     TR
+    ID
   }
 
   type DataSource {

--- a/wren-ui/src/utils/language.ts
+++ b/wren-ui/src/utils/language.ts
@@ -18,4 +18,5 @@ export const getLanguageText = (language: ProjectLanguage) =>
     [ProjectLanguage.NL]: 'Dutch',
     [ProjectLanguage.AZ_AZ]: 'Azerbaijani',
     [ProjectLanguage.TR]: 'Turkish',
+    [ProjectLanguage.ID]: 'Indonesian',
   })[language] || language;


### PR DESCRIPTION
Add Indonesian language support using ISO 639-1 code ID across the wren-ui project. The code 'ID' follows the ISO 639-1:2002 standard for the Indonesian language and is uppercased to match the existing enum convention (TR, NL, AR, PT, RU, ZH_CN, etc.).

Changes include:

- Added ID = 'ID' to ProjectLanguage enum in __types__.ts

- Added ID = 'Indonesian' to WrenAILanguage enum in adaptor.ts

- Added ID to GraphQL ProjectLanguage enum in schema.ts

- Mapped ProjectLanguage.ID to 'Indonesian' in getLanguageText (language.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Indonesian language support to the application, enabling users to select Indonesian as their preferred language interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->