### PR TITLE
fix(wren-ai-service): make DDLChunker synchronous to fix asyncio Task passed to embedding node

### DIFF
--- a/wren-ai-service/src/pipelines/indexing/db_schema.py
+++ b/wren-ai-service/src/pipelines/indexing/db_schema.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import sys
 import uuid
@@ -29,7 +28,7 @@ logger = logging.getLogger("wren-ai-service")
 @component
 class DDLChunker:
     @component.output_types(documents=List[Document])
-    async def run(
+    def run(
         self,
         mdl: Dict[str, Any],
         column_batch_size: int,
@@ -48,7 +47,7 @@ class DDLChunker:
                 },
                 "content": chunk["payload"],
             }
-            for chunk in await self._get_ddl_commands(
+            for chunk in self._get_ddl_commands(
                 **mdl, column_batch_size=column_batch_size
             )
         ]
@@ -63,7 +62,7 @@ class DDLChunker:
             ]
         }
 
-    async def _model_preprocessor(
+    def _model_preprocessor(
         self, models: List[Dict[str, Any]], **kwargs
     ) -> List[Dict[str, Any]]:
         def _column_preprocessor(
@@ -81,9 +80,9 @@ class DDLChunker:
                 **addition,
             }
 
-        async def _preprocessor(model: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        def _preprocessor(model: Dict[str, Any], **kwargs) -> Dict[str, Any]:
             addition = {
-                key: await helper(model, **kwargs)
+                key: helper(model, **kwargs)
                 for key, helper in helper.MODEL_PREPROCESSORS.items()
                 if helper.condition(model, **kwargs)
             }
@@ -100,11 +99,9 @@ class DDLChunker:
                 "primaryKey": model.get("primaryKey", ""),
             }
 
-        tasks = [_preprocessor(model, **kwargs) for model in models]
+        return [_preprocessor(model, **kwargs) for model in models]
 
-        return await asyncio.gather(*tasks)
-
-    async def _get_ddl_commands(
+    def _get_ddl_commands(
         self,
         models: List[Dict[str, Any]],
         relationships: List[Dict[str, Any]],
@@ -115,7 +112,7 @@ class DDLChunker:
     ) -> List[dict]:
         return (
             self._convert_models_and_relationships(
-                await self._model_preprocessor(models, **kwargs),
+                self._model_preprocessor(models, **kwargs),
                 relationships,
                 column_batch_size,
             )
@@ -300,13 +297,13 @@ def validate_mdl(mdl_str: str, validator: MDLValidator) -> Dict[str, Any]:
 
 
 @observe(capture_input=False)
-async def chunk(
+def chunk(
     mdl: Dict[str, Any],
     chunker: DDLChunker,
     column_batch_size: int,
     project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    return await chunker.run(
+    return chunker.run(
         mdl=mdl,
         column_batch_size=column_batch_size,
         project_id=project_id,

--- a/wren-ai-service/tests/pytest/pipelines/indexing/test_db_schema.py
+++ b/wren-ai-service/tests/pytest/pipelines/indexing/test_db_schema.py
@@ -13,7 +13,7 @@ async def test_empty_mdl():
     chunker = DDLChunker()
     mdl = {"models": [], "views": [], "relationships": [], "metrics": []}
 
-    document = await chunker.run(mdl, column_batch_size=1)
+    document = chunker.run(mdl, column_batch_size=1)
     assert document == {"documents": []}
 
 
@@ -35,7 +35,7 @@ async def test_single_model():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document: Document = actual["documents"][0]
@@ -74,7 +74,7 @@ async def test_multiple_models():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_1: Document = actual["documents"][0]
@@ -119,7 +119,7 @@ async def test_column_is_primary_key():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -164,7 +164,7 @@ async def test_column_with_properties():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -221,7 +221,7 @@ async def test_column_with_nested_columns():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -264,7 +264,7 @@ async def test_column_with_calculated_property():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 2
 
     document_0: Document = actual["documents"][0]
@@ -328,7 +328,7 @@ async def test_column_with_relationship():
         "metrics": [],
     }
 
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 6
 
     document_0: Document = actual["documents"][0]
@@ -399,7 +399,7 @@ async def test_column_batch_size():
         "relationships": [],
         "metrics": [],
     }
-    actual = await chunker.run(mdl, column_batch_size=2)
+    actual = chunker.run(mdl, column_batch_size=2)
     assert len(actual["documents"]) == 3
 
     document_0: Document = actual["documents"][0]
@@ -453,7 +453,7 @@ async def test_view():
         "relationships": [],
         "metrics": [],
     }
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document_0: Document = actual["documents"][0]
@@ -483,7 +483,7 @@ async def test_view_with_properties():
         "relationships": [],
         "metrics": [],
     }
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document_0: Document = actual["documents"][0]
@@ -518,7 +518,7 @@ async def test_metric():
             }
         ],
     }
-    actual = await chunker.run(mdl, column_batch_size=1)
+    actual = chunker.run(mdl, column_batch_size=1)
     assert len(actual["documents"]) == 1
 
     document_0: Document = actual["documents"][0]

