### PR TITLE
fix(ci): split wasm RC publish into a token-based workflow

### DIFF
--- a/.github/workflows/publish-wren-core-wasm-rc.yml
+++ b/.github/workflows/publish-wren-core-wasm-rc.yml
@@ -1,0 +1,98 @@
+name: Publish wren-core-wasm to npm (RC, token-based)
+
+# Token-based variant of publish-wren-core-wasm.yml used by rc-release.yml.
+# npm Trusted Publishing only supports a single Trusted Publisher per package
+# and we want that slot reserved for stable releases triggered by
+# release-please.yml. RC publishes therefore authenticate with a classic
+# NPM_TOKEN secret instead of OIDC.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version number (e.g. 0.2.0-rc.1)"
+        required: true
+        type: string
+      tag_name:
+        description: "Git tag to checkout (e.g. wren-core-wasm-v0.2.0-rc.1)"
+        required: true
+        type: string
+      npm_tag:
+        description: "npm dist-tag"
+        required: false
+        type: string
+        default: "rc"
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build WASM + publish to npm (token-based)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name }}
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            core/wren-core-wasm/target/
+          key: wasm-cargo-${{ hashFiles('core/wren-core-wasm/Cargo.toml', 'core/wren-core-wasm/Cargo.lock') }}
+          restore-keys: wasm-cargo-
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm dependencies
+        working-directory: core/wren-core-wasm
+        run: npm install
+
+      - name: Set version in package.json
+        working-directory: core/wren-core-wasm
+        env:
+          VERSION: ${{ inputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version
+
+      - name: Build WASM (wasm-pack)
+        working-directory: core/wren-core-wasm
+        run: wasm-pack build --target web --release
+
+      - name: Build dist (TypeScript + copy)
+        working-directory: core/wren-core-wasm
+        run: npm run build:dist
+
+      - name: Run integration tests
+        working-directory: core/wren-core-wasm
+        run: npm test
+
+      - name: Publish to npm
+        working-directory: core/wren-core-wasm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TAG: ${{ inputs.npm_tag }}
+        run: npm publish --tag "$NPM_TAG" --access public

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -146,14 +146,16 @@ jobs:
   publish-wren-core-wasm:
     needs: create-rc
     if: inputs.component == 'wren-core-wasm'
-    uses: ./.github/workflows/publish-wren-core-wasm.yml
+    # RC publishes use the token-based variant. The OIDC variant is reserved
+    # for stable releases driven by release-please.yml — npm only allows one
+    # Trusted Publisher per package.
+    uses: ./.github/workflows/publish-wren-core-wasm-rc.yml
     with:
       version: ${{ needs.create-rc.outputs.version }}
       tag_name: ${{ needs.create-rc.outputs.tag_name }}
       npm_tag: rc
-    permissions:
-      contents: read
-      id-token: write
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-release:
     needs: [create-rc, publish-wren-core-py, publish-wren, publish-wren-core-wasm]


### PR DESCRIPTION
## Summary
npm Trusted Publishing has two constraints that conflict with our reusable-workflow setup:

1. Only **one** Trusted Publisher per package.
2. Validation matches the **calling** workflow's filename, not the reusable one that runs `npm publish`.

That means we have to choose which entrypoint owns the npm TP slot. We're keeping it for **`release-please.yml`** (stable releases) and switching `rc-release.yml`'s wasm publish back to a classic `NPM_TOKEN` flow.

## Changes
- **New** `.github/workflows/publish-wren-core-wasm-rc.yml` — same build pipeline as the OIDC variant but authenticates with `NODE_AUTH_TOKEN` from `NPM_TOKEN`. No `environment:`, no `id-token: write`.
- **`rc-release.yml`** — the `publish-wren-core-wasm` job now calls the new RC workflow and forwards `NPM_TOKEN`. Drops the `id-token: write` permission since it's no longer needed for that path.
- **`publish-wren-core-wasm.yml`** (OIDC) — unchanged. Still used by `release-please.yml`.
- **Python publishes** (`publish-wren-core-py.yml`, `publish-wren.yml`) — unchanged.

## Required repo setup before merging
1. Add an **`NPM_TOKEN`** secret (Settings → Secrets and variables → Actions) that has publish access to `@wrenai/wren-core-wasm`. A granular token scoped to that one package is the safest choice.
2. Update the **npm Trusted Publisher** config for `@wrenai/wren-core-wasm`:
   - Workflow filename: `rc-release.yml` → **`release-please.yml`**
   - Everything else (org/repo/environment) stays the same.

After both are in place:
- RC dispatches via `rc-release.yml` publish with `NPM_TOKEN`.
- Stable releases triggered by `release-please.yml` continue to use OIDC Trusted Publishing.

## Test plan
- [ ] Add `NPM_TOKEN` secret and update npm TP workflow filename.
- [ ] Re-dispatch **RC Release** with `component=wren-core-wasm` and confirm publish succeeds.
- [ ] Next stable release-please merge for `wren-core-wasm` should still publish via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established dedicated RC release workflow for wren-core-wasm npm package featuring integrated automation for WebAssembly compilation, comprehensive testing, and npm publication
  * Enhanced release process with improved authentication mechanisms and streamlined version management
  * RC releases now published with public access and proper tagging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->