### PR TITLE
docs(sdk): move Pydantic AI from Coming soon to Available

### DIFF
--- a/docs/core/sdk/overview.md
+++ b/docs/core/sdk/overview.md
@@ -5,10 +5,7 @@ Wren AI Core integrates with popular AI agent frameworks. Each SDK exposes a CLI
 ## Available
 
 - **[LangChain / LangGraph](./langchain.md)** — `wren-langchain` on PyPI
-
-## Coming soon
-
-- Pydantic-AI
+- **[Pydantic AI](./pydantic.md)** — `wren-pydantic` on PyPI
 
 ## Other access modes
 


### PR DESCRIPTION
wren-pydantic shipped (PR #2255), so the overview now lists it alongside wren-langchain under Available. The Coming soon section is dropped since it is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK overview to list Pydantic AI as an available integration with accompanying documentation and PyPI package reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2266)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->