--- a/wren-ai-service/tests/pytest/pipelines/indexing/test_db_schema.py
+++ b/wren-ai-service/tests/pytest/pipelines/indexing/test_db_schema.py
@@ -8,8 +8,7 @@ from pytest_mock import MockFixture
 from src.pipelines.indexing.db_schema import DBSchema, DDLChunker
 
 
-@pytest.mark.asyncio
-async def test_empty_mdl():
+def test_empty_mdl():
     chunker = DDLChunker()
     mdl = {"models": [], "views": [], "relationships": [], "metrics": []}
 
@@ -17,8 +16,7 @@ async def test_empty_mdl():
     assert document == {"documents": []}
 
 
-@pytest.mark.asyncio
-async def test_single_model():
+def test_single_model():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -49,8 +47,7 @@ async def test_single_model():
     )
 
 
-@pytest.mark.asyncio
-async def test_multiple_models():
+def test_multiple_models():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -98,8 +95,7 @@ async def test_multiple_models():
     )
 
 
-@pytest.mark.asyncio
-async def test_column_is_primary_key():
+def test_column_is_primary_key():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -140,8 +136,7 @@ async def test_column_is_primary_key():
     )
 
 
-@pytest.mark.asyncio
-async def test_column_with_properties():
+def test_column_with_properties():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -195,8 +190,7 @@ async def test_column_with_properties():
     )
 
 
-@pytest.mark.asyncio
-async def test_column_with_nested_columns():
+def test_column_with_nested_columns():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -242,8 +236,7 @@ async def test_column_with_nested_columns():
     )
 
 
-@pytest.mark.asyncio
-async def test_column_with_calculated_property():
+def test_column_with_calculated_property():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -285,8 +278,7 @@ async def test_column_with_calculated_property():
     )
 
 
-@pytest.mark.asyncio
-async def test_column_with_relationship():
+def test_column_with_relationship():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -381,8 +373,7 @@ async def test_column_with_relationship():
     )
 
 
-@pytest.mark.asyncio
-async def test_column_batch_size():
+def test_column_batch_size():
     chunker = DDLChunker()
     mdl = {
         "models": [
@@ -444,8 +435,7 @@ async def test_column_batch_size():
     )
 
 
-@pytest.mark.asyncio
-async def test_view():
+def test_view():
     chunker = DDLChunker()
     mdl = {
         "models": [],
@@ -468,8 +458,7 @@ async def test_view():
     )
 
 
-@pytest.mark.asyncio
-async def test_view_with_properties():
+def test_view_with_properties():
     chunker = DDLChunker()
     mdl = {
         "models": [],
@@ -498,8 +487,7 @@ async def test_view_with_properties():
     )
 
 
-@pytest.mark.asyncio
-async def test_metric():
+def test_metric():
     chunker = DDLChunker()
     mdl = {
         "models": [],


### PR DESCRIPTION
Fixes #2138

## Problem

When Hamilton's `AsyncDriver` executes the DB schema indexing DAG, it wraps async nodes in asyncio Tasks. Under complex MDL schemas (many tables with many relationships), the async `chunk` node's Task was sometimes passed **unawaited** to the downstream `embedding` node.

This caused `embedding` to receive an asyncio Task object (e.g. `"<Task finished name='Task-1479' coro=<AsyncGraphAd..."`) instead of the actual `{"documents": [...]}` dict, which then caused `embedder.run()` to send invalid content to the embedding endpoint, returning a `400 Bad Request` from Ollama.

The bug was consistently reproducible with complex MDL schemas (20+ tables, 30+ relationships) but did not appear with simpler schemas, matching the issue description.

## Solution

Make `DDLChunker.run()` and its internal helpers synchronous, eliminating the async Task from the Hamilton DAG. This matches the pattern used by **all other indexing pipelines** (`HistoricalQuestion`, `TableDescription`, `ProjectMeta`, `SqlPairs`) where the `chunk` node is already synchronous.

The async machinery in `_model_preprocessor` (using `asyncio.gather`) was unnecessary because:
- `MODEL_PREPROCESSORS` is empty by default — the `await` in the dict comprehension never executes
- All actual work (string manipulation, dict building) is CPU-bound and has no I/O to parallelize

**Changes:**
- `DDLChunker.run()`: `async def` → `def`, removes `await`
- `DDLChunker._get_ddl_commands()`: `async def` → `def`, removes `await`  
- `DDLChunker._model_preprocessor()`: `async def` → `def`, removes `asyncio.gather`
- `DDLChunker._preprocessor()` (inner): `async def` → `def`, removes `await` in dict comprehension
- `chunk()` Hamilton node: `async def` → `def`, removes `await`
- Removes now-unused `import asyncio`
- Updates tests to call `chunker.run()` synchronously

## Testing

- All existing unit tests in `test_db_schema.py` updated and pass with the sync interface
- The `test_pipeline_run` integration test (which uses the full `DBSchema` Hamilton pipeline) continues to work since the downstream `embedding`, `clean`, and `write` nodes remain async

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted the database schema indexing pipeline from asynchronous to synchronous execution, simplifying the DDL chunking and preprocessing flow while preserving indexing behavior.
* **Tests**
  * Updated test suite to match the synchronous pipeline changes, converting async tests to synchronous equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->