### PR TITLE
fix(ci): add environment: npm to wasm publish for Trusted Publishing

### DIFF
--- a/.github/workflows/publish-wren-core-wasm.yml
+++ b/.github/workflows/publish-wren-core-wasm.yml
@@ -24,6 +24,9 @@ jobs:
   build-and-publish:
     name: Build WASM + publish to npm
     runs-on: ubuntu-latest
+    # Required by the npm Trusted Publisher config (Environment name: npm).
+    # The 'npm' environment must exist under repo Settings → Environments.
+    environment: npm
     permissions:
       contents: read
       id-token: write
@@ -58,13 +61,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # Trusted Publishing requires Node.js >= 22.14.0; pin to 24 (latest LTS line).
-          # Intentionally do NOT pass registry-url here: setup-node would auto-write
-          # an .npmrc containing
-          #   //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-          #   always-auth=true
-          # which prevents npm from falling back to OIDC, so Trusted Publishing
-          # fails with a confusing 404 even when correctly configured on npm.
           node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Ensure npm meets Trusted Publishing requirement (>= 11.5.1)
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
The wasm publish job is still failing — most recently with `ENEEDAUTH` (https://github.com/Canner/WrenAI/actions/runs/25354035171/job/74339499436). The npm CLI never went through the OIDC handshake.

The npm Trusted Publisher config for `@wrenai/wren-core-wasm` has **Environment name: `npm`** set. With that field set, npm requires the OIDC token to carry an `environment: npm` claim. GitHub only adds that claim when the job runs inside a deployment environment, and our publish job didn't declare one — so npm rejected the publish. (Before #2235 the symptom was a 404; after, it's `ENEEDAUTH`. Both are downstream symptoms of the same missing claim.)

## Fix
- Add `environment: npm` to the `build-and-publish` job.
- Restore `registry-url: https://registry.npmjs.org` on `setup-node`. Removing it in #2235 was the wrong direction — the npm Trusted Publishers docs explicitly set it, and the real blocker wasn't the auto-written `.npmrc` but the missing environment claim.

## Required repo setup
**Before merging**, create a GitHub Actions environment named `npm`:

> Repo → Settings → Environments → New environment → name `npm`

(That's the same name configured on npm's side.) Optional but recommended: protect it with required reviewers and a branch restriction so only `main` (or release branches) can publish.

If the environment doesn't exist when the workflow runs, the job will fail with a clear "environment not found" error.

## Test plan
- [ ] Create the `npm` environment in repo settings.
- [ ] Re-dispatch **RC Release** with `component=wren-core-wasm` and confirm `npm publish` succeeds via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing workflow configuration to improve package publication reliability and security through enhanced registry setup and environment requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->