### PR TITLE
feat: cube PyO3 binding + wren cube CLI + memory indexing

### DIFF
--- a/core/wren-core-py/src/cube.rs
+++ b/core/wren-core-py/src/cube.rs
@@ -1,0 +1,22 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use wren_core::mdl::{cube_query_to_sql as cube_query_to_sql_rs, CubeQuery};
+use wren_core_base::mdl::manifest::Manifest;
+
+/// Translate a structured CubeQuery (JSON) into a SQL string using the cube
+/// definitions in the supplied manifest (JSON).
+///
+/// Both inputs are JSON strings so the binding stays serde-driven and
+/// callers don't need to construct typed Rust objects from Python.
+///
+/// Raises `ValueError` on bad JSON or on translation errors (unknown
+/// cube/measure/dimension, cyclic derived measures, …).
+#[pyfunction]
+pub fn cube_query_to_sql(cube_query_json: &str, manifest_json: &str) -> PyResult<String> {
+    let query: CubeQuery = serde_json::from_str(cube_query_json)
+        .map_err(|e| PyValueError::new_err(format!("Invalid CubeQuery JSON: {e}")))?;
+    let manifest: Manifest = serde_json::from_str(manifest_json)
+        .map_err(|e| PyValueError::new_err(format!("Invalid manifest JSON: {e}")))?;
+    cube_query_to_sql_rs(&query, &manifest)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+}

--- a/core/wren-core-py/src/lib.rs
+++ b/core/wren-core-py/src/lib.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use remote_functions::PyRemoteFunction;
 
 pub mod context;
+mod cube;
 mod errors;
 mod extractor;
 mod manifest;
@@ -25,5 +26,6 @@ fn wren_core_wrapper(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(validation::validate_rlac_rule, m)?)?;
     m.add_function(wrap_pyfunction!(manifest::is_backward_compatible, m)?)?;
     m.add_function(wrap_pyfunction!(manifest::migrate_manifest_json, m)?)?;
+    m.add_function(wrap_pyfunction!(cube::cube_query_to_sql, m)?)?;
     Ok(())
 }

