### PR TITLE
fix(ci): drop registry-url from setup-node so wasm publish uses OIDC

### DIFF
--- a/.github/workflows/publish-wren-core-wasm.yml
+++ b/.github/workflows/publish-wren-core-wasm.yml
@@ -57,9 +57,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # Trusted Publishing requires Node.js >= 22.14.0; pin to 24 (latest LTS line)
+          # Trusted Publishing requires Node.js >= 22.14.0; pin to 24 (latest LTS line).
+          # Intentionally do NOT pass registry-url here: setup-node would auto-write
+          # an .npmrc containing
+          #   //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+          #   always-auth=true
+          # which prevents npm from falling back to OIDC, so Trusted Publishing
+          # fails with a confusing 404 even when correctly configured on npm.
           node-version: 24
-          registry-url: https://registry.npmjs.org
 
       - name: Ensure npm meets Trusted Publishing requirement (>= 11.5.1)
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
After #2232 the wasm publish job [still failed](https://github.com/Canner/WrenAI/actions/runs/25312631735/job/74202876899) with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@wrenai%2fwren-core-wasm
npm error 404  The requested resource '@wrenai/wren-core-wasm@0.2.0-rc.1' could not be found or you do not have permission to access it.
```

\`\`\`
npm warn Unknown user config "always-auth". This will stop working in the next major version of npm.
\`\`\`

## Root cause
`actions/setup-node@v4` with `registry-url: https://registry.npmjs.org` writes an `.npmrc` containing:

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
always-auth=true
```

After we removed `NODE_AUTH_TOKEN` for Trusted Publishing, the placeholder interpolates to an empty string. npm CLI then publishes with an empty bearer token instead of negotiating OIDC and the registry returns 404 / no permission. The `always-auth` warning above is from that same auto-generated `.npmrc`.

Per [npm's Trusted Publishers announcement](https://github.blog/changelog/2025-07-31-npm-trusted-publishers/):

> When publishing on a configured trusted publisher, run `npm publish` in CI **without any token or `_authToken` settings**.

## Fix
Drop `registry-url` from `setup-node`. With no `.npmrc` written, npm uses its default registry (`https://registry.npmjs.org/`) and detects the GitHub Actions OIDC environment to perform Trusted Publishing.

## Test plan
- [ ] Re-dispatch **RC Release** with `component=wren-core-wasm` and confirm publish succeeds via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to version 24 in build infrastructure.
  * Enhanced publishing security by refining authentication token handling during the release process.
  * Upgraded npm to the latest version to ensure compatibility with publishing prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->