### PR TITLE
feat(sdk): add wren-pydantic package for Pydantic AI integration

### DIFF
--- a/.github/workflows/publish-wren-pydantic.yml
+++ b/.github/workflows/publish-wren-pydantic.yml
@@ -1,0 +1,120 @@
+name: Publish wren-pydantic to PyPI
+
+# Mirrors .github/workflows/publish-wren.yml. Inputs come from
+# workflow_call (orchestrated by release-please or manual dispatch wrapper),
+# not from untrusted issue/PR/comment events, so direct `${{ inputs.* }}`
+# interpolation is safe in run/env contexts here. If you ever wire this to
+# a public event source, switch to `env:` + shell variables first.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version number (e.g. 0.1.0 or 0.1.0rc1)"
+        required: true
+        type: string
+      tag_name:
+        description: "Git tag to checkout (e.g. wren-pydantic-v0.1.0)"
+        required: true
+        type: string
+      pypi_target:
+        description: "Publish target (pypi or testpypi)"
+        required: false
+        type: string
+        default: "pypi"
+
+permissions:
+  # Workflow-wide default = read-only. The publish job scopes its own
+  # id-token: write below; build/validate-inputs run user code and don't
+  # need to mint OIDC tokens.
+  contents: read
+
+jobs:
+  validate-inputs:
+    name: Validate workflow inputs
+    runs-on: ubuntu-latest
+    steps:
+      # Reject typos like "test-pypi" / "PYPI" before they accidentally route
+      # to production: only the exact strings "pypi" or "testpypi" are valid.
+      - name: Check pypi_target
+        env:
+          PYPI_TARGET: ${{ inputs.pypi_target }}
+        run: |
+          case "$PYPI_TARGET" in
+            pypi|testpypi) ;;
+            *)
+              echo "::error::Invalid pypi_target '$PYPI_TARGET'. Expected 'pypi' or 'testpypi'."
+              exit 1
+              ;;
+          esac
+
+  build:
+    name: Build distribution
+    needs: validate-inputs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Set version
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: python
+        run: |
+          import re, os, sys
+          version = os.environ["VERSION"]
+          if not re.fullmatch(r"\d+\.\d+\.\d+(rc\d+)?", version):
+              print(f"::error::Unsupported version format: {version!r}. Expected X.Y.Z or X.Y.ZrcN.")
+              sys.exit(1)
+          for path, pattern in [
+              ("sdk/wren-pydantic/pyproject.toml", r'^(version\s*=\s*)".*?"'),
+              ("sdk/wren-pydantic/src/wren_pydantic/__init__.py", r'^(__version__\s*=\s*)".*?"'),
+          ]:
+              # Explicit utf-8 — pyproject.toml description and __init__.py docstring
+              # both contain non-ASCII; relying on platform default could corrupt them.
+              text = open(path, encoding="utf-8").read()
+              text, n = re.subn(pattern, rf'\1"{version}"', text, count=1, flags=re.MULTILINE)
+              if n != 1:
+                  print(f"::error::Failed to update version in {path}")
+                  sys.exit(1)
+              open(path, "w", encoding="utf-8").write(text)
+      - name: Install build tool
+        run: pip install build
+      - name: Build sdist and wheel
+        run: python -m build
+        working-directory: sdk/wren-pydantic
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: sdk/wren-pydantic/dist/
+
+  publish:
+    name: Publish to ${{ inputs.pypi_target }}
+    needs: build
+    runs-on: ubuntu-latest
+    # Scoped to publish only — least-privilege per least-privilege principle.
+    # `id-token: write` is what authenticates to PyPI via OIDC Trusted Publishing.
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: ${{ inputs.pypi_target }}
+      url: ${{ inputs.pypi_target == 'pypi' && 'https://pypi.org/project/wren-pydantic/' || 'https://test.pypi.org/project/wren-pydantic/' }}
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: List artifacts
+        run: ls -lhR dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ inputs.pypi_target == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          packages-dir: dist/
+          attestations: false

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -12,6 +12,7 @@ on:
           - wren
           - wren-core-wasm
           - wren-langchain
+          - wren-pydantic
       rc_version:
         description: "RC version override (e.g. 0.25.0-rc.2). Leave empty to auto-increment."
         required: false
@@ -169,8 +170,19 @@ jobs:
       contents: read
       id-token: write
 
+  publish-wren-pydantic:
+    needs: create-rc
+    if: inputs.component == 'wren-pydantic'
+    uses: ./.github/workflows/publish-wren-pydantic.yml
+    with:
+      version: ${{ needs.create-rc.outputs.pypi_version }}
+      tag_name: ${{ needs.create-rc.outputs.tag_name }}
+    permissions:
+      contents: read
+      id-token: write
+
   create-release:
-    needs: [create-rc, publish-wren-core-py, publish-wren, publish-wren-core-wasm, publish-wren-langchain]
+    needs: [create-rc, publish-wren-core-py, publish-wren, publish-wren-core-wasm, publish-wren-langchain, publish-wren-pydantic]
     if: always() && needs.create-rc.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,9 @@ jobs:
       wren-langchain--release_created: ${{ steps.release.outputs['sdk/wren-langchain--release_created'] }}
       wren-langchain--tag_name: ${{ steps.release.outputs['sdk/wren-langchain--tag_name'] }}
       wren-langchain--version: ${{ steps.release.outputs['sdk/wren-langchain--version'] }}
