### PR TITLE
chore: sync release-please manifest for wren 0.4.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "core/wren-core-py": "0.4.0",
-  "core/wren": "0.3.0",
+  "core/wren": "0.4.0",
   "core/wren-core-wasm": "0.1.0"
 }


### PR DESCRIPTION
## Summary
`wren-engine 0.4.0` is already published on [PyPI](https://pypi.org/project/wren-engine/0.4.0/) and the `wren-v0.4.0` git tag exists, but `.release-please-manifest.json` still points at `0.3.0` because release-please PR #2228 was never merged.

This bumps `core/wren` in the manifest from `0.3.0` to `0.4.0` so release-please's state matches reality.

## Effects
- After this merges, release-please will reconcile on the next push and **auto-close PR #2228** (and delete `release-please--branches--main--components--wren`) because there are no conventional commits between the new manifest baseline and HEAD that warrant a release.
- The next `wren` release will be computed from `0.4.0` once new conventional commits land.
- RC dispatch for `wren` (per #2232) will now correctly fail-fast with "no pending release" until that happens — this is the intended behaviour.

`core/wren-core-py` (manifest `0.4.0`, tag `wren-core-py-v0.4.0`) is already aligned and is **not** changed here.

## Test plan
- [x] Confirmed `wren-v0.4.0` tag and PyPI release exist.
- [ ] After merge, observe release-please workflow run on `main` close PR #2228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->