### PR TITLE
refactor(canner): use psycopg native driver, drop ibis dependency

### DIFF
--- a/core/wren/justfile
+++ b/core/wren/justfile
@@ -59,6 +59,9 @@ test-postgres:
 test-mysql:
     uv run pytest tests/connectors/test_mysql.py -v -m mysql
 
+test-canner:
+    uv run pytest tests/connectors/test_canner.py -v -m canner
+
 test-connector marker:
     uv run pytest tests/connectors/ -v -m {{ marker }}
 

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -10,6 +10,7 @@ postgres wire).
 from __future__ import annotations
 
 import json
+import re
 from decimal import ROUND_HALF_EVEN
 from decimal import Decimal as PyDecimal
 from typing import Any
@@ -116,6 +117,21 @@ def _arrow_type(column) -> pa.DataType:
         inner = _decimal_type(column)
         return pa.list_(inner) if inner is not None else pa.list_(pa.string())
     return _PG_OID_TO_ARROW.get(column.type_code, pa.string())
+
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip any trailing ``;`` characters and surrounding whitespace.
+
+    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _t LIMIT N`` breaks when
+    ``sql`` ends in a semicolon — Postgres/Canner reject ``SELECT 1;`` inside
+    a subquery. We only strip the *terminating* run of semicolons/whitespace,
+    so semicolons inside string literals (e.g. ``SELECT 'a;b' FROM t``) are
+    preserved.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _coerce_decimal(value, target_type: pa.DataType):
@@ -228,7 +244,9 @@ class CannerConnector(ConnectorABC):
         import psycopg  # noqa: PLC0415
 
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _t LIMIT {limit}"
+            sql = (
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _t LIMIT {limit}"
+            )
 
         try:
             with self.connection.cursor() as cursor:
@@ -249,7 +267,7 @@ class CannerConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         import psycopg  # noqa: PLC0415
 
