### PR TITLE
fix(ci): resolve component to manifest path in rc-release workflow

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -48,12 +48,22 @@ jobs:
           RC_VERSION_INPUT: ${{ inputs.rc_version }}
           COMPONENT: ${{ inputs.component }}
         run: |
-          # Read current version from manifest
+          # Read current version from manifest. The manifest is keyed by package
+          # path (e.g. "core/wren-core-py"), so resolve the path from
+          # release-please-config.json by matching the component name.
           BASE_VERSION=$(python3 -c "
-          import json
+          import json, sys
+          with open('release-please-config.json') as f:
+              config = json.load(f)
+          path = next(
+              (p for p, pkg in config['packages'].items() if pkg.get('component') == '${COMPONENT}'),
+              None,
+          )
+          if path is None:
+              sys.exit(\"component '${COMPONENT}' not found in release-please-config.json\")
           with open('.release-please-manifest.json') as f:
               manifest = json.load(f)
-          print(manifest['${COMPONENT}'])
+          print(manifest[path])
           ")
 
           if [ -n "$RC_VERSION_INPUT" ]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,15 +13,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      wren-core-py--release_created: ${{ steps.release.outputs['wren-core-py--release_created'] }}
-      wren-core-py--tag_name: ${{ steps.release.outputs['wren-core-py--tag_name'] }}
-      wren-core-py--version: ${{ steps.release.outputs['wren-core-py--version'] }}
-      wren--release_created: ${{ steps.release.outputs['wren--release_created'] }}
-      wren--tag_name: ${{ steps.release.outputs['wren--tag_name'] }}
-      wren--version: ${{ steps.release.outputs['wren--version'] }}
-      wren-core-wasm--release_created: ${{ steps.release.outputs['wren-core-wasm--release_created'] }}
-      wren-core-wasm--tag_name: ${{ steps.release.outputs['wren-core-wasm--tag_name'] }}
-      wren-core-wasm--version: ${{ steps.release.outputs['wren-core-wasm--version'] }}
+      wren-core-py--release_created: ${{ steps.release.outputs['core/wren-core-py--release_created'] }}
+      wren-core-py--tag_name: ${{ steps.release.outputs['core/wren-core-py--tag_name'] }}
+      wren-core-py--version: ${{ steps.release.outputs['core/wren-core-py--version'] }}
+      wren--release_created: ${{ steps.release.outputs['core/wren--release_created'] }}
+      wren--tag_name: ${{ steps.release.outputs['core/wren--tag_name'] }}
+      wren--version: ${{ steps.release.outputs['core/wren--version'] }}
+      wren-core-wasm--release_created: ${{ steps.release.outputs['core/wren-core-wasm--release_created'] }}
+      wren-core-wasm--tag_name: ${{ steps.release.outputs['core/wren-core-wasm--tag_name'] }}
+      wren-core-wasm--version: ${{ steps.release.outputs['core/wren-core-wasm--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Summary
- The **Determine RC version** step in `rc-release.yml` failed with `KeyError: 'wren-core-py'` ([failing run](https://github.com/Canner/WrenAI/actions/runs/25307731420/job/74187339147#step:4:49)).
- `.release-please-manifest.json` is keyed by package path (e.g. `core/wren-core-py`), but the workflow looked it up by the component name (`wren-core-py`).
- Resolve the component → path via `release-please-config.json` before reading the manifest, with a clear error if the component isn't configured.

## Test plan
- [x] Locally verified the new lookup against `release-please-config.json` + `.release-please-manifest.json` for `wren-core-py` → `0.4.0`, `wren` → `0.3.0`, `wren-core-wasm` → `0.1.0`, and an unknown component (fails with a readable message).
- [ ] Re-run the **RC Release** workflow with `component=wren-core-py` and confirm the **Determine RC version** step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved RC version resolution in the release workflow to determine base versions more reliably from manifest configuration.
  * Updated release outputs wiring so core component release metadata (tag, version, release-created) are routed consistently for downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->