### PR TITLE
fix(ci): read next-release version from release-please branch in rc-release

### DIFF
--- a/.github/workflows/publish-wren-core-wasm.yml
+++ b/.github/workflows/publish-wren-core-wasm.yml
@@ -16,9 +16,6 @@ on:
         required: false
         type: string
         default: "latest"
-    secrets:
-      NPM_TOKEN:
-        required: true
 
 permissions:
   contents: read
@@ -27,6 +24,9 @@ jobs:
   build-and-publish:
     name: Build WASM + publish to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,6 +60,9 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Install npm dependencies
         working-directory: core/wren-core-wasm
         run: npm install
@@ -85,6 +88,5 @@ jobs:
       - name: Publish to npm
         working-directory: core/wren-core-wasm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ inputs.npm_tag }}
         run: npm publish --tag "$NPM_TAG" --access public

--- a/.github/workflows/publish-wren-core-wasm.yml
+++ b/.github/workflows/publish-wren-core-wasm.yml
@@ -57,10 +57,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Trusted Publishing requires Node.js >= 22.14.0; pin to 24 (latest LTS line)
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
+      - name: Ensure npm meets Trusted Publishing requirement (>= 11.5.1)
         run: npm install -g npm@latest
 
       - name: Install npm dependencies

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -76,6 +76,8 @@ jobs:
           if path is None:
               sys.exit(f\"component '{component}' not found in release-please-config.json\")
           manifest = json.loads(os.environ['MANIFEST_JSON'])
+          if path not in manifest:
+              sys.exit(f\"path '{path}' for component '{component}' not in manifest\")
           print(manifest[path])
           ")
           echo "::notice::Base version for $COMPONENT: $BASE_VERSION (from $MANIFEST_SOURCE)"

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -149,8 +149,9 @@ jobs:
       version: ${{ needs.create-rc.outputs.version }}
       tag_name: ${{ needs.create-rc.outputs.tag_name }}
       npm_tag: rc
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: read
+      id-token: write
 
   create-release:
     needs: [create-rc, publish-wren-core-py, publish-wren, publish-wren-core-wasm]

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -48,23 +48,37 @@ jobs:
           RC_VERSION_INPUT: ${{ inputs.rc_version }}
           COMPONENT: ${{ inputs.component }}
         run: |
-          # Read current version from manifest. The manifest is keyed by package
-          # path (e.g. "core/wren-core-py"), so resolve the path from
-          # release-please-config.json by matching the component name.
-          BASE_VERSION=$(python3 -c "
-          import json, sys
+          # The base version for an RC is the *next* release version, which
+          # release-please stores in the manifest on its per-component release
+          # branch (e.g. release-please--branches--main--components--wren).
+          # main's manifest only holds the *last released* version.
+          RELEASE_BRANCH="release-please--branches--main--components--${COMPONENT}"
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+            git fetch --depth=1 origin "$RELEASE_BRANCH"
+            MANIFEST_JSON=$(git show "FETCH_HEAD:.release-please-manifest.json")
+            MANIFEST_SOURCE="release-please branch '$RELEASE_BRANCH'"
+          else
+            echo "::error::No release-please branch '$RELEASE_BRANCH'. RC releases require a pending release-please PR (i.e. conventional commits since the last release for '$COMPONENT')."
+            exit 1
+          fi
+
+          # Manifest is keyed by package path (e.g. "core/wren-core-py"), so
+          # resolve the path from release-please-config.json by component name.
+          BASE_VERSION=$(MANIFEST_JSON="$MANIFEST_JSON" python3 -c "
+          import json, os, sys
           with open('release-please-config.json') as f:
               config = json.load(f)
+          component = os.environ['COMPONENT']
           path = next(
-              (p for p, pkg in config['packages'].items() if pkg.get('component') == '${COMPONENT}'),
+              (p for p, pkg in config['packages'].items() if pkg.get('component') == component),
               None,
           )
           if path is None:
-              sys.exit(\"component '${COMPONENT}' not found in release-please-config.json\")
-          with open('.release-please-manifest.json') as f:
-              manifest = json.load(f)
+              sys.exit(f\"component '{component}' not found in release-please-config.json\")
+          manifest = json.loads(os.environ['MANIFEST_JSON'])
           print(manifest[path])
           ")
+          echo "::notice::Base version for $COMPONENT: $BASE_VERSION (from $MANIFEST_SOURCE)"
 
           if [ -n "$RC_VERSION_INPUT" ]; then
             # Validate: must start with BASE_VERSION-rc. and end with a positive integer

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,5 +58,6 @@ jobs:
     with:
       version: ${{ needs.release-please.outputs['wren-core-wasm--version'] }}
       tag_name: ${{ needs.release-please.outputs['wren-core-wasm--tag_name'] }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
## Summary
Triggering **RC Release** for `wren` produced `wren-v0.3.0-rc.1` instead of the expected `wren-v0.4.0-rc.1`. Same class of bug for the other components.

`.release-please-manifest.json` on `main` stores the **last released** version, not the next one. The next version lives on the per-component release-please branch (`release-please--branches--main--components--<component>`), where release-please bumps the manifest entry as part of the proposed release PR.

This change reads the manifest from that branch when computing `BASE_VERSION`. If the branch doesn't exist (no pending release for the component), the workflow now fails with a clear error message instead of silently producing an RC for the already-released version.

## Verification
Locally resolved next-release versions from each release-please branch:

| component | manifest on `main` (released) | manifest on release-please branch (next) |
|---|---|---|
| `wren` | `0.3.0` | `0.4.0` ✅ |
| `wren-core-py` | `0.4.0` | `0.5.0` ✅ |
| `wren-core-wasm` | `0.1.0` | `0.2.0` ✅ |

After this fix, dispatching `RC Release` with `component=wren` will produce `wren-v0.4.0-rc.1`.

## Cleanup note
Three RC tags were created with the buggy versions and should probably be deleted manually:
- `wren-v0.3.0-rc.1`
- `wren-core-py-v0.4.0-rc.1`
- `wren-core-wasm-v0.1.0-rc.2`

## Test plan
- [x] Verified the new lookup against the three release-please branches.
- [ ] Re-dispatch **RC Release** with `component=wren` and confirm it tags `wren-v0.4.0-rc.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release candidate version lookup now fetches release metadata from the component branch remotely, improving reliability of automated releases.
  * Publishing workflow switched to platform trusted publishing (id-token based) and no longer relies on an injected npm secret.
  * Node runtime pinned to v24 and the workflow updates npm globally before install/publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->