-        wrapped = f"SELECT * FROM ({sql}) AS _t LIMIT 0"
+        wrapped = f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _t LIMIT 0"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(wrapped)

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -1,78 +1,271 @@
-from contextlib import closing
-from functools import cache
+"""Canner Enterprise connector using the Postgres wire protocol via psycopg.
+
+Canner Enterprise exposes a Postgres-compatible endpoint, so we connect with
+``psycopg`` directly and build Arrow tables from the cursor description instead
+of going through ibis. The OID map below covers the types canner emits for
+Trino-flavoured queries (VARCHAR, DECIMAL, ROW/ARRAY/MAP serialised through the
+postgres wire).
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import ROUND_HALF_EVEN
+from decimal import Decimal as PyDecimal
 from typing import Any
 
-import ibis
-import ibis.expr.schema as sch
 import pyarrow as pa
-from ibis import BaseBackend
-from ibis.backends.sql.compilers.postgres import compiler as postgres_compiler
-from ibis.expr.datatypes import Decimal
-from ibis.expr.datatypes.core import UUID
-from ibis.expr.types import Table
 from loguru import logger
 
 from wren.connector.base import ConnectorABC
 from wren.model.data_source import DataSource
+from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+
+# Postgres OID → Arrow type. Canner publishes Trino-style values over the
+# Postgres wire, so VARCHAR/CHAR map to string, DECIMAL to decimal128,
+# BIGINT/INT/SMALLINT to int, BOOLEAN to bool, DATE/TIMESTAMP/TIMESTAMP_TZ to
+# Arrow date/timestamp, and complex types (ROW/ARRAY/MAP) come back as JSON
+# strings that we expose as Arrow strings.
+_PG_OID_TO_ARROW: dict[int, pa.DataType] = {
+    16: pa.bool_(),
+    17: pa.binary(),
+    18: pa.string(),
+    19: pa.string(),
+    20: pa.int64(),
+    21: pa.int16(),
+    23: pa.int32(),
+    25: pa.string(),
+    26: pa.int64(),
+    114: pa.string(),
+    142: pa.string(),
+    700: pa.float32(),
+    701: pa.float64(),
+    650: pa.string(),
+    774: pa.string(),
+    790: pa.string(),
+    829: pa.string(),
+    869: pa.string(),
+    1040: pa.string(),
+    1042: pa.string(),
+    1043: pa.string(),
+    1082: pa.date32(),
+    1083: pa.time64("us"),
+    1114: pa.timestamp("us"),
+    1184: pa.timestamp("us", tz="UTC"),
+    1186: pa.duration("us"),
+    2950: pa.string(),
+    3802: pa.string(),
+    1266: pa.string(),
+    3614: pa.string(),
+    3615: pa.string(),
+    3904: pa.string(),
+    3906: pa.string(),
+    3908: pa.string(),
+    3910: pa.string(),
+    3912: pa.string(),
+    3926: pa.string(),
+    199: pa.list_(pa.string()),
+    1000: pa.list_(pa.bool_()),
+    1003: pa.list_(pa.string()),
+    1005: pa.list_(pa.int16()),
+    1007: pa.list_(pa.int32()),
+    1009: pa.list_(pa.string()),
+    1014: pa.list_(pa.string()),
+    1015: pa.list_(pa.string()),
+    1016: pa.list_(pa.int64()),
+    1021: pa.list_(pa.float32()),
+    1022: pa.list_(pa.float64()),
+    1028: pa.list_(pa.string()),
+    1041: pa.list_(pa.string()),
+    1115: pa.list_(pa.timestamp("us")),
+    1182: pa.list_(pa.string()),
+    1183: pa.list_(pa.string()),
+    1185: pa.list_(pa.timestamp("us", tz="UTC")),
+    1187: pa.list_(pa.string()),
+    1270: pa.list_(pa.string()),
+    2951: pa.list_(pa.string()),
+    3807: pa.list_(pa.string()),
+}
 
 
-@cache
-def _get_pg_type_names(connection: BaseBackend) -> dict[int, str]:
-    with closing(connection.raw_sql("SELECT oid, typname FROM pg_type")) as cur:
-        return dict(cur.fetchall())
+def _decimal_type(column) -> pa.DataType:
+    """Pick the narrowest decimal128 that fits a NUMERIC column."""
+    scale = column.scale if column.scale is not None else 9
+    scale = max(0, min(scale, 38))
+    precision = column.precision if column.precision is not None else 38
+    if precision <= 0 or precision > 38:
+        precision = 38
+    precision = max(precision, scale, 1)
+    precision = min(precision, 38)
+    return pa.decimal128(precision, scale)
+
+
+def _arrow_type(column) -> pa.DataType:
+    if column.type_code == 1700:
+        return _decimal_type(column)
+    if column.type_code == 1231:
+        return pa.list_(_decimal_type(column))
+    return _PG_OID_TO_ARROW.get(column.type_code, pa.string())
+
+
+def _coerce_decimal(value, target_type: pa.DataType):
+    if value is None or not isinstance(value, PyDecimal):
+        return value
+    quantize_value = PyDecimal(f"1E-{target_type.scale}")
+    try:
+        return value.quantize(quantize_value, rounding=ROUND_HALF_EVEN)
+    except Exception:
+        return value
+
+
+def _build_column(
+    values: list, arrow_type: pa.DataType, pg_type_oid: int | None = None
+) -> pa.Array:
+    if arrow_type == pa.string():
+        processed: list[Any] = []
+        for value in values:
+            if value is None:
+                # json/jsonb come back as None when SQL NULL but canner often
+                # emits a literal "null" — preserve that to match the JSON
+                # serialisation expectation downstream.
+                if pg_type_oid in {114, 3802}:
+                    processed.append("null")
+                else:
+                    processed.append(None)
+            elif isinstance(value, dict | list):
+                processed.append(json.dumps(value, default=str))
+            elif not isinstance(value, str):
+                processed.append(str(value))
+            else:
+                processed.append(value)
+        return pa.array(processed, type=pa.string(), from_pandas=True)
+
+    if pa.types.is_binary(arrow_type):
+        processed = [
+            bytes(value) if isinstance(value, memoryview) else value for value in values
+        ]
+        return pa.array(processed, type=pa.binary(), from_pandas=True)
+
+    if pa.types.is_decimal(arrow_type):
+        processed = [_coerce_decimal(value, arrow_type) for value in values]
+        return pa.array(processed, type=arrow_type, from_pandas=True)
+
+    if pa.types.is_list(arrow_type) and pa.types.is_string(arrow_type.value_type):
+        processed = []
+        for value in values:
+            if value is None:
+                processed.append(None)
+                continue
+            items: list[Any] = []
+            for item in value:
+                if item is None:
+                    items.append(None)
+                elif isinstance(item, dict | list):
+                    items.append(json.dumps(item, default=str))
+                elif isinstance(item, str):
+                    items.append(item)
+                else:
+                    items.append(str(item))
+            processed.append(items)
+        return pa.array(processed, type=arrow_type, from_pandas=True)
+
+    if pa.types.is_list(arrow_type) and pa.types.is_decimal(arrow_type.value_type):
+        processed = []
+        for value in values:
+            if value is None:
+                processed.append(None)
+            else:
+                processed.append(
+                    [_coerce_decimal(item, arrow_type.value_type) for item in value]
+                )
+        return pa.array(processed, type=arrow_type, from_pandas=True)
+
+    return pa.array(values, type=arrow_type, from_pandas=True)
+
+
+def _build_arrow_table(cursor) -> pa.Table:
+    """Convert a psycopg cursor result into a PyArrow table."""
+    if cursor.description is None:
+        return pa.table({})
+
+    rows = cursor.fetchall()
+    fields = [
+        pa.field(column.name, _arrow_type(column), nullable=True)
+        for column in cursor.description
+    ]
+    schema = pa.schema(fields)
+
+    if not rows:
+        arrays = [pa.array([], type=field.type) for field in schema]
+    else:
+        arrays = [
+            _build_column(
+                [row[index] for row in rows],
+                field.type,
+                cursor.description[index].type_code,
+            )
+            for index, field in enumerate(schema)
+        ]
+
+    return pa.table(dict(zip([field.name for field in schema], arrays)), schema=schema)
 
 
 class CannerConnector(ConnectorABC):
     def __init__(self, connection_info):
         self.connection = DataSource.canner.get_connection(connection_info)
+        self._closed = False
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        schema = self._get_schema(sql)
-        ibis_table = self.connection.sql(sql, schema=schema)
+        import psycopg  # noqa: PLC0415
+
         if limit is not None:
-            ibis_table = ibis_table.limit(limit)
-        ibis_table = self._handle_pyarrow_unsupported_type(ibis_table)
-        return ibis_table.to_pyarrow()
+            sql = f"SELECT * FROM ({sql}) AS _t LIMIT {limit}"
 
-    def _handle_pyarrow_unsupported_type(self, ibis_table: Table, **kwargs) -> Table:
-        result_table = ibis_table
-        for name, dtype in ibis_table.schema().items():
-            if isinstance(dtype, Decimal):
-                col = result_table[name]
-                decimal_type = Decimal(precision=38, scale=9)
-                rounded_col = col.cast(decimal_type).round(9)
-                result_table = result_table.mutate(**{name: rounded_col})
-            elif isinstance(dtype, UUID):
-                result_table = result_table.mutate(
-                    **{name: result_table[name].cast("string")}
-                )
-        return result_table
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql)
+                return _build_arrow_table(cursor)
+        except psycopg.errors.QueryCanceled:
+            raise
+        except (WrenError, TimeoutError):
+            raise
+        except Exception as e:
+            raise WrenError(
+                ErrorCode.GENERIC_USER_ERROR,
+                str(e),
+                phase=ErrorPhase.SQL_EXECUTION,
+                metadata={DIALECT_SQL: sql},
+            ) from e
 
-    def dry_run(self, sql: str) -> Any:
-        return self.connection.raw_sql(f"SELECT * FROM ({sql}) LIMIT 0")
+    def dry_run(self, sql: str) -> None:
+        import psycopg  # noqa: PLC0415
+
+        wrapped = f"SELECT * FROM ({sql}) AS _t LIMIT 0"
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(wrapped)
+        except psycopg.errors.QueryCanceled:
+            raise
+        except (WrenError, TimeoutError):
+            raise
+        except Exception as e:
+            raise WrenError(
+                ErrorCode.GENERIC_USER_ERROR,
+                str(e),
+                phase=ErrorPhase.SQL_DRY_RUN,
+                metadata={DIALECT_SQL: sql},
+            ) from e
 
     def close(self) -> None:
+        if self._closed or not hasattr(self, "connection") or self.connection is None:
+            return
         try:
-            if hasattr(self.connection, "con") and hasattr(
-                self.connection.con, "close"
-            ):
-                self.connection.con.close()
-            elif hasattr(self.connection, "close"):
-                self.connection.close()
+            self.connection.close()
         except Exception as e:
             logger.warning(f"Error closing Canner connection: {e}")
-
-    def _get_schema(self, sql: str) -> sch.Schema:
-        cur = self.dry_run(sql)
-        type_names = _get_pg_type_names(self.connection)
-        return ibis.schema(
-            {
-                desc.name: postgres_compiler.type_mapper.from_string(
-                    type_names[desc.type_code]
-                )
-                for desc in cur.description
-            }
-        )
+        finally:
+            self._closed = True
+            self.connection = None
 
 
 def create_connector(connection_info) -> CannerConnector:

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -125,13 +125,10 @@ def _build_column(
         processed: list[Any] = []
         for value in values:
             if value is None:
-                # json/jsonb come back as None when SQL NULL but canner often
-                # emits a literal "null" — preserve that to match the JSON
-                # serialisation expectation downstream.
-                if pg_type_oid in {114, 3802}:
-                    processed.append("null")
-                else:
-                    processed.append(None)
+                # SQL NULL stays as Python None regardless of source oid; the
+                # caller is responsible for distinguishing a JSON ``null``
+                # literal from a SQL NULL.
+                processed.append(None)
             elif isinstance(value, dict | list):
                 processed.append(json.dumps(value, default=str))
             elif not isinstance(value, str):
@@ -207,7 +204,9 @@ def _build_arrow_table(cursor) -> pa.Table:
             for index, field in enumerate(schema)
         ]
 
-    return pa.table(dict(zip([field.name for field in schema], arrays)), schema=schema)
+    # Use positional construction so duplicate column names (e.g. self-joins)
+    # survive — dict-based construction silently drops duplicates.
+    return pa.Table.from_arrays(arrays, schema=schema)
 
 
 class CannerConnector(ConnectorABC):

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -282,6 +282,9 @@ class CannerConnector(ConnectorABC):
                 phase=ErrorPhase.SQL_DRY_RUN,
                 metadata={DIALECT_SQL: sql},
             ) from e
+        # Explicit return to honour the ConnectorABC.dry_run() contract — the
+        # cursor result must not leak out of this method.
+        return None
 
     def close(self) -> None:
         if self._closed or not hasattr(self, "connection") or self.connection is None:

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -88,10 +88,16 @@ _PG_OID_TO_ARROW: dict[int, pa.DataType] = {
 }
 
 
-def _decimal_type(column) -> pa.DataType:
-    """Pick the narrowest decimal128 that fits a NUMERIC column."""
-    scale = column.scale if column.scale is not None else 9
-    scale = max(0, min(scale, 38))
+def _decimal_type(column) -> pa.DataType | None:
+    """Pick the narrowest decimal128 that fits a NUMERIC column.
+
+    Returns ``None`` when the column has no explicit typmod (``scale is
+    None``) — the caller falls back to ``pa.string()`` so that high-precision
+    values round-trip without silent rounding via ``Decimal.quantize``.
+    """
+    if column.scale is None:
+        return None
+    scale = max(0, min(column.scale, 38))
     precision = column.precision if column.precision is not None else 38
     if precision <= 0 or precision > 38:
         precision = 38
@@ -102,9 +108,13 @@ def _decimal_type(column) -> pa.DataType:
 
 def _arrow_type(column) -> pa.DataType:
     if column.type_code == 1700:
-        return _decimal_type(column)
+        # Unconstrained NUMERIC (no typmod) falls back to string to preserve
+        # the exact textual representation — quantising to an arbitrary scale
+        # would silently round high-precision values.
+        return _decimal_type(column) or pa.string()
     if column.type_code == 1231:
-        return pa.list_(_decimal_type(column))
+        inner = _decimal_type(column)
+        return pa.list_(inner) if inner is not None else pa.list_(pa.string())
     return _PG_OID_TO_ARROW.get(column.type_code, pa.string())
 
 

--- a/core/wren/src/wren/model/data_source.py
+++ b/core/wren/src/wren/model/data_source.py
@@ -305,13 +305,16 @@ class DataSourceExtension(Enum):
         return ibis.bigquery.connect(client=bq_client, credentials=credentials)
 
     @staticmethod
-    def get_canner_connection(info: CannerConnectionInfo) -> BaseBackend:
-        return ibis.postgres.connect(
+    def get_canner_connection(info: CannerConnectionInfo):
+        import psycopg  # noqa: PLC0415
+
+        return psycopg.connect(
             host=info.host,
             port=int(info.port),
-            database=info.workspace,
+            dbname=info.workspace,
             user=info.user,
             password=info.pat.get_secret_value(),
+            autocommit=True,
         )
 
     @staticmethod

--- a/core/wren/tests/conftest.py
+++ b/core/wren/tests/conftest.py
@@ -16,3 +16,6 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers", "postgres: PostgreSQL connector tests — requires Docker"
     )
     config.addinivalue_line("markers", "mysql: MySQL connector tests — requires Docker")
+    config.addinivalue_line(
+        "markers", "canner: Canner connector tests — requires Docker"
+    )

--- a/core/wren/tests/connectors/test_canner.py
+++ b/core/wren/tests/connectors/test_canner.py
@@ -137,6 +137,22 @@ def test_build_column_quantises_decimal_values() -> None:
     assert array.to_pylist() == [Decimal("12.3457"), None]
 
 
+def test_arrow_type_for_unconstrained_numeric_falls_back_to_string() -> None:
+    # NUMERIC without typmod (scale is None) must not silently quantise — we
+    # surface it as a string so high-precision values round-trip intact.
+    assert _arrow_type(_column(1700)) == pa.string()
+    # NUMERIC[] inherits the same behaviour for its element type.
+    assert _arrow_type(_column(1231)) == pa.list_(pa.string())
+
+
+def test_build_column_preserves_unconstrained_numeric_precision() -> None:
+    # Regression: previously NUMERIC without typmod defaulted to scale=9, so
+    # values past the 9th decimal were silently rounded by Decimal.quantize.
+    high_precision = Decimal("12345678901234567890.123456789012345")
+    array = _build_column([high_precision, None], pa.string(), 1700)
+    assert array.to_pylist() == [str(high_precision), None]
+
+
 # ── end-to-end testcontainer test ─────────────────────────────────────────
 
 
@@ -236,3 +252,15 @@ def test_canner_connector_dry_run_raises_for_invalid_sql(canner_connector) -> No
 
     with pytest.raises(WrenError):
         canner_connector.dry_run("SELECT * FROM no_such_table")
+
+
+def test_canner_connector_preserves_unconstrained_numeric_precision(
+    canner_connector,
+) -> None:
+    # Regression: unconstrained NUMERIC must round-trip without silent rounding.
+    # The cursor description reports scale=None for an unconstrained cast, so
+    # the connector falls back to pa.string() to keep the exact textual value.
+    literal = "12345678901234567890.123456789012345"
+    table = canner_connector.query(f"SELECT '{literal}'::numeric AS n")
+    assert table.schema.field("n").type == pa.string()
+    assert table.to_pylist() == [{"n": literal}]

--- a/core/wren/tests/connectors/test_canner.py
+++ b/core/wren/tests/connectors/test_canner.py
@@ -15,7 +15,12 @@ from urllib.parse import urlparse
 import pyarrow as pa
 import pytest
 
-from wren.connector.canner import CannerConnector, _arrow_type, _build_column
+from wren.connector.canner import (
+    CannerConnector,
+    _arrow_type,
+    _build_column,
+    _strip_trailing_semicolon,
+)
 from wren.model import CannerConnectionInfo
 
 psycopg = pytest.importorskip("psycopg")
@@ -153,6 +158,24 @@ def test_build_column_preserves_unconstrained_numeric_precision() -> None:
     assert array.to_pylist() == [str(high_precision), None]
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("SELECT 1", "SELECT 1"),
+        ("SELECT 1;", "SELECT 1"),
+        ("SELECT 1  ;  ", "SELECT 1"),
+        ("SELECT 1;;", "SELECT 1"),
+        ("SELECT 1;\n", "SELECT 1"),
+        # Semicolons inside string literals are *not* terminators — only the
+        # trailing run is stripped.
+        ("SELECT 'a;b' FROM t", "SELECT 'a;b' FROM t"),
+        ("SELECT 'a;b' FROM t;", "SELECT 'a;b' FROM t"),
+    ],
+)
+def test_strip_trailing_semicolon(raw: str, expected: str) -> None:
+    assert _strip_trailing_semicolon(raw) == expected
+
+
 # ── end-to-end testcontainer test ─────────────────────────────────────────
 
 
@@ -264,3 +287,22 @@ def test_canner_connector_preserves_unconstrained_numeric_precision(
     table = canner_connector.query(f"SELECT '{literal}'::numeric AS n")
     assert table.schema.field("n").type == pa.string()
     assert table.to_pylist() == [{"n": literal}]
+
+
+def test_canner_connector_query_wraps_sql_with_trailing_semicolon(
+    canner_connector,
+) -> None:
+    # Regression: a trailing semicolon on the user SQL must not break the
+    # ``SELECT * FROM (...) AS _t LIMIT N`` wrap that the connector applies
+    # when ``limit`` is provided.
+    table = canner_connector.query("SELECT 1 AS x;", limit=1)
+    assert table.num_rows == 1
+    assert table.to_pylist() == [{"x": 1}]
+
+
+def test_canner_connector_dry_run_wraps_sql_with_trailing_semicolon(
+    canner_connector,
+) -> None:
+    # Same regression for dry_run, which always wraps as ``... LIMIT 0``.
+    assert canner_connector.dry_run("SELECT 1 AS x;") is None
+    assert canner_connector.dry_run("SELECT 1 AS x  ;  ") is None

--- a/core/wren/tests/connectors/test_canner.py
+++ b/core/wren/tests/connectors/test_canner.py
@@ -1,0 +1,212 @@
+"""Canner connector tests.
+
+Canner Enterprise speaks the Postgres wire protocol, so we point a
+``PostgresContainer`` at the connector and stand up tables with the data
+types Canner publishes (Trino-style VARCHAR/DECIMAL/ARRAY/ROW/MAP plus the
+usual postgres numeric/date/time types) to exercise the native psycopg
+Arrow builder.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from urllib.parse import urlparse
+
+import pyarrow as pa
+import pytest
+
+from wren.connector.canner import CannerConnector, _arrow_type, _build_column
+from wren.model import CannerConnectionInfo
+
+psycopg = pytest.importorskip("psycopg")
+testcontainers_postgres = pytest.importorskip("testcontainers.postgres")
+PostgresContainer = testcontainers_postgres.PostgresContainer
+
+pytestmark = pytest.mark.canner
+
+
+_FIXTURE_DDL = """
+    CREATE TABLE canner_demo (
+        id              BIGINT PRIMARY KEY,
+        name            VARCHAR(64) NOT NULL,
+        flag            BOOLEAN,
+        amount          DECIMAL(18, 4),
+        ratio           DOUBLE PRECISION,
+        small           SMALLINT,
+        sample_date     DATE,
+        sample_ts       TIMESTAMP,
+        sample_tstz     TIMESTAMPTZ,
+        tags            VARCHAR[],
+        struct_col      JSON,
+        map_col         JSONB
+    )
+"""
+
+_FIXTURE_ROWS = [
+    (
+        1,
+        "alpha",
+        True,
+        Decimal("12.3400"),
+        1.5,
+        7,
+        "2024-01-02",
+        "2024-01-02 03:04:05",
+        "2024-01-02 03:04:05+00",
+        ["a", "b"],
+        '{"k": "v"}',
+        '{"m": 1}',
+    ),
+    (
+        2,
+        "beta",
+        False,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ),
+]
+
+
+# ── helper-level unit tests ───────────────────────────────────────────────
+
+
+def _column(type_code: int, precision: int | None = None, scale: int | None = None):
+    class _Col:
+        pass
+
+    col = _Col()
+    col.type_code = type_code
+    col.precision = precision
+    col.scale = scale
+    return col
+
+
+def test_arrow_type_maps_canner_scalars() -> None:
+    # VARCHAR / CHAR / TEXT → string
+    assert _arrow_type(_column(1043)) == pa.string()
+    assert _arrow_type(_column(1042)) == pa.string()
+    assert _arrow_type(_column(25)) == pa.string()
+    # BIGINT / INTEGER / SMALLINT → int
+    assert _arrow_type(_column(20)) == pa.int64()
+    assert _arrow_type(_column(23)) == pa.int32()
+    assert _arrow_type(_column(21)) == pa.int16()
+    # BOOLEAN → bool
+    assert _arrow_type(_column(16)) == pa.bool_()
+    # DOUBLE / REAL → float
+    assert _arrow_type(_column(701)) == pa.float64()
+    assert _arrow_type(_column(700)) == pa.float32()
+    # DATE / TIMESTAMP / TIMESTAMPTZ → date/timestamp
+    assert _arrow_type(_column(1082)) == pa.date32()
+    assert _arrow_type(_column(1114)) == pa.timestamp("us")
+    assert _arrow_type(_column(1184)) == pa.timestamp("us", tz="UTC")
+    # NUMERIC honours precision/scale
+    assert _arrow_type(_column(1700, precision=18, scale=4)) == pa.decimal128(18, 4)
+    # JSON/JSONB (ROW/MAP) → string
+    assert _arrow_type(_column(114)) == pa.string()
+    assert _arrow_type(_column(3802)) == pa.string()
+    # ARRAY → list
+    assert _arrow_type(_column(1009)) == pa.list_(pa.string())
+
+
+def test_build_column_serialises_complex_values_to_json() -> None:
+    array = _build_column([{"k": "v"}, [1, 2], "raw", None], pa.string(), 114)
+    # SQL-NULL for json/jsonb is preserved as the literal "null" string to
+    # match the JSON serialisation contract.
+    assert array.to_pylist() == ['{"k": "v"}', "[1, 2]", "raw", "null"]
+
+
+def test_build_column_quantises_decimal_values() -> None:
+    array = _build_column(
+        [Decimal("12.345678"), None],
+        pa.decimal128(18, 4),
+    )
+    assert array.to_pylist() == [Decimal("12.3457"), None]
+
+
+# ── end-to-end testcontainer test ─────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def canner_connector():
+    with PostgresContainer("postgres:16") as pg:
+        url = pg.get_connection_url().replace("+psycopg2", "")
+        parsed = urlparse(url)
+
+        with psycopg.connect(url, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(_FIXTURE_DDL)
+                cur.executemany(
+                    """
+                    INSERT INTO canner_demo VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    """,
+                    _FIXTURE_ROWS,
+                )
+
+        # CannerConnectionInfo treats `workspace` like a postgres database and
+        # `pat` like a password — pass them through directly.
+        connection_info = CannerConnectionInfo(
+            host=parsed.hostname,
+            port=str(parsed.port),
+            user=parsed.username,
+            pat=parsed.password,
+            workspace=parsed.path.lstrip("/"),
+        )
+        connector = CannerConnector(connection_info)
+        try:
+            yield connector
+        finally:
+            connector.close()
+
+
+def test_canner_connector_query_returns_arrow_table(canner_connector) -> None:
+    table = canner_connector.query("SELECT * FROM canner_demo ORDER BY id")
+
+    assert table.num_rows == 2
+    assert table.schema.field("id").type == pa.int64()
+    assert table.schema.field("name").type == pa.string()
+    assert table.schema.field("flag").type == pa.bool_()
+    assert table.schema.field("amount").type == pa.decimal128(18, 4)
+    assert table.schema.field("ratio").type == pa.float64()
+    assert table.schema.field("small").type == pa.int16()
+    assert table.schema.field("sample_date").type == pa.date32()
+    assert table.schema.field("sample_ts").type == pa.timestamp("us")
+    assert table.schema.field("sample_tstz").type == pa.timestamp("us", tz="UTC")
+    assert table.schema.field("tags").type == pa.list_(pa.string())
+    assert table.schema.field("struct_col").type == pa.string()
+    assert table.schema.field("map_col").type == pa.string()
+
+    row = table.to_pylist()[0]
+    assert row["id"] == 1
+    assert row["name"] == "alpha"
+    assert row["flag"] is True
+    assert row["amount"] == Decimal("12.3400")
+    assert row["tags"] == ["a", "b"]
+    # complex types come back as JSON strings
+    assert row["struct_col"] == '{"k": "v"}'
+    assert row["map_col"] == '{"m": 1}'
+
+
+def test_canner_connector_query_applies_limit(canner_connector) -> None:
+    table = canner_connector.query("SELECT * FROM canner_demo ORDER BY id", limit=1)
+    assert table.num_rows == 1
+
+
+def test_canner_connector_dry_run_succeeds(canner_connector) -> None:
+    # Returns None and must not raise on a valid statement.
+    assert canner_connector.dry_run("SELECT 1 AS x") is None
+
+
+def test_canner_connector_dry_run_raises_for_invalid_sql(canner_connector) -> None:
+    from wren.model.error import WrenError  # noqa: PLC0415
+
+    with pytest.raises(WrenError):
+        canner_connector.dry_run("SELECT * FROM no_such_table")

--- a/core/wren/tests/connectors/test_canner.py
+++ b/core/wren/tests/connectors/test_canner.py
@@ -117,9 +117,16 @@ def test_arrow_type_maps_canner_scalars() -> None:
 
 def test_build_column_serialises_complex_values_to_json() -> None:
     array = _build_column([{"k": "v"}, [1, 2], "raw", None], pa.string(), 114)
-    # SQL-NULL for json/jsonb is preserved as the literal "null" string to
-    # match the JSON serialisation contract.
-    assert array.to_pylist() == ['{"k": "v"}', "[1, 2]", "raw", "null"]
+    # SQL NULL must stay Python None — only actual JSON literals are stringified.
+    assert array.to_pylist() == ['{"k": "v"}', "[1, 2]", "raw", None]
+
+
+def test_build_column_preserves_sql_null_for_jsonb() -> None:
+    # Regression: a SQL NULL in a json (114) / jsonb (3802) column must stay
+    # Python None rather than being coerced to the string "null".
+    for oid in (114, 3802):
+        array = _build_column([None], pa.string(), oid)
+        assert array.to_pylist() == [None]
 
 
 def test_build_column_quantises_decimal_values() -> None:
@@ -184,7 +191,8 @@ def test_canner_connector_query_returns_arrow_table(canner_connector) -> None:
     assert table.schema.field("struct_col").type == pa.string()
     assert table.schema.field("map_col").type == pa.string()
 
-    row = table.to_pylist()[0]
+    rows = table.to_pylist()
+    row = rows[0]
     assert row["id"] == 1
     assert row["name"] == "alpha"
     assert row["flag"] is True
@@ -194,10 +202,28 @@ def test_canner_connector_query_returns_arrow_table(canner_connector) -> None:
     assert row["struct_col"] == '{"k": "v"}'
     assert row["map_col"] == '{"m": 1}'
 
+    # SQL NULL in a JSON/JSONB column stays Python None — it must not be
+    # silently coerced into the string "null".
+    null_row = rows[1]
+    assert null_row["struct_col"] is None
+    assert null_row["map_col"] is None
+
 
 def test_canner_connector_query_applies_limit(canner_connector) -> None:
     table = canner_connector.query("SELECT * FROM canner_demo ORDER BY id", limit=1)
     assert table.num_rows == 1
+
+
+def test_canner_connector_query_preserves_duplicate_column_names(
+    canner_connector,
+) -> None:
+    # Regression: dict-based pa.Table construction silently drops duplicate
+    # column names — a self-join projecting both ``id`` columns must keep both.
+    table = canner_connector.query(
+        "SELECT a.id, b.id FROM canner_demo a, canner_demo b ORDER BY a.id, b.id LIMIT 1"
+    )
+    assert table.num_columns == 2
+    assert [field.name for field in table.schema] == ["id", "id"]
 
 
 def test_canner_connector_dry_run_succeeds(canner_connector) -> None:

--- a/core/wren/tests/connectors/test_canner.py
+++ b/core/wren/tests/connectors/test_canner.py
@@ -176,6 +176,30 @@ def test_strip_trailing_semicolon(raw: str, expected: str) -> None:
     assert _strip_trailing_semicolon(raw) == expected
 
 
+def test_dry_run_returns_none_contract() -> None:
+    # Regression: ConnectorABC.dry_run() must return None. The cursor result
+    # must not leak out of the method, even on the success path.
+    class _FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def execute(self, _sql: str) -> "_FakeCursor":
+            return self
+
+    class _FakeConnection:
+        def cursor(self) -> _FakeCursor:
+            return _FakeCursor()
+
+    connector = CannerConnector.__new__(CannerConnector)
+    connector.connection = _FakeConnection()
+    connector._closed = False
+
+    assert connector.dry_run("SELECT 1") is None
+
+
 # ── end-to-end testcontainer test ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Canner Enterprise speaks the Postgres wire protocol; the connector now uses
`psycopg` directly instead of the ibis postgres backend.

## Changes

- `connector/canner.py`: native psycopg cursor with a self-contained PG OID -> Arrow type map covering the canner-flavoured types (VARCHAR/CHAR -> string, DECIMAL -> decimal128, BIGINT/INT/SMALLINT -> int, BOOLEAN -> bool, DATE/TIMESTAMP/TIMESTAMPTZ -> date/timestamp, ROW/ARRAY/MAP serialised as JSON strings). Errors are wrapped as `WrenError` with the dialect SQL attached, mirroring the existing postgres connector contract.
- `model/data_source.py::get_canner_connection`: returns a `psycopg.Connection` (autocommit) instead of an ibis backend.

## Tests

- `tests/connectors/test_canner.py` exercises the type-mapping helpers and runs the connector against a `PostgresContainer` with the common canner result types (incl. JSON/JSONB and arrays).
- New `canner` marker registered in `tests/conftest.py`; `just test-canner` target added.

## Test plan

- [x] `just test-canner` (7 passed)
- [x] `just lint`
- [ ] Verify against a live canner endpoint in a downstream environment

[Wren Engine PR template](.github/PULL_REQUEST_TEMPLATE.md) acceptance criteria:

- [x] No ibis import path remains through `wren.connector.canner`.
- [x] Tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector now runs queries directly against Postgres with improved type mapping and more accurate handling of numerics, JSON, arrays, and limits; dry-run and connection-close behavior improved.

* **Tests**
  * Added comprehensive unit and integration tests covering types, query execution, limits, dry-run, error handling, and regressions; pytest marker for connector tests added.

* **Chores**
  * New test-canner recipe to run the connector test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2269)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->