### PR TITLE
deps(ci): add langchain to rc release ci

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -11,6 +11,7 @@ on:
           - wren-core-py
           - wren
           - wren-core-wasm
+          - wren-langchain
       rc_version:
         description: "RC version override (e.g. 0.25.0-rc.2). Leave empty to auto-increment."
         required: false
@@ -157,8 +158,19 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-wren-langchain:
+    needs: create-rc
+    if: inputs.component == 'wren-langchain'
+    uses: ./.github/workflows/publish-wren-langchain.yml
+    with:
+      version: ${{ needs.create-rc.outputs.pypi_version }}
+      tag_name: ${{ needs.create-rc.outputs.tag_name }}
+    permissions:
+      contents: read
+      id-token: write
+
   create-release:
-    needs: [create-rc, publish-wren-core-py, publish-wren, publish-wren-core-wasm]
+    needs: [create-rc, publish-wren-core-py, publish-wren, publish-wren-core-wasm, publish-wren-langchain]
     if: always() && needs.create-rc.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to enable RC releases for the `wren-langchain` component, including automated publishing and release creation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->