### PR TITLE
docs: post-rebrand cleanup — core docs naming, README quick start, quickstart skill repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,25 +40,30 @@
 > 📣 **2026-05-07** — Wren Engine has merged into this repo under [`core/`](./core). The previous `Canner/wren-engine` repo is archived. The previous WrenAI GenBI app is preserved on the [`legacy/v1`](https://github.com/Canner/WrenAI/tree/legacy/v1) branch (tag `v1-final`). [Read the announcement →](https://github.com/Canner/WrenAI/discussions/2205)
 ---
 
-WrenAI is an open-source context layer for MCP clients and AI agents. It translates SQL queries through a semantic layer ([MDL](./core/wren-mdl/) — Modeling Definition Language) and executes them against 20+ data sources (PostgreSQL, BigQuery, Snowflake, Spark, etc.). The Rust engine is powered by [Apache DataFusion](https://datafusion.apache.org/). Use it as a Python SDK, a CLI, a WASM module in the browser, or as building blocks for AI-agent skills.
+## Why WrenAI?
+
+AI agents fail on business data not because they can't write SQL — they fail because they don't know what your warehouse means. Overlapping tables, inconsistent naming, metric definitions scattered across dashboards and SQL files: an LLM with raw database access guesses just as badly as a new hire on day one.
+
+WrenAI is the open context layer that fills that gap. You model your business in **[MDL](./core/wren-mdl/)** (Modeling Definition Language) — entities, relationships, calculations, governed access patterns — and any agent (Claude, Cursor, ChatGPT, internal copilots, customer-facing apps) queries through the same layer your analysts already use.
+
+A Rust engine powered by [Apache DataFusion](https://datafusion.apache.org/) translates the modeled SQL and runs it against 20+ data sources (PostgreSQL, BigQuery, Snowflake, Spark, etc.). Use it as a Python SDK, a CLI, a WASM module in the browser, or as building blocks for agent skills.
 
 ## Quick start
 
+The fastest path is to let an AI coding agent (Claude Code, Cursor, Aider, etc.) drive the install:
+
 ```bash
-pip install wren-engine
-
-mkdir my-project && cd my-project
-wren context init
-
-# add a connection profile (interactive)
-wren profile add my-db --interactive
-
-# prepare your MDL project (edit wren_project.yml and add models)
-
-wren --sql 'SELECT order_id FROM "orders" LIMIT 10'
+# Install WrenAI skills into your AI agent
+npx skills add Canner/WrenAI --skill '*'
 ```
 
-Full CLI guide: [`core/wren/README.md`](./core/wren/README.md). Installable extras for each connector are listed there.
+Start a new agent session and ask:
+
+> Use the `wren-onboarding` skill to install and set up Wren AI Core.
+
+The `wren-onboarding` skill walks the agent through environment checks, package install, project scaffolding, the first data source connection, and a first query.
+
+Full CLI guide and manual install steps: [`core/wren/README.md`](./core/wren/README.md). Installable extras for each connector are listed there.
 
 
 ## Supported Data Sources

--- a/docs/core/concepts/architecture.md
+++ b/docs/core/concepts/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Wren Engine CLI is a modular Python application that transforms semantic SQL through an MDL layer before executing it against your database. This page explains how the components fit together.
+Wren AI Core CLI is a modular Python application that transforms semantic SQL through an MDL layer before executing it against your database. This page explains how the components fit together.
 
 ## Overview
 

--- a/docs/core/concepts/benefits_llm.md
+++ b/docs/core/concepts/benefits_llm.md
@@ -1,10 +1,10 @@
-# Why Wren Engine helps AI agents
+# Why Wren AI Core helps AI agents
 
-Wren Engine gives AI agents a reliable way to understand business data before they generate SQL or answer questions. Instead of asking an LLM to infer meaning directly from raw tables and column names, Wren Engine provides structured business context through MDL, relationships, metrics, and governed access patterns.
+Wren AI Core gives AI agents a reliable way to understand business data before they generate SQL or answer questions. Instead of asking an LLM to infer meaning directly from raw tables and column names, Wren AI Core provides structured business context through MDL, relationships, metrics, and governed access patterns.
 
-This matters because most failures in text-to-SQL systems do not come from SQL syntax alone. They come from missing context: unclear business definitions, ambiguous joins, inconsistent metric logic, and access to the wrong data. Wren Engine reduces those failures by acting as an open context layer between AI agents and your data sources.
+This matters because most failures in text-to-SQL systems do not come from SQL syntax alone. They come from missing context: unclear business definitions, ambiguous joins, inconsistent metric logic, and access to the wrong data. Wren AI Core reduces those failures by acting as an open context layer between AI agents and your data sources.
 
-## What Wren Engine provides to LLM workflows
+## What Wren AI Core provides to LLM workflows
 
 ### 1. Shared business context
 
@@ -19,7 +19,7 @@ With that context in place, an agent has a better chance of mapping a question l
 
 ### 2. More reliable planning for text-to-SQL
 
-LLMs are good at pattern matching, but they are weaker when a query depends on domain-specific modeling rules. Wren Engine improves planning by giving the agent explicit structure instead of forcing it to reconstruct business logic from raw schema alone.
+LLMs are good at pattern matching, but they are weaker when a query depends on domain-specific modeling rules. Wren AI Core improves planning by giving the agent explicit structure instead of forcing it to reconstruct business logic from raw schema alone.
 
 This helps reduce:
 
@@ -30,7 +30,7 @@ This helps reduce:
 
 ### 3. Better context for RAG and agent memory
 
-RAG systems work best when the retrieved context is structured, relevant, and grounded in how the business actually defines data. Wren Engine gives retrieval systems higher-quality context by exposing modeled entities, documented relationships, and reusable logic instead of only raw database metadata.
+RAG systems work best when the retrieved context is structured, relevant, and grounded in how the business actually defines data. Wren AI Core gives retrieval systems higher-quality context by exposing modeled entities, documented relationships, and reusable logic instead of only raw database metadata.
 
 This makes it easier for an agent to retrieve the right context for:
 
@@ -43,11 +43,11 @@ This makes it easier for an agent to retrieve the right context for:
 
 When multiple AI agents, MCP clients, or applications access the same modeled context, they can reason from the same definitions. That consistency is important for teams that want a single place to define how metrics, dimensions, and relationships should behave.
 
-Instead of each agent inventing its own interpretation, Wren Engine helps standardize the context they operate on.
+Instead of each agent inventing its own interpretation, Wren AI Core helps standardize the context they operate on.
 
 ### 5. Governed access to data
 
-AI systems should not have unlimited freedom to reference every object in a warehouse. Wren Engine helps narrow and structure what an agent can work with by operating against modeled data definitions rather than arbitrary warehouse exploration alone.
+AI systems should not have unlimited freedom to reference every object in a warehouse. Wren AI Core helps narrow and structure what an agent can work with by operating against modeled data definitions rather than arbitrary warehouse exploration alone.
 
 That improves safety and governance by:
 
@@ -58,7 +58,7 @@ That improves safety and governance by:
 
 ### 6. Memory and self-learning
 
-Most text-to-SQL systems treat every question as if it were the first. Wren Engine breaks that pattern with a built-in [memory layer](../guides/memory.md) that learns from successful queries and gets better over time.
+Most text-to-SQL systems treat every question as if it were the first. Wren AI Core breaks that pattern with a built-in [memory layer](../guides/memory.md) that learns from successful queries and gets better over time.
 
 The memory system works at two levels:
 
@@ -74,6 +74,6 @@ The practical effect is fewer wrong answers over time — without retraining a m
 
 AI agents need more than schema access. They need context they can plan with.
 
-Wren Engine is designed for that layer of the stack: it turns raw warehouse structure into usable business context, exposes that context through MCP-friendly workflows, and helps agents generate more accurate, explainable, and governable data interactions.
+Wren AI Core is designed for that layer of the stack: it turns raw warehouse structure into usable business context, exposes that context through MCP-friendly workflows, and helps agents generate more accurate, explainable, and governable data interactions.
 
-If you are building AI-native analytics, text-to-SQL experiences, or agent workflows over enterprise data, Wren Engine helps bridge the gap between raw data systems and trustworthy agent behavior.
+If you are building AI-native analytics, text-to-SQL experiences, or agent workflows over enterprise data, Wren AI Core helps bridge the gap between raw data systems and trustworthy agent behavior.

--- a/docs/core/concepts/what_is_context.md
+++ b/docs/core/concepts/what_is_context.md
@@ -1,6 +1,6 @@
 # What is context?
 
-In Wren Engine, context is the structured business understanding an AI agent needs in order to work with data correctly. It goes beyond raw schemas and table access. Context helps an agent understand what your data means, which sources to trust, how entities relate to each other, how metrics should be calculated, and what rules or guidance should shape its behavior.
+In Wren AI Core, context is the structured business understanding an AI agent needs in order to work with data correctly. It goes beyond raw schemas and table access. Context helps an agent understand what your data means, which sources to trust, how entities relate to each other, how metrics should be calculated, and what rules or guidance should shape its behavior.
 
 For AI agents, this matters because answering a question is rarely just a SQL generation problem. The harder problem is knowing what the question means inside a business. Questions like "What is revenue growth last quarter?" depend on business definitions, trusted sources, time conventions, relationships, and sometimes team-specific instructions. Context is what makes those answers reliable.
 
@@ -16,7 +16,7 @@ Context helps agents:
 - apply business rules consistently
 - generate more reliable answers across multi-step workflows
 
-This is why Wren Engine is positioned as an open context layer for AI agents: it helps turn raw data systems into usable context that agents can reason over.
+This is why Wren AI Core is positioned as an open context layer for AI agents: it helps turn raw data systems into usable context that agents can reason over.
 
 ## Context vs. semantics
 
@@ -49,9 +49,9 @@ But for AI agents, a semantic layer alone is often not enough. Agents also need 
 
 This idea aligns with the argument in a16z's article [Your Data Agents Need Context](https://a16z.com/your-data-agents-need-context/): a modern context layer should be a superset of the traditional semantic layer, adding the business and operational grounding that autonomous agents need.
 
-## What context includes in Wren Engine
+## What context includes in Wren AI Core
 
-Wren Engine builds context from structured modeling and execution primitives, including:
+Wren AI Core builds context from structured modeling and execution primitives, including:
 
 - MDL definitions for models, relationships, calculations, and views
 - business-facing dataset structure

--- a/docs/core/concepts/what_is_mdl.md
+++ b/docs/core/concepts/what_is_mdl.md
@@ -1,14 +1,14 @@
 # What is Modeling Definition Language (MDL)?
 
-Modeling Definition Language (MDL) is the way Wren Engine describes business data in a structured, machine-readable form. It defines models, relationships, calculations, and views so that both humans and AI agents can work from the same business context.
+Modeling Definition Language (MDL) is the way Wren AI Core describes business data in a structured, machine-readable form. It defines models, relationships, calculations, and views so that both humans and AI agents can work from the same business context.
 
-Instead of exposing only raw tables and columns, MDL gives your data a logical shape. It tells Wren Engine how datasets relate to each other, how business metrics should be defined, and how analytical logic should be reused across queries.
+Instead of exposing only raw tables and columns, MDL gives your data a logical shape. It tells Wren AI Core how datasets relate to each other, how business metrics should be defined, and how analytical logic should be reused across queries.
 
 ## Why MDL matters
 
 Raw schemas are not enough for reliable analytics or AI-driven querying. A warehouse may contain hundreds of tables, inconsistent naming, and business logic scattered across dashboards or SQL scripts. MDL helps centralize that logic into a form that is easier to understand, review, and execute.
 
-With MDL, Wren Engine can provide AI agents with the context they need to:
+With MDL, Wren AI Core can provide AI agents with the context they need to:
 
 - understand business entities and terminology
 - follow defined relationships between datasets
@@ -25,11 +25,11 @@ MDL is used to model the business-facing structure of your data. Depending on yo
 - calculated fields and reusable metrics
 - views built on top of modeled datasets
 
-This gives Wren Engine a consistent representation of how your data should behave, rather than forcing every user or agent to rediscover that logic from scratch.
+This gives Wren AI Core a consistent representation of how your data should behave, rather than forcing every user or agent to rediscover that logic from scratch.
 
 ## How MDL helps AI agents
 
-AI agents perform better when they can reason over structured context instead of guessing from raw schema alone. MDL helps by giving Wren Engine an explicit description of your business layer.
+AI agents perform better when they can reason over structured context instead of guessing from raw schema alone. MDL helps by giving Wren AI Core an explicit description of your business layer.
 
 That improves agent behavior in several ways:
 
@@ -38,7 +38,7 @@ That improves agent behavior in several ways:
 - more consistent metric definitions across queries
 - clearer grounding for text-to-SQL and RAG workflows
 
-In this sense, MDL is one of the core building blocks that lets Wren Engine act as an open context layer for AI agents.
+In this sense, MDL is one of the core building blocks that lets Wren AI Core act as an open context layer for AI agents.
 
 ## Benefits of MDL
 
@@ -56,12 +56,12 @@ Because MDL is structured and explicit, it is easier for data teams to review, m
 
 ### 4. More reliable execution
 
-Wren Engine can plan and generate queries more reliably when it has modeled definitions to work from. This helps reduce errors caused by incomplete schema interpretation or one-off query logic.
+Wren AI Core can plan and generate queries more reliably when it has modeled definitions to work from. This helps reduce errors caused by incomplete schema interpretation or one-off query logic.
 
 ### 5. A stronger foundation for agentic analytics
 
-If you want AI agents to operate on business data safely and accurately, they need more than access. They need context. MDL gives Wren Engine that context in a durable, portable form.
+If you want AI agents to operate on business data safely and accurately, they need more than access. They need context. MDL gives Wren AI Core that context in a durable, portable form.
 
 ## In short
 
-MDL is the modeling language that powers Wren Engine. It turns raw data structures into usable business context, making analytics workflows easier to govern for people and easier to reason over for AI agents.
+MDL is the modeling language that powers Wren AI Core. It turns raw data structures into usable business context, making analytics workflows easier to govern for people and easier to reason over for AI agents.

--- a/docs/core/get_started/connect.md
+++ b/docs/core/get_started/connect.md
@@ -1,6 +1,6 @@
 # Connect Your Database
 
-This guide walks you through connecting Wren Engine to your own database — from creating a profile to running your first query. If you haven't installed the CLI yet, see [Installation](./installation.md) first.
+This guide walks you through connecting Wren AI Core to your own database — from creating a profile to running your first query. If you haven't installed the CLI yet, see [Installation](./installation.md) first.
 
 ---
 

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start: Wren CLI with jaffle_shop
 
-Use natural-language questions against the **jaffle\_shop** dataset using **Wren Engine CLI** and **Claude Code** — no cloud database, no Docker, no MCP server.
+Use natural-language questions against the **jaffle\_shop** dataset using **Wren AI Core CLI** and **Claude Code** — no cloud database, no Docker, no MCP server.
 
 > **Time:** ~15 minutes
 >
@@ -176,7 +176,7 @@ This creates:
 
 The generated `wren_project.yml` contains default values for `catalog` and `schema`:
 
-> **Note:** `catalog` and `schema` in `wren_project.yml` define the **Wren Engine namespace** — they have nothing to do with your database's catalog or schema. Keep the defaults (`wren` / `public`). The actual database location of each table is specified per-model in the `table_reference` section.
+> **Note:** `catalog` and `schema` in `wren_project.yml` define the **Wren AI Core namespace** — they have nothing to do with your database's catalog or schema. Keep the defaults (`wren` / `public`). The actual database location of each table is specified per-model in the `table_reference` section.
 
 ---
 

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -80,22 +80,24 @@ wren version
 
 ## Step 3 — Install CLI skills
 
-Skills are workflow guides that tell your AI coding agent how to use the Wren CLI effectively. Install both skills:
+Skills are workflow guides that tell your AI coding agent how to use the Wren CLI effectively. Install the skill bundle:
 
 ```bash
-npx skills add Canner/wren-engine --skill '*'
+npx skills add Canner/WrenAI --skill '*'
 # or:
-curl -fsSL https://raw.githubusercontent.com/Canner/wren-engine/main/skills/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Canner/WrenAI/main/skills/install.sh | bash
 ```
 
 The CLI auto-detects your installed agent. To target a specific one, add `--agent <name>` (e.g., `claude-code`, `cursor`, `windsurf`, `cline`).
 
-This installs two skills:
+This quickstart uses two of the installed skills:
 
 | Skill | Purpose |
 |-------|---------|
 | **wren-usage** | Day-to-day workflow — gather context, recall past queries, write SQL, store results |
 | **wren-generate-mdl** | One-time setup — explore database schema and generate the MDL project |
+
+For the full skill list (including `wren-onboarding` and `wren-dlt-connector`), see [Installation](./installation.md#install-skills).
 
 ---
 

--- a/docs/core/guides/memory.md
+++ b/docs/core/guides/memory.md
@@ -1,6 +1,6 @@
 # Memory
 
-Wren Engine includes a **memory layer** — a LanceDB-backed semantic index that gives AI agents the context they need to write accurate SQL. Instead of sending the entire schema to an LLM on every question, the memory layer provides targeted context: relevant tables, columns, and past query examples.
+Wren AI Core includes a **memory layer** — a LanceDB-backed semantic index that gives AI agents the context they need to write accurate SQL. Instead of sending the entire schema to an LLM on every question, the memory layer provides targeted context: relevant tables, columns, and past query examples.
 
 ## Why memory matters
 

--- a/docs/core/guides/modeling/overview.md
+++ b/docs/core/guides/modeling/overview.md
@@ -1,8 +1,8 @@
 # Overview
 
-## Data modeling in Wren Engine
+## Data modeling in Wren AI Core
 
-Wren Engine uses Modeling Definition Language (MDL) to describe business data in a structured, queryable form. Modeling is how you turn physical tables and raw schemas into context that can be reused by SQL clients and AI agents.
+Wren AI Core uses Modeling Definition Language (MDL) to describe business data in a structured, queryable form. Modeling is how you turn physical tables and raw schemas into context that can be reused by SQL clients and AI agents.
 
 In practice, the modeling layer defines:
 
@@ -11,7 +11,7 @@ In practice, the modeling layer defines:
 - which calculations should be reused
 - which query interfaces should be published as stable objects
 
-This guide provides a high-level map of the core modeling primitives in Wren Engine.
+This guide provides a high-level map of the core modeling primitives in Wren AI Core.
 
 ## Core modeling objects
 
@@ -33,7 +33,7 @@ See [Model](./model.md).
 
 ### Relationship
 
-A **Relationship** defines how two models are connected. Wren Engine uses relationship metadata to plan joins and enable relationship-aware expressions.
+A **Relationship** defines how two models are connected. Wren AI Core uses relationship metadata to plan joins and enable relationship-aware expressions.
 
 Use a relationship when you need to:
 
@@ -102,4 +102,4 @@ Use this rule of thumb:
 
 ## Why this matters
 
-Good modeling is not only about query convenience. It is how Wren Engine turns raw warehouse structure into durable business context. Once models, relationships, and calculations are defined centrally, queries become easier to write, easier to review, and more consistent across users, applications, and AI agents.
+Good modeling is not only about query convenience. It is how Wren AI Core turns raw warehouse structure into durable business context. Once models, relationships, and calculations are defined centrally, queries become easier to write, easier to review, and more consistent across users, applications, and AI agents.

--- a/docs/core/guides/modeling/wren_project.md
+++ b/docs/core/guides/modeling/wren_project.md
@@ -98,13 +98,13 @@ data_source: postgres
 | `schema_version` | Directory layout version. `2` = folder-per-entity, `3` = adds `dialect` field support (current). Owned by the CLI — do not bump manually. |
 | `name` | Project name |
 | `version` | User's own project version (free-form, no effect on parsing) |
-| `catalog` | **Wren Engine namespace** — NOT your database catalog. Identifies this MDL project within the engine. Default: `wren`. |
-| `schema` | **Wren Engine namespace** — NOT your database schema. Default: `public`. |
+| `catalog` | **Wren AI Core namespace** — NOT your database catalog. Identifies this MDL project within the engine. Default: `wren`. |
+| `schema` | **Wren AI Core namespace** — NOT your database schema. Default: `public`. |
 | `data_source` | Data source type (e.g. `postgres`, `bigquery`, `snowflake`) |
 
 > **`catalog` / `schema` are NOT database settings.**
 >
-> These two fields define the Wren Engine's internal namespace for addressing models in SQL. They exist to support future multi-project querying. For single-project use, keep the defaults (`catalog: wren`, `schema: public`).
+> These two fields define the Wren AI Core's internal namespace for addressing models in SQL. They exist to support future multi-project querying. For single-project use, keep the defaults (`catalog: wren`, `schema: public`).
 >
 > Your database's actual catalog and schema are specified per-model in the `table_reference` section of each model's `metadata.yml`.
 
@@ -114,7 +114,7 @@ The same field names appear in two places with completely different meanings:
 
 | Location | Refers to | Example | When to change |
 |----------|-----------|---------|----------------|
-| `wren_project.yml` → `catalog`, `schema` | Wren Engine namespace | `wren`, `public` | Only for multi-project setups |
+| `wren_project.yml` → `catalog`, `schema` | Wren AI Core namespace | `wren`, `public` | Only for multi-project setups |
 | `models/*/metadata.yml` → `table_reference.catalog`, `table_reference.schema` | Database location | `""`, `main` | Must match your actual database |
 
 ### Model (`models/<name>/metadata.yml`)


### PR DESCRIPTION
## Summary

Three cleanup commits after the Wren AI Core rebrand:

- **Naming** (9 files under `docs/core/{concepts,guides,get_started}`): rename "Wren Engine" → "Wren AI Core" to align with the rebrand. The PyPI package name `wren-engine` is preserved everywhere it appears (it is the actual package identifier on PyPI).
- **README** (`README.md`): add a "Why WrenAI?" section before Quick start so a first-time reader gets the problem framing — context layer for AI agents — instead of diving straight into mechanics. Rewrite Quick start as the agent-driven path (`npx skills add Canner/WrenAI --skill '*'` → ask `wren-onboarding` skill). The previous Quick start used `pip install wren-engine` (without `[main]` extra) and ended with `SELECT order_id FROM "orders"` against a freshly scaffolded project that has no orders table — not actually runnable. The full CLI guide is preserved one click away in `core/wren/README.md`.
- **Quickstart skill bundle URL** (`docs/core/get_started/quickstart.md`): point at `Canner/WrenAI` instead of the archived `Canner/wren-engine`; clarify wording around how many skills the bundle installs.

Mirror change for the docs site is in [Canner/docs.getwren.ai#fix/fix-oss-document]. Sync verified byte-to-byte across all sync-action paths — the next `sync-docs` run after merge is a no-op diff.

## Test plan

- [ ] README Quick start `npx skills add Canner/WrenAI --skill '*'` resolves and installs
- [ ] No remaining "Wren Engine" string in `docs/core/`
- [ ] After merge: `sync-docs.yml` triggers, completes with `changed=false`, no auto-PR is created on docs.getwren.ai (the mirror commit is already there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Repositioned WrenAI as an "open context layer" for AI agents backed by Rust engine powered by Apache DataFusion
  * Updated quick-start guide with new AI-coding-agent-driven installation using `npx skills add Canner/WrenAI` command
  * Refreshed onboarding workflow with `wren-onboarding` skill for setup and initial queries
  * Standardized product terminology throughout documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->