+      wren-pydantic--release_created: ${{ steps.release.outputs['sdk/wren-pydantic--release_created'] }}
+      wren-pydantic--tag_name: ${{ steps.release.outputs['sdk/wren-pydantic--tag_name'] }}
+      wren-pydantic--version: ${{ steps.release.outputs['sdk/wren-pydantic--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -75,6 +78,17 @@ jobs:
     with:
       version: ${{ needs.release-please.outputs['wren-langchain--version'] }}
       tag_name: ${{ needs.release-please.outputs['wren-langchain--tag_name'] }}
+    permissions:
+      contents: read
+      id-token: write
+
+  publish-wren-pydantic:
+    needs: release-please
+    if: needs.release-please.outputs['wren-pydantic--release_created'] == 'true'
+    uses: ./.github/workflows/publish-wren-pydantic.yml
+    with:
+      version: ${{ needs.release-please.outputs['wren-pydantic--version'] }}
+      tag_name: ${{ needs.release-please.outputs['wren-pydantic--tag_name'] }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/sdk-pydantic-ci.yml
+++ b/.github/workflows/sdk-pydantic-ci.yml
@@ -14,13 +14,13 @@ on:
   pull_request:
     paths:
       - 'sdk/wren-pydantic/**'
-      - '.github/workflows/sdk-langchain-ci.yml'
+      - '.github/workflows/sdk-pydantic-ci.yml'
   push:
     branches:
       - main
     paths:
       - 'sdk/wren-pydantic/**'
-      - '.github/workflows/sdk-langchain-ci.yml'
+      - '.github/workflows/sdk-pydantic-ci.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sdk-pydantic-ci.yml
+++ b/.github/workflows/sdk-pydantic-ci.yml
@@ -1,0 +1,96 @@
+name: wren-pydantic CI
+
+# Trigger sources are controlled events (pull_request, push to main,
+# workflow_dispatch). No untrusted issue / comment / external payload is
+# interpolated into run/env contexts in this file. ${{ matrix.* }} and
+# ${{ github.* }} usages below are confined to YAML-level fields
+# (name, with, group), not run scripts.
+
+permissions:
+  # Lint / test / build only — no PR comments, statuses, or labels written.
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'sdk/wren-pydantic/**'
+      - '.github/workflows/sdk-langchain-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdk/wren-pydantic/**'
+      - '.github/workflows/sdk-langchain-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: sdk/wren-pydantic
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Ubuntu's system Python is PEP 668 externally-managed; use a hosted
+      # toolcache Python so `uv pip install --system` is allowed to write.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v4
+      - name: Install package + dev deps
+        run: uv pip install --system -e ".[dev]"
+      - name: ruff check
+        run: ruff check .
+      - name: ruff format check
+        run: ruff format --check .
+
+  test:
+    name: tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v4
+      - name: Install package + dev deps
+        run: uv pip install --system -e ".[dev]"
+      - name: Run default test suite
+        # pytest config skips tests marked `slow` (LanceDB + sentence-transformer
+        # heavyweights). Slow tests are opt-in locally; we add a dedicated CI
+        # job for them later if worth the runner cost.
+        run: pytest -v
+
+  build:
+    name: build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v4
+      - name: Install build tool
+        run: uv pip install --system build
+      - name: Build distributions
+        run: python -m build
+      - name: Verify LICENSE bundled in wheel
+        run: |
+          set -euo pipefail
+          unzip -l dist/wren_pydantic-*.whl | grep -q "dist-info/licenses/LICENSE"
+          echo "LICENSE present in wheel"
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: wren-pydantic-dist
+          path: sdk/wren-pydantic/dist/

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "core/wren-core-py": "0.5.0",
   "core/wren": "0.5.0",
   "core/wren-core-wasm": "0.3.0",
-  "sdk/wren-langchain": "0.1.0"
+  "sdk/wren-langchain": "0.1.0",
+  "sdk/wren-pydantic": "0.1.0"
 }

--- a/docs/core/sdk/pydantic.md
+++ b/docs/core/sdk/pydantic.md
@@ -1,0 +1,229 @@
+# wren-pydantic
+
+Pydantic AI integration for Wren AI Core. Attach a CLI-prepared Wren project to your agent as a toolkit, with the semantic layer doing schema resolution, memory recall, and SQL execution.
+
+**Use this SDK when**: you're building a [Pydantic AI](https://ai.pydantic.dev) agent that needs to answer data questions against a Wren project. For one-shot CLI use, the `wren` command is fine on its own.
+
+---
+
+## Prerequisites
+
+> ⚠️ **Caution — Wren CLI required first.** This SDK is a thin adapter over a Wren project that the `wren` CLI has already prepared (profile + MDL + optional memory index). Without those, `WrenToolkit.from_project()` has nothing to attach to and will fail at construction. Follow the [install guide](https://docs.getwren.ai/oss/get_started/installation) before installing this package.
+
+Minimum CLI bootstrap:
+
+```bash
+wren profile add my_project --datasource postgres   # or mysql, duckdb, ...
+wren context init
+wren context set-profile my_project                  # binds profile to project
+wren context build                                   # produces target/mdl.json
+wren memory index                                    # optional but recommended
+```
+
+See [Connect Your Database](../get_started/connect.md) for the full CLI setup walkthrough including `.env` configuration and per-datasource notes.
+
+---
+
+## Installation
+
+Pick the datasource extra that matches your project's `data_source`:
+
+```bash
+pip install "wren-pydantic[postgres,memory]"   # or mysql, bigquery, ...
+```
+
+| Extra | Purpose |
+|---|---|
+| `postgres` / `mysql` / `bigquery` / `snowflake` / `clickhouse` / `trino` / `mssql` / `databricks` / `redshift` / `spark` / `athena` / `oracle` | Datasource pass-through (DuckDB needs no extra) |
+| `memory` | Enables the 3 memory tools (`wren_fetch_context`, `wren_recall_queries`, `wren_store_query`) |
+| `all` | All datasources at once — useful for experimentation, heavy for production |
+
+If `wren-engine` is already installed (e.g. you use the CLI), the bare `pip install wren-pydantic` is enough — your existing extras carry over.
+
+---
+
+## Quickstart
+
+```python
+from wren_pydantic import WrenToolkit
+from pydantic_ai import Agent
+
+toolkit = WrenToolkit.from_project("./analytics_db")
+
+agent = Agent(
+    "openai:gpt-4o",
+    instructions=toolkit.instructions(),
+    toolsets=[toolkit.toolset()],
+)
+
+result = agent.run_sync("Top 5 customers by revenue last quarter?")
+print(result.output)
+```
+
+The toolkit reads your project's MDL, connection profile, and `instructions.md`; the instructions string teaches the agent the recommended workflow (recall → fetch context → write SQL → store the result).
+
+---
+
+## API Reference
+
+### `WrenToolkit.from_project(path, *, profile=None)`
+
+Build a toolkit from a CLI-prepared Wren project directory.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `path` | `str \| Path` | Project root (the directory containing `wren_project.yml`) |
+| `profile` | `str \| None` | Optional profile name. Resolution order: this kwarg → `profile:` field in `wren_project.yml` → globally active profile |
+
+Memory tools are auto-detected: present `<path>/.wren/memory/` exposes 3 memory tools alongside 3 runtime tools; absent → only runtime tools.
+
+### `toolkit.toolset(*, include_memory_write=True, takes_ctx=False)`
+
+Return a Pydantic AI `FunctionToolset` bound to this toolkit.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `include_memory_write` | `True` | Set `False` to expose memory as read-only (drops `wren_store_query`) |
+| `takes_ctx` | `False` | Set `True` to inject `ctx: RunContext` as the first parameter of every tool — for mixing with `deps_type=`-typed tools |
+
+Returns a `FunctionToolset` with 3 runtime tools + 0/2/3 memory tools depending on memory state and `include_memory_write`.
+
+### `toolkit.instructions(*, toolset=None)`
+
+Wren-aware instructions string that adapts to enabled tools and includes your project's `instructions.md` when present. Pass the same `toolset` you give to `Agent` if you customized it (e.g. `include_memory_write=False`) so the workflow drops the persistence step instead of instructing the agent to call a tool that doesn't exist.
+
+### Tools (LLM-facing)
+
+| Tool | Returns | Purpose |
+|---|---|---|
+| `wren_query` | `WrenQueryResult` | Execute SQL through Wren's semantic layer; capped at 1000 rows |
+| `wren_dry_plan` | `str` | Plan SQL without execution; verifies it targets MDL models correctly |
+| `wren_list_models` | `list[ModelSummary]` | List project models with column counts and descriptions |
+| `wren_fetch_context` | `FetchContextResult` | Retrieve schema and business context for a natural-language question |
+| `wren_recall_queries` | `list[RecalledPair]` | Surface similar past NL→SQL pairs as few-shot examples |
+| `wren_store_query` | `str` | Persist a confirmed NL→SQL pair (registered with `retries=0` — write failures don't loop) |
+
+Each tool is registered with `retries=2` so the LLM gets two chances to self-correct on SQL or metadata errors. Errors classified as infrastructure (connection failures, missing files) propagate as `WrenError` instead of becoming `ModelRetry`.
+
+### Direct Python API
+
+When you want to call Wren outside an agent loop:
+
+```python
+toolkit.query("SELECT ...")            # → pyarrow.Table
+toolkit.dry_plan("SELECT ...")          # → str (target-dialect SQL)
+toolkit.dry_run("SELECT ...")           # → None (validates without execution)
+
+toolkit.memory.fetch("revenue trends")
+toolkit.memory.recall("top customers", limit=3)
+toolkit.memory.store(nl="...", sql="...", tags=["revenue"])
+```
+
+Sync only — no `aquery` / `afetch` variants. The underlying engine is sync I/O; Pydantic AI auto-bridges sync tools to its async run loop, so wrapping them in `asyncio.to_thread` would be fake-async with no real concurrency benefit. Revisit when Core ships an async-native engine.
+
+---
+
+## Integration patterns
+
+### Structured output via `output_type=`
+
+Pydantic AI's killer feature: ask the model to return its answer as a typed Pydantic instance, validated by the framework. Works out of the box with our toolset:
+
+```python
+from pydantic import BaseModel
+
+class TopCustomers(BaseModel):
+    period: str
+    customers: list[str]
+
+agent = Agent(
+    "openai:gpt-4o",
+    instructions=toolkit.instructions(),
+    toolsets=[toolkit.toolset()],
+    output_type=TopCustomers,    # ← framework validates output into this type
+)
+result = agent.run_sync("Top 5 customers last quarter?")
+print(result.output.customers)  # already a list[str], no parsing needed
+```
+
+See [`examples/pydantic_ai_structured_demo.py`](https://github.com/Canner/WrenAI/blob/main/sdk/wren-pydantic/examples/pydantic_ai_structured_demo.py) for the runnable version.
+
+### Read-only memory (shared / curated projects)
+
+Use `include_memory_write=False` when the agent should learn from past queries but not pollute the memory store:
+
+```python
+toolset = toolkit.toolset(include_memory_write=False)
+agent = Agent(
+    "openai:gpt-4o",
+    instructions=toolkit.instructions(toolset=toolset),  # keep prompt in sync
+    toolsets=[toolset],
+)
+```
+
+Passing `toolset=` to `instructions()` ensures the workflow drops the "store the query" step instead of instructing the agent to call a tool that no longer exists.
+
+### Mixing with `deps_type=` tools
+
+When you want to combine Wren tools with your own dependency-injected tools in the same agent, opt into `takes_ctx=True`:
+
+```python
+@dataclass
+class MyDeps:
+    api_client: ApiClient
+
+agent = Agent(
+    "openai:gpt-4o",
+    deps_type=MyDeps,
+    toolsets=[toolkit.toolset(takes_ctx=True)],   # ← required when deps_type is set
+)
+
+# Your own tool that uses deps:
+@agent.tool
+def lookup_external(ctx: RunContext[MyDeps], id: str) -> str:
+    return ctx.deps.api_client.fetch(id)
+```
+
+Wren tools ignore the context internally (the toolkit captures its own state) — `takes_ctx=True` just adds the parameter so the signature is compatible with Pydantic AI's deps-typed registration.
+
+### Multiple projects, one program
+
+One toolkit binds to one project. To query multiple Wren projects, build separate toolkits and coordinate in Python:
+
+```python
+loans = WrenToolkit.from_project("./loans_proj")
+events = WrenToolkit.from_project("./events_proj")
+
+loans_agent = Agent(model=..., toolsets=[loans.toolset()], instructions=loans.instructions())
+events_agent = Agent(model=..., toolsets=[events.toolset()], instructions=events.instructions())
+```
+
+Cross-project joins must happen in Python, not in SQL — each project has its own MDL and connection.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `table 'wren.<schema>.<x>' not found` at SQL_PLANNING | Agent wrote `schema.table` instead of MDL model name | Tighten instructions to forbid physical names; or have the agent call `wren_list_models` first |
+| Connection goes to the wrong database | Project has no `profile:` pin → falls back to global active | Run `wren context set-profile <name>` to pin the binding |
+| `MissingSecretError` | `${VAR}` in profile not resolved | Fill the matching key in `<project>/.env` |
+| `wren_query` returns capped row count | Hard cap at 1000 rows per tool call | Add `LIMIT` to your SQL, or use the direct API (`toolkit.query`) for larger pulls |
+
+---
+
+## Compatibility
+
+| `wren-pydantic` | `wren-engine` | `pydantic-ai` |
+|---|---|---|
+| 0.1.x | >= 0.5.0 | >= 1.0, < 2.0 |
+
+---
+
+## Limitations
+
+- **Sync direct API only.** See API Reference for the rationale.
+- **One toolkit per agent.** For multiple Wren projects, build separate toolkits + agents and federate in Python.
+- **No hot reload.** `target/mdl.json` is re-read per tool call so `wren context build` updates are picked up live; profile changes require constructing a new toolkit.
+- **Don't run `wren memory index` while an agent is using the same project.** The index operation drops and recreates the LanceDB schema table; concurrent reads may transiently fail.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,14 @@
       "extra-files": [
         "src/wren_langchain/__init__.py"
       ]
+    },
+    "sdk/wren-pydantic": {
+      "component": "wren-pydantic",
+      "release-type": "python",
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        "src/wren_pydantic/__init__.py"
+      ]
     }
   }
 }

--- a/sdk/wren-pydantic/.gitignore
+++ b/sdk/wren-pydantic/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.coverage
+dist/
+build/
+.venv/
+uv.lock

--- a/sdk/wren-pydantic/CHANGELOG.md
+++ b/sdk/wren-pydantic/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Changelog
-
-All notable changes to `wren-pydantic` are documented here.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/sdk/wren-pydantic/CHANGELOG.md
+++ b/sdk/wren-pydantic/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to `wren-pydantic` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/sdk/wren-pydantic/LICENSE
+++ b/sdk/wren-pydantic/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canner, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/wren-pydantic/README.md
+++ b/sdk/wren-pydantic/README.md
@@ -23,4 +23,150 @@ print(result.output)
 > memory index). Follow the [install guide](https://docs.getwren.ai/oss/get_started/installation)
 > before installing this package.
 
-Full documentation: [docs/core/sdk/pydantic.md](https://github.com/Canner/WrenAI/blob/main/docs/core/sdk/pydantic.md)
+Runnable demos:
+
+- [`examples/pydantic_ai_demo.py`](./examples/pydantic_ai_demo.py) — sync
+  3-line quickstart. Smallest amount of code; recommended starting point.
+- [`examples/pydantic_ai_structured_demo.py`](./examples/pydantic_ai_structured_demo.py) —
+  same shape with `output_type=` for structured / validated agent output.
+
+## Prerequisites
+
+This package assumes you have already used the Wren CLI to prepare a project:
+
+```bash
+wren profile add my_project --datasource duckdb   # or mysql, postgres, ...
+wren context init
+wren context set-profile my_project               # binds profile to project
+wren context build                                # produces target/mdl.json
+wren memory index                                 # optional but recommended
+```
+
+If you haven't installed the CLI yet, install `wren-engine` first:
+
+```bash
+pip install "wren-engine[memory,postgres]"
+```
+
+## Installation
+
+`wren-pydantic` exposes datasource and memory extras that pass through to the
+matching `wren-engine` extras, so you only have to install once:
+
+```bash
+# Match the datasource your wren_project.yml uses (DuckDB needs no extra):
+pip install "wren-pydantic[mysql]"
+pip install "wren-pydantic[postgres,memory]"
+pip install "wren-pydantic[bigquery,memory]"
+
+# Available datasource extras: postgres, mysql, bigquery, snowflake,
+# clickhouse, trino, mssql, databricks, redshift, spark, athena, oracle.
+
+# `memory` extra enables the three memory tools (wren_fetch_context,
+# wren_recall_queries, wren_store_query). Without it the toolkit exposes
+# only the three runtime tools.
+
+# Install everything for experimentation:
+pip install "wren-pydantic[all,memory]"
+```
+
+If `wren-engine` is already installed (e.g. you use the CLI), the bare
+`pip install wren-pydantic` is enough — your existing extras carry over.
+
+## What you get
+
+`WrenToolkit.from_project(path)` exposes:
+
+- **6 LLM-facing tools** (3 runtime + 3 memory when `.wren/memory/` exists):
+  - `wren_query` — execute SQL through Wren's semantic layer, returns
+    a `WrenQueryResult` (typed Pydantic model)
+  - `wren_dry_plan` — plan SQL without execution; verifies it targets MDL
+    models correctly
+  - `wren_list_models` — list project models with column counts and
+    descriptions
+  - `wren_fetch_context` — retrieve schema/business context for a question
+  - `wren_recall_queries` — surface similar past NL→SQL pairs as few-shot
+    examples
+  - `wren_store_query` — persist a confirmed NL→SQL pair for future recall
+    (`retries=0` — write failures don't loop)
+- **Direct Python API** (sync; no async wrappers — see `docs/core/sdk/pydantic.md`
+  for why):
+  ```python
+  toolkit.query("SELECT ...")              # → pyarrow.Table
+  toolkit.dry_plan("SELECT ...")            # → str (target-dialect SQL)
+  toolkit.dry_run("SELECT ...")             # → None (validates without exec)
+  toolkit.memory.fetch("revenue trends")
+  toolkit.memory.recall("top customers")
+  toolkit.memory.store(nl="...", sql="...", tags=["..."])
+  ```
+- **`toolkit.instructions()`** — Pydantic-AI-aware instructions string
+  that adapts to enabled tools and includes your project's
+  `instructions.md` when present.
+
+Errors from the engine are converted into Pydantic AI's `ModelRetry`
+with phase-aware framing — the agent can self-correct on SQL or
+metadata errors. Infrastructure errors (connection failures, missing
+DuckDB files) propagate as `WrenError` for outer code to handle.
+
+## Configuration
+
+```python
+WrenToolkit.from_project(
+    path,                # required — path to your prepared Wren project
+    profile="prod",      # optional — picks a named profile (default: active)
+)
+
+toolkit.toolset(
+    include_memory_write=True,   # set False to keep memory read-only
+    takes_ctx=False,             # set True if mixing with deps_type= tools
+)
+
+toolkit.instructions(toolset=toolset)  # pass same toolset for prompt sync
+```
+
+Memory is **auto-detected** from the project: present `<path>/.wren/memory/`
+exposes the 3 memory tools alongside the 3 runtime tools; absent → only the
+runtime tools. To enable, run `wren memory index` from the project root; to
+disable, delete the directory. There is no override kwarg.
+
+`include_memory_write=False` removes `wren_store_query` from the toolset
+while keeping `wren_fetch_context` and `wren_recall_queries`. Use this for
+shared / curated memory stores.
+
+`takes_ctx=True` exposes `ctx: RunContext` as the first parameter of every
+tool. Use this when mixing wren tools with your own `deps_type=`-typed
+tools in the same agent. The context is ignored internally — the toolkit
+already captures its own state.
+
+## Compatibility matrix
+
+| `wren-pydantic` | `wren-engine` | `pydantic-ai` |
+|---|---|---|
+| 0.1.x | >= 0.5.0 | >= 1.0, < 2.0 |
+
+## Known limitations (v0.1)
+
+- **Sync direct API only.** `aquery` / `adry_plan` etc. are not provided —
+  Pydantic AI auto-bridges sync tools to its async run loop, and the
+  underlying `WrenEngine` is sync I/O so an async wrapper would be fake-async
+  with no real concurrency benefit. Revisit when Core ships an async-native
+  engine.
+- **One toolkit per agent.** If you need to query multiple Wren projects,
+  build separate toolkits + agents and federate in Python.
+- **Memory is auto-detected** from `.wren/memory/` and there is no kwarg to
+  override. To enable, run `wren memory index`; to disable, delete the
+  directory.
+- **No hot reload mechanism.** `target/mdl.json` is re-read on every tool
+  call so `wren context build` updates are picked up automatically. Profile
+  changes require constructing a new toolkit.
+- **Don't run `wren memory index` while an agent is using the same project.**
+  The index operation drops and recreates the LanceDB schema table;
+  concurrent reads may transiently fail.
+
+## License
+
+Apache License 2.0. See [LICENSE](./LICENSE) for the full text.
+
+The names "Wren", "WrenAI", and the project's logos are trademarks of
+Canner, Inc. and are not licensed under Apache 2.0; their use is governed
+separately.

--- a/sdk/wren-pydantic/README.md
+++ b/sdk/wren-pydantic/README.md
@@ -1,0 +1,26 @@
+# wren-pydantic
+
+Pydantic AI integration for [Wren AI Core](https://github.com/Canner/WrenAI).
+
+Attach a CLI-prepared Wren project to a Pydantic AI agent in three lines:
+
+```python
+from wren_pydantic import WrenToolkit
+from pydantic_ai import Agent
+
+toolkit = WrenToolkit.from_project("./analytics_db")
+agent = Agent(
+    "openai:gpt-4o",
+    instructions=toolkit.instructions(),
+    toolsets=[toolkit.toolset()],
+)
+result = agent.run_sync("How many enterprise customers do we have?")
+print(result.output)
+```
+
+> ⚠️ **Wren CLI required first.** This SDK is a thin adapter over a Wren
+> project that the `wren` CLI has already prepared (profile + MDL + optional
+> memory index). Follow the [install guide](https://docs.getwren.ai/oss/get_started/installation)
+> before installing this package.
+
+Full documentation: [docs/core/sdk/pydantic.md](https://github.com/Canner/WrenAI/blob/main/docs/core/sdk/pydantic.md)

--- a/sdk/wren-pydantic/examples/pydantic_ai_demo.py
+++ b/sdk/wren-pydantic/examples/pydantic_ai_demo.py
@@ -1,0 +1,49 @@
+"""3-line quickstart: attach a CLI-prepared Wren project to a Pydantic AI agent.
+
+Prereq:
+    wren profile add my_project --datasource duckdb
+    wren context init
+    wren context set-profile my_project
+    wren context build
+
+Run:
+    OPENAI_API_KEY=sk-... python examples/pydantic_ai_demo.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from pydantic_ai import Agent
+
+from wren_pydantic import WrenToolkit
+
+
+def main() -> None:
+    project_path = Path(os.environ.get("PROJECT_PATH", "./analytics_db")).expanduser()
+    if not (project_path / "wren_project.yml").exists():
+        print(
+            f"PROJECT_PATH={project_path} doesn't look like a Wren project "
+            "(no wren_project.yml). Run `wren context init` there first, "
+            "or set PROJECT_PATH to an existing project.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    toolkit = WrenToolkit.from_project(project_path)
+    agent = Agent(
+        "openai:gpt-4o",
+        instructions=toolkit.instructions(),
+        toolsets=[toolkit.toolset()],
+    )
+
+    question = "How many rows are in each model in this project?"
+    result = agent.run_sync(question)
+    print(f"Q: {question}\n")
+    print(result.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/wren-pydantic/examples/pydantic_ai_structured_demo.py
+++ b/sdk/wren-pydantic/examples/pydantic_ai_structured_demo.py
@@ -1,0 +1,57 @@
+"""Structured output example using Pydantic AI's `output_type=`.
+
+Shows how to combine the Wren toolset with a typed agent output — the
+framework validates the model's response against the declared schema,
+making downstream code easier to write.
+
+Prereq: same as pydantic_ai_demo.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from pydantic import BaseModel
+from pydantic_ai import Agent
+
+from wren_pydantic import WrenToolkit
+
+
+class TopCustomers(BaseModel):
+    """The agent must return its answer in this shape."""
+
+    period: str
+    customers: list[str]
+    notes: str | None = None
+
+
+def main() -> None:
+    project_path = Path(os.environ.get("PROJECT_PATH", "./analytics_db")).expanduser()
+    if not (project_path / "wren_project.yml").exists():
+        print(f"PROJECT_PATH={project_path} not a Wren project", file=sys.stderr)
+        sys.exit(1)
+
+    toolkit = WrenToolkit.from_project(project_path)
+    agent = Agent(
+        "openai:gpt-4o",
+        instructions=toolkit.instructions(),
+        toolsets=[toolkit.toolset()],
+        output_type=TopCustomers,
+    )
+
+    result = agent.run_sync(
+        "Top 5 customers by revenue last quarter — return names only."
+    )
+    # result.output is a validated TopCustomers instance, not a free-form string.
+    print(f"Period: {result.output.period}")
+    print("Customers:")
+    for name in result.output.customers:
+        print(f"  - {name}")
+    if result.output.notes:
+        print(f"\nNotes: {result.output.notes}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/wren-pydantic/pyproject.toml
+++ b/sdk/wren-pydantic/pyproject.toml
@@ -1,0 +1,112 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "wren-pydantic"
+version = "0.1.0"
+description = "Pydantic AI integration for Wren AI Core — attach a CLI-prepared Wren project to your agent in three lines."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Wren AI", email = "contact@getwren.ai" }]
+keywords = [
+  "wrenai", "wren", "pydantic-ai", "pydantic", "agent", "ai-agent",
+  "sql", "context-layer", "semantic", "mdl", "data-modeling", "analytics",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Database",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Typing :: Typed",
+]
+dependencies = [
+  # Core: provides WrenEngine, MemoryStore, profile resolution, MDL handling.
+  "wren-engine>=0.5.0",
+  # Pydantic AI v1 is GA. Pin major so breaking changes are an explicit
+  # opt-in via CHANGELOG.
+  "pydantic-ai>=1.0,<2.0",
+  "pydantic>=2",
+]
+
+[project.optional-dependencies]
+# ── Datasource pass-through extras ────────────────────────────────────────
+# Pick the one matching your project's `data_source` (in wren_project.yml).
+# These chain through to the matching `wren-engine[<datasource>]` extra so
+# you don't have to install the connector dependency twice.
+#
+#   pip install "wren-pydantic[mysql]"
+#   pip install "wren-pydantic[mysql,memory]"
+#
+# DuckDB is built into wren-engine — no extra needed.
+postgres   = ["wren-engine[postgres]>=0.5.0"]
+mysql      = ["wren-engine[mysql]>=0.5.0"]
+bigquery   = ["wren-engine[bigquery]>=0.5.0"]
+snowflake  = ["wren-engine[snowflake]>=0.5.0"]
+clickhouse = ["wren-engine[clickhouse]>=0.5.0"]
+trino      = ["wren-engine[trino]>=0.5.0"]
+mssql      = ["wren-engine[mssql]>=0.5.0"]
+databricks = ["wren-engine[databricks]>=0.5.0"]
+redshift   = ["wren-engine[redshift]>=0.5.0"]
+spark      = ["wren-engine[spark]>=0.5.0"]
+athena     = ["wren-engine[athena]>=0.5.0"]
+oracle     = ["wren-engine[oracle]>=0.5.0"]
+
+# ── Memory extra ──────────────────────────────────────────────────────────
+# Required to use the three memory tools (wren_fetch_context,
+# wren_recall_queries, wren_store_query). Pulls in LanceDB and the
+# sentence-transformer model deps via wren-engine.
+#
+# Without this, the toolkit auto-detects no memory and exposes only the
+# three runtime tools.
+memory = ["wren-engine[memory]>=0.5.0"]
+
+# ── Convenience aggregate ─────────────────────────────────────────────────
+# Installs every datasource + memory at once. Useful for CI / examples,
+# heavyweight for production where you usually want only one datasource.
+all = ["wren-engine[all]>=0.5.0"]
+
+# ── Dev / test deps ───────────────────────────────────────────────────────
+dev = [
+  "pytest>=8",
+  "pytest-mock>=3",
+  "ruff>=0.4",
+  # Tests run real DuckDB + LanceDB integrations, so memory deps are required.
+  "wren-engine[memory]>=0.5.0",
+]
+
+[project.urls]
+Homepage      = "https://getwren.ai"
+Documentation = "https://github.com/Canner/WrenAI/tree/main/sdk/wren-pydantic#readme"
+Repository    = "https://github.com/Canner/WrenAI"
+Issues        = "https://github.com/Canner/WrenAI/issues"
+Changelog     = "https://github.com/Canner/WrenAI/blob/main/sdk/wren-pydantic/CHANGELOG.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/wren_pydantic"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "PLC"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+# Default run skips tests marked `slow` (currently the LanceDB integration
+# tests which load a sentence-transformer model, ~30-40s). Run them explicitly
+# with `pytest -m slow` or `pytest -m "slow or not slow"` for everything.
+addopts = "-ra -m \"not slow\""
+markers = [
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/sdk/wren-pydantic/src/wren_pydantic/__init__.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/__init__.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+from wren_pydantic._toolkit import WrenToolkit
+from wren_pydantic.exceptions import MemoryNotEnabledError, WrenToolkitInitError
+
 __version__ = "0.1.0"
 
-__all__ = ["__version__"]
+__all__ = [
+    "MemoryNotEnabledError",
+    "WrenToolkit",
+    "WrenToolkitInitError",
+    "__version__",
+]

--- a/sdk/wren-pydantic/src/wren_pydantic/__init__.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/__init__.py
@@ -1,0 +1,7 @@
+"""wren-pydantic: Pydantic AI integration for Wren AI Core."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/sdk/wren-pydantic/src/wren_pydantic/_errors.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_errors.py
@@ -1,0 +1,163 @@
+"""WrenError → ModelRetry mapping for Pydantic AI tools.
+
+Pydantic AI's idiom for "the LLM should retry with a corrected call" is to
+raise ``ModelRetry(msg)`` from inside a tool — the framework forwards the
+message to the LLM as a ``RetryPromptPart`` and loops up to the tool's
+configured ``retries=`` count.
+
+Wren errors split into two classes:
+
+- **Propagate** (infra-class ErrorCodes): config / connection / filesystem
+  failures. Retrying won't help; let them bubble out of the agent so the
+  user's outer try/except can deal with them.
+- **Retry** (everything else): SQL / model-lookup / validation failures
+  the LLM can plausibly self-correct by adjusting its next tool call.
+
+Secret redaction (recursive) and a 4KB cap apply to the message body so
+neither db passwords nor multi-MB metadata blobs end up in the retry
+prompt forwarded to the model.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic_ai import ModelRetry
+from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+
+_SECRET_PATTERNS = ("password", "secret", "token", "credential")
+
+METADATA_CAP_BYTES = 4 * 1024
+"""Hard cap on the bytes of metadata we serialize into a ModelRetry message.
+Anything over this is replaced with a truncation marker — keeps retry
+prompts compact and avoids leaking large blobs to the LLM."""
+
+_DIALECT_SQL_EXCERPT_CHARS = 200
+"""How many characters of the planned dialect SQL to include in
+SQL_EXECUTION retry messages. Long enough for the model to see the bad
+fragment, short enough to keep the prompt focused."""
+
+
+# ErrorCodes that signal infra / config issues the LLM can't fix by retrying.
+# All other codes flow through to_model_retry().
+_PROPAGATE_CODES: frozenset[ErrorCode] = frozenset(
+    {
+        ErrorCode.GET_CONNECTION_ERROR,
+        ErrorCode.INVALID_CONNECTION_INFO,
+        ErrorCode.DUCKDB_FILE_NOT_FOUND,
+        ErrorCode.ATTACH_DUCKDB_ERROR,
+        ErrorCode.GENERIC_INTERNAL_ERROR,
+        ErrorCode.NOT_IMPLEMENTED,
+    }
+)
+
+
+def should_propagate(exc: WrenError) -> bool:
+    """Whether this WrenError should bubble past the agent instead of
+    becoming a ModelRetry. Used by tool wrappers to decide between
+    ``raise`` and ``raise to_model_retry(...)``."""
+    return exc.error_code in _PROPAGATE_CODES
+
+
+def redact_secrets(data: Any) -> Any:
+    """Replace values whose keys contain secret patterns with '***'.
+
+    Recursively walks nested dicts and lists. Input is not mutated.
+    Match is case-insensitive substring against the key name.
+    """
+
+    def _walk(value: Any, key_hint: str | None = None) -> Any:
+        if key_hint and any(pat in key_hint.lower() for pat in _SECRET_PATTERNS):
+            return "***"
+        if isinstance(value, dict):
+            return {k: _walk(v, k) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_walk(v, key_hint) for v in value]
+        return value
+
+    return _walk(data)
+
+
+def _build_message(exc: WrenError) -> str:
+    """Build the human-readable retry message for *exc*.
+
+    Phase-aware framing tells the LLM what kind of problem it hit so the
+    next attempt focuses on the right thing. SQL_EXECUTION includes a
+    dialect-SQL excerpt so the LLM sees what was actually sent.
+    """
+    phase = exc.phase
+    msg = exc.message
+
+    if phase == ErrorPhase.SQL_PARSING:
+        framing = f"SQL parse error: {msg}. Fix the SQL syntax and retry."
+    elif phase == ErrorPhase.SQL_PLANNING:
+        framing = f"SQL planning error: {msg}. Check model/column names and retry."
+    elif phase == ErrorPhase.SQL_TRANSPILE:
+        framing = f"SQL transpile error (target dialect): {msg}. Simplify and retry."
+    elif phase == ErrorPhase.SQL_DRY_RUN:
+        framing = f"SQL dry-run failed: {msg}. The query is invalid at planning."
+    elif phase == ErrorPhase.SQL_EXECUTION:
+        framing = f"Database execution error: {msg}."
+    elif phase == ErrorPhase.METADATA_FETCHING:
+        framing = (
+            f"Metadata lookup failed: {msg}. "
+            "Verify the model name with wren_list_models and retry."
+        )
+    elif phase == ErrorPhase.MDL_EXTRACTION:
+        framing = f"MDL extraction failed: {msg}. Check schema references and retry."
+    elif phase == ErrorPhase.VALIDATION:
+        framing = f"Validation error: {msg}. Adjust the SQL and retry."
+    else:
+        framing = f"Wren error: {msg}."
+
+    # SQL_EXECUTION carries the dialect SQL — include a truncated excerpt
+    # so the LLM sees what actually hit the database.
+    metadata = redact_secrets(exc.metadata or {})
+    if (
+        phase == ErrorPhase.SQL_EXECUTION
+        and isinstance(metadata, dict)
+        and DIALECT_SQL in metadata
+    ):
+        dialect = str(metadata[DIALECT_SQL])
+        if len(dialect) > _DIALECT_SQL_EXCERPT_CHARS:
+            dialect = dialect[:_DIALECT_SQL_EXCERPT_CHARS] + "..."
+        framing += f" Dialect SQL was: {dialect}"
+
+    # Hard cap. Serialize any extra metadata only if there's room.
+    if len(framing.encode("utf-8")) > METADATA_CAP_BYTES:
+        return _cap(framing)
+
+    if metadata and phase != ErrorPhase.SQL_EXECUTION:
+        # Non-SQL_EXECUTION errors: optionally append serialized metadata
+        # if it fits within the remaining cap budget.
+        try:
+            meta_str = json.dumps(metadata, default=str, ensure_ascii=False)
+        except (TypeError, ValueError):
+            meta_str = str(metadata)
+        candidate = f"{framing} metadata={meta_str}"
+        if len(candidate.encode("utf-8")) <= METADATA_CAP_BYTES:
+            return candidate
+
+    return _cap(framing)
+
+
+def _cap(text: str) -> str:
+    """Truncate *text* (bytes-aware) to the metadata cap, marking the cut."""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= METADATA_CAP_BYTES:
+        return text
+    # Leave room for the marker
+    marker = "... [truncated]"
+    keep = METADATA_CAP_BYTES - len(marker.encode("utf-8"))
+    return encoded[:keep].decode("utf-8", errors="ignore") + marker
+
+
+def to_model_retry(exc: WrenError) -> ModelRetry:
+    """Convert a retry-class WrenError into a ModelRetry the LLM can act on.
+
+    Callers must check ``should_propagate(exc)`` first — calling this on a
+    propagate-class error still produces a ModelRetry but the LLM won't be
+    able to fix the underlying issue, so it'll waste retry budget.
+    """
+    return ModelRetry(_build_message(exc))

--- a/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
@@ -1,0 +1,245 @@
+"""Build a Wren-aware system prompt for LangChain/LangGraph agents.
+
+The workflow distilled here mirrors the Wren CLI's `wren-usage` skill —
+recall → fetch context → write SQL → dry_plan if complex → execute → store —
+adapted to the SDK's tool surface.
+
+Defaults are deliberately strong ("recall by default", "store by default")
+because empirical testing showed soft phrasing ("for non-trivial questions",
+"when useful") was almost always interpreted by GPT-4o as "skip". The CLI
+skill takes the same stance and bakes the strong defaults into its workflow.
+
+The prompt is **derived from the actual tool list** so it stays in sync with
+``toolkit.toolset(include_memory_write=...)``. If a caller hides
+``wren_store_query``, the workflow drops the persistence step rather than
+instructing the agent to call a tool that no longer exists.
+
+Three markdown sections (any may be empty):
+  1. Workflow rules — auto-adapted to the supplied tool list.
+  2. Available tools — bullet list rendered from the same list.
+  3. Project-specific instructions — content of ``<project>/instructions.md``
+     when present; silently omitted when absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from wren_pydantic._toolkit import WrenToolkit
+
+
+_INTRO = (
+    "You use Wren Engine as the semantic layer for data querying. SQL "
+    "targets MDL model names (defined in `target/mdl.json`); the engine "
+    "translates to the target database dialect."
+)
+
+# Workflow step blobs. Composed conditionally based on which tools are present.
+_STEP_RECALL = """1. Recall similar past NL→SQL pairs:
+   `wren_recall_queries(question="<user's question>", limit=3)`
+   Use the results as few-shot examples. Empty results are fine — continue
+   to the next step. Do NOT skip this step on the grounds that the question
+   seems simple; past pairs may use better joins, filters, or column names
+   than you would write from scratch."""
+
+_STEP_FETCH = """2. Fetch schema and business context:
+   `wren_fetch_context(question="<user's question>")`
+   Optionally narrow scope with `model="<name>"` or
+   `item_type="model" | "column" | "relationship" | "view"`."""
+
+_STEP_LIST_MODELS_FALLBACK = """1. If you don't already know the available models, call `wren_list_models()`
+   to enumerate them."""
+
+_STEP_COMPOSE = (
+    "{n}. Compose SQL targeting Wren model names — NEVER raw database tables."
+)
+
+_STEP_DRY_PLAN = """{n}. (Complex queries only) Verify with `wren_dry_plan(sql="...")` before
+   executing. "Complex" = subqueries, multi-step CTEs, or JOINs not
+   already defined as MDL relationships. Simple GROUP BY or
+   model-defined JOINs can skip this step."""
+
+_STEP_QUERY = """{n}. Execute: `wren_query(sql="...", limit=100)`. Raise the limit only when
+   you genuinely need more rows."""
+
+_STEP_STORE = """{n}. Persist the NL→SQL pair: `wren_store_query(nl="<user's original \
+question>", sql="<the SQL you ran>", tags=[...])`.
+
+   Store BY DEFAULT after a successful query. Skip ONLY when:
+   - The query failed (`ok=false`).
+   - The user said the result is wrong.
+   - The SQL is exploratory (e.g. `SELECT * FROM x LIMIT 10` with no
+     analytical clauses).
+   - There is no natural-language question (e.g. the user pasted raw SQL).
+   - The user explicitly said don't save.
+
+   The `nl` value should be the user's original question, not a paraphrase."""
+
+
+def _build_workflow_section(tool_names: set[str]) -> str:
+    """Compose the workflow header from tool blobs based on which tools are
+    actually available. Numbering is dynamic so steps stay sequential when
+    optional ones are dropped."""
+    has_recall = "wren_recall_queries" in tool_names
+    has_fetch = "wren_fetch_context" in tool_names
+    has_store = "wren_store_query" in tool_names
+    has_dry_plan = "wren_dry_plan" in tool_names
+    has_list_models = "wren_list_models" in tool_names
+
+    steps: list[str] = []
+    if has_recall:
+        steps.append(_STEP_RECALL)
+    if has_fetch:
+        steps.append(_STEP_FETCH)
+    elif has_list_models and not has_recall:
+        steps.append(_STEP_LIST_MODELS_FALLBACK)
+
+    next_n = len(steps) + 1
+    steps.append(_STEP_COMPOSE.format(n=next_n))
+    next_n += 1
+    if has_dry_plan:
+        steps.append(_STEP_DRY_PLAN.format(n=next_n))
+        next_n += 1
+    steps.append(_STEP_QUERY.format(n=next_n))
+    next_n += 1
+    if has_store:
+        steps.append(_STEP_STORE.format(n=next_n))
+
+    intro = "Run these steps in order:" if len(steps) > 2 else ""
+    body = "\n\n".join(steps)
+    if intro:
+        body = f"{intro}\n\n{body}"
+    return f"# Workflow for every data question\n\n{body}"
+
+
+def _error_recovery_section(*, has_fetch_context: bool, has_list_models: bool) -> str:
+    if has_fetch_context:
+        find_name_hint = (
+            'use `wren_fetch_context(question="<bad name>", '
+            'item_type="model")` (or `item_type="column"`) to find the '
+            "correct one."
+        )
+    elif has_list_models:
+        find_name_hint = (
+            "use `wren_list_models()` to enumerate models and inspect their columns."
+        )
+    else:
+        find_name_hint = "consult the project's MDL files directly."
+    return f"""# Error recovery
+
+If a tool returns `ok=false`, inspect `error.phase` and `error.message`:
+
+- `SQL_PARSING` → SQL syntax error. Read the message, fix, and retry.
+- `METADATA_FETCHING` / `MDL_EXTRACTION` → wrong model or column name;
+  {find_name_hint}
+- `SQL_EXECUTION` → database-side error. `error.metadata.dialect_sql` shows
+  the translated SQL — diagnose against the message (type mismatch, missing
+  function, permission, timeout). Add explicit `CAST` or simplify the query
+  if needed.
+
+Don't silently abandon. Either fix and retry, or report the failure to the
+user along with what you tried."""
+
+
+def _things_to_avoid_section(tool_names: set[str]) -> str:
+    bullets = []
+    if "wren_fetch_context" in tool_names:
+        bullets.append(
+            "- Don't guess model or column names — call `wren_fetch_context` first."
+        )
+    elif "wren_list_models" in tool_names:
+        bullets.append(
+            "- Don't guess model or column names — call `wren_list_models()` "
+            "first when in doubt."
+        )
+    if "wren_recall_queries" in tool_names:
+        bullets.append(
+            '- Don\'t skip `wren_recall_queries` on questions that seem "simple" — '
+            "past pairs are often the most accurate template."
+        )
+    if "wren_store_query" in tool_names:
+        bullets.append(
+            "- Don't store failed queries, queries the user said are wrong, "
+            "or exploratory queries."
+        )
+        bullets.append("- Don't store SQL that has no clear natural-language question.")
+    bullets.append(
+        "- Don't write SQL against raw database tables — always use MDL model names."
+    )
+    return "# Things to avoid\n\n" + "\n".join(bullets)
+
+
+def build_instructions(
+    toolkit: WrenToolkit, *, toolset: object | None = None
+) -> str:
+    """Render the instructions prompt.
+
+    ``toolset`` is the Pydantic AI ``FunctionToolset`` actually given to
+    the agent. When ``None``, the toolkit's default ``toolset()`` output
+    is used. Pass the same toolset you give to ``Agent(toolsets=...)`` so
+    the instructions stay in sync — e.g., when
+    ``include_memory_write=False`` drops ``wren_store_query``, the
+    workflow's persistence step drops too.
+    """
+    if toolset is None:
+        toolset = toolkit.toolset()
+    tool_list = _extract_tool_list(toolset)
+    tool_names = {t.name for t in tool_list}
+
+    sections: list[str] = [_INTRO]
+    sections.append(_build_workflow_section(tool_names))
+    sections.append(
+        _error_recovery_section(
+            has_fetch_context="wren_fetch_context" in tool_names,
+            has_list_models="wren_list_models" in tool_names,
+        )
+    )
+    sections.append(_things_to_avoid_section(tool_names))
+
+    tools_section = _build_tools_section(tool_list)
+    if tools_section:
+        sections.append(tools_section)
+
+    instructions_section = _build_instructions_section(toolkit._project_path)
+    if instructions_section:
+        sections.append(instructions_section)
+
+    return "\n\n".join(sections)
+
+
+def _extract_tool_list(toolset: object) -> list:
+    """Pull the registered tools from a Pydantic AI FunctionToolset as a list.
+
+    Pydantic AI stores tools in ``toolset.tools`` (dict) or ``._tools``;
+    both forms are tolerated.
+    """
+    tools_attr = getattr(toolset, "tools", None)
+    if tools_attr is None:
+        tools_attr = getattr(toolset, "_tools", None)
+    if tools_attr is None:
+        return []
+    if isinstance(tools_attr, dict):
+        return list(tools_attr.values())
+    return list(tools_attr)
+
+
+def _build_tools_section(tool_list: list) -> str:
+    if not tool_list:
+        return ""
+    lines = ["## Available tools"]
+    for tool in tool_list:
+        description = (tool.description or "").strip().split("\n")[0]
+        lines.append(f"- `{tool.name}`: {description}")
+    return "\n".join(lines)
+
+
+def _build_instructions_section(project_path: Path) -> str:
+    instructions_file = project_path / "instructions.md"
+    if not instructions_file.exists():
+        return ""
+    body = instructions_file.read_text().strip()
+    if not body:
+        return ""
+    return f"## Project-specific instructions\n\n{body}"

--- a/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
@@ -1,4 +1,4 @@
-"""Build a Wren-aware system prompt for LangChain/LangGraph agents.
+"""Build a Wren-aware system prompt for Pydantic AI agents.
 
 The workflow distilled here mirrors the Wren CLI's `wren-usage` skill —
 recall → fetch context → write SQL → dry_plan if complex → execute → store —
@@ -24,7 +24,7 @@ Three markdown sections (any may be empty):
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from wren_pydantic._toolkit import WrenToolkit
@@ -171,9 +171,7 @@ def _things_to_avoid_section(tool_names: set[str]) -> str:
     return "# Things to avoid\n\n" + "\n".join(bullets)
 
 
-def build_instructions(
-    toolkit: WrenToolkit, *, toolset: object | None = None
-) -> str:
+def build_instructions(toolkit: WrenToolkit, *, toolset: object | None = None) -> str:
     """Render the instructions prompt.
 
     ``toolset`` is the Pydantic AI ``FunctionToolset`` actually given to

--- a/sdk/wren-pydantic/src/wren_pydantic/_memory_api.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_memory_api.py
@@ -1,0 +1,98 @@
+"""Direct Python subscope for memory operations.
+
+Exposed as ``toolkit.memory``. Operations raise ``MemoryNotEnabledError``
+when memory is disabled — distinct error model from LLM tools, which
+silently filter out memory tools when disabled.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from wren_pydantic.exceptions import MemoryNotEnabledError
+
+if TYPE_CHECKING:
+    from wren.memory.store import MemoryStore
+
+    from wren_pydantic._toolkit import WrenToolkit
+
+
+class _MemoryAPI:
+    """Thin wrapper around ``wren.memory.MemoryStore`` bound to a toolkit."""
+
+    def __init__(self, toolkit: WrenToolkit):
+        self._toolkit = toolkit
+
+    def fetch(
+        self,
+        question: str,
+        *,
+        limit: int = 5,
+        item_type: str | None = None,
+        model: str | None = None,
+        threshold: int | None = None,
+    ) -> dict[str, Any]:
+        """Return schema/business context relevant to *question*."""
+        store = self._store()
+        manifest = self._toolkit._mdl_source.load_manifest()
+        kwargs: dict[str, Any] = {
+            "query": question,
+            "manifest": manifest,
+            "limit": limit,
+        }
+        if item_type is not None:
+            kwargs["item_type"] = item_type
+        if model is not None:
+            kwargs["model_name"] = model
+        if threshold is not None:
+            kwargs["threshold"] = threshold
+        return store.get_context(**kwargs)
+
+    def recall(
+        self,
+        question: str,
+        *,
+        limit: int = 3,
+    ) -> list[dict[str, Any]]:
+        """Return up to *limit* past NL→SQL pairs similar to *question*."""
+        store = self._store()
+        return store.recall_queries(query=question, limit=limit)
+
+    def store(
+        self,
+        nl: str,
+        sql: str,
+        *,
+        tags: list[str] | None = None,
+    ) -> None:
+        """Persist a confirmed NL→SQL pair for future recall.
+
+        Tags are joined with commas before storage; Core's MemoryStore stores
+        them as an opaque string. Tags must therefore not contain commas
+        themselves — a tag like ``"revenue, Q1"`` would be silently split into
+        two tags on any future consumer that splits on the separator. We
+        reject such inputs early with ``ValueError`` rather than corrupt
+        the round-trip.
+        Empty/None tags map to no tag.
+        """
+        if tags:
+            for tag in tags:
+                if "," in tag:
+                    raise ValueError(
+                        f"tag {tag!r} contains a comma; commas are reserved as the "
+                        "separator for the underlying storage format. "
+                        "Replace commas with dashes or spaces."
+                    )
+        store = self._store()
+        tag_str = ",".join(tags) if tags else None
+        store.store_query(nl_query=nl, sql_query=sql, tags=tag_str)
+
+    def _store(self) -> MemoryStore:
+        if not self._toolkit._memory.enabled:
+            raise MemoryNotEnabledError(
+                "memory is not enabled for this toolkit. "
+                "Run `wren memory index` in your project to enable it."
+            )
+        if self._toolkit._memory_store_cache is None:
+            self._toolkit._memory_store_cache = self._toolkit._memory.open()
+        return self._toolkit._memory_store_cache

--- a/sdk/wren-pydantic/src/wren_pydantic/_models.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_models.py
@@ -1,0 +1,70 @@
+"""Typed Pydantic return models for tools facing the LLM.
+
+Pydantic AI tools return native Python objects (or Pydantic models) that the
+framework serializes for the model. This module defines the four return
+types our six tools use; each has a stable schema, validates inputs, and
+serializes cleanly through ``model_dump`` for log/audit trails.
+
+Wren-langchain's parallel is a hand-rolled envelope dict — here we lean on
+Pydantic's validation + JSON-schema generation, which Pydantic AI consumes
+to expose typed tool outputs to the model.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class WrenQueryResult(BaseModel):
+    """Result of ``wren_query``: columns, rows, and overflow flag.
+
+    ``truncated=True`` signals the result was capped by either the
+    tool-level ``limit`` argument or the toolkit-wide ``MAX_QUERY_ROWS``
+    safety cap. Callers should surface this to the LLM so it knows the
+    answer may be partial.
+    """
+
+    columns: list[str]
+    rows: list[dict[str, Any]]
+    row_count: int = Field(ge=0)
+    truncated: bool
+
+
+class ModelSummary(BaseModel):
+    """Per-model entry returned by ``wren_list_models``.
+
+    ``description`` is optional — projects that haven't filled in
+    ``properties.description`` in their model YAML omit it.
+    """
+
+    name: str
+    column_count: int = Field(ge=0)
+    description: str | None = None
+
+
+class FetchContextResult(BaseModel):
+    """Result of ``wren_fetch_context``.
+
+    ``strategy`` mirrors Core's MemoryStore behavior: small projects get
+    the entire schema dump (``full_schema``), large ones get embedding
+    search hits (``search``). ``items`` is heterogeneous in v0.1 — same
+    shape Core returns. v0.2 may tighten this into a discriminated union.
+    """
+
+    strategy: Literal["search", "full_schema"]
+    items: list[dict[str, Any]]
+
+
+class RecalledPair(BaseModel):
+    """One NL→SQL pair returned by ``wren_recall_queries``.
+
+    ``score`` is optional because Core may not always emit it (e.g. for
+    the seed pairs loaded from ``queries.yml``).
+    """
+
+    nl: str
+    sql: str
+    tags: list[str] = Field(default_factory=list)
+    score: float | None = None

--- a/sdk/wren-pydantic/src/wren_pydantic/_models.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_models.py
@@ -5,31 +5,44 @@ framework serializes for the model. This module defines the four return
 types our six tools use; each has a stable schema, validates inputs, and
 serializes cleanly through ``model_dump`` for log/audit trails.
 
-Wren-langchain's parallel is a hand-rolled envelope dict — here we lean on
-Pydantic's validation + JSON-schema generation, which Pydantic AI consumes
-to expose typed tool outputs to the model.
+The shapes here are pinned to Core's return shapes (see
+``core/wren/src/wren/memory/store.py`` ``get_context`` and
+``recall_queries``). Drift in Core surfaces here as a ValidationError,
+not silently as a wrong tool result.
 """
 
 from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class WrenQueryResult(BaseModel):
     """Result of ``wren_query``: columns, rows, and overflow flag.
 
-    ``truncated=True`` signals the result was capped by either the
-    tool-level ``limit`` argument or the toolkit-wide ``MAX_QUERY_ROWS``
-    safety cap. Callers should surface this to the LLM so it knows the
-    answer may be partial.
+    ``row_count`` is the count of rows in this payload (always equal to
+    ``len(rows)``). ``truncated=True`` signals the result was capped by
+    either the tool-level ``limit`` argument or the toolkit-wide
+    ``MAX_QUERY_ROWS`` safety cap — i.e. the *underlying* result set is
+    larger than what's returned. Callers surface this to the LLM so it
+    knows the answer may be partial.
     """
 
     columns: list[str]
     rows: list[dict[str, Any]]
     row_count: int = Field(ge=0)
     truncated: bool
+
+    @model_validator(mode="after")
+    def _row_count_matches_rows(self) -> WrenQueryResult:
+        if self.row_count != len(self.rows):
+            raise ValueError(
+                f"row_count ({self.row_count}) must equal len(rows) "
+                f"({len(self.rows)}); use `truncated=True` to signal the "
+                "underlying result set was larger than the returned rows."
+            )
+        return self
 
 
 class ModelSummary(BaseModel):
@@ -45,26 +58,43 @@ class ModelSummary(BaseModel):
 
 
 class FetchContextResult(BaseModel):
-    """Result of ``wren_fetch_context``.
+    """Result of ``wren_fetch_context``, matching Core's get_context shape.
 
-    ``strategy`` mirrors Core's MemoryStore behavior: small projects get
-    the entire schema dump (``full_schema``), large ones get embedding
-    search hits (``search``). ``items`` is heterogeneous in v0.1 — same
-    shape Core returns. v0.2 may tighten this into a discriminated union.
+    Core emits one of two payloads:
+
+    - Small schemas (under threshold): ``{"strategy": "full", "schema": <text>}``
+    - Large schemas: ``{"strategy": "search", "results": [<dict>, ...]}``
+
+    We expose both keys but only one is populated per response. The
+    ``schema`` key is aliased to ``schema_text`` to avoid clashing with
+    ``BaseModel`` internals.
     """
 
-    strategy: Literal["search", "full_schema"]
-    items: list[dict[str, Any]]
+    model_config = ConfigDict(populate_by_name=True)
+
+    strategy: Literal["full", "search"]
+    schema_text: str | None = Field(default=None, alias="schema")
+    results: list[dict[str, Any]] | None = None
 
 
 class RecalledPair(BaseModel):
     """One NL→SQL pair returned by ``wren_recall_queries``.
 
-    ``score`` is optional because Core may not always emit it (e.g. for
-    the seed pairs loaded from ``queries.yml``).
+    Field names mirror Core's LanceDB row keys verbatim. ``tags`` is a
+    comma-joined string (Core's storage format, not a list) — the SDK
+    surfaces it raw and lets the agent split if it needs to. ``score``
+    is aliased to LanceDB's ``_distance`` field and only present after a
+    vector search; seeded pairs from ``queries.yml`` have no score.
+
+    Extra keys (e.g. ``text``, ``created_at``) from Core are tolerated
+    via ``extra="ignore"`` so a Core upgrade adding fields doesn't
+    break this model.
     """
 
-    nl: str
-    sql: str
-    tags: list[str] = Field(default_factory=list)
-    score: float | None = None
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    nl_query: str
+    sql_query: str
+    datasource: str = ""
+    tags: str = ""
+    score: float | None = Field(default=None, alias="_distance")

--- a/sdk/wren-pydantic/src/wren_pydantic/_providers/connection.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_providers/connection.py
@@ -1,0 +1,80 @@
+"""Connection providers resolve a Wren profile to (datasource, connection_info).
+
+Layer order (highest priority first):
+  1. ``explicit_profile=`` kwarg passed to ``WrenToolkit.from_project``
+  2. ``profile:`` field in the project's ``wren_project.yml``
+  3. The user's globally active profile (``wren profile switch ...``)
+
+Secrets in profile values (``${ENV_VAR}``) are expanded via Core's
+``expand_profile_secrets`` before the connection is exposed.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from wren.context import load_project_config
+from wren.profile import (  # noqa: F401  re-exported for monkeypatching in tests
+    expand_profile_secrets,
+    get_active_profile,
+    list_profiles,
+)
+
+from wren_pydantic.exceptions import WrenToolkitInitError
+
+
+class ProfileConnectionProvider:
+    """Resolves a profile via the 3-layer fallback and exposes connection info."""
+
+    def __init__(
+        self,
+        *,
+        project_path: Path,
+        explicit_profile: str | None = None,
+    ):
+        self._project_path = project_path
+        profile_dict = self._resolve_profile(explicit_profile)
+        profile_dict = expand_profile_secrets(profile_dict)
+        # ``datasource`` is part of the profile dict but logically separate.
+        self._datasource = profile_dict.pop("datasource", None)
+        self._connection_info = profile_dict
+
+    def _resolve_profile(self, explicit: str | None) -> dict[str, Any]:
+        # Layer 1: explicit kwarg. Use `is not None` so a misconfigured caller
+        # passing `profile=""` raises a clear "profile not found" error instead
+        # of silently falling through to the project-config / active layers.
+        if explicit is not None:
+            return self._lookup_named_profile(explicit)
+
+        # Layer 2: profile name from wren_project.yml
+        project_profile_name = self._project_config_profile()
+        if project_profile_name:
+            return self._lookup_named_profile(project_profile_name)
+
+        # Layer 3: globally active profile
+        _, active = get_active_profile()
+        if not active:
+            raise WrenToolkitInitError(
+                "no active Wren profile found. "
+                "Run `wren profile add` and `wren profile switch` first."
+            )
+        return dict(active)
+
+    def _lookup_named_profile(self, name: str) -> dict[str, Any]:
+        profiles = list_profiles()
+        if name not in profiles:
+            raise WrenToolkitInitError(
+                f"profile {name!r} not found in ~/.wren/profiles.yml. "
+                f"Available: {sorted(profiles)}"
+            )
+        return dict(profiles[name])
+
+    def _project_config_profile(self) -> str | None:
+        config = load_project_config(self._project_path)
+        value = config.get("profile")
+        return str(value) if value else None
+
+    def datasource(self) -> str | None:
+        return self._datasource
+
+    def connection_info(self) -> dict[str, Any]:
+        return dict(self._connection_info)

--- a/sdk/wren-pydantic/src/wren_pydantic/_providers/mdl_source.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_providers/mdl_source.py
@@ -1,0 +1,42 @@
+"""MDL sources resolve where the manifest comes from.
+
+v0.1 ships only ``ProjectMDLSource`` which reads ``target/mdl.json`` from a
+prepared Wren project directory. Each ``load_manifest()`` call re-reads the
+file from disk so that ``wren context build`` updates by an external CLI run
+are picked up on the next tool invocation without needing ``toolkit.reload()``.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wren_pydantic.exceptions import WrenToolkitInitError
+
+
+class ProjectMDLSource:
+    """Read the manifest from ``<project>/target/mdl.json``."""
+
+    def __init__(self, *, project_path: Path):
+        self._project_path = project_path
+        self._mdl_path = project_path / "target" / "mdl.json"
+
+    def load_manifest(self) -> dict[str, Any]:
+        if not self._mdl_path.exists():
+            raise WrenToolkitInitError(
+                f"target/mdl.json not found at {self._mdl_path}. "
+                "Run `wren context build` first."
+            )
+        try:
+            return json.loads(self._mdl_path.read_text())
+        except json.JSONDecodeError as exc:
+            # Normalize malformed manifest into the common init-error contract
+            # so callers don't need to special-case JSON errors.
+            raise WrenToolkitInitError(
+                f"target/mdl.json at {self._mdl_path} is not valid JSON: {exc.msg} "
+                f"(line {exc.lineno}, col {exc.colno}). "
+                "Re-run `wren context build` to regenerate it."
+            ) from exc
+
+    @property
+    def mdl_path(self) -> Path:
+        return self._mdl_path

--- a/sdk/wren-pydantic/src/wren_pydantic/_providers/memory.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_providers/memory.py
@@ -1,0 +1,41 @@
+"""Memory providers resolve where the long-lived context store lives.
+
+v0.1 ships:
+  - ``LocalLanceDBMemoryProvider``: opens a ``MemoryStore`` against a local
+    ``.wren/memory/`` directory.
+  - ``NoopMemoryProvider``: signals that memory is disabled. Direct API calls
+    raise ``MemoryNotEnabledError``; LLM-facing tools are filtered out.
+
+Auto-selection is performed by ``WrenToolkit.from_project`` based on whether
+``<project>/.wren/memory/`` exists.
+"""
+
+from pathlib import Path
+
+from wren.memory.store import MemoryStore
+
+from wren_pydantic.exceptions import MemoryNotEnabledError
+
+
+class LocalLanceDBMemoryProvider:
+    """Lazily opens a local LanceDB-backed ``MemoryStore`` on first use."""
+
+    enabled = True
+
+    def __init__(self, *, memory_path: Path):
+        self._memory_path = memory_path
+
+    def open(self) -> MemoryStore:
+        return MemoryStore(path=self._memory_path)
+
+
+class NoopMemoryProvider:
+    """Inert provider used when no ``.wren/memory/`` exists in the project."""
+
+    enabled = False
+
+    def open(self) -> MemoryStore:
+        raise MemoryNotEnabledError(
+            "memory is not enabled for this toolkit. "
+            "Run `wren memory index` in your project to enable it."
+        )

--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -1,0 +1,172 @@
+"""WrenToolkit: facade over an existing CLI-prepared Wren project.
+
+Sync-only direct API (query / dry_plan / dry_run). Pydantic AI accepts
+sync tool functions and auto-bridges them to the async run loop, so we
+don't repackage the engine's sync I/O as fake-async wrappers — see
+plan §3 Commit 2.1 for the rationale.
+
+The toolset() and instructions() methods aren't on this class yet; they
+land in Phase 2.3 and Phase 4.1 respectively.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from wren.engine import WrenEngine
+
+from wren_pydantic._providers.connection import ProfileConnectionProvider
+from wren_pydantic._providers.mdl_source import ProjectMDLSource
+from wren_pydantic._providers.memory import (
+    LocalLanceDBMemoryProvider,
+    NoopMemoryProvider,
+)
+from wren_pydantic.exceptions import WrenToolkitInitError
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+class WrenToolkit:
+    """Adapter that exposes an existing Wren project as Pydantic AI tools."""
+
+    def __init__(
+        self,
+        *,
+        project_path: Path,
+        mdl_source: ProjectMDLSource,
+        connection_provider: ProfileConnectionProvider,
+        memory_provider: LocalLanceDBMemoryProvider | NoopMemoryProvider,
+    ):
+        self._project_path = project_path
+        self._mdl_source = mdl_source
+        self._connection = connection_provider
+        self._memory = memory_provider
+        # Connector is cached at the toolkit level to avoid reconnecting on
+        # every query. The engine itself is rebuilt per call so manifest
+        # changes are picked up read-through.
+        self._connector_cache: Any = None
+        # MemoryStore is heavy (loads sentence-transformer model) — cache
+        # the instance and let LanceDB handle data versioning internally.
+        self._memory_store_cache: Any = None
+
+    # ── Direct Python API (sync only — see module docstring) ──────────────
+
+    def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        """Execute SQL through the Wren context layer. Returns a pyarrow Table."""
+        engine = self._build_engine()
+        try:
+            result = engine.query(sql, limit=limit)
+        finally:
+            self._connector_cache = engine._connector
+        return result
+
+    def dry_plan(self, sql: str) -> str:
+        """Plan SQL through MDL and return the expanded SQL in target dialect."""
+        return self._build_engine().dry_plan(sql)
+
+    def dry_run(self, sql: str) -> None:
+        """Validate SQL by planning and asking the DB to plan it without executing."""
+        engine = self._build_engine()
+        try:
+            engine.dry_run(sql)
+        finally:
+            self._connector_cache = engine._connector
+
+    # ── Internal ───────────────────────────────────────────────────────────
+
+    def _build_engine(self) -> WrenEngine:
+        """Construct a fresh WrenEngine with a read-through manifest.
+
+        The connector is reused across calls when available so DB authentication
+        only happens once per toolkit lifetime.
+        """
+        manifest = self._mdl_source.load_manifest()
+        manifest_str = base64.b64encode(json.dumps(manifest).encode("utf-8")).decode()
+        engine = WrenEngine(
+            manifest_str=manifest_str,
+            data_source=self._connection.datasource(),
+            connection_info=self._connection.connection_info(),
+        )
+        if self._connector_cache is not None:
+            engine._connector = self._connector_cache
+        return engine
+
+    @classmethod
+    def from_project(
+        cls,
+        path: str | Path,
+        *,
+        profile: str | None = None,
+    ) -> WrenToolkit:
+        """Build a toolkit from a CLI-prepared Wren project directory.
+
+        Memory is auto-detected from ``<path>/.wren/memory/``: present →
+        memory tools are exposed, absent → only the 3 runtime tools.
+        To enable, run ``wren memory index`` in the project; to disable,
+        delete the directory. There is no kwarg to override.
+        """
+        project_path = Path(path).expanduser().resolve()
+
+        if not (project_path / "wren_project.yml").exists():
+            raise WrenToolkitInitError(
+                f"wren_project.yml not found at {project_path}. "
+                "Is this a Wren project? Run `wren context init` to create one."
+            )
+
+        if not (project_path / "target" / "mdl.json").exists():
+            raise WrenToolkitInitError(
+                f"target/mdl.json not found at {project_path}/target/mdl.json. "
+                "Run `wren context build` first."
+            )
+
+        cls._load_project_dotenv(project_path)
+
+        mdl_source = ProjectMDLSource(project_path=project_path)
+        connection = ProfileConnectionProvider(
+            project_path=project_path,
+            explicit_profile=profile,
+        )
+        memory_provider = cls._resolve_memory_provider(project_path)
+
+        return cls(
+            project_path=project_path,
+            mdl_source=mdl_source,
+            connection_provider=connection,
+            memory_provider=memory_provider,
+        )
+
+    @staticmethod
+    def _load_project_dotenv(project_path: Path) -> None:
+        """Load ``<project>/.env`` into ``os.environ`` if present.
+
+        Required for SDK ergonomics: when a caller passes
+        ``from_project("/some/path")`` from anywhere on the filesystem, they
+        expect that project's secrets to resolve. Core's ``expand_profile_secrets``
+        discovers ``.env`` relative to CWD, which doesn't help here.
+
+        Uses ``override=False`` so values the user already exported in their
+        shell still win, matching Core's policy.
+        """
+        env_path = project_path / ".env"
+        if not env_path.exists():
+            return
+        try:
+            from dotenv import load_dotenv  # noqa: PLC0415
+        except ImportError:
+            return
+        load_dotenv(env_path, override=False)
+
+    @staticmethod
+    def _resolve_memory_provider(
+        project_path: Path,
+    ) -> LocalLanceDBMemoryProvider | NoopMemoryProvider:
+        memory_dir = project_path / ".wren" / "memory"
+        # Require a directory (not a regular file or broken symlink) so we
+        # never construct LocalLanceDBMemoryProvider against an invalid root.
+        if memory_dir.is_dir():
+            return LocalLanceDBMemoryProvider(memory_path=memory_dir)
+        return NoopMemoryProvider()

--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -53,6 +53,16 @@ class WrenToolkit:
         # the instance and let LanceDB handle data versioning internally.
         self._memory_store_cache: Any = None
 
+    # ── Memory subscope (exposed as toolkit.memory) ────────────────────────
+
+    @property
+    def memory(self):
+        if not hasattr(self, "_memory_api"):
+            from wren_pydantic._memory_api import _MemoryAPI  # noqa: PLC0415
+
+            self._memory_api = _MemoryAPI(self)
+        return self._memory_api
+
     # ── Pydantic AI adapter ───────────────────────────────────────────────
 
     def toolset(self, *, takes_ctx: bool = False):

--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -4,9 +4,6 @@ Sync-only direct API (query / dry_plan / dry_run). Pydantic AI accepts
 sync tool functions and auto-bridges them to the async run loop, so we
 don't repackage the engine's sync I/O as fake-async wrappers — see
 plan §3 Commit 2.1 for the rationale.
-
-The toolset() and instructions() methods aren't on this class yet; they
-land in Phase 2.3 and Phase 4.1 respectively.
 """
 
 from __future__ import annotations

--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -65,18 +65,42 @@ class WrenToolkit:
 
     # ── Pydantic AI adapter ───────────────────────────────────────────────
 
-    def toolset(self, *, takes_ctx: bool = False):
+    def toolset(
+        self,
+        *,
+        include_memory_write: bool = True,
+        takes_ctx: bool = False,
+    ):
         """Return a Pydantic AI ``FunctionToolset`` bound to this toolkit.
+
+        Memory tools are auto-filtered when memory is disabled (no
+        ``.wren/memory/`` directory in the project).
+        ``include_memory_write=False`` removes ``wren_store_query`` while
+        keeping the read-only memory tools (``wren_fetch_context``,
+        ``wren_recall_queries``). When memory is disabled,
+        ``include_memory_write`` has no effect — no memory tools are
+        registered regardless of its value.
 
         ``takes_ctx=True`` registers each tool with ``ctx: RunContext`` as
         its first parameter. Use this when mixing wren tools with other
         ``deps_type=...`` tools in the same agent; the context object is
-        ignored internally (toolkit captures its own state). Memory tool
-        wiring lands in Phase 3.
+        ignored internally (toolkit captures its own state).
         """
         from wren_pydantic._tools import build_runtime_toolset  # noqa: PLC0415
 
-        return build_runtime_toolset(self, takes_ctx=takes_ctx)
+        ts = build_runtime_toolset(self, takes_ctx=takes_ctx)
+        if self._memory.enabled:
+            from wren_pydantic._tools_memory import (  # noqa: PLC0415
+                build_memory_toolset,
+            )
+
+            build_memory_toolset(
+                self,
+                include_write=include_memory_write,
+                takes_ctx=takes_ctx,
+                toolset=ts,
+            )
+        return ts
 
     # ── Direct Python API (sync only — see module docstring) ──────────────
 

--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -53,6 +53,21 @@ class WrenToolkit:
         # the instance and let LanceDB handle data versioning internally.
         self._memory_store_cache: Any = None
 
+    # ── Pydantic AI adapter ───────────────────────────────────────────────
+
+    def toolset(self, *, takes_ctx: bool = False):
+        """Return a Pydantic AI ``FunctionToolset`` bound to this toolkit.
+
+        ``takes_ctx=True`` registers each tool with ``ctx: RunContext`` as
+        its first parameter. Use this when mixing wren tools with other
+        ``deps_type=...`` tools in the same agent; the context object is
+        ignored internally (toolkit captures its own state). Memory tool
+        wiring lands in Phase 3.
+        """
+        from wren_pydantic._tools import build_runtime_toolset  # noqa: PLC0415
+
+        return build_runtime_toolset(self, takes_ctx=takes_ctx)
+
     # ── Direct Python API (sync only — see module docstring) ──────────────
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:

--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -102,6 +102,23 @@ class WrenToolkit:
             )
         return ts
 
+    def instructions(self, *, toolset: object | None = None) -> str:
+        """Return a Wren-aware instructions string suitable for Pydantic AI.
+
+        Composition mirrors the wren-langchain SDK:
+          1. Workflow rules — derived from the supplied toolset's tools.
+          2. Available tools — bullet list rendered from the same toolset.
+          3. Project-specific instructions (from ``instructions.md`` if present).
+
+        Pass the same ``toolset`` you give to ``Agent(toolsets=...)`` so the
+        workflow stays in sync — e.g. ``toolset(include_memory_write=False)``
+        drops the persistence step instead of telling the LLM to call a
+        tool that no longer exists.
+        """
+        from wren_pydantic._instructions import build_instructions  # noqa: PLC0415
+
+        return build_instructions(self, toolset=toolset)
+
     # ── Direct Python API (sync only — see module docstring) ──────────────
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:

--- a/sdk/wren-pydantic/src/wren_pydantic/_tools.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_tools.py
@@ -55,9 +55,7 @@ def _register_query(toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx
     if takes_ctx:
 
         @toolset.tool(retries=2)
-        def wren_query(
-            ctx: RunContext, sql: str, limit: int = 100
-        ) -> WrenQueryResult:
+        def wren_query(ctx: RunContext, sql: str, limit: int = 100) -> WrenQueryResult:
             """Execute SQL through the Wren semantic layer and return rows.
 
             Use after wren_dry_plan looks correct. Default limit is 100;

--- a/sdk/wren-pydantic/src/wren_pydantic/_tools.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_tools.py
@@ -1,0 +1,181 @@
+"""Runtime tools (wren_query, wren_dry_plan, wren_list_models) for Pydantic AI.
+
+Each tool returns a typed Pydantic model (or list of them) for LLM-friendly
+serialization. Errors from the underlying toolkit go through the WrenError
+→ ModelRetry mapping in _errors.py:
+
+- Retry-class WrenError → ModelRetry(...) with phase-aware message
+- Propagate-class WrenError → re-raised as-is (infra errors)
+- Limit-validation errors → ModelRetry (LLM picked a bad limit, can fix)
+
+Tools are sync (def, not async def). Pydantic AI auto-bridges sync tools
+to its async run loop, so wrapping sync engine I/O in asyncio.to_thread
+buys nothing — see plan §3 Commit 2.2 for the design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic_ai import FunctionToolset, ModelRetry, RunContext
+from wren.model.error import WrenError
+
+from wren_pydantic._errors import should_propagate, to_model_retry
+from wren_pydantic._models import ModelSummary, WrenQueryResult
+
+if TYPE_CHECKING:
+    from wren_pydantic._toolkit import WrenToolkit
+
+
+# Hard cap for the LLM-facing `wren_query` tool. Bounded payload size so
+# a runaway `limit` value (typo or hallucinated huge number) doesn't
+# balloon memory. Direct API (toolkit.query) keeps no cap — that's the
+# Python-programmer surface and should respect what the caller asks for.
+MAX_QUERY_ROWS = 1000
+
+
+def build_runtime_toolset(
+    toolkit: WrenToolkit, *, takes_ctx: bool = False
+) -> FunctionToolset:
+    """Build a FunctionToolset with the 3 runtime tools bound to *toolkit*.
+
+    ``takes_ctx=True`` registers each tool with ``ctx: RunContext`` as the
+    first parameter (the context is ignored internally — the toolkit
+    already captures all required state). Use this when mixing wren tools
+    with other deps-typed tools in the same agent.
+    """
+    toolset = FunctionToolset()
+    _register_query(toolset, toolkit, takes_ctx=takes_ctx)
+    _register_dry_plan(toolset, toolkit, takes_ctx=takes_ctx)
+    _register_list_models(toolset, toolkit, takes_ctx=takes_ctx)
+    return toolset
+
+
+def _register_query(toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx: bool):
+    if takes_ctx:
+
+        @toolset.tool(retries=2)
+        def wren_query(
+            ctx: RunContext, sql: str, limit: int = 100
+        ) -> WrenQueryResult:
+            """Execute SQL through the Wren semantic layer and return rows.
+
+            Use after wren_dry_plan looks correct. Default limit is 100;
+            increase only when needed. Hard cap is 1000 rows — beyond
+            that, aggregate in SQL.
+            """
+            return _run_query(toolkit, sql, limit)
+
+    else:
+
+        @toolset.tool_plain(retries=2)
+        def wren_query(sql: str, limit: int = 100) -> WrenQueryResult:
+            """Execute SQL through the Wren semantic layer and return rows.
+
+            Use after wren_dry_plan looks correct. Default limit is 100;
+            increase only when needed. Hard cap is 1000 rows — beyond
+            that, aggregate in SQL.
+            """
+            return _run_query(toolkit, sql, limit)
+
+
+def _register_dry_plan(
+    toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx: bool
+):
+    if takes_ctx:
+
+        @toolset.tool(retries=2)
+        def wren_dry_plan(ctx: RunContext, sql: str) -> str:
+            """Plan SQL through MDL and return the target-dialect SQL.
+
+            Cheap (no DB round-trip). Use this to verify your SQL
+            targets Wren models correctly before running wren_query.
+            """
+            return _run_dry_plan(toolkit, sql)
+
+    else:
+
+        @toolset.tool_plain(retries=2)
+        def wren_dry_plan(sql: str) -> str:
+            """Plan SQL through MDL and return the target-dialect SQL.
+
+            Cheap (no DB round-trip). Use this to verify your SQL
+            targets Wren models correctly before running wren_query.
+            """
+            return _run_dry_plan(toolkit, sql)
+
+
+def _register_list_models(
+    toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx: bool
+):
+    if takes_ctx:
+
+        @toolset.tool(retries=2)
+        def wren_list_models(ctx: RunContext) -> list[ModelSummary]:
+            """List all models in this Wren project with column counts."""
+            return _run_list_models(toolkit)
+
+    else:
+
+        @toolset.tool_plain(retries=2)
+        def wren_list_models() -> list[ModelSummary]:
+            """List all models in this Wren project with column counts."""
+            return _run_list_models(toolkit)
+
+
+# ── Inner helpers ────────────────────────────────────────────────────────
+
+
+def _run_query(toolkit: WrenToolkit, sql: str, limit: int) -> WrenQueryResult:
+    if limit < 1 or limit > MAX_QUERY_ROWS:
+        raise ModelRetry(
+            f"limit must be between 1 and {MAX_QUERY_ROWS} (got {limit}). "
+            "Aggregate in SQL if you need more rows."
+        )
+
+    try:
+        table = toolkit.query(sql, limit=limit)
+    except WrenError as exc:
+        if should_propagate(exc):
+            raise
+        raise to_model_retry(exc) from exc
+
+    row_count = table.num_rows
+    # If the engine returned exactly `limit` rows, we can't tell whether more
+    # rows existed upstream — surface as truncated so the LLM knows the
+    # answer may be partial.
+    truncated = row_count >= limit
+    return WrenQueryResult(
+        columns=list(table.column_names),
+        rows=table.to_pylist(),
+        row_count=row_count,
+        truncated=truncated,
+    )
+
+
+def _run_dry_plan(toolkit: WrenToolkit, sql: str) -> str:
+    try:
+        return toolkit.dry_plan(sql)
+    except WrenError as exc:
+        if should_propagate(exc):
+            raise
+        raise to_model_retry(exc) from exc
+
+
+def _run_list_models(toolkit: WrenToolkit) -> list[ModelSummary]:
+    try:
+        manifest = toolkit._mdl_source.load_manifest()
+    except WrenError as exc:
+        if should_propagate(exc):
+            raise
+        raise to_model_retry(exc) from exc
+
+    models = manifest.get("models") or []
+    return [
+        ModelSummary(
+            name=m["name"],
+            column_count=len(m.get("columns") or []),
+            description=(m.get("properties") or {}).get("description"),
+        )
+        for m in models
+    ]

--- a/sdk/wren-pydantic/src/wren_pydantic/_tools_memory.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_tools_memory.py
@@ -115,9 +115,7 @@ def _register_recall_queries(
     else:
 
         @toolset.tool_plain(retries=2)
-        def wren_recall_queries(
-            question: str, limit: int = 3
-        ) -> list[RecalledPair]:
+        def wren_recall_queries(question: str, limit: int = 3) -> list[RecalledPair]:
             """Recall up to *limit* past NL→SQL pairs similar to *question*.
 
             Useful as few-shot examples before writing new SQL. Pairs

--- a/sdk/wren-pydantic/src/wren_pydantic/_tools_memory.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_tools_memory.py
@@ -1,0 +1,216 @@
+"""Memory tools (wren_fetch_context, wren_recall_queries, wren_store_query).
+
+Three tools registered into a FunctionToolset when the project has a
+``.wren/memory/`` directory. ``include_write=False`` keeps the two
+read-only tools and drops ``wren_store_query`` — useful for shared /
+curated memory stores.
+
+``wren_store_query`` is registered with ``retries=0``: write failures
+generally aren't fixable by retrying the same call, and the LLM has
+already done the analytical work — better to surface the failure than
+to loop.
+
+Sync tools (def, not async def) — same rationale as the runtime tools.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from pydantic_ai import FunctionToolset, RunContext
+from wren.model.error import WrenError
+
+from wren_pydantic._errors import should_propagate, to_model_retry
+from wren_pydantic._models import FetchContextResult, RecalledPair
+
+if TYPE_CHECKING:
+    from wren_pydantic._toolkit import WrenToolkit
+
+
+def build_memory_toolset(
+    toolkit: WrenToolkit,
+    *,
+    include_write: bool,
+    takes_ctx: bool,
+    toolset: FunctionToolset | None = None,
+) -> FunctionToolset:
+    """Build (or extend) a FunctionToolset with the memory tools.
+
+    When *toolset* is supplied, register onto it (composes cleanly with
+    the runtime toolset). When None, build a fresh one.
+    """
+    ts = toolset or FunctionToolset()
+    _register_fetch_context(ts, toolkit, takes_ctx=takes_ctx)
+    _register_recall_queries(ts, toolkit, takes_ctx=takes_ctx)
+    if include_write:
+        _register_store_query(ts, toolkit, takes_ctx=takes_ctx)
+    return ts
+
+
+# ── wren_fetch_context ────────────────────────────────────────────────────
+
+
+def _register_fetch_context(
+    toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx: bool
+):
+    if takes_ctx:
+
+        @toolset.tool(retries=2)
+        def wren_fetch_context(
+            ctx: RunContext,
+            question: str,
+            limit: int = 5,
+            item_type: (
+                Literal["model", "column", "relationship", "view"] | None
+            ) = None,
+            model: str | None = None,
+        ) -> FetchContextResult:
+            """Fetch relevant schema and business context for an analytical question.
+
+            Call this BEFORE writing SQL so you query the correct Wren
+            models and columns. Use item_type to narrow scope (e.g.
+            only columns) and model to narrow to a single model.
+            """
+            return _run_fetch(toolkit, question, limit, item_type, model)
+
+    else:
+
+        @toolset.tool_plain(retries=2)
+        def wren_fetch_context(
+            question: str,
+            limit: int = 5,
+            item_type: (
+                Literal["model", "column", "relationship", "view"] | None
+            ) = None,
+            model: str | None = None,
+        ) -> FetchContextResult:
+            """Fetch relevant schema and business context for an analytical question.
+
+            Call this BEFORE writing SQL so you query the correct Wren
+            models and columns. Use item_type to narrow scope (e.g.
+            only columns) and model to narrow to a single model.
+            """
+            return _run_fetch(toolkit, question, limit, item_type, model)
+
+
+# ── wren_recall_queries ───────────────────────────────────────────────────
+
+
+def _register_recall_queries(
+    toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx: bool
+):
+    if takes_ctx:
+
+        @toolset.tool(retries=2)
+        def wren_recall_queries(
+            ctx: RunContext, question: str, limit: int = 3
+        ) -> list[RecalledPair]:
+            """Recall up to *limit* past NL→SQL pairs similar to *question*.
+
+            Useful as few-shot examples before writing new SQL. Pairs
+            are previously confirmed by users (or seeded for the project).
+            """
+            return _run_recall(toolkit, question, limit)
+
+    else:
+
+        @toolset.tool_plain(retries=2)
+        def wren_recall_queries(
+            question: str, limit: int = 3
+        ) -> list[RecalledPair]:
+            """Recall up to *limit* past NL→SQL pairs similar to *question*.
+
+            Useful as few-shot examples before writing new SQL. Pairs
+            are previously confirmed by users (or seeded for the project).
+            """
+            return _run_recall(toolkit, question, limit)
+
+
+# ── wren_store_query (retries=0) ──────────────────────────────────────────
+
+
+def _register_store_query(
+    toolset: FunctionToolset, toolkit: WrenToolkit, *, takes_ctx: bool
+):
+    if takes_ctx:
+
+        @toolset.tool(retries=0)
+        def wren_store_query(
+            ctx: RunContext,
+            nl: str,
+            sql: str,
+            tags: list[str] | None = None,
+        ) -> str:
+            """Save a confirmed natural-language → SQL pair for future recall.
+
+            Call this AFTER wren_query succeeds and the result was
+            useful, so future agent runs can recall the example via
+            wren_recall_queries.
+            """
+            return _run_store(toolkit, nl, sql, tags)
+
+    else:
+
+        @toolset.tool_plain(retries=0)
+        def wren_store_query(
+            nl: str,
+            sql: str,
+            tags: list[str] | None = None,
+        ) -> str:
+            """Save a confirmed natural-language → SQL pair for future recall.
+
+            Call this AFTER wren_query succeeds and the result was
+            useful, so future agent runs can recall the example via
+            wren_recall_queries.
+            """
+            return _run_store(toolkit, nl, sql, tags)
+
+
+# ── Inner helpers ────────────────────────────────────────────────────────
+
+
+def _run_fetch(
+    toolkit: WrenToolkit,
+    question: str,
+    limit: int,
+    item_type: str | None,
+    model: str | None,
+) -> FetchContextResult:
+    try:
+        result = toolkit.memory.fetch(
+            question, limit=limit, item_type=item_type, model=model
+        )
+    except WrenError as exc:
+        if should_propagate(exc):
+            raise
+        raise to_model_retry(exc) from exc
+    return FetchContextResult.model_validate(result)
+
+
+def _run_recall(toolkit: WrenToolkit, question: str, limit: int) -> list[RecalledPair]:
+    try:
+        rows = toolkit.memory.recall(question, limit=limit)
+    except WrenError as exc:
+        if should_propagate(exc):
+            raise
+        raise to_model_retry(exc) from exc
+    return [RecalledPair.model_validate(r) for r in rows]
+
+
+def _run_store(
+    toolkit: WrenToolkit,
+    nl: str,
+    sql: str,
+    tags: list[str] | None,
+) -> str:
+    # Normalize None → [] up front so downstream callers see a list.
+    tags_list = tags or []
+    try:
+        toolkit.memory.store(nl=nl, sql=sql, tags=tags_list)
+    except WrenError as exc:
+        if should_propagate(exc):
+            raise
+        raise to_model_retry(exc) from exc
+    if tags_list:
+        return f"Stored NL→SQL pair (tags: {', '.join(tags_list)})."
+    return "Stored NL→SQL pair."

--- a/sdk/wren-pydantic/src/wren_pydantic/exceptions.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/exceptions.py
@@ -1,0 +1,18 @@
+"""SDK-specific exception types for wren-pydantic."""
+
+
+class WrenToolkitInitError(Exception):
+    """Raised when ``WrenToolkit.from_project(...)`` cannot validate prerequisites.
+
+    Examples include missing ``wren_project.yml``, missing ``target/mdl.json``,
+    or unresolvable profile.
+    """
+
+
+class MemoryNotEnabledError(Exception):
+    """Raised when memory operations are called but no memory provider is active.
+
+    Triggered by direct API access to ``toolkit.memory.*`` when the toolkit
+    was initialized against a project without ``.wren/memory/``. LLM-facing
+    tools handle this case via tool filtering, not by raising.
+    """

--- a/sdk/wren-pydantic/tests/conformance/test_pydantic_ai_contract.py
+++ b/sdk/wren-pydantic/tests/conformance/test_pydantic_ai_contract.py
@@ -1,0 +1,180 @@
+"""Pydantic AI integration contract tests.
+
+Verifies that:
+- Each tool registered by WrenToolkit.toolset() has the expected name,
+  Pydantic AI Tool shape, and JSON-compatible schema.
+- A Pydantic AI Agent constructed against the toolkit's toolset can be
+  invoked end-to-end via TestModel (no real LLM cost), producing the
+  expected tool-call sequence.
+- ModelRetry raised inside a tool turns into a RetryPromptPart in the
+  agent's message history.
+
+Tests use Pydantic AI's TestModel — a deterministic stand-in that fills
+every tool call with synthetic args. Means we exercise the wiring (tool
+registration → invocation → return-type serialization → retry handling)
+without depending on any actual LLM.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from wren_pydantic import WrenToolkit
+
+
+# ── Tool registration shape ───────────────────────────────────────────────
+
+
+def test_runtime_tools_have_non_empty_names(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset()
+    tools = ts.tools if isinstance(getattr(ts, "tools", None), dict) else ts._tools
+    if isinstance(tools, dict):
+        names = list(tools.keys())
+    else:
+        names = [t.name for t in tools]
+    assert all(isinstance(n, str) and len(n) > 0 for n in names)
+
+
+def test_each_tool_exposes_description(tmp_project, fake_active_profile):
+    """Every tool needs a non-empty description so the LLM knows when to call it."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset()
+    tools = ts.tools if isinstance(getattr(ts, "tools", None), dict) else ts._tools
+    entries = list(tools.values()) if isinstance(tools, dict) else list(tools)
+    for entry in entries:
+        assert entry.description, f"{entry.name} has no description"
+
+
+def test_runtime_only_when_memory_disabled(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset()
+    names = _names(ts)
+    assert "wren_fetch_context" not in names
+    assert "wren_recall_queries" not in names
+    assert "wren_store_query" not in names
+
+
+def test_six_tools_when_memory_enabled_and_write_allowed(
+    tmp_project, fake_active_profile
+):
+    (tmp_project / ".wren" / "memory").mkdir(parents=True)
+    fake_store = MagicMock(name="MemoryStore")
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        toolkit = WrenToolkit.from_project(tmp_project)
+        ts = toolkit.toolset()
+    assert len(_names(ts)) == 6
+
+
+def _names(toolset) -> list[str]:
+    tools = (
+        toolset.tools
+        if isinstance(getattr(toolset, "tools", None), dict)
+        else toolset._tools
+    )
+    if isinstance(tools, dict):
+        return list(tools.keys())
+    return [t.name for t in tools]
+
+
+# ── End-to-end via TestModel ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_query_table():
+    """Patch toolkit.query to return a small pyarrow table without needing
+    a real engine."""
+    table = pa.table({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+    with patch.object(WrenToolkit, "query", return_value=table) as m:
+        yield m
+
+
+def test_test_model_drives_wren_list_models_call(
+    tmp_project, fake_active_profile, mock_query_table
+):
+    """TestModel auto-fills any tool the agent could call. With
+    call_tools=['wren_list_models'], the agent invokes it once."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    agent = Agent(
+        TestModel(call_tools=["wren_list_models"]),
+        toolsets=[toolkit.toolset()],
+    )
+    result = agent.run_sync("list the models")
+    # Agent ran without crashing — wiring works end-to-end.
+    assert result is not None
+
+
+def test_agent_run_sync_with_no_tools_called(
+    tmp_project, fake_active_profile
+):
+    """TestModel(call_tools=[]) skips all tools — verifies the toolset can
+    coexist with an agent that decides not to invoke anything."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    agent = Agent(
+        TestModel(call_tools=[]),
+        toolsets=[toolkit.toolset()],
+    )
+    result = agent.run_sync("hi")
+    assert result is not None
+
+
+# ── ModelRetry flow ───────────────────────────────────────────────────────
+
+
+def test_model_retry_flow_surfaces_through_agent(tmp_project, fake_active_profile):
+    """A WrenError raised inside a tool becomes a ModelRetry that the agent
+    forwards back to the model. With TestModel, the retry causes the call
+    to fail (TestModel doesn't self-correct), but the error path should
+    exercise without crashing the runner."""
+    from wren.model.error import ErrorCode, ErrorPhase, WrenError
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+    with patch.object(
+        WrenToolkit,
+        "query",
+        side_effect=WrenError(
+            error_code=ErrorCode.INVALID_SQL,
+            message="bad sql",
+            phase=ErrorPhase.SQL_PARSING,
+        ),
+    ):
+        agent = Agent(
+            TestModel(call_tools=["wren_query"]),
+            toolsets=[toolkit.toolset()],
+        )
+        # TestModel sends bad-args by default — combined with our
+        # WrenError-side-effect, this should produce a ModelRetry. The
+        # agent burns its retry budget and raises UnexpectedModelBehavior;
+        # we just want to verify the retry path runs without our code
+        # crashing.
+        with pytest.raises(Exception):  # noqa: BLE001 — accept either retry exhaustion
+            agent.run_sync("query")
+
+
+# ── Instructions string is a valid Agent argument ─────────────────────────
+
+
+def test_instructions_is_str_and_non_empty(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    instr = toolkit.instructions()
+    assert isinstance(instr, str)
+    assert len(instr) > 100  # arbitrary but non-trivial
+
+
+def test_agent_accepts_instructions_and_toolset_together(
+    tmp_project, fake_active_profile
+):
+    """The 3-line quickstart shape: Agent(model, instructions, toolsets)
+    must construct without error."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    agent = Agent(
+        TestModel(call_tools=[]),
+        instructions=toolkit.instructions(),
+        toolsets=[toolkit.toolset()],
+    )
+    assert agent is not None

--- a/sdk/wren-pydantic/tests/conformance/test_pydantic_ai_contract.py
+++ b/sdk/wren-pydantic/tests/conformance/test_pydantic_ai_contract.py
@@ -26,7 +26,6 @@ from pydantic_ai.models.test import TestModel
 
 from wren_pydantic import WrenToolkit
 
-
 # ── Tool registration shape ───────────────────────────────────────────────
 
 
@@ -109,9 +108,7 @@ def test_test_model_drives_wren_list_models_call(
     assert result is not None
 
 
-def test_agent_run_sync_with_no_tools_called(
-    tmp_project, fake_active_profile
-):
+def test_agent_run_sync_with_no_tools_called(tmp_project, fake_active_profile):
     """TestModel(call_tools=[]) skips all tools — verifies the toolset can
     coexist with an agent that decides not to invoke anything."""
     toolkit = WrenToolkit.from_project(tmp_project)
@@ -131,7 +128,7 @@ def test_model_retry_flow_surfaces_through_agent(tmp_project, fake_active_profil
     forwards back to the model. With TestModel, the retry causes the call
     to fail (TestModel doesn't self-correct), but the error path should
     exercise without crashing the runner."""
-    from wren.model.error import ErrorCode, ErrorPhase, WrenError
+    from wren.model.error import ErrorCode, ErrorPhase, WrenError  # noqa: PLC0415
 
     toolkit = WrenToolkit.from_project(tmp_project)
     with patch.object(

--- a/sdk/wren-pydantic/tests/conftest.py
+++ b/sdk/wren-pydantic/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared pytest fixtures for wren-pydantic tests."""
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def tmp_project(tmp_path):
+    """A minimal valid Wren project directory.
+
+    Layout:
+      <tmp_path>/
+        wren_project.yml
+        target/mdl.json
+    """
+    (tmp_path / "wren_project.yml").write_text("schema_version: 1\n")
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "mdl.json").write_text(json.dumps({"models": []}))
+    return tmp_path
+
+
+@pytest.fixture
+def fake_active_profile(monkeypatch):
+    """Patch profile resolution to return a duckdb in-memory active profile."""
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.list_profiles",
+        lambda: {"test": {"datasource": "duckdb", "path": ":memory:"}},
+    )
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.get_active_profile",
+        lambda: ("test", {"datasource": "duckdb", "path": ":memory:"}),
+    )

--- a/sdk/wren-pydantic/tests/test_smoke.py
+++ b/sdk/wren-pydantic/tests/test_smoke.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 
 def test_package_imports():
-    import wren_pydantic
+    import wren_pydantic  # noqa: PLC0415
 
     assert wren_pydantic.__version__ == "0.1.0"

--- a/sdk/wren-pydantic/tests/test_smoke.py
+++ b/sdk/wren-pydantic/tests/test_smoke.py
@@ -1,0 +1,9 @@
+"""Package skeleton smoke test — imports and exposes __version__."""
+
+from __future__ import annotations
+
+
+def test_package_imports():
+    import wren_pydantic
+
+    assert wren_pydantic.__version__ == "0.1.0"

--- a/sdk/wren-pydantic/tests/unit/test_errors.py
+++ b/sdk/wren-pydantic/tests/unit/test_errors.py
@@ -1,0 +1,153 @@
+"""Tests for WrenError → ModelRetry mapping.
+
+Mirrors wren-langchain's test_envelope.py but adapts to Pydantic AI's
+ModelRetry idiom. Covers phase-aware messages, secret redaction (recursive),
+4KB cap, dialect_sql truncation, and the propagate vs retry split.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import ModelRetry
+from wren.model.error import ErrorCode, ErrorPhase, WrenError
+
+from wren_pydantic._errors import (
+    METADATA_CAP_BYTES,
+    redact_secrets,
+    should_propagate,
+    to_model_retry,
+)
+
+
+# ── Propagate vs retry classification ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        ErrorCode.GET_CONNECTION_ERROR,
+        ErrorCode.INVALID_CONNECTION_INFO,
+        ErrorCode.DUCKDB_FILE_NOT_FOUND,
+        ErrorCode.ATTACH_DUCKDB_ERROR,
+    ],
+)
+def test_should_propagate_returns_true_for_infra_codes(code):
+    exc = WrenError(error_code=code, message="boom")
+    assert should_propagate(exc) is True
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        ErrorCode.INVALID_SQL,
+        ErrorCode.MODEL_NOT_FOUND,
+        ErrorCode.VALIDATION_ERROR,
+        ErrorCode.GENERIC_USER_ERROR,
+    ],
+)
+def test_should_propagate_returns_false_for_retry_codes(code):
+    exc = WrenError(error_code=code, message="boom")
+    assert should_propagate(exc) is False
+
+
+# ── Message construction per phase ────────────────────────────────────────
+
+
+def test_to_model_retry_sql_parsing_phase_signals_fixable_sql():
+    exc = WrenError(
+        error_code=ErrorCode.INVALID_SQL,
+        message="unexpected token at line 1",
+        phase=ErrorPhase.SQL_PARSING,
+    )
+    retry = to_model_retry(exc)
+    assert isinstance(retry, ModelRetry)
+    text = str(retry).lower()
+    assert "sql" in text and ("parse" in text or "parsing" in text)
+    assert "unexpected token" in str(retry)
+
+
+def test_to_model_retry_metadata_fetching_phase_hints_model_lookup():
+    exc = WrenError(
+        error_code=ErrorCode.MODEL_NOT_FOUND,
+        message="model 'orders' not found",
+        phase=ErrorPhase.METADATA_FETCHING,
+    )
+    retry = to_model_retry(exc)
+    text = str(retry).lower()
+    assert "model" in text or "metadata" in text
+    assert "orders" in str(retry)
+
+
+def test_to_model_retry_sql_execution_includes_dialect_sql_excerpt():
+    """SQL_EXECUTION errors include the planned dialect SQL (truncated)
+    so the LLM can self-correct against what was actually sent."""
+    long_sql = "SELECT " + "x, " * 200 + "y FROM events"
+    exc = WrenError(
+        error_code=ErrorCode.GENERIC_USER_ERROR,
+        message="(1064, 'syntax error')",
+        phase=ErrorPhase.SQL_EXECUTION,
+        metadata={"dialectSql": long_sql},
+    )
+    retry = to_model_retry(exc)
+    text = str(retry)
+    assert "SELECT" in text
+    # Excerpt is capped — exact value documented in code, just verify
+    # it's substantially shorter than the original.
+    assert len(text) < len(long_sql) + 500
+    assert "..." in text  # truncation marker
+
+
+def test_to_model_retry_no_phase_still_builds_a_message():
+    """phase=None shouldn't crash — fall back to a generic retry message."""
+    exc = WrenError(error_code=ErrorCode.GENERIC_USER_ERROR, message="something off")
+    retry = to_model_retry(exc)
+    assert "something off" in str(retry)
+
+
+# ── Redaction + cap ───────────────────────────────────────────────────────
+
+
+def test_redact_secrets_walks_nested_dicts_and_lists():
+    payload = {
+        "host": "db.example.com",
+        "connection_info": {
+            "password": "supersecret",
+            "options": [{"api_token": "xyz"}, {"port": 5432}],
+        },
+    }
+    cleaned = redact_secrets(payload)
+    assert cleaned["host"] == "db.example.com"
+    assert cleaned["connection_info"]["password"] == "***"
+    assert cleaned["connection_info"]["options"][0]["api_token"] == "***"
+    assert cleaned["connection_info"]["options"][1]["port"] == 5432
+    # input unchanged
+    assert payload["connection_info"]["password"] == "supersecret"
+
+
+def test_to_model_retry_redacts_secrets_in_metadata():
+    exc = WrenError(
+        error_code=ErrorCode.GET_CONNECTION_ERROR,
+        message="auth failed",
+        phase=ErrorPhase.SQL_EXECUTION,
+        metadata={"connection_info": {"password": "supersecret"}},
+    )
+    # propagate path doesn't apply here — we want to test the message
+    # builder still redacts when called directly
+    from wren_pydantic._errors import _build_message  # noqa: PLC0415
+
+    msg = _build_message(exc)
+    assert "supersecret" not in msg
+    assert "***" in msg or "password" not in msg.lower()
+
+
+def test_to_model_retry_caps_message_at_4kb():
+    """Even when metadata is huge, the ModelRetry message stays under cap."""
+    huge_metadata = {"junk": "x" * 100_000}
+    exc = WrenError(
+        error_code=ErrorCode.GENERIC_USER_ERROR,
+        message="error with big metadata",
+        phase=ErrorPhase.SQL_EXECUTION,
+        metadata=huge_metadata,
+    )
+    retry = to_model_retry(exc)
+    assert len(str(retry).encode("utf-8")) <= METADATA_CAP_BYTES + 1024

--- a/sdk/wren-pydantic/tests/unit/test_errors.py
+++ b/sdk/wren-pydantic/tests/unit/test_errors.py
@@ -18,7 +18,6 @@ from wren_pydantic._errors import (
     to_model_retry,
 )
 
-
 # ── Propagate vs retry classification ─────────────────────────────────────
 
 

--- a/sdk/wren-pydantic/tests/unit/test_exceptions.py
+++ b/sdk/wren-pydantic/tests/unit/test_exceptions.py
@@ -1,0 +1,21 @@
+"""Tests for SDK-specific exception types."""
+
+import pytest
+
+from wren_pydantic.exceptions import (
+    MemoryNotEnabledError,
+    WrenToolkitInitError,
+)
+
+
+def test_wren_toolkit_init_error_carries_message():
+    with pytest.raises(WrenToolkitInitError, match="missing target/mdl.json"):
+        raise WrenToolkitInitError("missing target/mdl.json")
+
+
+def test_memory_not_enabled_error_is_distinct_type():
+    """MemoryNotEnabledError is its own class, not a generic ValueError."""
+    err = MemoryNotEnabledError("memory provider not configured")
+    assert isinstance(err, MemoryNotEnabledError)
+    assert isinstance(err, Exception)
+    assert "memory provider" in str(err)

--- a/sdk/wren-pydantic/tests/unit/test_instructions.py
+++ b/sdk/wren-pydantic/tests/unit/test_instructions.py
@@ -1,0 +1,154 @@
+"""Tests for the instructions builder."""
+
+from unittest.mock import MagicMock, patch
+
+from wren_pydantic import WrenToolkit
+
+
+def _enable_memory(tmp_project):
+    (tmp_project / ".wren" / "memory").mkdir(parents=True)
+    return tmp_project
+
+
+def test_instructions_returns_str(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+    assert isinstance(prompt, str)
+    assert len(prompt) > 0
+
+
+def test_instructions_includes_workflow_section(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+    assert "Wren" in prompt
+    # Workflow rule about Wren model names being preferred over raw tables.
+    assert "model" in prompt.lower()
+
+
+def test_instructions_lists_enabled_tools_in_summary(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+    assert "wren_query" in prompt
+    assert "wren_dry_plan" in prompt
+    assert "wren_list_models" in prompt
+
+
+def test_instructions_omits_memory_tools_when_disabled(
+    tmp_project, fake_active_profile
+):
+    """When memory is off, prompt should not reference memory tools."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+    assert "wren_fetch_context" not in prompt
+    assert "wren_recall_queries" not in prompt
+    assert "wren_store_query" not in prompt
+
+
+def test_instructions_includes_memory_tools_when_enabled(
+    tmp_project, fake_active_profile
+):
+    project = _enable_memory(tmp_project)
+    fake_store = MagicMock(name="MemoryStore")
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        toolkit = WrenToolkit.from_project(project)
+        prompt = toolkit.instructions()
+
+    assert "wren_fetch_context" in prompt
+    assert "wren_recall_queries" in prompt
+    assert "wren_store_query" in prompt
+
+
+def test_instructions_appends_project_instructions_when_present(
+    tmp_project, fake_active_profile
+):
+    (tmp_project / "instructions.md").write_text(
+        "# Domain\n\nThis project tracks B2B SaaS revenue.\n"
+    )
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+
+    assert "B2B SaaS revenue" in prompt
+    assert "Project-specific instructions" in prompt
+
+
+def test_instructions_silently_skips_instructions_when_absent(
+    tmp_project, fake_active_profile
+):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+    # No "Project-specific instructions" section header should appear.
+    assert "Project-specific instructions" not in prompt
+
+
+def test_memory_workflow_uses_strong_default_language(tmp_project, fake_active_profile):
+    """Memory-enabled prompt must use 'by default'/'only when' phrasing,
+    not hedge words like 'non-trivial' or 'useful', because empirical testing
+    showed soft phrasing causes GPT-4o to skip recall/store reliably."""
+    project = tmp_project
+    (project / ".wren" / "memory").mkdir(parents=True)
+    fake_store = MagicMock(name="MemoryStore")
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        toolkit = WrenToolkit.from_project(project)
+        prompt = toolkit.instructions()
+
+    # Strong-default phrasing must appear.
+    assert "by default" in prompt.lower()
+    assert "only when" in prompt.lower()
+
+    # Hedges that we explicitly removed must NOT appear.
+    assert "non-trivial" not in prompt.lower()
+    assert "if helpful" not in prompt.lower()
+    assert "useful" not in prompt.lower()
+
+
+def test_error_phase_guidance_present_in_prompt(tmp_project, fake_active_profile):
+    """The prompt must instruct the agent how to react to ok=false envelopes
+    by phase, so it can fix-and-retry instead of silently abandoning."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    prompt = toolkit.instructions()
+
+    assert "SQL_PARSING" in prompt
+    assert "SQL_EXECUTION" in prompt
+
+
+def test_instructions_respects_include_memory_write_false(
+    tmp_project, fake_active_profile
+):
+    """When the caller passes a tool list with `wren_store_query` filtered out,
+    the workflow must drop the persistence step and the tools section must not
+    list it. Otherwise the prompt would tell the LLM to call a tool the agent
+    doesn't actually have."""
+    project = tmp_project
+    (project / ".wren" / "memory").mkdir(parents=True)
+    fake_store = MagicMock(name="MemoryStore")
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        toolkit = WrenToolkit.from_project(project)
+        tools_no_write = toolkit.toolset(include_memory_write=False)
+        prompt = toolkit.instructions(toolset=tools_no_write)
+
+    # Read tools (fetch + recall) still mentioned.
+    assert "wren_fetch_context" in prompt
+    assert "wren_recall_queries" in prompt
+    # Write tool dropped both from workflow steps and tools listing.
+    assert "wren_store_query" not in prompt
+    assert "Persist the NL→SQL pair" not in prompt
+
+
+def test_instructions_default_uses_full_tool_set(tmp_project, fake_active_profile):
+    """Without an explicit tools= override, the prompt mirrors toolset()
+    defaults — full memory workflow when memory is enabled."""
+    project = tmp_project
+    (project / ".wren" / "memory").mkdir(parents=True)
+    fake_store = MagicMock(name="MemoryStore")
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        toolkit = WrenToolkit.from_project(project)
+        prompt = toolkit.instructions()
+
+    # Default toolset() includes all 6, so the workflow has all 3 memory steps.
+    assert "wren_fetch_context" in prompt
+    assert "wren_recall_queries" in prompt
+    assert "wren_store_query" in prompt

--- a/sdk/wren-pydantic/tests/unit/test_memory_api.py
+++ b/sdk/wren-pydantic/tests/unit/test_memory_api.py
@@ -1,0 +1,112 @@
+"""Tests for the _MemoryAPI subscope (toolkit.memory.*)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wren_pydantic import WrenToolkit
+from wren_pydantic.exceptions import MemoryNotEnabledError
+
+
+def _enable_memory(tmp_project):
+    """Helper: create .wren/memory directory so memory auto-enables."""
+    (tmp_project / ".wren" / "memory").mkdir(parents=True)
+    return tmp_project
+
+
+def test_memory_fetch_calls_get_context_with_manifest(tmp_project, fake_active_profile):
+    """toolkit.memory.fetch passes the loaded manifest to MemoryStore.get_context."""
+    project = _enable_memory(tmp_project)
+    fake_store = MagicMock(name="MemoryStore")
+    fake_store.get_context.return_value = {"strategy": "search", "results": []}
+
+    toolkit = WrenToolkit.from_project(project)
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        result = toolkit.memory.fetch("revenue trends", limit=3)
+
+    assert result == {"strategy": "search", "results": []}
+    fake_store.get_context.assert_called_once()
+    kwargs = fake_store.get_context.call_args.kwargs
+    assert kwargs["query"] == "revenue trends"
+    assert kwargs["limit"] == 3
+    # manifest is loaded read-through and passed through.
+    assert "manifest" in kwargs
+
+
+def test_memory_recall_calls_recall_queries(tmp_project, fake_active_profile):
+    project = _enable_memory(tmp_project)
+    fake_store = MagicMock(name="MemoryStore")
+    fake_store.recall_queries.return_value = [{"nl": "x", "sql": "SELECT 1"}]
+
+    toolkit = WrenToolkit.from_project(project)
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        result = toolkit.memory.recall("top customers", limit=5)
+
+    assert result == [{"nl": "x", "sql": "SELECT 1"}]
+    fake_store.recall_queries.assert_called_once_with(query="top customers", limit=5)
+
+
+def test_memory_store_calls_store_query(tmp_project, fake_active_profile):
+    project = _enable_memory(tmp_project)
+    fake_store = MagicMock(name="MemoryStore")
+
+    toolkit = WrenToolkit.from_project(project)
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        toolkit.memory.store(
+            nl="top customers",
+            sql="SELECT * FROM customers ORDER BY revenue DESC LIMIT 10",
+            tags=["revenue", "ranking"],
+        )
+
+    fake_store.store_query.assert_called_once()
+    kwargs = fake_store.store_query.call_args.kwargs
+    assert kwargs["nl_query"] == "top customers"
+    assert kwargs["sql_query"].startswith("SELECT")
+    # SDK joins list[str] tags into a Core-compatible comma-separated string.
+    assert kwargs["tags"] == "revenue,ranking"
+
+
+def test_memory_fetch_raises_when_memory_disabled(tmp_project, fake_active_profile):
+    """Direct API access when memory is disabled raises MemoryNotEnabledError."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with pytest.raises(MemoryNotEnabledError):
+        toolkit.memory.fetch("anything")
+
+
+def test_memory_store_rejects_tags_containing_commas(tmp_project, fake_active_profile):
+    """Commas separate tags in the underlying storage format. A tag like
+    "revenue, Q1" would silently corrupt the round-trip if passed through —
+    we reject early with ValueError instead."""
+    project = _enable_memory(tmp_project)
+    fake_store = MagicMock(name="MemoryStore")
+
+    toolkit = WrenToolkit.from_project(project)
+
+    with patch("wren_pydantic._providers.memory.MemoryStore", return_value=fake_store):
+        with pytest.raises(ValueError, match="comma"):
+            toolkit.memory.store(nl="x", sql="SELECT 1", tags=["revenue, Q1"])
+
+    fake_store.store_query.assert_not_called()
+
+
+def test_memory_store_caches_across_calls(tmp_project, fake_active_profile):
+    """The MemoryStore instance is constructed once and reused across operations."""
+    project = _enable_memory(tmp_project)
+    fake_store = MagicMock(name="MemoryStore")
+    fake_store.get_context.return_value = {}
+    fake_store.recall_queries.return_value = []
+
+    toolkit = WrenToolkit.from_project(project)
+
+    with patch(
+        "wren_pydantic._providers.memory.MemoryStore", return_value=fake_store
+    ) as ctor:
+        toolkit.memory.fetch("x")
+        toolkit.memory.recall("y")
+        toolkit.memory.fetch("z")
+
+    assert ctor.call_count == 1  # constructed exactly once

--- a/sdk/wren-pydantic/tests/unit/test_models.py
+++ b/sdk/wren-pydantic/tests/unit/test_models.py
@@ -1,0 +1,57 @@
+"""Pydantic return-model unit tests for tool outputs."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from wren_pydantic._models import (
+    FetchContextResult,
+    ModelSummary,
+    RecalledPair,
+    WrenQueryResult,
+)
+
+
+def test_wren_query_result_round_trip():
+    payload = WrenQueryResult(
+        columns=["id", "name"],
+        rows=[{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}],
+        row_count=2,
+        truncated=False,
+    )
+    dumped = payload.model_dump()
+    restored = WrenQueryResult.model_validate(dumped)
+    assert restored == payload
+
+
+def test_wren_query_result_rejects_negative_row_count():
+    with pytest.raises(ValidationError, match="row_count"):
+        WrenQueryResult(columns=[], rows=[], row_count=-1, truncated=False)
+
+
+def test_wren_query_result_truncated_flag_marks_limit_overflow():
+    """Caller sets truncated=True when row_count exceeded the requested limit."""
+    payload = WrenQueryResult(columns=["c"], rows=[{"c": 1}], row_count=1, truncated=True)
+    assert payload.truncated is True
+
+
+def test_model_summary_description_optional():
+    """description is optional — a model with no description in MDL should still build."""
+    summary = ModelSummary(name="orders", column_count=8)
+    assert summary.description is None
+    assert summary.name == "orders"
+
+
+def test_fetch_context_result_strategy_enum_enforced():
+    """strategy must be either 'search' or 'full_schema' — anything else fails."""
+    FetchContextResult(strategy="search", items=[])
+    FetchContextResult(strategy="full_schema", items=[])
+    with pytest.raises(ValidationError, match="strategy"):
+        FetchContextResult(strategy="something_else", items=[])
+
+
+def test_recalled_pair_defaults_empty_tags_and_no_score():
+    pair = RecalledPair(nl="top customers", sql="SELECT * FROM customers")
+    assert pair.tags == []
+    assert pair.score is None

--- a/sdk/wren-pydantic/tests/unit/test_models.py
+++ b/sdk/wren-pydantic/tests/unit/test_models.py
@@ -18,7 +18,6 @@ from wren_pydantic._models import (
     WrenQueryResult,
 )
 
-
 # ── WrenQueryResult ───────────────────────────────────────────────────────
 
 
@@ -48,7 +47,9 @@ def test_wren_query_result_row_count_must_equal_len_rows():
 
 
 def test_wren_query_result_truncated_flag_marks_limit_overflow():
-    payload = WrenQueryResult(columns=["c"], rows=[{"c": 1}], row_count=1, truncated=True)
+    payload = WrenQueryResult(
+        columns=["c"], rows=[{"c": 1}], row_count=1, truncated=True
+    )
     assert payload.truncated is True
 
 

--- a/sdk/wren-pydantic/tests/unit/test_models.py
+++ b/sdk/wren-pydantic/tests/unit/test_models.py
@@ -1,4 +1,10 @@
-"""Pydantic return-model unit tests for tool outputs."""
+"""Pydantic return-model unit tests for tool outputs.
+
+Models must match Core's MemoryStore.get_context() and recall_queries()
+return shapes verbatim (see core/wren/src/wren/memory/store.py). Tests
+pin those contracts so a Core upgrade that drifts surfaces here, not
+later in a tool call against the real engine.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +17,9 @@ from wren_pydantic._models import (
     RecalledPair,
     WrenQueryResult,
 )
+
+
+# ── WrenQueryResult ───────────────────────────────────────────────────────
 
 
 def test_wren_query_result_round_trip():
@@ -30,28 +39,99 @@ def test_wren_query_result_rejects_negative_row_count():
         WrenQueryResult(columns=[], rows=[], row_count=-1, truncated=False)
 
 
+def test_wren_query_result_row_count_must_equal_len_rows():
+    """The model is the row count of *this payload* — must equal len(rows)."""
+    with pytest.raises(ValidationError, match="row_count"):
+        WrenQueryResult(
+            columns=["c"], rows=[{"c": 1}, {"c": 2}], row_count=99, truncated=True
+        )
+
+
 def test_wren_query_result_truncated_flag_marks_limit_overflow():
-    """Caller sets truncated=True when row_count exceeded the requested limit."""
     payload = WrenQueryResult(columns=["c"], rows=[{"c": 1}], row_count=1, truncated=True)
     assert payload.truncated is True
 
 
+# ── ModelSummary ──────────────────────────────────────────────────────────
+
+
 def test_model_summary_description_optional():
-    """description is optional — a model with no description in MDL should still build."""
     summary = ModelSummary(name="orders", column_count=8)
     assert summary.description is None
     assert summary.name == "orders"
 
 
-def test_fetch_context_result_strategy_enum_enforced():
-    """strategy must be either 'search' or 'full_schema' — anything else fails."""
-    FetchContextResult(strategy="search", items=[])
-    FetchContextResult(strategy="full_schema", items=[])
+# ── FetchContextResult ────────────────────────────────────────────────────
+# Core's get_context returns one of:
+#   {"strategy": "full",   "schema": "<text>"}
+#   {"strategy": "search", "results": [<dict>, ...]}
+
+
+def test_fetch_context_full_strategy_accepts_schema_key():
+    """`full` payload uses `schema` key (aliased to schema_text)."""
+    payload = FetchContextResult.model_validate(
+        {"strategy": "full", "schema": "the full schema text"}
+    )
+    assert payload.strategy == "full"
+    assert payload.schema_text == "the full schema text"
+    assert payload.results is None
+
+
+def test_fetch_context_search_strategy_uses_results_key():
+    payload = FetchContextResult.model_validate(
+        {"strategy": "search", "results": [{"item_type": "column", "name": "loan_id"}]}
+    )
+    assert payload.strategy == "search"
+    assert payload.results == [{"item_type": "column", "name": "loan_id"}]
+    assert payload.schema_text is None
+
+
+def test_fetch_context_rejects_unknown_strategy():
     with pytest.raises(ValidationError, match="strategy"):
-        FetchContextResult(strategy="something_else", items=[])
+        FetchContextResult.model_validate({"strategy": "something_else"})
 
 
-def test_recalled_pair_defaults_empty_tags_and_no_score():
-    pair = RecalledPair(nl="top customers", sql="SELECT * FROM customers")
-    assert pair.tags == []
+# ── RecalledPair ──────────────────────────────────────────────────────────
+# Core's recall_queries returns dicts with keys text, nl_query, sql_query,
+# datasource, created_at, tags (comma-joined string), _distance (after search).
+
+
+def test_recalled_pair_accepts_core_keys():
+    payload = RecalledPair.model_validate(
+        {
+            "text": "top customers",
+            "nl_query": "top customers",
+            "sql_query": "SELECT * FROM customers",
+            "datasource": "postgres",
+            "tags": "revenue,ranking",
+            "_distance": 0.18,
+        }
+    )
+    assert payload.nl_query == "top customers"
+    assert payload.sql_query == "SELECT * FROM customers"
+    assert payload.tags == "revenue,ranking"  # Core stores as comma string
+    assert payload.score == pytest.approx(0.18)
+
+
+def test_recalled_pair_score_optional_for_seeded_pairs():
+    """Pairs loaded from queries.yml have no _distance until they're searched."""
+    pair = RecalledPair.model_validate(
+        {"nl_query": "top", "sql_query": "SELECT 1", "tags": ""}
+    )
     assert pair.score is None
+    assert pair.tags == ""
+
+
+def test_recalled_pair_ignores_unknown_keys():
+    """Forward-compat: Core may add fields (e.g. `created_at`) without
+    breaking validation."""
+    pair = RecalledPair.model_validate(
+        {
+            "nl_query": "q",
+            "sql_query": "SELECT 1",
+            "tags": "",
+            "created_at": "2026-05-11T00:00:00Z",
+            "future_field": "noise",
+        }
+    )
+    assert pair.nl_query == "q"

--- a/sdk/wren-pydantic/tests/unit/test_providers_connection.py
+++ b/sdk/wren-pydantic/tests/unit/test_providers_connection.py
@@ -1,0 +1,84 @@
+"""Tests for ConnectionProvider implementations."""
+
+import pytest
+
+from wren_pydantic._providers.connection import ProfileConnectionProvider
+from wren_pydantic.exceptions import WrenToolkitInitError
+
+
+def test_explicit_profile_kwarg_resolves_first(monkeypatch, tmp_path):
+    """Layer 1: explicit profile= kwarg wins over project config and active."""
+    fake_profiles = {
+        "prod": {"datasource": "postgres", "host": "prod.db", "port": 5432},
+        "dev": {"datasource": "duckdb", "path": ":memory:"},
+    }
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.list_profiles",
+        lambda: fake_profiles,
+    )
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.get_active_profile",
+        lambda: ("dev", fake_profiles["dev"]),
+    )
+
+    provider = ProfileConnectionProvider(
+        project_path=tmp_path,
+        explicit_profile="prod",
+    )
+
+    assert provider.datasource() == "postgres"
+    assert provider.connection_info() == {"host": "prod.db", "port": 5432}
+
+
+def test_project_config_profile_field_resolves_second(monkeypatch, tmp_path):
+    """Layer 2: wren_project.yml's `profile:` field used when no explicit kwarg."""
+    fake_profiles = {
+        "from_project": {"datasource": "mysql", "host": "from-project.db"},
+        "active": {"datasource": "duckdb", "path": ":memory:"},
+    }
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.list_profiles",
+        lambda: fake_profiles,
+    )
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.get_active_profile",
+        lambda: ("active", fake_profiles["active"]),
+    )
+    (tmp_path / "wren_project.yml").write_text("profile: from_project\n")
+
+    provider = ProfileConnectionProvider(project_path=tmp_path)
+
+    assert provider.datasource() == "mysql"
+    assert provider.connection_info() == {"host": "from-project.db"}
+
+
+def test_active_profile_resolves_third_when_no_explicit_or_project(
+    monkeypatch, tmp_path
+):
+    """Layer 3: globally active profile is used when no explicit and no project config."""
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.list_profiles",
+        lambda: {"only": {"datasource": "snowflake"}},
+    )
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.get_active_profile",
+        lambda: ("only", {"datasource": "snowflake", "account": "abc"}),
+    )
+
+    provider = ProfileConnectionProvider(project_path=tmp_path)
+
+    assert provider.datasource() == "snowflake"
+    assert provider.connection_info() == {"account": "abc"}
+
+
+def test_unknown_profile_name_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.list_profiles",
+        lambda: {"prod": {"datasource": "postgres", "host": "x"}},
+    )
+
+    with pytest.raises(WrenToolkitInitError, match="profile.*not found"):
+        ProfileConnectionProvider(
+            project_path=tmp_path,
+            explicit_profile="nonexistent",
+        )

--- a/sdk/wren-pydantic/tests/unit/test_providers_mdl.py
+++ b/sdk/wren-pydantic/tests/unit/test_providers_mdl.py
@@ -1,0 +1,58 @@
+"""Tests for MDLSource implementations."""
+
+import json
+
+import pytest
+
+from wren_pydantic._providers.mdl_source import ProjectMDLSource
+from wren_pydantic.exceptions import WrenToolkitInitError
+
+
+def test_project_mdl_source_reads_target_mdl_json(tmp_path):
+    """ProjectMDLSource reads the project's target/mdl.json on every load."""
+    target = tmp_path / "target"
+    target.mkdir()
+    manifest = {"models": [{"name": "orders"}]}
+    (target / "mdl.json").write_text(json.dumps(manifest))
+
+    source = ProjectMDLSource(project_path=tmp_path)
+
+    assert source.load_manifest() == manifest
+
+
+def test_project_mdl_source_picks_up_file_changes_between_calls(tmp_path):
+    """Subsequent load_manifest() calls reflect on-disk changes (read-through)."""
+    target = tmp_path / "target"
+    target.mkdir()
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(json.dumps({"models": [{"name": "v1"}]}))
+
+    source = ProjectMDLSource(project_path=tmp_path)
+    first = source.load_manifest()
+
+    mdl_file.write_text(json.dumps({"models": [{"name": "v2"}]}))
+    second = source.load_manifest()
+
+    assert first["models"][0]["name"] == "v1"
+    assert second["models"][0]["name"] == "v2"
+
+
+def test_project_mdl_source_raises_on_missing_target(tmp_path):
+    """A missing target/mdl.json raises WrenToolkitInitError when loading."""
+    source = ProjectMDLSource(project_path=tmp_path)
+
+    with pytest.raises(WrenToolkitInitError, match="target/mdl.json"):
+        source.load_manifest()
+
+
+def test_project_mdl_source_normalizes_malformed_json_to_init_error(tmp_path):
+    """Malformed mdl.json must surface as WrenToolkitInitError, not raw JSONDecodeError,
+    so callers don't need to special-case JSON internals."""
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "mdl.json").write_text("{not valid json")
+
+    source = ProjectMDLSource(project_path=tmp_path)
+
+    with pytest.raises(WrenToolkitInitError, match="not valid JSON"):
+        source.load_manifest()

--- a/sdk/wren-pydantic/tests/unit/test_providers_memory.py
+++ b/sdk/wren-pydantic/tests/unit/test_providers_memory.py
@@ -1,0 +1,43 @@
+"""Tests for MemoryProvider implementations."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wren_pydantic._providers.memory import (
+    LocalLanceDBMemoryProvider,
+    NoopMemoryProvider,
+)
+from wren_pydantic.exceptions import MemoryNotEnabledError
+
+
+def test_noop_memory_provider_is_disabled():
+    """NoopMemoryProvider reports as disabled and raises on open()."""
+    provider = NoopMemoryProvider()
+
+    assert provider.enabled is False
+
+    with pytest.raises(MemoryNotEnabledError):
+        provider.open()
+
+
+def test_local_lancedb_provider_is_enabled(tmp_path):
+    """A local provider is enabled (regardless of whether the dir exists yet)."""
+    provider = LocalLanceDBMemoryProvider(memory_path=tmp_path / ".wren" / "memory")
+    assert provider.enabled is True
+
+
+def test_local_lancedb_provider_open_constructs_memory_store(tmp_path):
+    """open() lazily constructs a wren.memory.MemoryStore at the given path."""
+    memory_path = tmp_path / ".wren" / "memory"
+    provider = LocalLanceDBMemoryProvider(memory_path=memory_path)
+
+    fake_store = MagicMock(name="MemoryStore")
+    with patch(
+        "wren_pydantic._providers.memory.MemoryStore",
+        return_value=fake_store,
+    ) as ctor:
+        store = provider.open()
+
+    assert store is fake_store
+    ctor.assert_called_once_with(path=memory_path)

--- a/sdk/wren-pydantic/tests/unit/test_toolkit_init.py
+++ b/sdk/wren-pydantic/tests/unit/test_toolkit_init.py
@@ -1,0 +1,104 @@
+"""Tests for WrenToolkit construction (from_project)."""
+
+import pytest
+from wren.profile import _reset_env_loaded_for_tests
+
+from wren_pydantic import WrenToolkit
+from wren_pydantic._providers.memory import (
+    LocalLanceDBMemoryProvider,
+    NoopMemoryProvider,
+)
+from wren_pydantic.exceptions import WrenToolkitInitError
+
+
+def test_from_project_raises_when_project_yml_missing(tmp_path, fake_active_profile):
+    """A directory without wren_project.yml is not a Wren project."""
+    with pytest.raises(WrenToolkitInitError, match="wren_project.yml"):
+        WrenToolkit.from_project(tmp_path)
+
+
+def test_from_project_raises_when_target_mdl_missing(tmp_path, fake_active_profile):
+    """A project without target/mdl.json hasn't been built."""
+    (tmp_path / "wren_project.yml").write_text("schema_version: 1\n")
+    with pytest.raises(WrenToolkitInitError, match="target/mdl.json"):
+        WrenToolkit.from_project(tmp_path)
+
+
+def test_from_project_returns_toolkit_when_prereqs_met(
+    tmp_project, fake_active_profile
+):
+    """from_project returns a WrenToolkit when all prerequisites exist."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    assert isinstance(toolkit, WrenToolkit)
+
+
+def test_from_project_relative_path_resolves(
+    tmp_project, fake_active_profile, monkeypatch
+):
+    """from_project accepts relative paths and resolves them."""
+    monkeypatch.chdir(tmp_project.parent)
+    toolkit = WrenToolkit.from_project(tmp_project.name)
+    assert isinstance(toolkit, WrenToolkit)
+
+
+def test_memory_auto_detect_disabled_when_dir_missing(tmp_project, fake_active_profile):
+    """Without .wren/memory/, memory auto-detects as Noop."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    assert isinstance(toolkit._memory, NoopMemoryProvider)
+
+
+def test_memory_auto_detect_enabled_when_dir_exists(tmp_project, fake_active_profile):
+    """With .wren/memory/, memory auto-detects as LocalLanceDB."""
+    (tmp_project / ".wren" / "memory").mkdir(parents=True)
+    toolkit = WrenToolkit.from_project(tmp_project)
+    assert isinstance(toolkit._memory, LocalLanceDBMemoryProvider)
+
+
+def test_from_project_loads_dotenv_from_project_path(tmp_project, monkeypatch):
+    """from_project loads <path>/.env so ${VAR} secrets resolve regardless of CWD.
+
+    Regression: previously the SDK relied on Core's CWD-relative .env discovery,
+    which fails when the user runs Python from anywhere other than the project
+    directory.
+    """
+    # Stage 1: a profile that references an env var the caller's shell does NOT have.
+    sentinel_var = "WREN_LANGCHAIN_TEST_HOST_DOES_NOT_EXIST_IN_SHELL"
+    monkeypatch.delenv(sentinel_var, raising=False)
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.list_profiles",
+        lambda: {
+            "test": {
+                "datasource": "duckdb",
+                "host": f"${{{sentinel_var}}}",
+                "format": "duckdb",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "wren_pydantic._providers.connection.get_active_profile",
+        lambda: (
+            "test",
+            {
+                "datasource": "duckdb",
+                "host": f"${{{sentinel_var}}}",
+                "format": "duckdb",
+            },
+        ),
+    )
+
+    # Stage 2: place the var only inside the project's .env.
+    (tmp_project / ".env").write_text(f"{sentinel_var}=resolved-from-project-env\n")
+
+    # Stage 3: run from a different CWD so Core's CWD-walk would NOT find the file.
+    monkeypatch.chdir(tmp_project.parent)
+    _reset_env_loaded_for_tests()
+
+    try:
+        toolkit = WrenToolkit.from_project(tmp_project)
+        assert (
+            toolkit._connection.connection_info()["host"] == "resolved-from-project-env"
+        )
+    finally:
+        # Reset the global loader flag again so this test cannot leak its
+        # half-loaded state into whatever runs next in the session.
+        _reset_env_loaded_for_tests()

--- a/sdk/wren-pydantic/tests/unit/test_toolkit_runtime.py
+++ b/sdk/wren-pydantic/tests/unit/test_toolkit_runtime.py
@@ -1,0 +1,121 @@
+"""Tests for WrenToolkit runtime API: query, dry_plan, dry_run."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+
+from wren_pydantic import WrenToolkit
+
+
+def test_query_invokes_wren_engine_with_resolved_manifest(
+    tmp_project, fake_active_profile
+):
+    """toolkit.query reads the manifest fresh and delegates to WrenEngine.query."""
+    fake_table = pa.table({"x": [1, 2, 3]})
+    fake_engine = MagicMock(name="WrenEngine")
+    fake_engine.query.return_value = fake_table
+    fake_engine._connector = MagicMock(name="connector")
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch(
+        "wren_pydantic._toolkit.WrenEngine", return_value=fake_engine
+    ) as engine_ctor:
+        result = toolkit.query("SELECT 1", limit=10)
+
+    assert result is fake_table
+    fake_engine.query.assert_called_once_with("SELECT 1", limit=10)
+    # Engine constructed with manifest bytes + datasource + connection_info
+    engine_ctor.assert_called_once()
+    kwargs = engine_ctor.call_args.kwargs
+    assert kwargs["data_source"] == "duckdb"
+    assert kwargs["connection_info"] == {"path": ":memory:"}
+
+
+def test_connector_is_reused_across_query_calls(tmp_project, fake_active_profile):
+    """Second query reuses the cached connector instead of reconnecting.
+
+    Distinguishes "what engine 2 starts with" from "what gets injected" by
+    seeding each fresh engine with a different connector. If reuse is broken,
+    engine 2's `_connector` would remain its own initial mock; if reuse works,
+    it gets replaced with engine 1's connector before `query()` runs.
+    """
+    first_connector = MagicMock(name="first_connector")
+    second_initial_connector = MagicMock(name="second_initial_connector")
+    engines = []
+
+    def make_engine(*args, **kwargs):
+        engine = MagicMock(name=f"engine{len(engines)}")
+        engine._connector = first_connector if not engines else second_initial_connector
+        engines.append(engine)
+        return engine
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_pydantic._toolkit.WrenEngine", side_effect=make_engine):
+        toolkit.query("SELECT 1")
+        toolkit.query("SELECT 2")
+
+    # Engine 1 keeps its connector; engine 2's initial connector got
+    # overwritten with the cached one from engine 1 before query() ran.
+    assert engines[0]._connector is first_connector
+    assert engines[1]._connector is first_connector
+    assert engines[1]._connector is not second_initial_connector
+
+
+def test_manifest_is_read_through_on_every_call(
+    tmp_project, fake_active_profile, monkeypatch
+):
+    """Each query re-reads target/mdl.json so external CLI rebuilds are picked up."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine._connector = MagicMock()
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    # Replace the manifest content between calls.
+    mdl_path = tmp_project / "target" / "mdl.json"
+    mdl_path.write_text('{"models": [{"name": "v1"}]}')
+
+    with patch(
+        "wren_pydantic._toolkit.WrenEngine", return_value=fake_engine
+    ) as engine_ctor:
+        toolkit.query("SELECT 1")
+
+        # Simulate `wren context build` updating the file.
+        mdl_path.write_text('{"models": [{"name": "v2"}]}')
+        toolkit.query("SELECT 2")
+
+    first_manifest_b64 = engine_ctor.call_args_list[0].kwargs["manifest_str"]
+    second_manifest_b64 = engine_ctor.call_args_list[1].kwargs["manifest_str"]
+    first = json.loads(base64.b64decode(first_manifest_b64))
+    second = json.loads(base64.b64decode(second_manifest_b64))
+    assert first["models"][0]["name"] == "v1"
+    assert second["models"][0]["name"] == "v2"
+
+
+def test_dry_plan_delegates_to_engine(tmp_project, fake_active_profile):
+    fake_engine = MagicMock(name="engine")
+    fake_engine.dry_plan.return_value = "SELECT * FROM cte_orders"
+    fake_engine._connector = MagicMock()
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_pydantic._toolkit.WrenEngine", return_value=fake_engine):
+        result = toolkit.dry_plan("SELECT * FROM orders")
+
+    assert result == "SELECT * FROM cte_orders"
+    fake_engine.dry_plan.assert_called_once_with("SELECT * FROM orders")
+
+
+def test_dry_run_delegates_to_engine(tmp_project, fake_active_profile):
+    fake_engine = MagicMock(name="engine")
+    fake_engine._connector = MagicMock()
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_pydantic._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.dry_run("SELECT 1")
+
+    fake_engine.dry_run.assert_called_once_with("SELECT 1")

--- a/sdk/wren-pydantic/tests/unit/test_tools_memory.py
+++ b/sdk/wren-pydantic/tests/unit/test_tools_memory.py
@@ -1,0 +1,209 @@
+"""Unit tests for the 3 memory tools.
+
+Tests against a mocked toolkit.memory. Verifies:
+- Registration: 2 or 3 tools depending on include_write
+- Return-type shapes: FetchContextResult / list[RecalledPair] / str
+- WrenError → ModelRetry mapping fires
+- wren_store_query uses retries=0 (write failures don't retry)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai import ModelRetry
+from wren.model.error import ErrorCode, ErrorPhase, WrenError
+
+from wren_pydantic._models import FetchContextResult, RecalledPair
+from wren_pydantic._tools_memory import build_memory_toolset
+
+
+_UNSET = object()
+
+
+def _mock_toolkit(*, fetch=_UNSET, recall=_UNSET, store_raises=None):
+    tk = MagicMock(name="WrenToolkit")
+    tk.memory.fetch.return_value = (
+        {"strategy": "full", "schema": "schema text"} if fetch is _UNSET else fetch
+    )
+    tk.memory.recall.return_value = (
+        [
+            {
+                "nl_query": "top customers",
+                "sql_query": "SELECT * FROM customers",
+                "tags": "",
+                "_distance": 0.12,
+            }
+        ]
+        if recall is _UNSET
+        else recall
+    )
+    if store_raises is not None:
+        tk.memory.store.side_effect = store_raises
+    return tk
+
+
+def _get_tool(toolset, name: str):
+    tools = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if isinstance(tools, dict):
+        entry = tools[name]
+    else:
+        entry = next(t for t in tools if getattr(t, "name", None) == name)
+    return getattr(entry, "function", entry)
+
+
+def _registered_names(toolset) -> list[str]:
+    tools = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if isinstance(tools, dict):
+        return list(tools.keys())
+    return [getattr(t, "name", None) for t in tools]
+
+
+def _entry(toolset, name: str):
+    tools = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if isinstance(tools, dict):
+        return tools[name]
+    return next(t for t in tools if getattr(t, "name", None) == name)
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+
+def test_build_memory_toolset_registers_three_tools_when_include_write():
+    toolkit = _mock_toolkit()
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    assert sorted(_registered_names(ts)) == [
+        "wren_fetch_context",
+        "wren_recall_queries",
+        "wren_store_query",
+    ]
+
+
+def test_build_memory_toolset_drops_store_when_include_write_false():
+    toolkit = _mock_toolkit()
+    ts = build_memory_toolset(toolkit, include_write=False, takes_ctx=False)
+    names = _registered_names(ts)
+    assert "wren_store_query" not in names
+    assert sorted(names) == ["wren_fetch_context", "wren_recall_queries"]
+
+
+# ── wren_fetch_context ────────────────────────────────────────────────────
+
+
+def test_fetch_context_returns_typed_full_payload():
+    toolkit = _mock_toolkit(fetch={"strategy": "full", "schema": "schema text"})
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_fetch_context")
+
+    result = fn(question="What are orders?", limit=5)
+    assert isinstance(result, FetchContextResult)
+    assert result.strategy == "full"
+    assert result.schema_text == "schema text"
+
+
+def test_fetch_context_returns_typed_search_payload():
+    toolkit = _mock_toolkit(
+        fetch={
+            "strategy": "search",
+            "results": [{"item_type": "column", "name": "loan_id"}],
+        }
+    )
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_fetch_context")
+
+    result = fn(question="loan ids")
+    assert result.strategy == "search"
+    assert result.results == [{"item_type": "column", "name": "loan_id"}]
+
+
+def test_fetch_context_wraps_wren_error_as_model_retry():
+    toolkit = _mock_toolkit()
+    toolkit.memory.fetch.side_effect = WrenError(
+        error_code=ErrorCode.GENERIC_USER_ERROR,
+        message="memory unavailable",
+        phase=ErrorPhase.METADATA_FETCHING,
+    )
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_fetch_context")
+
+    with pytest.raises(ModelRetry, match="memory unavailable"):
+        fn(question="x")
+
+
+# ── wren_recall_queries ───────────────────────────────────────────────────
+
+
+def test_recall_returns_typed_pair_list():
+    toolkit = _mock_toolkit(
+        recall=[
+            {
+                "nl_query": "top customers",
+                "sql_query": "SELECT * FROM customers",
+                "tags": "revenue,ranking",
+                "_distance": 0.18,
+            }
+        ]
+    )
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_recall_queries")
+
+    result = fn(question="top customers", limit=3)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], RecalledPair)
+    assert result[0].nl_query == "top customers"
+    assert result[0].tags == "revenue,ranking"
+
+
+def test_recall_empty_returns_empty_list():
+    toolkit = _mock_toolkit(recall=[])
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_recall_queries")
+    assert fn(question="nothing matches") == []
+
+
+# ── wren_store_query ──────────────────────────────────────────────────────
+
+
+def test_store_returns_success_string():
+    toolkit = _mock_toolkit()
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_store_query")
+
+    result = fn(nl="top customers", sql="SELECT * FROM customers", tags=["revenue"])
+    assert isinstance(result, str)
+    assert "stored" in result.lower() or "saved" in result.lower()
+
+
+def test_store_handles_none_tags_as_empty():
+    toolkit = _mock_toolkit()
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    fn = _get_tool(ts, "wren_store_query")
+    fn(nl="x", sql="SELECT 1", tags=None)
+    # toolkit.memory.store called with tags=[]
+    call_kwargs = toolkit.memory.store.call_args.kwargs
+    assert call_kwargs["tags"] == []
+
+
+def test_store_query_retries_zero():
+    """Write failures shouldn't retry — locked via tool registration."""
+    toolkit = _mock_toolkit()
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=False)
+    entry = _entry(ts, "wren_store_query")
+    # The Tool object exposes max_retries (Pydantic AI's name for retries).
+    # We expect 0; other tools default to 2. (Don't use `or` here — 0 is falsy.)
+    assert entry.max_retries == 0
+
+
+# ── takes_ctx ─────────────────────────────────────────────────────────────
+
+
+def test_takes_ctx_true_injects_ctx_into_fetch_signature():
+    import inspect
+
+    toolkit = _mock_toolkit()
+    ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=True)
+    fn = _get_tool(ts, "wren_fetch_context")
+    params = list(inspect.signature(fn).parameters)
+    assert params[0] == "ctx"

--- a/sdk/wren-pydantic/tests/unit/test_tools_memory.py
+++ b/sdk/wren-pydantic/tests/unit/test_tools_memory.py
@@ -18,7 +18,6 @@ from wren.model.error import ErrorCode, ErrorPhase, WrenError
 from wren_pydantic._models import FetchContextResult, RecalledPair
 from wren_pydantic._tools_memory import build_memory_toolset
 
-
 _UNSET = object()
 
 
@@ -200,7 +199,7 @@ def test_store_query_retries_zero():
 
 
 def test_takes_ctx_true_injects_ctx_into_fetch_signature():
-    import inspect
+    import inspect  # noqa: PLC0415
 
     toolkit = _mock_toolkit()
     ts = build_memory_toolset(toolkit, include_write=True, takes_ctx=True)

--- a/sdk/wren-pydantic/tests/unit/test_tools_runtime.py
+++ b/sdk/wren-pydantic/tests/unit/test_tools_runtime.py
@@ -234,9 +234,9 @@ def test_wren_list_models_wraps_error_as_model_retry():
 
 def test_takes_ctx_true_registers_tools_with_ctx_param():
     """With takes_ctx=True, tool signatures expose ctx: RunContext as first arg."""
-    import inspect
+    import inspect  # noqa: PLC0415
 
-    from pydantic_ai import RunContext  # noqa: F401  (type ref for clarity)
+    from pydantic_ai import RunContext  # noqa: F401, PLC0415  (type ref for clarity)
 
     toolkit = _mock_toolkit()
     ts = build_runtime_toolset(toolkit, takes_ctx=True)

--- a/sdk/wren-pydantic/tests/unit/test_tools_runtime.py
+++ b/sdk/wren-pydantic/tests/unit/test_tools_runtime.py
@@ -1,0 +1,247 @@
+"""Unit tests for the 3 runtime tools (wren_query, wren_dry_plan, wren_list_models).
+
+Tests run against a mocked toolkit — the toolkit's direct API is unit-tested
+in test_toolkit_runtime.py. Here we verify the tool wrappers:
+- Registration shape under FunctionToolset
+- Successful return: typed Pydantic models match the tool's annotated return
+- Error path: WrenError → ModelRetry mapping fires
+- Propagate-class WrenError re-raises instead of becoming ModelRetry
+- `limit` clamping for wren_query
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+from pydantic_ai import ModelRetry
+from wren.model.error import ErrorCode, ErrorPhase, WrenError
+
+from wren_pydantic._models import ModelSummary, WrenQueryResult
+from wren_pydantic._tools import MAX_QUERY_ROWS, build_runtime_toolset
+
+
+def _mock_toolkit(*, manifest=None, query_table=None, dry_plan_sql="EXPANDED SQL"):
+    """Build a MagicMock that quacks like a WrenToolkit for tool tests."""
+    tk = MagicMock(name="WrenToolkit")
+    tk._mdl_source.load_manifest.return_value = manifest or {
+        "models": [
+            {"name": "orders", "columns": [{"name": "id"}, {"name": "total"}]},
+        ]
+    }
+    tk.query.return_value = query_table or pa.table({"id": [1, 2], "name": ["a", "b"]})
+    tk.dry_plan.return_value = dry_plan_sql
+    return tk
+
+
+def _get_tool(toolset, name: str):
+    """Pull a tool function from the toolset by registered name. The exact
+    accessor depends on Pydantic AI's internals — try the documented path
+    first, fall back to introspecting the toolset's tool list."""
+    # Pydantic AI's FunctionToolset stores tools internally; tests should
+    # call the registered function directly. Use add-via-decorator style.
+    tools_dict = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if tools_dict is None:
+        raise AttributeError(f"toolset has no tools attribute: {dir(toolset)}")
+    # tools may be a dict {name: Tool} or list of tools — handle both
+    if isinstance(tools_dict, dict):
+        entry = tools_dict[name]
+    else:
+        entry = next(t for t in tools_dict if getattr(t, "name", None) == name)
+    # The wrapped function — Pydantic AI's Tool object exposes .function
+    return getattr(entry, "function", entry)
+
+
+# ── Registration shape ────────────────────────────────────────────────────
+
+
+def test_build_runtime_toolset_registers_three_tools():
+    toolkit = _mock_toolkit()
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    tool_names = _registered_names(ts)
+    assert sorted(tool_names) == ["wren_dry_plan", "wren_list_models", "wren_query"]
+
+
+def _registered_names(toolset) -> list[str]:
+    tools = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if isinstance(tools, dict):
+        return list(tools.keys())
+    return [getattr(t, "name", None) for t in tools]
+
+
+# ── wren_query ────────────────────────────────────────────────────────────
+
+
+def test_wren_query_returns_typed_result():
+    toolkit = _mock_toolkit()
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    result = fn(sql="SELECT * FROM orders", limit=100)
+
+    assert isinstance(result, WrenQueryResult)
+    assert result.columns == ["id", "name"]
+    assert result.row_count == 2
+    assert result.truncated is False
+
+
+def test_wren_query_rejects_limit_below_one():
+    toolkit = _mock_toolkit()
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    with pytest.raises(ModelRetry, match="limit"):
+        fn(sql="SELECT 1", limit=0)
+
+
+def test_wren_query_rejects_limit_above_max():
+    toolkit = _mock_toolkit()
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    with pytest.raises(ModelRetry, match=str(MAX_QUERY_ROWS)):
+        fn(sql="SELECT 1", limit=MAX_QUERY_ROWS + 1)
+
+
+def test_wren_query_wraps_wren_error_as_model_retry():
+    toolkit = _mock_toolkit()
+    toolkit.query.side_effect = WrenError(
+        error_code=ErrorCode.INVALID_SQL,
+        message="syntax error near 'FORM'",
+        phase=ErrorPhase.SQL_PARSING,
+    )
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    with pytest.raises(ModelRetry, match="syntax error"):
+        fn(sql="SELECT * FORM orders", limit=10)
+
+
+def test_wren_query_propagates_infra_errors():
+    """GET_CONNECTION_ERROR is in propagate set — re-raises as WrenError, not ModelRetry."""
+    toolkit = _mock_toolkit()
+    toolkit.query.side_effect = WrenError(
+        error_code=ErrorCode.GET_CONNECTION_ERROR,
+        message="cannot connect",
+    )
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    with pytest.raises(WrenError, match="cannot connect"):
+        fn(sql="SELECT 1", limit=10)
+
+
+def test_wren_query_truncated_when_engine_returns_more_than_limit():
+    """When the engine returns row_count == limit, we flag truncated=True
+    because we can't tell whether there were more rows."""
+    big_table = pa.table({"c": list(range(100))})
+    toolkit = _mock_toolkit(query_table=big_table)
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    result = fn(sql="SELECT * FROM big", limit=100)
+    assert result.truncated is True
+
+
+# ── wren_dry_plan ─────────────────────────────────────────────────────────
+
+
+def test_wren_dry_plan_returns_string():
+    toolkit = _mock_toolkit(dry_plan_sql="WITH a AS (SELECT 1) SELECT * FROM a")
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_dry_plan")
+
+    result = fn(sql="SELECT 1")
+    assert isinstance(result, str)
+    assert "WITH" in result
+
+
+def test_wren_dry_plan_wraps_error_as_model_retry():
+    toolkit = _mock_toolkit()
+    toolkit.dry_plan.side_effect = WrenError(
+        error_code=ErrorCode.INVALID_SQL,
+        message="invalid statement",
+        phase=ErrorPhase.SQL_PARSING,
+    )
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_dry_plan")
+
+    with pytest.raises(ModelRetry, match="invalid statement"):
+        fn(sql="bogus")
+
+
+# ── wren_list_models ──────────────────────────────────────────────────────
+
+
+def test_wren_list_models_returns_typed_summaries():
+    manifest = {
+        "models": [
+            {
+                "name": "orders",
+                "columns": [{"name": "id"}, {"name": "total"}, {"name": "user_id"}],
+                "properties": {"description": "Order facts"},
+            },
+            {
+                "name": "users",
+                "columns": [{"name": "id"}, {"name": "email"}],
+            },
+        ]
+    }
+    toolkit = _mock_toolkit(manifest=manifest)
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_list_models")
+
+    result = fn()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(s, ModelSummary) for s in result)
+
+    orders = next(s for s in result if s.name == "orders")
+    assert orders.column_count == 3
+    assert orders.description == "Order facts"
+
+    users = next(s for s in result if s.name == "users")
+    assert users.description is None
+
+
+def test_wren_list_models_empty_manifest():
+    toolkit = _mock_toolkit(manifest={"models": []})
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_list_models")
+
+    result = fn()
+    assert result == []
+
+
+def test_wren_list_models_wraps_error_as_model_retry():
+    toolkit = _mock_toolkit()
+    toolkit._mdl_source.load_manifest.side_effect = WrenError(
+        error_code=ErrorCode.MDL_NOT_FOUND,
+        message="target/mdl.json missing",
+        phase=ErrorPhase.MDL_EXTRACTION,
+    )
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_list_models")
+
+    with pytest.raises(ModelRetry, match="missing"):
+        fn()
+
+
+# ── takes_ctx variant ─────────────────────────────────────────────────────
+
+
+def test_takes_ctx_true_registers_tools_with_ctx_param():
+    """With takes_ctx=True, tool signatures expose ctx: RunContext as first arg."""
+    import inspect
+
+    from pydantic_ai import RunContext  # noqa: F401  (type ref for clarity)
+
+    toolkit = _mock_toolkit()
+    ts = build_runtime_toolset(toolkit, takes_ctx=True)
+    fn = _get_tool(ts, "wren_query")
+
+    sig = inspect.signature(fn)
+    params = list(sig.parameters)
+    assert params[0] == "ctx"

--- a/sdk/wren-pydantic/tests/unit/test_toolset_facade.py
+++ b/sdk/wren-pydantic/tests/unit/test_toolset_facade.py
@@ -1,0 +1,63 @@
+"""Unit tests for WrenToolkit.toolset() — the Pydantic AI adapter facade."""
+
+from __future__ import annotations
+
+import inspect
+
+from pydantic_ai import FunctionToolset
+
+from wren_pydantic import WrenToolkit
+
+
+def _registered_names(toolset: FunctionToolset) -> list[str]:
+    tools = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if isinstance(tools, dict):
+        return list(tools.keys())
+    return [getattr(t, "name", None) for t in tools]
+
+
+def _get_tool(toolset: FunctionToolset, name: str):
+    tools = getattr(toolset, "tools", None) or getattr(toolset, "_tools", None)
+    if isinstance(tools, dict):
+        entry = tools[name]
+    else:
+        entry = next(t for t in tools if getattr(t, "name", None) == name)
+    return getattr(entry, "function", entry)
+
+
+def test_toolset_returns_three_runtime_tools_when_memory_disabled(
+    tmp_project, fake_active_profile
+):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset()
+
+    names = _registered_names(ts)
+    assert sorted(names) == ["wren_dry_plan", "wren_list_models", "wren_query"]
+
+
+def test_toolset_takes_ctx_false_omits_ctx_param(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset(takes_ctx=False)
+    fn = _get_tool(ts, "wren_query")
+
+    params = list(inspect.signature(fn).parameters)
+    assert "ctx" not in params
+
+
+def test_toolset_takes_ctx_true_adds_ctx_first_param(tmp_project, fake_active_profile):
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset(takes_ctx=True)
+    fn = _get_tool(ts, "wren_query")
+
+    params = list(inspect.signature(fn).parameters)
+    assert params[0] == "ctx"
+
+
+def test_toolset_returns_fresh_instance_each_call(tmp_project, fake_active_profile):
+    """Each call builds a fresh FunctionToolset — toolkit state is captured
+    in tool closures, so multiple toolsets can coexist with different
+    takes_ctx settings."""
+    toolkit = WrenToolkit.from_project(tmp_project)
+    a = toolkit.toolset(takes_ctx=False)
+    b = toolkit.toolset(takes_ctx=True)
+    assert a is not b

--- a/sdk/wren-pydantic/tests/unit/test_toolset_facade.py
+++ b/sdk/wren-pydantic/tests/unit/test_toolset_facade.py
@@ -61,3 +61,60 @@ def test_toolset_returns_fresh_instance_each_call(tmp_project, fake_active_profi
     a = toolkit.toolset(takes_ctx=False)
     b = toolkit.toolset(takes_ctx=True)
     assert a is not b
+
+
+def test_toolset_includes_memory_tools_when_memory_dir_exists(
+    tmp_project, fake_active_profile
+):
+    """When .wren/memory/ exists, the toolset gains the 3 memory tools."""
+    (tmp_project / ".wren" / "memory").mkdir(parents=True)
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset()
+
+    names = _registered_names(ts)
+    assert sorted(names) == [
+        "wren_dry_plan",
+        "wren_fetch_context",
+        "wren_list_models",
+        "wren_query",
+        "wren_recall_queries",
+        "wren_store_query",
+    ]
+
+
+def test_toolset_drops_store_query_when_include_memory_write_false(
+    tmp_project, fake_active_profile
+):
+    (tmp_project / ".wren" / "memory").mkdir(parents=True)
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+    ts = toolkit.toolset(include_memory_write=False)
+
+    names = _registered_names(ts)
+    assert "wren_store_query" not in names
+    assert "wren_fetch_context" in names
+    assert "wren_recall_queries" in names
+    # 5 tools total (3 runtime + 2 read-only memory)
+    assert len(names) == 5
+
+
+def test_toolset_include_memory_write_ignored_when_memory_disabled(
+    tmp_project, fake_active_profile
+):
+    """When memory is disabled, include_memory_write has no effect —
+    still only the 3 runtime tools."""
+    toolkit = WrenToolkit.from_project(tmp_project)  # no .wren/memory
+    ts_default = toolkit.toolset(include_memory_write=True)
+    ts_no_write = toolkit.toolset(include_memory_write=False)
+
+    assert sorted(_registered_names(ts_default)) == [
+        "wren_dry_plan",
+        "wren_list_models",
+        "wren_query",
+    ]
+    assert sorted(_registered_names(ts_no_write)) == [
+        "wren_dry_plan",
+        "wren_list_models",
+        "wren_query",
+    ]


### PR DESCRIPTION
## Summary

- New `sdk/wren-pydantic` package — Pydantic AI integration for Wren AI Core, sibling to `sdk/wren-langchain`
- 6 LLM-facing tools (3 runtime + 3 memory) via `FunctionToolset`
- `WrenError → ModelRetry` mapping with phase-aware messages, recursive secret redaction, 4KB cap
- Typed Pydantic return models pinned to Core's `MemoryStore` shapes (no envelope dicts)
- Full CI / publish / release-please / rc-release wiring mirroring wren-langchain

## What's included

| Surface | Detail |
|---|---|
| `WrenToolkit.from_project(path, profile=)` | Same signature as langchain — eager validates `wren_project.yml` + `target/mdl.json`, loads `.env`, resolves memory provider via `.wren/memory/`, 3-tier profile fallback |
| `toolkit.toolset(*, include_memory_write=True, takes_ctx=False)` | Returns `FunctionToolset`; auto-filters memory tools when disabled; `takes_ctx=True` for mixing with `deps_type=` tools |
| `toolkit.instructions(*, toolset=None)` | Builds an instructions string from same content as langchain `system_prompt()` |
| `toolkit.memory.fetch / recall / store` | Direct Python API |
| `toolkit.query / dry_plan / dry_run` | Sync direct API — no async wrappers (rationale below) |

## Design decisions (locked during planning)

- **Sync only** — Pydantic AI auto-bridges sync tools to async; underlying engine is sync I/O so wrapping in `asyncio.to_thread` would be fake-async with no concurrency benefit. Aligns with wren-langchain.
- **`ModelRetry` over envelope** — framework-idiomatic; phase-aware messages give LLM enough context to self-correct (`SQL_PARSING`, `METADATA_FETCHING`, `SQL_EXECUTION` with dialect-SQL excerpt, etc.)
- **`retries=0` on `wren_store_query`** — write failures don't loop; LLM has already done the analytical work
- **`retries=2` on read tools** — gives the LLM two chances to fix SQL or model-name errors
- **Pydantic return models pinned to Core's shapes** — `FetchContextResult` uses `{strategy: full|search, schema/results}`, `RecalledPair` uses Core's `nl_query`/`sql_query`/`tags`-as-comma-string/`_distance`. Drift in Core surfaces here as test failures.
- **No async direct API** — defer until Core ships async-native engine

See [scoping doc](https://github.com/Canner/WrenAI/blob/feat/add-pydantic-sdk/.tmp/v0.1-pydantic-ai-sdk-scoping.md) and [implementation plan](https://github.com/Canner/WrenAI/blob/feat/add-pydantic-sdk/.tmp/v0.1-pydantic-ai-sdk-implementation-plan.md) (untracked — local only).

## Commit structure

21 commits in chronological order:

1. `feat(sdk): scaffold wren-pydantic package skeleton`
2. `feat(pydantic): add exceptions module`
3. `feat(pydantic): copy provider modules from wren-langchain`
4. `feat(pydantic): add Pydantic return models for tool outputs`
5. `fix(pydantic): align return models with Core's actual MemoryStore shapes` (caught by code-review; lifted return-type schemas had wrong field names/literals — fixed before downstream code depended on them)
6. `feat(pydantic): WrenError → ModelRetry mapping`
7. `feat(pydantic): WrenToolkit class — from_project + sync direct API`
8. `feat(pydantic): runtime tools (query, dry_plan, list_models)`
9. `feat(pydantic): WrenToolkit.toolset() facade`
10. `feat(pydantic): _MemoryAPI subscope (sync only)`
11. `feat(pydantic): memory tools (fetch_context, recall_queries, store_query)`
12. `feat(pydantic): wire memory tools into WrenToolkit.toolset()`
13. `feat(pydantic): instructions() prompt builder`
14. `style(pydantic): clean up _instructions.py — unused import + docstring`
15. `test(pydantic): Pydantic AI conformance suite`
16. `feat(pydantic): example scripts`
17. `docs(pydantic): README + docs/core/sdk/pydantic.md`
18. `chore(ci): add wren-pydantic CI workflow`
19. `feat(ci): publish workflow for wren-pydantic`
20. `chore(release): wire wren-pydantic into release-please + rc-release`
21. `style(pydantic): silence PLC0415 for legitimate local imports in tests`

## Test plan

- [x] 109 tests passing locally (84 unit + 9 conformance + 16 lifted from wren-langchain)
- [x] `ruff check .` + `ruff format --check .` clean
- [x] `pip install -e .` works against `wren-engine>=0.5.0` from local + PyPI
- [x] Both example scripts (`pydantic_ai_demo.py`, `pydantic_ai_structured_demo.py`) tested with real OpenAI agent against DuckDB + Postgres projects
- [x] 7 additional scenario scripts in `.tmp/pydantic-test-scenarios/` (untracked) exercise output_type, custom prompts, read-only memory, takes_ctx + deps_type, message history, and multi-project federation — all run successfully against `/tmp/wren-federate-demo/proj_loans` and `proj_events`
- [ ] Reviewer: skim `docs/core/sdk/pydantic.md` against an agent dev's mental model
- [ ] Reviewer: compare API parity matrix vs wren-langchain (covered in scoping doc §3)

## Out of scope (deliberate, deferred to v0.2)

- Async direct API (`aquery` / `afetch` etc.) — gated on Core supporting async-native engine
- Async tool functions — Pydantic AI auto-bridges sync; no need
- Multi-toolkit-per-agent helper — one toolkit per project is the right shape
- MCPServer integration — separate workstream
- Shared `wren-sdk-core` package extraction between langchain + pydantic — premature; revisit when drift becomes painful

## Compatibility

| `wren-pydantic` | `wren-engine` | `pydantic-ai` |
|---|---|---|
| 0.1.x | >= 0.5.0 | >= 1.0, < 2.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wren-pydantic SDK with WrenToolkit exposing LLM tools for query, dry-plan, and model discovery.
  * Optional project-backed memory: fetch, recall, and (opt-in) store capabilities.
  * Included runnable examples demonstrating quickstart and structured output.

* **Documentation**
  * Comprehensive SDK docs, README, and changelog with quickstarts and troubleshooting.

* **Tests**
  * Extensive unit and conformance tests covering toolkit, tools, memory, providers, models, and error mappings.

* **Chores**
  * CI and publish workflows plus release configuration and initial package metadata/license.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2255)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->