--- a/core/wren-core-py/tests/test_cube.py
+++ b/core/wren-core-py/tests/test_cube.py
@@ -1,0 +1,142 @@
+"""Tests for the cube_query_to_sql PyO3 binding."""
+
+import json
+
+import pytest
+
+from wren_core import cube_query_to_sql
+
+MANIFEST = json.dumps(
+    {
+        "catalog": "test",
+        "schema": "public",
+        "models": [
+            {
+                "name": "orders",
+                "tableReference": {"schema": "main", "table": "orders"},
+                "columns": [
+                    {"name": "o_totalprice", "type": "double"},
+                    {"name": "o_orderstatus", "type": "varchar"},
+                    {"name": "o_orderdate", "type": "date"},
+                ],
+            }
+        ],
+        "cubes": [
+            {
+                "name": "order_metrics",
+                "baseObject": "orders",
+                "measures": [
+                    {
+                        "name": "revenue",
+                        "expression": "SUM(o_totalprice)",
+                        "type": "DOUBLE",
+                    },
+                    {
+                        "name": "order_count",
+                        "expression": "COUNT(*)",
+                        "type": "BIGINT",
+                    },
+                ],
+                "dimensions": [
+                    {
+                        "name": "status",
+                        "expression": "o_orderstatus",
+                        "type": "VARCHAR",
+                    }
+                ],
+                "timeDimensions": [
+                    {
+                        "name": "created_at",
+                        "expression": "o_orderdate",
+                        "type": "DATE",
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+def test_basic_cube_query():
+    query = json.dumps(
+        {
+            "cube": "order_metrics",
+            "measures": ["revenue"],
+            "dimensions": ["status"],
+        }
+    )
+    sql = cube_query_to_sql(query, MANIFEST)
+    assert "SUM(o_totalprice) AS revenue" in sql
+    assert "o_orderstatus AS status" in sql
+    assert "FROM orders" in sql
+    assert "GROUP BY" in sql
+
+
+def test_time_dimension_with_date_range():
+    query = json.dumps(
+        {
+            "cube": "order_metrics",
+            "measures": ["revenue"],
+            "timeDimensions": [
+                {
+                    "dimension": "created_at",
+                    "granularity": "month",
+                    "dateRange": ["2024-01-01", "2025-01-01"],
+                }
+            ],
+        }
+    )
+    sql = cube_query_to_sql(query, MANIFEST)
+    assert "DATE_TRUNC('month', o_orderdate)" in sql
+    assert "o_orderdate >= '2024-01-01'" in sql
+    assert "o_orderdate < '2025-01-01'" in sql
+
+
+def test_filter_eq():
+    query = json.dumps(
+        {
+            "cube": "order_metrics",
+            "measures": ["revenue"],
+            "filters": [
+                {"dimension": "status", "operator": "eq", "value": "completed"}
+            ],
+        }
+    )
+    sql = cube_query_to_sql(query, MANIFEST)
+    assert "WHERE o_orderstatus = 'completed'" in sql
+
+
+def test_limit_offset():
+    query = json.dumps(
+        {
+            "cube": "order_metrics",
+            "measures": ["revenue"],
+            "limit": 10,
+            "offset": 5,
+        }
+    )
+    sql = cube_query_to_sql(query, MANIFEST)
+    assert sql.endswith("LIMIT 10 OFFSET 5")
+
+
+def test_unknown_cube_error():
+    query = json.dumps({"cube": "nonexistent", "measures": ["revenue"]})
+    with pytest.raises(ValueError, match="not found"):
+        cube_query_to_sql(query, MANIFEST)
+
+
+def test_unknown_measure_error():
+    query = json.dumps({"cube": "order_metrics", "measures": ["no_such"]})
+    with pytest.raises(ValueError, match="Unknown measure"):
+        cube_query_to_sql(query, MANIFEST)
+
+
+def test_invalid_cube_query_json():
+    with pytest.raises(ValueError, match="Invalid CubeQuery JSON"):
+        cube_query_to_sql("not json at all", MANIFEST)
+
+
+def test_invalid_manifest_json():
+    query = json.dumps({"cube": "order_metrics", "measures": ["revenue"]})
+    with pytest.raises(ValueError, match="Invalid manifest JSON"):
+        cube_query_to_sql(query, "not json")

--- a/core/wren/src/wren/cli.py
+++ b/core/wren/src/wren/cli.py
@@ -633,9 +633,11 @@ def docs_connection_info(
 
 app.add_typer(docs_app)
 
+from wren.cube_cli import cube_app  # noqa: E402, PLC0415
 from wren.utils_cli import utils_app  # noqa: E402, PLC0415
 
 app.add_typer(context_app)
+app.add_typer(cube_app)
 app.add_typer(utils_app)
 
 try:

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -994,7 +994,7 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                 ValidationError(
                     "error",
                     f"{src_path} > {name}",
-                    "cube missing 'baseObject'",
+                    "cube missing 'base_object'",
                 )
             )
         elif base not in all_entity_names:
@@ -1002,7 +1002,7 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                 ValidationError(
                     "error",
                     f"{src_path} > {name}",
-                    f"baseObject '{base}' is not a defined model or view",
+                    f"base_object '{base}' is not a defined model or view",
                 )
             )
 
@@ -1019,13 +1019,17 @@ def validate_project(project_path: Path) -> list[ValidationError]:
         # Sanity-check hierarchy levels reference declared dimensions /
         # time_dimensions. Rust-side validation does the same check, but
         # surfacing it at YAML time gives faster feedback before build.
+        # Only keep string names so a malformed YAML entry doesn't leak a
+        # non-hashable value into the set lookup below.
         dim_names = {
-            d.get("name") for d in (cube.get("dimensions") or []) if isinstance(d, dict)
+            d.get("name")
+            for d in (cube.get("dimensions") or [])
+            if isinstance(d, dict) and isinstance(d.get("name"), str)
         }
         td_names = {
             td.get("name")
             for td in (cube.get("time_dimensions") or [])
-            if isinstance(td, dict)
+            if isinstance(td, dict) and isinstance(td.get("name"), str)
         }
         known_dims = dim_names | td_names
         hierarchies = cube.get("hierarchies") or {}
@@ -1034,6 +1038,15 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                 if not isinstance(levels, list):
                     continue
                 for level in levels:
+                    if not isinstance(level, str):
+                        errors.append(
+                            ValidationError(
+                                "error",
+                                f"{src_path} > {name} > hierarchies.{hname}",
+                                "hierarchy levels must be strings",
+                            )
+                        )
+                        continue
                     if level not in known_dims:
                         errors.append(
                             ValidationError(

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -584,6 +584,25 @@ def _load_views_v2(project_path: Path) -> list[dict]:
     return views
 
 
+def load_cubes(project_path: Path) -> list[dict]:
+    """Load cubes from project_path/cubes/*.yml.
+
+    Each file is one cube definition. Files use the same YAML shape on
+    every schema version (no v1/v2 dispatch — cubes were added after the
+    directory-per-entity migration).
+    """
+    cubes_dir = project_path / "cubes"
+    if not cubes_dir.is_dir():
+        return []
+    cubes = []
+    for f in sorted(cubes_dir.glob("*.yml")):
+        data = yaml.safe_load(f.read_text())
+        if isinstance(data, dict):
+            data["_source_file"] = f.name
+            cubes.append(data)
+    return cubes
+
+
 def load_relationships(project_path: Path) -> list[dict]:
     """Load relationships from project_path/relationships.yml."""
     rel_file = project_path / "relationships.yml"
@@ -615,12 +634,15 @@ def build_manifest(project_path: Path) -> dict:
     models = load_models(project_path)
     views = load_views(project_path)
     relationships = load_relationships(project_path)
+    cubes = load_cubes(project_path)
 
     # Strip internal metadata
     for m in models:
         m.pop("_source_dir", None)
     for v in views:
         v.pop("_source_dir", None)
+    for c in cubes:
+        c.pop("_source_file", None)
 
     manifest: dict = {
         "catalog": project_config.get("catalog", "wren"),
@@ -628,6 +650,7 @@ def build_manifest(project_path: Path) -> dict:
         "models": models,
         "relationships": relationships,
         "views": views,
+        "cubes": cubes,
     }
     data_source = project_config.get("data_source")
     if data_source:
@@ -731,6 +754,7 @@ def validate_project(project_path: Path) -> list[ValidationError]:
     models = load_models(project_path)
     views = load_views(project_path)
     relationships = load_relationships(project_path)
+    cubes = load_cubes(project_path)
 
     model_names: set[str] = set()
     view_names: set[str] = set()
@@ -946,6 +970,78 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                     "warning", f"relationships > {rel_name}", "missing join_type"
                 )
             )
+
+    # Check cubes — only structural / reference checks here. Deep validation
+    # (measure cycles, hierarchy levels) runs Rust-side in
+    # AnalyzedWrenMDL::analyze (see wren-core lineage::validate_cubes).
+    cube_names: set[str] = set()
+    for i, cube in enumerate(cubes):
+        src = cube.get("_source_file", f"cubes[{i}]")
+        src_path = f"cubes/{src}"
+        name = cube.get("name")
+        if not name:
+            errors.append(ValidationError("error", src_path, "cube missing 'name'"))
+            continue
+        if name in cube_names:
+            errors.append(
+                ValidationError("error", src_path, f"duplicate cube name '{name}'")
+            )
+        cube_names.add(name)
+
+        base = cube.get("base_object")
+        if not base:
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"{src_path} > {name}",
+                    "cube missing 'baseObject'",
+                )
+            )
+        elif base not in all_entity_names:
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"{src_path} > {name}",
+                    f"baseObject '{base}' is not a defined model or view",
+                )
+            )
+
+        measures = cube.get("measures") or []
+        if not measures:
+            errors.append(
+                ValidationError(
+                    "warning",
+                    f"{src_path} > {name}",
+                    "cube has no measures",
+                )
+            )
+
+        # Sanity-check hierarchy levels reference declared dimensions /
+        # time_dimensions. Rust-side validation does the same check, but
+        # surfacing it at YAML time gives faster feedback before build.
+        dim_names = {
+            d.get("name") for d in (cube.get("dimensions") or []) if isinstance(d, dict)
+        }
+        td_names = {
+            td.get("name")
+            for td in (cube.get("time_dimensions") or [])
+            if isinstance(td, dict)
+        }
+        known_dims = dim_names | td_names
+        hierarchies = cube.get("hierarchies") or {}
+        if isinstance(hierarchies, dict):
+            for hname, levels in hierarchies.items():
+                if not isinstance(levels, list):
+                    continue
+                for level in levels:
+                    if level not in known_dims:
+                        errors.append(
+                            ValidationError(
+                                "error",
+                                f"{src_path} > {name} > hierarchies.{hname}",
+                                f"references unknown dimension '{level}'",
+                            )
+                        )
 
     return errors
 

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -107,6 +107,7 @@ def init(
     # Create directory structure
     (project_path / "models").mkdir(parents=True, exist_ok=True)
     (project_path / "views").mkdir(parents=True, exist_ok=True)
+    (project_path / "cubes").mkdir(parents=True, exist_ok=True)
 
     # wren_project.yml
     project_yml = (

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -1,0 +1,284 @@
+"""Typer sub-app for ``wren cube`` commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+cube_app = typer.Typer(
+    name="cube",
+    help="Query and inspect cubes — structured measure/dimension queries over the semantic layer.",
+)
+
+
+_MdlOpt = Annotated[
+    Optional[str],
+    typer.Option(
+        "--mdl",
+        "-m",
+        help="Path to MDL JSON file. Defaults to <project>/target/mdl.json.",
+    ),
+]
+
+
+def _load_mdl_json(mdl: str | None) -> str:
+    """Return the raw JSON contents of mdl.json (decoded if a path is given)."""
+    from wren.cli import _require_mdl  # noqa: PLC0415
+
+    path_str = _require_mdl(mdl)
+    path = Path(path_str).expanduser()
+    if path.exists():
+        return path.read_text()
+    typer.echo(f"Error: MDL file not found: {path}", err=True)
+    raise typer.Exit(1)
+
+
+def _parse_filter(spec: str) -> dict:
+    """Parse a CLI ``--filter`` spec.
+
+    Format::
+
+        dimension:operator                # e.g. status:is_null
+        dimension:operator:value          # e.g. status:eq:completed
+        dimension:in:a,b,c                # IN filter, comma-separated values
+
+    Values are kept as strings; numeric operators rely on the engine to
+    coerce. ``in`` / ``not_in`` always produce a list value.
+    """
+    parts = spec.split(":", 2)
+    if len(parts) < 2:
+        raise typer.BadParameter(f"--filter expects 'dim:op[:value]', got '{spec}'")
+    dim, op = parts[0], parts[1]
+    f: dict = {"dimension": dim, "operator": op}
+    if len(parts) == 3:
+        raw = parts[2]
+        if op in {"in", "not_in"}:
+            f["value"] = [v.strip() for v in raw.split(",") if v.strip()]
+        else:
+            f["value"] = raw
+    return f
+
+
+def _parse_time_dimension(spec: str) -> dict:
+    """Parse a ``--time-dimension`` spec ``name:granularity[:start,end]``."""
+    parts = spec.split(":", 2)
+    if len(parts) < 2:
+        raise typer.BadParameter(
+            f"--time-dimension expects 'name:granularity[:start,end]', got '{spec}'"
+        )
+    td: dict = {"dimension": parts[0], "granularity": parts[1]}
+    if len(parts) == 3:
+        dates = [d.strip() for d in parts[2].split(",")]
+        if len(dates) != 2:
+            raise typer.BadParameter(
+                "--time-dimension dateRange must be 'start,end' (exactly two dates)"
+            )
+        td["dateRange"] = dates
+    return td
+
+
+def _build_cube_query(
+    cube: str,
+    measures: str,
+    dimensions: str,
+    time_dimension: str | None,
+    filters: list[str],
+    limit: int | None,
+    offset: int | None,
+) -> dict:
+    q: dict = {
+        "cube": cube,
+        "measures": [m.strip() for m in measures.split(",") if m.strip()],
+    }
+    if dimensions:
+        q["dimensions"] = [d.strip() for d in dimensions.split(",") if d.strip()]
+    if time_dimension:
+        q["timeDimensions"] = [_parse_time_dimension(time_dimension)]
+    if filters:
+        q["filters"] = [_parse_filter(f) for f in filters]
+    if limit is not None:
+        q["limit"] = limit
+    if offset is not None:
+        q["offset"] = offset
+    return q
+
+
+def _load_cube_query_from(source: str) -> dict:
+    """Load a CubeQuery dict from ``-`` (stdin) or a JSON file path."""
+    if source == "-":
+        return json.loads(sys.stdin.read())
+    p = Path(source).expanduser()
+    if not p.exists():
+        typer.echo(f"Error: CubeQuery file not found: {p}", err=True)
+        raise typer.Exit(1)
+    return json.loads(p.read_text())
+
+
+# ── wren cube list ─────────────────────────────────────────────────────────
+
+
+@cube_app.command(name="list")
+def list_cubes(mdl: _MdlOpt = None) -> None:
+    """List all cubes defined in the project."""
+    mdl_json = _load_mdl_json(mdl)
+    manifest = json.loads(mdl_json)
+    cubes = manifest.get("cubes", []) or []
+    if not cubes:
+        typer.echo("No cubes defined.")
+        return
+    for cube in cubes:
+        name = cube.get("name", "<unnamed>")
+        base = cube.get("baseObject", "?")
+        measures = ", ".join(m.get("name", "") for m in cube.get("measures", []))
+        dims = ", ".join(d.get("name", "") for d in cube.get("dimensions", []))
+        time_dims = ", ".join(
+            td.get("name", "") for td in cube.get("timeDimensions", [])
+        )
+        typer.echo(f"  {name} (base: {base})")
+        if measures:
+            typer.echo(f"    measures: {measures}")
+        if dims:
+            typer.echo(f"    dimensions: {dims}")
+        if time_dims:
+            typer.echo(f"    time dimensions: {time_dims}")
+
+
+# ── wren cube describe ─────────────────────────────────────────────────────
+
+
+@cube_app.command()
+def describe(
+    name: Annotated[str, typer.Argument(help="Cube name to describe")],
+    mdl: _MdlOpt = None,
+) -> None:
+    """Print the full schema for a cube (JSON)."""
+    mdl_json = _load_mdl_json(mdl)
+    manifest = json.loads(mdl_json)
+    cubes = manifest.get("cubes", []) or []
+    cube = next((c for c in cubes if c.get("name") == name), None)
+    if cube is None:
+        typer.echo(f"Cube '{name}' not found.", err=True)
+        raise typer.Exit(1)
+    typer.echo(json.dumps(cube, indent=2))
+
+
+# ── wren cube query ────────────────────────────────────────────────────────
+
+
+@cube_app.command()
+def query(
+    cube: Annotated[
+        Optional[str],
+        typer.Option("--cube", "-c", help="Cube name"),
+    ] = None,
+    measures: Annotated[
+        Optional[str],
+        typer.Option("--measures", help="Comma-separated measure names"),
+    ] = None,
+    dimensions: Annotated[
+        Optional[str],
+        typer.Option("--dimensions", help="Comma-separated dimension names"),
+    ] = None,
+    time_dimension: Annotated[
+        Optional[str],
+        typer.Option(
+            "--time-dimension",
+            help="Format: name:granularity[:start,end]",
+        ),
+    ] = None,
+    filter_: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--filter",
+            help=(
+                "Repeatable. Format: dim:op[:value]. "
+                "For 'in'/'not_in', value is comma-separated."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        Optional[int], typer.Option("--limit", "-l", help="Max rows to return")
+    ] = None,
+    offset: Annotated[
+        Optional[int], typer.Option("--offset", help="Skip N rows")
+    ] = None,
+    from_json: Annotated[
+        Optional[str],
+        typer.Option(
+            "--from",
+            help="Load CubeQuery from a JSON file (or '-' for stdin).",
+        ),
+    ] = None,
+    sql_only: Annotated[
+        bool,
+        typer.Option(
+            "--sql-only",
+            help="Print the generated SQL and exit without executing.",
+        ),
+    ] = False,
+    mdl: _MdlOpt = None,
+    connection_info: Annotated[
+        Optional[str],
+        typer.Option("--connection-info", help="Inline JSON connection string"),
+    ] = None,
+    connection_file: Annotated[
+        Optional[str],
+        typer.Option("--connection-file", help="Path to JSON connection file"),
+    ] = None,
+    output: Annotated[
+        str, typer.Option("--output", "-o", help="Output format: json|csv|table")
+    ] = "table",
+) -> None:
+    """Execute a structured cube query.
+
+    Build the query from CLI flags (``--cube`` / ``--measures`` / …) or load
+    it from JSON via ``--from <file|->``. The CubeQuery is translated to
+    SQL by wren-core, then executed through WrenEngine just like a regular
+    ``wren query``.
+    """
+    if from_json:
+        cube_query = _load_cube_query_from(from_json)
+    else:
+        if not cube or not measures:
+            typer.echo(
+                "Error: --cube and --measures are required (or use --from).",
+                err=True,
+            )
+            raise typer.Exit(1)
+        cube_query = _build_cube_query(
+            cube,
+            measures,
+            dimensions or "",
+            time_dimension,
+            filter_ or [],
+            limit,
+            offset,
+        )
+
+    mdl_json = _load_mdl_json(mdl)
+
+    from wren_core import cube_query_to_sql  # noqa: PLC0415
+
+    try:
+        sql = cube_query_to_sql(json.dumps(cube_query), mdl_json)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from e
+
+    if sql_only:
+        typer.echo(sql)
+        return
+
+    from wren.cli import _build_engine, _print_result  # noqa: PLC0415
+
+    with _build_engine(mdl, connection_info, connection_file) as engine:
+        try:
+            result = engine.query(sql)
+        except Exception as e:
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1) from e
+    _print_result(result, output)

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -57,9 +57,18 @@ def _parse_filter(spec: str) -> dict:
     if len(parts) == 3:
         raw = parts[2]
         if op in {"in", "not_in"}:
-            f["value"] = [v.strip() for v in raw.split(",") if v.strip()]
+            values = [v.strip() for v in raw.split(",") if v.strip()]
+            if not values:
+                raise typer.BadParameter(
+                    f"--filter with {op} requires at least one value, got '{spec}'"
+                )
+            f["value"] = values
         else:
             f["value"] = raw
+    elif op in {"in", "not_in"}:
+        raise typer.BadParameter(
+            f"--filter with {op} expects 'dim:{op}:value1,value2,…', got '{spec}'"
+        )
     return f
 
 
@@ -110,12 +119,38 @@ def _build_cube_query(
 def _load_cube_query_from(source: str) -> dict:
     """Load a CubeQuery dict from ``-`` (stdin) or a JSON file path."""
     if source == "-":
-        return json.loads(sys.stdin.read())
-    p = Path(source).expanduser()
-    if not p.exists():
-        typer.echo(f"Error: CubeQuery file not found: {p}", err=True)
+        raw = sys.stdin.read()
+        label = "stdin"
+    else:
+        p = Path(source).expanduser()
+        if not p.exists():
+            typer.echo(f"Error: CubeQuery file not found: {p}", err=True)
+            raise typer.Exit(1)
+        raw = p.read_text()
+        label = str(p)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error: invalid JSON in {label}: {e}", err=True)
+        raise typer.Exit(1) from e
+    if not isinstance(data, dict):
+        typer.echo(f"Error: CubeQuery in {label} must be a JSON object.", err=True)
         raise typer.Exit(1)
-    return json.loads(p.read_text())
+    return data
+
+
+def _load_manifest_dict(mdl: str | None) -> dict:
+    """Read mdl.json, parse, surface clean errors on bad JSON / non-object."""
+    mdl_json = _load_mdl_json(mdl)
+    try:
+        manifest = json.loads(mdl_json)
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error: invalid MDL JSON: {e}", err=True)
+        raise typer.Exit(1) from e
+    if not isinstance(manifest, dict):
+        typer.echo("Error: MDL JSON must be an object.", err=True)
+        raise typer.Exit(1)
+    return manifest
 
 
 # ── wren cube list ─────────────────────────────────────────────────────────
@@ -124,8 +159,7 @@ def _load_cube_query_from(source: str) -> dict:
 @cube_app.command(name="list")
 def list_cubes(mdl: _MdlOpt = None) -> None:
     """List all cubes defined in the project."""
-    mdl_json = _load_mdl_json(mdl)
-    manifest = json.loads(mdl_json)
+    manifest = _load_manifest_dict(mdl)
     cubes = manifest.get("cubes", []) or []
     if not cubes:
         typer.echo("No cubes defined.")
@@ -156,8 +190,7 @@ def describe(
     mdl: _MdlOpt = None,
 ) -> None:
     """Print the full schema for a cube (JSON)."""
-    mdl_json = _load_mdl_json(mdl)
-    manifest = json.loads(mdl_json)
+    manifest = _load_manifest_dict(mdl)
     cubes = manifest.get("cubes", []) or []
     cube = next((c for c in cubes if c.get("name") == name), None)
     if cube is None:

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -58,8 +58,11 @@ def describe_schema(manifest: dict) -> str:
     for view in manifest.get("views", []):
         _describe_view(view, lines)
 
-    for cube in manifest.get("cubes", []) or []:
-        _describe_cube(cube, lines)
+    cubes = manifest.get("cubes", []) or []
+    if isinstance(cubes, list):
+        for cube in cubes:
+            if isinstance(cube, dict):
+                _describe_cube(cube, lines)
 
     return "\n".join(lines)
 
@@ -126,7 +129,7 @@ def _describe_cube(cube: dict, lines: list[str]) -> None:
     name = cube.get("name", "")
     base = cube.get("baseObject", "?")
     lines.append(f"### Cube: {name} (base: {base})")
-    measures = cube.get("measures", []) or []
+    measures = [m for m in (cube.get("measures") or []) if isinstance(m, dict)]
     if measures:
         lines.append("  Measures:")
         for m in measures:
@@ -139,7 +142,7 @@ def _describe_cube(cube: dict, lines: list[str]) -> None:
             if expr:
                 line += f": {expr}"
             lines.append(line)
-    dims = cube.get("dimensions", []) or []
+    dims = [d for d in (cube.get("dimensions") or []) if isinstance(d, dict)]
     if dims:
         lines.append("  Dimensions:")
         for d in dims:
@@ -152,7 +155,7 @@ def _describe_cube(cube: dict, lines: list[str]) -> None:
             if expr and expr != dname:
                 line += f": {expr}"
             lines.append(line)
-    tdims = cube.get("timeDimensions", []) or []
+    tdims = [td for td in (cube.get("timeDimensions") or []) if isinstance(td, dict)]
     if tdims:
         lines.append("  Time dimensions:")
         for td in tdims:
@@ -169,8 +172,11 @@ def _describe_cube(cube: dict, lines: list[str]) -> None:
     if isinstance(hierarchies, dict) and hierarchies:
         lines.append("  Hierarchies:")
         for hname, levels in hierarchies.items():
-            if isinstance(levels, list):
-                lines.append(f"    - {hname}: {' → '.join(levels)}")
+            if not isinstance(levels, list):
+                continue
+            safe = [lv for lv in levels if isinstance(lv, str)]
+            if safe:
+                lines.append(f"    - {hname}: {' → '.join(safe)}")
     lines.append("")
 
 
@@ -205,15 +211,22 @@ def extract_schema_items(manifest: dict) -> list[dict]:
     for view in manifest.get("views", []):
         items.append(_view_record(view, mdl_h, now))
 
-    for cube in manifest.get("cubes", []) or []:
-        items.append(_cube_record(cube, mdl_h, now))
-        cube_name = cube.get("name", "")
-        for measure in cube.get("measures", []) or []:
-            items.append(_measure_record(measure, cube_name, mdl_h, now))
-        for dim in cube.get("dimensions", []) or []:
-            items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
-        for tdim in cube.get("timeDimensions", []) or []:
-            items.append(_time_dimension_record(tdim, cube_name, mdl_h, now))
+    cubes = manifest.get("cubes", []) or []
+    if isinstance(cubes, list):
+        for cube in cubes:
+            if not isinstance(cube, dict):
+                continue
+            items.append(_cube_record(cube, mdl_h, now))
+            cube_name = cube.get("name", "")
+            for measure in cube.get("measures", []) or []:
+                if isinstance(measure, dict):
+                    items.append(_measure_record(measure, cube_name, mdl_h, now))
+            for dim in cube.get("dimensions", []) or []:
+                if isinstance(dim, dict):
+                    items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
+            for tdim in cube.get("timeDimensions", []) or []:
+                if isinstance(tdim, dict):
+                    items.append(_time_dimension_record(tdim, cube_name, mdl_h, now))
 
     return items
 
@@ -328,10 +341,16 @@ def _view_record(view: dict, mdl_h: str, now: datetime) -> dict:
 def _cube_record(cube: dict, mdl_h: str, now: datetime) -> dict:
     name = cube.get("name", "")
     base = cube.get("baseObject", "?")
-    measures = ", ".join(m.get("name", "") for m in cube.get("measures", []) or [])
-    dims = ", ".join(d.get("name", "") for d in cube.get("dimensions", []) or [])
+    measures = ", ".join(
+        m.get("name", "") for m in (cube.get("measures") or []) if isinstance(m, dict)
+    )
+    dims = ", ".join(
+        d.get("name", "") for d in (cube.get("dimensions") or []) if isinstance(d, dict)
+    )
     time_dims = ", ".join(
-        td.get("name", "") for td in cube.get("timeDimensions", []) or []
+        td.get("name", "")
+        for td in (cube.get("timeDimensions") or [])
+        if isinstance(td, dict)
     )
 
     parts = [f"Cube '{name}' over '{base}'"]

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -58,6 +58,9 @@ def describe_schema(manifest: dict) -> str:
     for view in manifest.get("views", []):
         _describe_view(view, lines)
 
+    for cube in manifest.get("cubes", []) or []:
+        _describe_cube(cube, lines)
+
     return "\n".join(lines)
 
 
@@ -119,6 +122,58 @@ def _describe_relationship(rel: dict, lines: list[str]) -> None:
     lines.append("")
 
 
+def _describe_cube(cube: dict, lines: list[str]) -> None:
+    name = cube.get("name", "")
+    base = cube.get("baseObject", "?")
+    lines.append(f"### Cube: {name} (base: {base})")
+    measures = cube.get("measures", []) or []
+    if measures:
+        lines.append("  Measures:")
+        for m in measures:
+            mname = m.get("name", "")
+            expr = m.get("expression", "")
+            mtype = m.get("type", "")
+            line = f"    - {mname}"
+            if mtype:
+                line += f" ({mtype})"
+            if expr:
+                line += f": {expr}"
+            lines.append(line)
+    dims = cube.get("dimensions", []) or []
+    if dims:
+        lines.append("  Dimensions:")
+        for d in dims:
+            dname = d.get("name", "")
+            expr = d.get("expression", "")
+            dtype = d.get("type", "")
+            line = f"    - {dname}"
+            if dtype:
+                line += f" ({dtype})"
+            if expr and expr != dname:
+                line += f": {expr}"
+            lines.append(line)
+    tdims = cube.get("timeDimensions", []) or []
+    if tdims:
+        lines.append("  Time dimensions:")
+        for td in tdims:
+            tname = td.get("name", "")
+            expr = td.get("expression", "")
+            ttype = td.get("type", "")
+            line = f"    - {tname}"
+            if ttype:
+                line += f" ({ttype})"
+            if expr and expr != tname:
+                line += f": {expr}"
+            lines.append(line)
+    hierarchies = cube.get("hierarchies") or {}
+    if isinstance(hierarchies, dict) and hierarchies:
+        lines.append("  Hierarchies:")
+        for hname, levels in hierarchies.items():
+            if isinstance(levels, list):
+                lines.append(f"    - {hname}: {' → '.join(levels)}")
+    lines.append("")
+
+
 def _describe_view(view: dict, lines: list[str]) -> None:
     name = view["name"]
     stmt = view.get("statement", "")
@@ -149,6 +204,16 @@ def extract_schema_items(manifest: dict) -> list[dict]:
 
     for view in manifest.get("views", []):
         items.append(_view_record(view, mdl_h, now))
+
+    for cube in manifest.get("cubes", []) or []:
+        items.append(_cube_record(cube, mdl_h, now))
+        cube_name = cube.get("name", "")
+        for measure in cube.get("measures", []) or []:
+            items.append(_measure_record(measure, cube_name, mdl_h, now))
+        for dim in cube.get("dimensions", []) or []:
+            items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
+        for tdim in cube.get("timeDimensions", []) or []:
+            items.append(_time_dimension_record(tdim, cube_name, mdl_h, now))
 
     return items
 
@@ -254,6 +319,110 @@ def _view_record(view: dict, mdl_h: str, now: datetime) -> dict:
         "item_name": name,
         "data_type": None,
         "expression": stmt or None,
+        "is_calculated": False,
+        "mdl_hash": mdl_h,
+        "indexed_at": now,
+    }
+
+
+def _cube_record(cube: dict, mdl_h: str, now: datetime) -> dict:
+    name = cube.get("name", "")
+    base = cube.get("baseObject", "?")
+    measures = ", ".join(m.get("name", "") for m in cube.get("measures", []) or [])
+    dims = ", ".join(d.get("name", "") for d in cube.get("dimensions", []) or [])
+    time_dims = ", ".join(
+        td.get("name", "") for td in cube.get("timeDimensions", []) or []
+    )
+
+    parts = [f"Cube '{name}' over '{base}'"]
+    if measures:
+        parts.append(f". Measures: {measures}")
+    if dims:
+        parts.append(f". Dimensions: {dims}")
+    if time_dims:
+        parts.append(f". Time dimensions: {time_dims}")
+    text = "".join(parts) + "."
+
+    return {
+        "text": text,
+        "item_type": "cube",
+        "model_name": base,
+        "item_name": name,
+        "data_type": None,
+        "expression": None,
+        "is_calculated": False,
+        "mdl_hash": mdl_h,
+        "indexed_at": now,
+    }
+
+
+def _measure_record(measure: dict, cube_name: str, mdl_h: str, now: datetime) -> dict:
+    name = measure.get("name", "")
+    expr = measure.get("expression") or None
+    dtype = measure.get("type") or None
+    text = f"Measure '{name}' in cube '{cube_name}'"
+    if dtype:
+        text += f" ({dtype})"
+    if expr:
+        text += f". Expression: {expr}"
+    text += "."
+    return {
+        "text": text,
+        "item_type": "measure",
+        "model_name": cube_name,
+        "item_name": name,
+        "data_type": dtype,
+        "expression": expr,
+        "is_calculated": True,
+        "mdl_hash": mdl_h,
+        "indexed_at": now,
+    }
+
+
+def _cube_dimension_record(
+    dim: dict, cube_name: str, mdl_h: str, now: datetime
+) -> dict:
+    name = dim.get("name", "")
+    expr = dim.get("expression") or None
+    dtype = dim.get("type") or None
+    text = f"Dimension '{name}' in cube '{cube_name}'"
+    if dtype:
+        text += f" ({dtype})"
+    if expr:
+        text += f". Expression: {expr}"
+    text += "."
+    return {
+        "text": text,
+        "item_type": "cube_dimension",
+        "model_name": cube_name,
+        "item_name": name,
+        "data_type": dtype,
+        "expression": expr,
+        "is_calculated": False,
+        "mdl_hash": mdl_h,
+        "indexed_at": now,
+    }
+
+
+def _time_dimension_record(
+    tdim: dict, cube_name: str, mdl_h: str, now: datetime
+) -> dict:
+    name = tdim.get("name", "")
+    expr = tdim.get("expression") or None
+    dtype = tdim.get("type") or None
+    text = f"Time dimension '{name}' in cube '{cube_name}'"
+    if dtype:
+        text += f" ({dtype})"
+    if expr:
+        text += f". Expression: {expr}"
+    text += "."
+    return {
+        "text": text,
+        "item_type": "time_dimension",
+        "model_name": cube_name,
+        "item_name": name,
+        "data_type": dtype,
+        "expression": expr,
         "is_calculated": False,
         "mdl_hash": mdl_h,
         "indexed_at": now,

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -856,7 +856,7 @@ def test_validate_cube_unknown_base_object(tmp_path):
         "name: bad\nbase_object: nosuch\nmeasures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
     )
     errors = validate_project(tmp_path)
-    assert any("baseObject 'nosuch'" in e.message for e in errors)
+    assert any("base_object 'nosuch'" in e.message for e in errors)
 
 
 def test_validate_cube_duplicate_name(tmp_path):
@@ -871,6 +871,39 @@ def test_validate_cube_duplicate_name(tmp_path):
     (cubes_dir / "b.yml").write_text(body)
     errors = validate_project(tmp_path)
     assert any("duplicate cube name" in e.message for e in errors)
+
+
+def test_validate_cube_missing_base_object_uses_snake_case(tmp_path):
+    """Validation error should reference the YAML field name (snake_case)."""
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "om.yml").write_text(
+        "name: order_metrics\n"
+        "measures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
+    )
+    errors = validate_project(tmp_path)
+    assert any("'base_object'" in e.message for e in errors)
+    assert not any("baseObject" in e.message for e in errors)
+
+
+def test_validate_cube_non_string_hierarchy_level(tmp_path):
+    """Non-string hierarchy levels must be reported, not crash."""
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "om.yml").write_text(
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
+        "dimensions: [{name: status, expression: o_orderstatus, type: VARCHAR}]\n"
+        "hierarchies:\n"
+        "  drill:\n"
+        "    - status\n"
+        "    - [nested, list]\n"
+    )
+    errors = validate_project(tmp_path)
+    assert any("hierarchy levels must be strings" in e.message for e in errors)
 
 
 def test_validate_cube_bad_hierarchy(tmp_path):

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -17,6 +17,7 @@ from wren.context import (
     convert_mdl_to_project,
     discover_project_path,
     get_schema_version,
+    load_cubes,
     load_instructions,
     load_models,
     load_relationships,
@@ -768,6 +769,139 @@ def test_validate_view_dialect_unknown(tmp_path):
     )
     errors = validate_project(tmp_path)
     assert any("unknown dialect" in e.message for e in errors)
+
+
+# ── Cubes ───────────────────────────────────────────────────────────────────
+
+
+def _make_v3_cube_project(tmp_path: Path) -> Path:
+    """v3 project with an orders model, ready for cubes/*.yml files."""
+    (tmp_path / "wren_project.yml").write_text(
+        "schema_version: 3\nname: test\ndata_source: postgres\ncatalog: wren\nschema: public\n"
+    )
+    d = tmp_path / "models" / "orders"
+    d.mkdir(parents=True)
+    (d / "metadata.yml").write_text(
+        "name: orders\n"
+        "table_reference:\n  table: orders\n"
+        "columns:\n"
+        "  - name: o_totalprice\n    type: double\n"
+        "  - name: o_orderstatus\n    type: varchar\n"
+    )
+    return tmp_path
+
+
+def test_load_cubes_returns_empty_when_no_dir(tmp_path):
+    assert load_cubes(tmp_path) == []
+
+
+def test_load_cubes_parses_yaml(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "order_metrics.yml").write_text(
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures:\n"
+        "  - name: revenue\n    expression: SUM(o_totalprice)\n    type: DOUBLE\n"
+        "dimensions:\n"
+        "  - name: status\n    expression: o_orderstatus\n    type: VARCHAR\n"
+    )
+    cubes = load_cubes(tmp_path)
+    assert len(cubes) == 1
+    assert cubes[0]["name"] == "order_metrics"
+    assert cubes[0]["base_object"] == "orders"
+    assert cubes[0]["measures"][0]["name"] == "revenue"
+
+
+def test_build_manifest_includes_cubes(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "order_metrics.yml").write_text(
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures:\n"
+        "  - name: revenue\n    expression: SUM(o_totalprice)\n    type: DOUBLE\n"
+    )
+    manifest = build_manifest(tmp_path)
+    assert "cubes" in manifest
+    assert manifest["cubes"][0]["name"] == "order_metrics"
+    assert "_source_file" not in manifest["cubes"][0]
+
+
+def test_build_json_cube_camel_case(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "order_metrics.yml").write_text(
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures:\n"
+        "  - name: revenue\n    expression: SUM(o_totalprice)\n    type: DOUBLE\n"
+        "time_dimensions:\n"
+        "  - name: created_at\n    expression: o_orderdate\n    type: DATE\n"
+    )
+    result = build_json(tmp_path)
+    cube = result["cubes"][0]
+    assert cube["baseObject"] == "orders"
+    assert cube["timeDimensions"][0]["name"] == "created_at"
+
+
+def test_validate_cube_unknown_base_object(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "bad.yml").write_text(
+        "name: bad\nbase_object: nosuch\nmeasures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
+    )
+    errors = validate_project(tmp_path)
+    assert any("baseObject 'nosuch'" in e.message for e in errors)
+
+
+def test_validate_cube_duplicate_name(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    body = (
+        "name: order_metrics\nbase_object: orders\n"
+        "measures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
+    )
+    (cubes_dir / "a.yml").write_text(body)
+    (cubes_dir / "b.yml").write_text(body)
+    errors = validate_project(tmp_path)
+    assert any("duplicate cube name" in e.message for e in errors)
+
+
+def test_validate_cube_bad_hierarchy(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "om.yml").write_text(
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
+        "dimensions: [{name: status, expression: o_orderstatus, type: VARCHAR}]\n"
+        "hierarchies:\n"
+        "  drill: [status, nonexistent_dim]\n"
+    )
+    errors = validate_project(tmp_path)
+    assert any("nonexistent_dim" in e.message for e in errors)
+
+
+def test_validate_cube_ok(tmp_path):
+    _make_v3_cube_project(tmp_path)
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "om.yml").write_text(
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures: [{name: c, expression: 'COUNT(*)', type: BIGINT}]\n"
+        "dimensions: [{name: status, expression: o_orderstatus, type: VARCHAR}]\n"
+    )
+    errors = validate_project(tmp_path)
+    # No cube-specific errors.
+    assert not any("cube" in e.message.lower() for e in errors)
 
 
 # ── Upgrade ──────────────────────────────────────────────────────────────────

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -1,0 +1,240 @@
+"""Unit tests for the `wren cube` CLI sub-app."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from wren.cli import app
+
+runner = CliRunner()
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_mdl(tmp_path: Path) -> Path:
+    """Write a minimal target/mdl.json with one model + one cube."""
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl = {
+        "catalog": "wren",
+        "schema": "public",
+        "models": [
+            {
+                "name": "orders",
+                "tableReference": {"schema": "main", "table": "orders"},
+                "columns": [
+                    {"name": "o_totalprice", "type": "double"},
+                    {"name": "o_orderstatus", "type": "varchar"},
+                ],
+            }
+        ],
+        "cubes": [
+            {
+                "name": "order_metrics",
+                "baseObject": "orders",
+                "measures": [
+                    {
+                        "name": "revenue",
+                        "expression": "SUM(o_totalprice)",
+                        "type": "DOUBLE",
+                    },
+                    {
+                        "name": "order_count",
+                        "expression": "COUNT(*)",
+                        "type": "BIGINT",
+                    },
+                ],
+                "dimensions": [
+                    {
+                        "name": "status",
+                        "expression": "o_orderstatus",
+                        "type": "VARCHAR",
+                    }
+                ],
+            }
+        ],
+    }
+    out = target / "mdl.json"
+    out.write_text(json.dumps(mdl))
+    return out
+
+
+# ── list ────────────────────────────────────────────────────────────────────
+
+
+def test_cube_list(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl)])
+    assert result.exit_code == 0, result.output
+    assert "order_metrics" in result.output
+    assert "base: orders" in result.output
+    assert "revenue" in result.output
+    assert "status" in result.output
+
+
+def test_cube_list_empty(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(json.dumps({"catalog": "c", "schema": "s", "cubes": []}))
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 0
+    assert "No cubes defined" in result.output
+
+
+# ── describe ────────────────────────────────────────────────────────────────
+
+
+def test_cube_describe(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app, ["cube", "describe", "order_metrics", "--mdl", str(mdl)]
+    )
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.output)
+    assert schema["name"] == "order_metrics"
+    assert schema["baseObject"] == "orders"
+    assert len(schema["measures"]) == 2
+
+
+def test_cube_describe_unknown(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(app, ["cube", "describe", "nosuch", "--mdl", str(mdl)])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+# ── query --sql-only ────────────────────────────────────────────────────────
+
+
+def test_cube_query_sql_only(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "SUM(o_totalprice) AS revenue" in result.output
+    assert "o_orderstatus AS status" in result.output
+    assert "FROM orders" in result.output
+    assert "GROUP BY" in result.output
+
+
+def test_cube_query_sql_only_filter(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--filter",
+            "status:eq:completed",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "WHERE o_orderstatus = 'completed'" in result.output
+
+
+def test_cube_query_sql_only_in_filter(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--filter",
+            "status:in:a,b,c",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "o_orderstatus IN ('a', 'b', 'c')" in result.output
+
+
+def test_cube_query_from_json_file(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    qfile = tmp_path / "q.json"
+    qfile.write_text(
+        json.dumps(
+            {
+                "cube": "order_metrics",
+                "measures": ["revenue", "order_count"],
+                "limit": 10,
+            }
+        )
+    )
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--from",
+            str(qfile),
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "SUM(o_totalprice) AS revenue" in result.output
+    assert "COUNT(*) AS order_count" in result.output
+    assert result.output.rstrip().endswith("LIMIT 10")
+
+
+def test_cube_query_unknown_cube(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "nosuch",
+            "--measures",
+            "revenue",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_cube_query_missing_required(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        ["cube", "query", "--measures", "revenue", "--mdl", str(mdl)],
+    )
+    assert result.exit_code == 1
+    assert "required" in result.output.lower()

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -230,6 +230,103 @@ def test_cube_query_unknown_cube(tmp_path):
     assert "not found" in result.output
 
 
+def test_cube_query_in_filter_requires_values(tmp_path):
+    """`status:in:` (empty) should be a clean CLI error, not silent empty IN()."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--filter",
+            "status:in:",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "in" in result.output.lower() and "value" in result.output.lower()
+
+
+def test_cube_query_in_filter_missing_value(tmp_path):
+    """`status:in` (no value segment) should also be rejected."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--filter",
+            "status:in",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "in" in result.output.lower() and "value" in result.output.lower()
+
+
+def test_cube_query_invalid_from_json(tmp_path):
+    """Malformed JSON file should produce a clean CLI error, not a traceback."""
+    mdl = _make_mdl(tmp_path)
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--from",
+            str(bad),
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "invalid JSON" in result.output
+
+
+def test_cube_query_from_json_not_object(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    bad = tmp_path / "list.json"
+    bad.write_text('["not", "an", "object"]')
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--from",
+            str(bad),
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "must be a JSON object" in result.output
+
+
+def test_cube_list_bad_mdl_json(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    bad_mdl = target / "mdl.json"
+    bad_mdl.write_text("not json at all")
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(bad_mdl)])
+    assert result.exit_code == 1
+    assert "invalid MDL JSON" in result.output
+
+
 def test_cube_query_missing_required(tmp_path):
     mdl = _make_mdl(tmp_path)
     result = runner.invoke(

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -162,6 +162,102 @@ class TestExtractSchemaItems:
         assert items[0]["item_type"] == "model"
 
 
+# ── Cube fixture ──────────────────────────────────────────────────────────
+
+_CUBE_MANIFEST = {
+    "catalog": "test",
+    "schema": "public",
+    "models": [
+        {
+            "name": "orders",
+            "tableReference": "test.public.orders",
+            "columns": [
+                {"name": "o_totalprice", "type": "double", "isCalculated": False},
+                {"name": "o_orderstatus", "type": "varchar", "isCalculated": False},
+                {"name": "o_orderdate", "type": "date", "isCalculated": False},
+            ],
+        }
+    ],
+    "cubes": [
+        {
+            "name": "order_metrics",
+            "baseObject": "orders",
+            "measures": [
+                {
+                    "name": "revenue",
+                    "expression": "SUM(o_totalprice)",
+                    "type": "DOUBLE",
+                },
+                {"name": "order_count", "expression": "COUNT(*)", "type": "BIGINT"},
+            ],
+            "dimensions": [
+                {"name": "status", "expression": "o_orderstatus", "type": "VARCHAR"}
+            ],
+            "timeDimensions": [
+                {"name": "created_at", "expression": "o_orderdate", "type": "DATE"}
+            ],
+            "hierarchies": {"time_drill": ["created_at"]},
+        }
+    ],
+}
+
+
+@pytest.mark.unit
+class TestCubeSchemaItems:
+    def test_cube_record(self):
+        items = extract_schema_items(_CUBE_MANIFEST)
+        cubes = [i for i in items if i["item_type"] == "cube"]
+        assert len(cubes) == 1
+        cube = cubes[0]
+        assert cube["item_name"] == "order_metrics"
+        assert cube["model_name"] == "orders"
+        assert "revenue" in cube["text"]
+        assert "status" in cube["text"]
+        assert "created_at" in cube["text"]
+
+    def test_measure_records(self):
+        items = extract_schema_items(_CUBE_MANIFEST)
+        measures = [i for i in items if i["item_type"] == "measure"]
+        assert len(measures) == 2
+        revenue = next(m for m in measures if m["item_name"] == "revenue")
+        assert revenue["expression"] == "SUM(o_totalprice)"
+        assert revenue["model_name"] == "order_metrics"
+        assert revenue["is_calculated"] is True
+
+    def test_cube_dimension_record(self):
+        items = extract_schema_items(_CUBE_MANIFEST)
+        dims = [i for i in items if i["item_type"] == "cube_dimension"]
+        assert len(dims) == 1
+        assert dims[0]["item_name"] == "status"
+        assert dims[0]["expression"] == "o_orderstatus"
+
+    def test_time_dimension_record(self):
+        items = extract_schema_items(_CUBE_MANIFEST)
+        tdims = [i for i in items if i["item_type"] == "time_dimension"]
+        assert len(tdims) == 1
+        assert tdims[0]["item_name"] == "created_at"
+        assert tdims[0]["expression"] == "o_orderdate"
+
+    def test_total_count(self):
+        items = extract_schema_items(_CUBE_MANIFEST)
+        # 1 model + 3 columns + 1 cube + 2 measures + 1 dim + 1 time-dim = 9
+        assert len(items) == 9
+
+    def test_describe_schema_includes_cube(self):
+        text = describe_schema(_CUBE_MANIFEST)
+        assert "### Cube: order_metrics (base: orders)" in text
+        assert "revenue (DOUBLE): SUM(o_totalprice)" in text
+        assert "status (VARCHAR): o_orderstatus" in text
+        assert "created_at (DATE): o_orderdate" in text
+        assert "time_drill: created_at" in text
+
+    def test_extract_skips_cubes_when_absent(self):
+        # The original _MANIFEST has no cubes — confirm nothing leaks in.
+        items = extract_schema_items(_MANIFEST)
+        cube_types = {"cube", "measure", "cube_dimension", "time_dimension"}
+        assert not any(i["item_type"] in cube_types for i in items)
+
+
 # ── describe_schema tests ─────────────────────────────────────────────────
 
 

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -257,6 +257,43 @@ class TestCubeSchemaItems:
         cube_types = {"cube", "measure", "cube_dimension", "time_dimension"}
         assert not any(i["item_type"] in cube_types for i in items)
 
+    def test_malformed_cube_entries_are_skipped(self):
+        """Non-dict cubes / measures / dimensions / non-string hierarchy levels
+        must not raise — the indexer should drop the bad entries and keep
+        going so semantic memory rebuilds never fail on dirty manifests."""
+        manifest = {
+            "cubes": [
+                "not a dict",
+                {
+                    "name": "ok_cube",
+                    "baseObject": "orders",
+                    "measures": [
+                        "not a dict",
+                        {"name": "revenue", "expression": "SUM(x)", "type": "DOUBLE"},
+                    ],
+                    "dimensions": [None, {"name": "status", "expression": "s"}],
+                    "timeDimensions": [{"name": "ts", "expression": "ts"}, 42],
+                    "hierarchies": {"drill": ["status", ["nested"], None]},
+                },
+            ]
+        }
+        items = extract_schema_items(manifest)
+        names = {(i["item_type"], i["item_name"]) for i in items}
+        assert ("cube", "ok_cube") in names
+        assert ("measure", "revenue") in names
+        assert ("cube_dimension", "status") in names
+        assert ("time_dimension", "ts") in names
+        # Bad entries are silently dropped, not promoted to records.
+        assert sum(1 for i in items if i["item_type"] == "measure") == 1
+        assert sum(1 for i in items if i["item_type"] == "cube_dimension") == 1
+        assert sum(1 for i in items if i["item_type"] == "time_dimension") == 1
+
+        # describe_schema also tolerates the same shape.
+        text = describe_schema(manifest)
+        assert "### Cube: ok_cube" in text
+        # Non-string hierarchy levels are filtered out of the printed line.
+        assert "drill: status" in text
+
 
 # ── describe_schema tests ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Phase D + E of the cube rollout (impl-cube-cli.md): expose the Rust cube translator to Python, surface it through the `wren` CLI, and teach the memory indexer about cubes.

### Phase D — `wren-core-py` binding (#0674865c)
- New `cube_query_to_sql(cube_query_json, manifest_json) -> str` pyfunction in `core/wren-core-py/src/cube.rs`. Serde-driven: both inputs are JSON, output is the generated SQL. Bad JSON / unknown cube / cyclic measures all raise `ValueError`.
- 8 pytest cases in `tests/test_cube.py` covering the happy path plus error modes.

### Phase E1+E2 — YAML pipeline (#d05a3efe)
- `core/wren/src/wren/context.py` gains `load_cubes()`, wires cubes into `build_manifest()` / `build_json()` (snake → camel), and extends `validate_project()` with structural cube checks (name uniqueness, `baseObject` exists, hierarchy levels reference declared dimensions). Deep validation (measure cycles) still happens Rust-side at `analyze` time.
- `wren context init` now scaffolds an empty `cubes/` directory.
- 8 new unit tests.

### Phase E3+E4+E6 — `wren cube` CLI (#25fcfa1c)
- New `core/wren/src/wren/cube_cli.py` with three commands:
  - `wren cube list`
  - `wren cube describe <name>`
  - `wren cube query` — build a CubeQuery from CLI flags (`--cube`, `--measures`, `--dimensions`, `--time-dimension name:granularity[:start,end]`, `--filter dim:op[:value]`, `--limit`, `--offset`) or load it from JSON via `--from <file|->`. `--sql-only` prints the generated SQL without executing.
- Registered via `app.add_typer(cube_app)` in `cli.py`.
- 10 new unit tests.

### Phase E5 — Memory indexing (#3b73847c)
- `extract_schema_items()` now emits records for cubes, measures, cube dimensions, and time dimensions so semantic search surfaces them alongside models and views.
- `describe_schema()` gains a cube section printing measures/dimensions/time dimensions/hierarchies.
- 7 new unit tests covering the new record types and `describe_schema` output.

## Test plan
- [x] `cargo test --lib -p wren-core cube::` — 33 cube unit tests pass (no regressions)
- [x] `cd core/wren-core-py && just test-py` — 33 pass (8 new + 25 existing)
- [x] `cd core/wren && uv run pytest tests/unit/` — 167 pass for cube-related modules (test_cube_cli, test_memory, test_context); a single unrelated `test_validate_strict_warns` continues to fail on this branch and on `feat/wasm-cube` HEAD, so the regression is pre-existing.
- [x] `cd core/wren && just lint` — clean
- [x] `cd core/wren-core-py && cargo clippy -- -D warnings` — clean
- [ ] CI on the wren / wren-core-py path-filtered workflows passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cube management commands: `wren cube list`, `describe`, and `query` for working with cubes in your project.
  * Cube definitions are now integrated into project structure with automatic validation.
  * Ability to convert cube queries to SQL and execute them directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2277)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->