### PR TITLE
test(wren-pydantic): stop hardcoding version in smoke test

### DIFF
--- a/sdk/wren-pydantic/tests/test_smoke.py
+++ b/sdk/wren-pydantic/tests/test_smoke.py
@@ -6,4 +6,5 @@ from __future__ import annotations
 def test_package_imports():
     import wren_pydantic  # noqa: PLC0415
 
-    assert wren_pydantic.__version__ == "0.1.0"
+    assert isinstance(wren_pydantic.__version__, str)
+    assert wren_pydantic.__version__


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `assert wren_pydantic.__version__ == "0.1.0"` in `tests/test_smoke.py` with a type/non-empty check.
- Unblocks release-please PRs that bump the version (e.g. #2261 — `tests (py3.11)` and `tests (py3.12)` both failed because `__version__` was already updated to `0.2.0` by release-please but the test still expected `0.1.0`).
- Future release-please bumps no longer need a corresponding test update.

## Why this assertion shape
The smoke test's job is to verify the package imports and exposes a version string. The exact value is enforced in `.github/workflows/publish-wren-pydantic.yml` (regex `\d+\.\d+\.\d+(rc\d+)?` during the build step), so the test doesn't need to duplicate that check.

## Test plan
- [ ] CI `tests (py3.11)` passes
- [ ] CI `tests (py3.12)` passes
- [ ] After merge, release-please rebases #2261 and its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved package version validation in smoke tests to ensure compatibility across different version formats, replacing a hard-coded version check with flexible string validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2267)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->