### PR TITLE
chore(core): point wren-core-py / wren / wren-core-wasm at Canner/WrenAI

### DIFF
--- a/core/wren-core-py/Cargo.toml
+++ b/core/wren-core-py/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Python bindings for Wren Engine semantic layer (wren-core)"
 license = "Apache-2.0"
-repository = "https://github.com/Canner/wren-engine"
+repository = "https://github.com/Canner/WrenAI"
 include = ["/src", "pyproject.toml", "Cargo.toml", "Cargo.lock"]
 
 [lib]

--- a/core/wren-core-py/pyproject.toml
+++ b/core/wren-core-py/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://www.getwren.ai/"
-Repository = "https://github.com/Canner/wren-engine"
-Issues = "https://github.com/Canner/wren-engine/issues"
+Repository = "https://github.com/Canner/WrenAI"
+Issues = "https://github.com/Canner/WrenAI/issues"
 
 [tool.poetry]
 name = "wren-core-py"

--- a/core/wren-core-wasm/AGENT_GUIDE.md
+++ b/core/wren-core-wasm/AGENT_GUIDE.md
@@ -6,7 +6,7 @@ Reference for AI agents generating browser-based HTML dashboard artifacts using 
 
 ```html
 <script type="module">
-  import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
+  import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.1.0/dist/index.js';
 </script>
 ```
 
@@ -103,7 +103,7 @@ const mdl = {
   <div id="status">Loading engine...</div>
 
   <script type="module">
-    import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
+    import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.1.0/dist/index.js';
 
     const status = document.getElementById('status');
 

--- a/core/wren-core-wasm/Cargo.toml
+++ b/core/wren-core-wasm/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Canner <dev@cannerdata.com>"]
 license = "Apache-2.0"
 description = "Wren Engine compiled to WebAssembly — browser-native semantic layer + query execution"
-repository = "https://github.com/Canner/wren-engine"
+repository = "https://github.com/Canner/WrenAI"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/core/wren-core-wasm/README.md
+++ b/core/wren-core-wasm/README.md
@@ -7,14 +7,14 @@ Query Parquet files directly in the browser through a semantic layer (MDL), with
 ## Installation
 
 ```bash
-npm install wren-core-wasm
+npm install @wrenai/wren-core-wasm
 ```
 
 Or use directly via CDN:
 
 ```html
 <script type="module">
-  import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
+  import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.1.0/dist/index.js';
 </script>
 ```
 
@@ -28,7 +28,7 @@ Or use directly via CDN:
 Load Parquet files from a URL-accessible location. DataFusion reads them via HTTP range requests.
 
 ```javascript
-import { WrenEngine } from 'wren-core-wasm';
+import { WrenEngine } from '@wrenai/wren-core-wasm';
 
 const engine = await WrenEngine.init();
 

--- a/core/wren-core-wasm/examples/test-cdn.html
+++ b/core/wren-core-wasm/examples/test-cdn.html
@@ -38,7 +38,7 @@
     <script type="module">
         // unpkg used instead of jsDelivr: jsDelivr's free CDN has a 50 MB per-file
         // limit and the WASM binary is ~68 MB raw. unpkg handles larger files.
-        import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
+        import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.1.0/dist/index.js';
 
         const logEl = document.getElementById('log');
 

--- a/core/wren-core-wasm/package.json
+++ b/core/wren-core-wasm/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Canner/WrenAI.git",
+    "url": "git+https://github.com/Canner/WrenAI.git",
     "directory": "core/wren-core-wasm"
   },
   "homepage": "https://github.com/Canner/WrenAI/tree/main/core/wren-core-wasm#readme",

--- a/core/wren-core-wasm/package.json
+++ b/core/wren-core-wasm/package.json
@@ -35,8 +35,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Canner/wren-engine.git",
-    "directory": "wren-core-wasm"
+    "url": "https://github.com/Canner/WrenAI.git",
+    "directory": "core/wren-core-wasm"
   },
   "sideEffects": false,
   "engines": {

--- a/core/wren-core-wasm/package.json
+++ b/core/wren-core-wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wren-core-wasm",
+  "name": "@wrenai/wren-core-wasm",
   "version": "0.1.0",
   "description": "Browser-native semantic SQL engine powered by DataFusion WASM",
   "type": "module",
@@ -37,6 +37,13 @@
     "type": "git",
     "url": "https://github.com/Canner/WrenAI.git",
     "directory": "core/wren-core-wasm"
+  },
+  "homepage": "https://github.com/Canner/WrenAI/tree/main/core/wren-core-wasm#readme",
+  "bugs": {
+    "url": "https://github.com/Canner/WrenAI/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "sideEffects": false,
   "engines": {

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -75,8 +75,8 @@ wren = "wren.cli:app"
 
 [project.urls]
 Homepage = "https://getwren.ai"
-Repository = "https://github.com/Canner/wren-engine"
-Issues = "https://github.com/Canner/wren-engine/issues"
+Repository = "https://github.com/Canner/WrenAI"
+Issues = "https://github.com/Canner/WrenAI/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/wren"]


### PR DESCRIPTION
## Summary

After the wren-engine import, the canonical repo URL is `Canner/WrenAI`. The published package manifests still pointed at `Canner/wren-engine`. Updating them so PyPI / npm / crates.io show the correct Repository and Issues links.

## Changes

| File | Field |
|---|---|
| `core/wren-core-py/Cargo.toml` | `repository` |
| `core/wren-core-py/pyproject.toml` | `Repository`, `Issues` |
| `core/wren/pyproject.toml` | `Repository`, `Issues` |
| `core/wren-core-wasm/Cargo.toml` | `repository` |
| `core/wren-core-wasm/package.json` | `repository.url` + `repository.directory` (now `core/wren-core-wasm`) |

## Intentionally NOT changed

- **`CHANGELOG.md` historical links** (`core/wren-core-py/CHANGELOG.md`, `core/wren/CHANGELOG.md`) — those reference real wren-engine PR numbers and commits. The archived `Canner/wren-engine` repo will keep resolving them; rewriting to `Canner/WrenAI` would dangle (different PR numbering on the new repo).
- `core/wren-core/Cargo.toml` — workspace root, no `repository` field set; sub-crates inherit nothing for this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package metadata and repository/issue links to point to the new WrenAI locations.
* **Documentation**
  * Updated installation and CDN examples to use the new scoped package name and adjusted example import URLs so guides and quick-start snippets reflect the new package identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->