### PR TITLE
feat(wren-core-wasm): cubeQuery + listCubes browser API

### DIFF
--- a/core/wren-core-wasm/AGENT_GUIDE.md
+++ b/core/wren-core-wasm/AGENT_GUIDE.md
@@ -92,6 +92,9 @@ For aggregation queries, prefer `cubeQuery()` over raw SQL. The cube layer
 generates correct `GROUP BY`, `DATE_TRUNC`, and `WHERE` clauses from a
 structured input — fewer hand-written errors for the agent.
 
+> ⚠️ Both `listCubes()` and `cubeQuery()` require `await engine.loadMDL(...)`
+> to have completed first — they throw an error otherwise.
+
 ### List available cubes
 
 ```javascript

--- a/core/wren-core-wasm/AGENT_GUIDE.md
+++ b/core/wren-core-wasm/AGENT_GUIDE.md
@@ -6,7 +6,7 @@ Reference for AI agents generating browser-based HTML dashboard artifacts using 
 
 ```html
 <script type="module">
-  import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.1.0/dist/index.js';
+  import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.3.0/dist/index.js';
 </script>
 ```
 
@@ -86,6 +86,60 @@ const mdl = {
 - **console.table**: `console.table(rows)`
 - **HTML table**: iterate `rows` to build `<tr>/<td>` elements
 
+## Cube Query API
+
+For aggregation queries, prefer `cubeQuery()` over raw SQL. The cube layer
+generates correct `GROUP BY`, `DATE_TRUNC`, and `WHERE` clauses from a
+structured input — fewer hand-written errors for the agent.
+
+### List available cubes
+
+```javascript
+const cubes = engine.listCubes();
+// → [{ name: "order_metrics", baseObject: "orders", measures: [...],
+//      dimensions: [...], timeDimensions: [...], hierarchies: {...} }]
+```
+
+### Execute a cube query
+
+```javascript
+const rows = await engine.cubeQuery({
+  cube: "order_metrics",
+  measures: ["revenue", "order_count"],
+  dimensions: ["status"],
+  timeDimensions: [{
+    dimension: "created_at",
+    granularity: "month",
+    dateRange: ["2024-01-01", "2025-01-01"],
+  }],
+  filters: [
+    { dimension: "status", operator: "eq", value: "completed" },
+  ],
+  limit: 100,
+});
+```
+
+`rows` has the same `Record<string, unknown>[]` shape as `query()`.
+
+### `cubeQuery` vs `query`
+
+| Situation | Use |
+|---|---|
+| Aggregating measures over dimensions (with optional time bucket) | `cubeQuery` |
+| Free-form SQL — joins across models, window functions, custom CTEs | `query` |
+| MDL has no cubes defined | `query` |
+
+### Filter operators
+
+`eq`, `neq`, `in`, `not_in`, `gt`, `gte`, `lt`, `lte`, `contains`,
+`starts_with`, `is_null`, `is_not_null`. Pass `value` as an array for
+`in`/`not_in`; omit `value` for `is_null`/`is_not_null`.
+
+### Time granularity
+
+`year` | `quarter` | `month` | `week` | `day` | `hour` | `minute`.
+`dateRange` is `[startInclusive, endExclusive]`.
+
 ## Complete HTML Template (Inline Mode)
 
 ```html
@@ -103,7 +157,7 @@ const mdl = {
   <div id="status">Loading engine...</div>
 
   <script type="module">
-    import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.1.0/dist/index.js';
+    import { WrenEngine } from 'https://unpkg.com/@wrenai/wren-core-wasm@0.3.0/dist/index.js';
 
     const status = document.getElementById('status');
 

--- a/core/wren-core-wasm/README.md
+++ b/core/wren-core-wasm/README.md
@@ -83,6 +83,44 @@ await engine.loadMDL(mdl, { source: '' });
 const rows = await engine.query('SELECT * FROM "Orders" LIMIT 10');
 ```
 
+## Examples
+
+The `examples/` directory ships runnable browser demos. They import the
+local WASM build from `pkg/`, so they always reflect the current source
+— useful while iterating on the Rust or TypeScript side.
+
+```bash
+# Build the WASM binary (debug build is fine for examples)
+just build-wasm-dev
+
+# Start the static dev server with CORS + Range support
+just serve
+```
+
+The server prints every demo URL on startup. Open any of them in a browser:
+
+| Demo | URL | What it shows |
+|---|---|---|
+| Inline data | http://localhost:8787/examples/inline.html | `registerJson` + raw SQL `query()` |
+| URL mode | http://localhost:8787/examples/url-mode.html | Remote Parquet via HTTP range requests |
+| CDN smoke test | http://localhost:8787/examples/test-cdn.html | Loading the published wheel from unpkg |
+| **Cube quickstart** | http://localhost:8787/examples/cube-quickstart.html | Minimal `cubeQuery()` — three preset queries (group-by, filter, time bucket) |
+| **Cube explorer** | http://localhost:8787/examples/cube-explorer.html | Form-driven builder for `CubeQuery` — pick measures/dimensions, add filters, choose granularity + date range |
+
+### Cube quickstart vs explorer
+
+- **Quickstart** loads a single `order_metrics` cube and fires hardcoded
+  `cubeQuery()` calls when you click a button. Read the source to see
+  the smallest end-to-end cube example.
+- **Explorer** is interactive: a checkbox/select form generates the
+  `CubeQuery` JSON live (shown next to the result), and you can add as
+  many filters as you like with all 12 `FilterOperator` values. The
+  demo data is spread across regions / customers / months so groupings
+  produce non-trivial numbers.
+
+After Rust changes, re-run `just build-wasm-dev` and refresh the page —
+the examples import directly from `pkg/wren_core_wasm.js`.
+
 ## API Reference
 
 ### `WrenEngine.init(options?)`

--- a/core/wren-core-wasm/examples/cube-explorer.html
+++ b/core/wren-core-wasm/examples/cube-explorer.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wren-core-wasm: Cube Explorer</title>
+    <style>
+        body { font-family: -apple-system, sans-serif; max-width: 1100px; margin: 1.5em auto; padding: 0 1em; color: #333; }
+        h1 { margin: 0 0 0.2em; }
+        .sub { color: #666; margin: 0 0 1em; font-size: 0.95em; }
+        .log { padding: 0.3em 0.6em; margin: 0.2em 0; border-left: 3px solid #666; font-size: 0.85em; }
+        .ok { border-color: #2a2; color: #2a2; }
+        .err { border-color: #a22; color: #a22; }
+        .layout { display: grid; grid-template-columns: 1fr 1.4fr; gap: 1.5em; }
+        @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+        .panel { border: 1px solid #ddd; border-radius: 6px; padding: 0.8em 1em; }
+        .panel h3 { margin: 0 0 0.6em; font-size: 1.05em; }
+        .field { margin: 0.45em 0; }
+        .field label { display: block; font-size: 0.85em; color: #555; margin-bottom: 0.15em; }
+        .checks { display: flex; flex-wrap: wrap; gap: 0.3em 0.8em; padding: 0.3em 0; }
+        .checks label { font-size: 0.9em; color: #333; }
+        select, input[type="text"], input[type="number"] { width: 100%; box-sizing: border-box; padding: 0.3em 0.4em; font-size: 0.9em; font-family: inherit; }
+        button { padding: 0.4em 0.9em; margin-right: 0.4em; cursor: pointer; font-size: 0.9em; }
+        button.primary { background: #2962ff; color: white; border: 1px solid #1a4ec2; }
+        .filter-row { display: grid; grid-template-columns: 1fr 130px 1.4fr 24px; gap: 0.3em; align-items: center; margin: 0.25em 0; }
+        .filter-row button { padding: 0 0.5em; line-height: 1; }
+        pre { background: #f7f7f7; padding: 0.7em; border-radius: 4px; font-size: 0.8em; overflow-x: auto; margin: 0.4em 0; }
+        table { border-collapse: collapse; margin: 0.4em 0; width: 100%; font-size: 0.85em; }
+        th, td { border: 1px solid #ddd; padding: 0.25em 0.55em; text-align: left; }
+        th { background: #f4f4f4; }
+        details { margin: 0.4em 0; }
+        details summary { cursor: pointer; font-size: 0.85em; color: #555; }
+        .row-meta { font-size: 0.85em; color: #666; margin: 0.3em 0; }
+    </style>
+</head>
+<body>
+    <h1>Cube Explorer</h1>
+    <p class="sub">Build <code>cubeQuery()</code> inputs by clicking. Useful for exploring what an agent can do without writing JSON by hand.</p>
+    <div id="log"></div>
+
+    <div class="layout">
+        <div class="panel">
+            <h3>Available cubes</h3>
+            <div class="field">
+                <label for="cube-select">Cube</label>
+                <select id="cube-select" disabled></select>
+            </div>
+            <details>
+                <summary>Cube schema</summary>
+                <pre id="cube-schema"></pre>
+            </details>
+
+            <h3 style="margin-top: 1.2em;">Build query</h3>
+
+            <div class="field">
+                <label>Measures (one or more)</label>
+                <div id="measures" class="checks"></div>
+            </div>
+
+            <div class="field">
+                <label>Dimensions</label>
+                <div id="dimensions" class="checks"></div>
+            </div>
+
+            <div class="field">
+                <label>Time dimension (optional)</label>
+                <div class="filter-row" style="grid-template-columns: 1fr 130px 1fr;">
+                    <select id="td-name"></select>
+                    <select id="td-granularity">
+                        <option value="">(no bucket)</option>
+                        <option value="year">year</option>
+                        <option value="quarter">quarter</option>
+                        <option value="month">month</option>
+                        <option value="week">week</option>
+                        <option value="day">day</option>
+                        <option value="hour">hour</option>
+                        <option value="minute">minute</option>
+                    </select>
+                    <input type="text" id="td-range" placeholder="2024-01-01,2025-01-01 (optional)">
+                </div>
+            </div>
+
+            <div class="field">
+                <label>Filters</label>
+                <div id="filters"></div>
+                <button id="add-filter" type="button">+ Add filter</button>
+            </div>
+
+            <div class="field" style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5em;">
+                <div>
+                    <label>Limit</label>
+                    <input type="number" id="limit" min="1" placeholder="(none)">
+                </div>
+                <div>
+                    <label>Offset</label>
+                    <input type="number" id="offset" min="0" placeholder="(none)">
+                </div>
+            </div>
+
+            <div style="margin-top: 0.8em;">
+                <button id="run" class="primary" disabled>Run cubeQuery</button>
+                <button id="reset" type="button">Reset</button>
+            </div>
+        </div>
+
+        <div class="panel">
+            <h3>Generated CubeQuery JSON</h3>
+            <pre id="query-json">{}</pre>
+
+            <h3>Result</h3>
+            <div class="row-meta" id="result-meta"></div>
+            <div id="result"></div>
+            <details>
+                <summary>Raw JSON</summary>
+                <pre id="result-raw"></pre>
+            </details>
+        </div>
+    </div>
+
+    <script type="module">
+        import init, { WrenEngine } from '../pkg/wren_core_wasm.js';
+
+        // ── Demo MDL ──
+        const mdl = {
+            catalog: 'wren',
+            schema: 'public',
+            models: [{
+                name: 'orders',
+                tableReference: { table: 'orders' },
+                columns: [
+                    { name: 'id', type: 'INTEGER' },
+                    { name: 'customer', type: 'VARCHAR' },
+                    { name: 'region', type: 'VARCHAR' },
+                    { name: 'status', type: 'VARCHAR' },
+                    { name: 'amount', type: 'DOUBLE' },
+                    { name: 'created_at', type: 'DATE' },
+                ],
+            }],
+            relationships: [], metrics: [], views: [],
+            cubes: [{
+                name: 'order_metrics',
+                baseObject: 'orders',
+                measures: [
+                    { name: 'revenue',     expression: 'SUM(amount)', type: 'DOUBLE' },
+                    { name: 'order_count', expression: 'COUNT(*)',    type: 'BIGINT' },
+                    { name: 'avg_order',   expression: 'revenue / order_count', type: 'DOUBLE' },
+                    { name: 'max_amount',  expression: 'MAX(amount)', type: 'DOUBLE' },
+                ],
+                dimensions: [
+                    { name: 'status',   expression: 'status',   type: 'VARCHAR' },
+                    { name: 'customer', expression: 'customer', type: 'VARCHAR' },
+                    { name: 'region',   expression: 'region',   type: 'VARCHAR' },
+                ],
+                timeDimensions: [
+                    { name: 'created_at', expression: 'created_at', type: 'DATE' },
+                ],
+                hierarchies: { time_drill: ['created_at'] },
+            }],
+        };
+
+        // Spread across regions / customers / months so groupings are interesting.
+        const data = [
+            { id:  1, customer: 'Alice', region: 'NA', status: 'open',      amount: 150, created_at: '2024-01-15' },
+            { id:  2, customer: 'Bob',   region: 'EU', status: 'open',      amount: 200, created_at: '2024-01-20' },
+            { id:  3, customer: 'Alice', region: 'NA', status: 'closed',    amount: 300, created_at: '2024-02-10' },
+            { id:  4, customer: 'Bob',   region: 'EU', status: 'open',      amount: 100, created_at: '2024-02-15' },
+            { id:  5, customer: 'Carol', region: 'APAC', status: 'cancelled', amount:  50, created_at: '2024-02-28' },
+            { id:  6, customer: 'Alice', region: 'NA', status: 'open',      amount: 250, created_at: '2024-03-05' },
+            { id:  7, customer: 'Carol', region: 'APAC', status: 'closed',  amount: 175, created_at: '2024-03-12' },
+            { id:  8, customer: 'Dan',   region: 'EU', status: 'open',      amount: 425, created_at: '2024-03-22' },
+            { id:  9, customer: 'Dan',   region: 'EU', status: 'cancelled', amount:  30, created_at: '2024-04-02' },
+            { id: 10, customer: 'Alice', region: 'NA', status: 'closed',    amount: 600, created_at: '2024-04-18' },
+            { id: 11, customer: 'Carol', region: 'APAC', status: 'open',    amount: 220, created_at: '2024-05-03' },
+            { id: 12, customer: 'Bob',   region: 'EU', status: 'closed',    amount: 380, created_at: '2024-05-19' },
+        ];
+
+        // ── DOM helpers ──
+        const $ = (id) => document.getElementById(id);
+        const logEl = $('log');
+        function log(msg, ok = true) {
+            const div = document.createElement('div');
+            div.className = `log ${ok ? 'ok' : 'err'}`;
+            div.textContent = msg;
+            logEl.appendChild(div);
+        }
+
+        const OPERATORS = ['eq', 'neq', 'in', 'not_in', 'gt', 'gte', 'lt', 'lte',
+                           'contains', 'starts_with', 'is_null', 'is_not_null'];
+
+        // ── State ──
+        let engine = null;
+        let currentCube = null;
+        let filterIdSeq = 0;
+
+        function checkboxGroup(containerId, items, namePrefix) {
+            const container = $(containerId);
+            container.innerHTML = '';
+            for (const item of items) {
+                const id = `${namePrefix}-${item.name}`;
+                const label = document.createElement('label');
+                label.innerHTML = `<input type="checkbox" id="${id}" value="${item.name}"> ${item.name} <span style="color:#999;font-size:0.85em;">${item.type || ''}</span>`;
+                container.appendChild(label);
+            }
+        }
+
+        function getCheckedValues(containerId) {
+            return [...$(containerId).querySelectorAll('input:checked')].map(el => el.value);
+        }
+
+        function renderFilters() {
+            const container = $('filters');
+            container.innerHTML = '';
+            for (const f of filterRows) {
+                const row = document.createElement('div');
+                row.className = 'filter-row';
+                row.innerHTML = `
+                    <select data-fid="${f.id}" data-attr="dim">
+                        ${[...currentCube.dimensions, ...currentCube.timeDimensions]
+                            .map(d => `<option value="${d.name}" ${f.dim === d.name ? 'selected' : ''}>${d.name}</option>`).join('')}
+                    </select>
+                    <select data-fid="${f.id}" data-attr="op">
+                        ${OPERATORS.map(o => `<option value="${o}" ${f.op === o ? 'selected' : ''}>${o}</option>`).join('')}
+                    </select>
+                    <input type="text" data-fid="${f.id}" data-attr="value" value="${f.value || ''}"
+                           placeholder="${(f.op === 'in' || f.op === 'not_in') ? 'a,b,c' : 'value (or empty for is_null/is_not_null)'}">
+                    <button type="button" data-fid="${f.id}" data-action="del" title="Remove">×</button>`;
+                container.appendChild(row);
+            }
+        }
+
+        let filterRows = [];
+
+        function addFilter() {
+            const dim = currentCube.dimensions[0]?.name
+                     || currentCube.timeDimensions[0]?.name
+                     || '';
+            filterRows.push({ id: ++filterIdSeq, dim, op: 'eq', value: '' });
+            renderFilters();
+        }
+
+        function readFilterRows() {
+            const result = [];
+            for (const f of filterRows) {
+                const dim = $('filters').querySelector(`[data-fid="${f.id}"][data-attr="dim"]`).value;
+                const op  = $('filters').querySelector(`[data-fid="${f.id}"][data-attr="op"]`).value;
+                const raw = $('filters').querySelector(`[data-fid="${f.id}"][data-attr="value"]`).value;
+                const filter = { dimension: dim, operator: op };
+                if (op === 'is_null' || op === 'is_not_null') {
+                    // No value.
+                } else if (op === 'in' || op === 'not_in') {
+                    filter.value = raw.split(',').map(s => s.trim()).filter(Boolean);
+                } else if (raw !== '') {
+                    // Try numeric first; fall back to string.
+                    const n = Number(raw);
+                    filter.value = (!Number.isNaN(n) && raw.trim() !== '') ? n : raw;
+                }
+                result.push(filter);
+            }
+            return result;
+        }
+
+        function buildQuery() {
+            if (!currentCube) return null;
+            const measures = getCheckedValues('measures');
+            const dimensions = getCheckedValues('dimensions');
+            const q = { cube: currentCube.name, measures };
+            if (dimensions.length) q.dimensions = dimensions;
+
+            const tdName = $('td-name').value;
+            const tdGran = $('td-granularity').value;
+            if (tdName && tdGran) {
+                const td = { dimension: tdName, granularity: tdGran };
+                const range = $('td-range').value.trim();
+                if (range) {
+                    const parts = range.split(',').map(s => s.trim());
+                    if (parts.length === 2) td.dateRange = parts;
+                }
+                q.timeDimensions = [td];
+            }
+
+            const filters = readFilterRows();
+            if (filters.length) q.filters = filters;
+
+            const limit = $('limit').value;
+            if (limit !== '') q.limit = Number(limit);
+            const offset = $('offset').value;
+            if (offset !== '') q.offset = Number(offset);
+
+            return q;
+        }
+
+        function renderTable(rows) {
+            if (!rows.length) return '<p>No rows.</p>';
+            const keys = Object.keys(rows[0]);
+            return '<table><tr>' + keys.map(k => `<th>${k}</th>`).join('')
+                + '</tr>' + rows.map(r => '<tr>' + keys.map(k => `<td>${r[k] ?? ''}</td>`).join('') + '</tr>').join('')
+                + '</table>';
+        }
+
+        async function runQuery() {
+            const q = buildQuery();
+            if (!q) return;
+            if (!q.measures || !q.measures.length) {
+                $('result').innerHTML = '<div class="log err">Pick at least one measure.</div>';
+                return;
+            }
+            try {
+                const t = performance.now();
+                const json = await engine.cubeQuery(JSON.stringify(q));
+                const rows = JSON.parse(json || '[]');
+                const ms = (performance.now() - t).toFixed(1);
+                $('result-meta').textContent = `${rows.length} row(s) in ${ms}ms`;
+                $('result').innerHTML = renderTable(rows);
+                $('result-raw').textContent = JSON.stringify(rows, null, 2);
+            } catch (e) {
+                $('result-meta').textContent = '';
+                $('result').innerHTML = `<div class="log err">${e.message || e}</div>`;
+                $('result-raw').textContent = '';
+            }
+        }
+
+        function syncQueryDisplay() {
+            const q = buildQuery();
+            $('query-json').textContent = q ? JSON.stringify(q, null, 2) : '{}';
+        }
+
+        function loadCube(cube) {
+            currentCube = cube;
+            $('cube-schema').textContent = JSON.stringify(cube, null, 2);
+            checkboxGroup('measures', cube.measures, 'm');
+            checkboxGroup('dimensions', cube.dimensions, 'd');
+
+            const tdSel = $('td-name');
+            tdSel.innerHTML = cube.timeDimensions
+                .map(td => `<option value="${td.name}">${td.name}</option>`).join('');
+            if (!cube.timeDimensions.length) {
+                tdSel.innerHTML = '<option value="">(none defined)</option>';
+            }
+
+            filterRows = [];
+            renderFilters();
+
+            // Sensible default: first measure + first dimension.
+            const firstMeasure = $('measures').querySelector('input');
+            if (firstMeasure) firstMeasure.checked = true;
+            const firstDim = $('dimensions').querySelector('input');
+            if (firstDim) firstDim.checked = true;
+            syncQueryDisplay();
+        }
+
+        function attachAutoSync() {
+            for (const ev of ['change', 'input']) {
+                document.addEventListener(ev, e => {
+                    if (e.target.closest('#measures, #dimensions, #filters, #td-name, #td-granularity, #td-range, #limit, #offset')) {
+                        syncQueryDisplay();
+                    }
+                });
+            }
+            $('filters').addEventListener('click', e => {
+                if (e.target.dataset?.action === 'del') {
+                    const fid = Number(e.target.dataset.fid);
+                    filterRows = filterRows.filter(f => f.id !== fid);
+                    renderFilters();
+                    syncQueryDisplay();
+                }
+            });
+            $('add-filter').addEventListener('click', () => { addFilter(); syncQueryDisplay(); });
+            $('run').addEventListener('click', runQuery);
+            $('reset').addEventListener('click', () => { loadCube(currentCube); });
+        }
+
+        // ── Boot ──
+        try {
+            await init();
+            engine = new WrenEngine();
+            log('Engine ready');
+
+            await engine.registerJson('orders', JSON.stringify(data));
+            log(`Registered "orders" (${data.length} rows)`);
+
+            await engine.loadMDL(JSON.stringify(mdl), '');
+            log('MDL loaded');
+
+            const cubes = JSON.parse(engine.listCubes() || '[]');
+            const sel = $('cube-select');
+            sel.innerHTML = cubes.map(c => `<option value="${c.name}">${c.name}</option>`).join('');
+            sel.disabled = false;
+            sel.addEventListener('change', e => {
+                const c = cubes.find(c => c.name === e.target.value);
+                if (c) loadCube(c);
+            });
+
+            attachAutoSync();
+            loadCube(cubes[0]);
+            $('run').disabled = false;
+
+            // Auto-run the default selection so the page lands populated.
+            runQuery();
+        } catch (e) {
+            log(`Init failed: ${e.message || e}`, false);
+            console.error(e);
+        }
+    </script>
+</body>
+</html>

--- a/core/wren-core-wasm/examples/cube-quickstart.html
+++ b/core/wren-core-wasm/examples/cube-quickstart.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wren-core-wasm: Cube Quickstart</title>
+    <style>
+        body { font-family: -apple-system, sans-serif; max-width: 800px; margin: 2em auto; padding: 0 1em; color: #333; }
+        .log { padding: 0.3em 0.6em; margin: 0.2em 0; border-left: 3px solid #666; font-size: 0.9em; }
+        .ok { border-color: #2a2; color: #2a2; }
+        .err { border-color: #a22; color: #a22; }
+        pre { background: #f4f4f4; padding: 0.6em; border-radius: 4px; font-size: 0.85em; overflow-x: auto; }
+        button { padding: 0.4em 1em; margin: 0.3em 0.3em 0.3em 0; cursor: pointer; }
+        table { border-collapse: collapse; margin: 0.5em 0; width: 100%; font-size: 0.9em; }
+        th, td { border: 1px solid #ddd; padding: 0.3em 0.6em; text-align: left; }
+        th { background: #f4f4f4; }
+        h3 { margin-top: 1.5em; }
+    </style>
+</head>
+<body>
+    <h1>Cube Quickstart</h1>
+    <p>The simplest <code>cubeQuery()</code> call: aggregate <code>revenue</code> by <code>status</code> over an <code>order_metrics</code> cube. The MDL embeds the cube definition next to the model.</p>
+    <div id="log"></div>
+
+    <h3>Cube definition (from MDL)</h3>
+    <pre id="cube-def"></pre>
+
+    <h3>Cube query</h3>
+    <pre id="query"></pre>
+    <button id="run" disabled>Run cubeQuery</button>
+    <button id="run-filtered" disabled>Run with filter (status = 'open')</button>
+    <button id="run-time" disabled>Run with month bucket</button>
+
+    <h3>Result</h3>
+    <div id="result"></div>
+
+    <script type="module">
+        import init, { WrenEngine } from '../pkg/wren_core_wasm.js';
+
+        const logEl = document.getElementById('log');
+        const resultEl = document.getElementById('result');
+
+        function log(msg, ok = true) {
+            const div = document.createElement('div');
+            div.className = `log ${ok ? 'ok' : 'err'}`;
+            div.textContent = msg;
+            logEl.appendChild(div);
+        }
+
+        function renderTable(rows) {
+            if (!rows.length) return '<p>No rows.</p>';
+            const keys = Object.keys(rows[0]);
+            return '<table><tr>' + keys.map(k => `<th>${k}</th>`).join('')
+                + '</tr>' + rows.map(r => '<tr>' + keys.map(k => `<td>${r[k] ?? ''}</td>`).join('') + '</tr>').join('')
+                + '</table>';
+        }
+
+        async function runCubeQuery(query) {
+            document.getElementById('query').textContent = JSON.stringify(query, null, 2);
+            try {
+                const t = performance.now();
+                const json = await engine.cubeQuery(JSON.stringify(query));
+                const rows = JSON.parse(json || '[]');
+                const ms = (performance.now() - t).toFixed(1);
+                resultEl.innerHTML = `<p>${rows.length} row(s) in ${ms}ms</p>` + renderTable(rows);
+            } catch (e) {
+                resultEl.innerHTML = `<div class="log err">${e.message || e}</div>`;
+            }
+        }
+
+        let engine = null;
+
+        const mdl = {
+            catalog: 'wren',
+            schema: 'public',
+            models: [{
+                name: 'orders',
+                tableReference: { table: 'orders' },
+                columns: [
+                    { name: 'id', type: 'INTEGER' },
+                    { name: 'customer', type: 'VARCHAR' },
+                    { name: 'status', type: 'VARCHAR' },
+                    { name: 'amount', type: 'DOUBLE' },
+                    { name: 'created_at', type: 'DATE' },
+                ],
+            }],
+            relationships: [], metrics: [], views: [],
+            cubes: [{
+                name: 'order_metrics',
+                baseObject: 'orders',
+                measures: [
+                    { name: 'revenue',     expression: 'SUM(amount)', type: 'DOUBLE' },
+                    { name: 'order_count', expression: 'COUNT(*)',    type: 'BIGINT' },
+                    // Derived measure inlined at query time.
+                    { name: 'avg_order',   expression: 'revenue / order_count', type: 'DOUBLE' },
+                ],
+                dimensions: [
+                    { name: 'status',   expression: 'status',   type: 'VARCHAR' },
+                    { name: 'customer', expression: 'customer', type: 'VARCHAR' },
+                ],
+                timeDimensions: [
+                    { name: 'created_at', expression: 'created_at', type: 'DATE' },
+                ],
+                hierarchies: { time_drill: ['created_at'] },
+            }],
+        };
+
+        try {
+            await init();
+            engine = new WrenEngine();
+            log('Engine ready');
+
+            await engine.registerJson('orders', JSON.stringify([
+                { id: 1, customer: 'Alice', status: 'open',      amount: 150, created_at: '2024-01-15' },
+                { id: 2, customer: 'Bob',   status: 'open',      amount: 200, created_at: '2024-01-20' },
+                { id: 3, customer: 'Alice', status: 'closed',    amount: 300, created_at: '2024-02-10' },
+                { id: 4, customer: 'Bob',   status: 'open',      amount: 100, created_at: '2024-02-15' },
+                { id: 5, customer: 'Carol', status: 'cancelled', amount:  50, created_at: '2024-02-28' },
+                { id: 6, customer: 'Alice', status: 'open',      amount: 250, created_at: '2024-03-05' },
+                { id: 7, customer: 'Carol', status: 'closed',    amount: 175, created_at: '2024-03-12' },
+            ]));
+            log('Registered "orders" table (7 rows)');
+
+            await engine.loadMDL(JSON.stringify(mdl), '');
+            log('MDL loaded with cube: order_metrics');
+
+            // Display the cube definition from the loaded MDL via listCubes().
+            const cubes = JSON.parse(engine.listCubes() || '[]');
+            document.getElementById('cube-def').textContent = JSON.stringify(cubes[0], null, 2);
+
+            document.getElementById('run').disabled = false;
+            document.getElementById('run-filtered').disabled = false;
+            document.getElementById('run-time').disabled = false;
+
+            // Default: revenue + order_count + avg_order grouped by status.
+            await runCubeQuery({
+                cube: 'order_metrics',
+                measures: ['revenue', 'order_count', 'avg_order'],
+                dimensions: ['status'],
+            });
+        } catch (e) {
+            log(`Init failed: ${e.message || e}`, false);
+            console.error(e);
+        }
+
+        document.getElementById('run').addEventListener('click', () => runCubeQuery({
+            cube: 'order_metrics',
+            measures: ['revenue', 'order_count', 'avg_order'],
+            dimensions: ['status'],
+        }));
+
+        document.getElementById('run-filtered').addEventListener('click', () => runCubeQuery({
+            cube: 'order_metrics',
+            measures: ['revenue', 'order_count'],
+            dimensions: ['customer'],
+            filters: [{ dimension: 'status', operator: 'eq', value: 'open' }],
+        }));
+
+        document.getElementById('run-time').addEventListener('click', () => runCubeQuery({
+            cube: 'order_metrics',
+            measures: ['revenue'],
+            timeDimensions: [{
+                dimension: 'created_at',
+                granularity: 'month',
+                dateRange: ['2024-01-01', '2024-04-01'],
+            }],
+        }));
+    </script>
+</body>
+</html>

--- a/core/wren-core-wasm/examples/serve.mjs
+++ b/core/wren-core-wasm/examples/serve.mjs
@@ -72,7 +72,9 @@ createServer(async (req, res) => {
     }
 }).listen(PORT, () => {
     console.log(`Serving on http://localhost:${PORT}`);
-    console.log(`  inline demo:   http://localhost:${PORT}/examples/inline.html`);
-    console.log(`  url-mode demo: http://localhost:${PORT}/examples/url-mode.html`);
-    console.log(`  cdn demo:      http://localhost:${PORT}/examples/test-cdn.html`);
+    console.log(`  inline demo:      http://localhost:${PORT}/examples/inline.html`);
+    console.log(`  url-mode demo:    http://localhost:${PORT}/examples/url-mode.html`);
+    console.log(`  cdn demo:         http://localhost:${PORT}/examples/test-cdn.html`);
+    console.log(`  cube quickstart:  http://localhost:${PORT}/examples/cube-quickstart.html`);
+    console.log(`  cube explorer:    http://localhost:${PORT}/examples/cube-explorer.html`);
 });

--- a/core/wren-core-wasm/sdk/src/index.ts
+++ b/core/wren-core-wasm/sdk/src/index.ts
@@ -5,6 +5,80 @@ export interface WrenProfile {
   source: string;
 }
 
+export type Granularity =
+  | "year"
+  | "quarter"
+  | "month"
+  | "week"
+  | "day"
+  | "hour"
+  | "minute";
+
+export type FilterOperator =
+  | "eq"
+  | "neq"
+  | "in"
+  | "not_in"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "contains"
+  | "starts_with"
+  | "is_null"
+  | "is_not_null";
+
+export type FilterValue =
+  | string
+  | number
+  | boolean
+  | (string | number | boolean)[];
+
+export interface TimeDimensionInput {
+  dimension: string;
+  granularity: Granularity;
+  /** Inclusive start, exclusive end. */
+  dateRange?: [string, string];
+}
+
+export interface CubeFilterInput {
+  dimension: string;
+  operator: FilterOperator;
+  /** Omit for `is_null`/`is_not_null`. Use an array for `in`/`not_in`. */
+  value?: FilterValue;
+}
+
+export interface CubeQueryInput {
+  cube: string;
+  measures: string[];
+  dimensions?: string[];
+  timeDimensions?: TimeDimensionInput[];
+  filters?: CubeFilterInput[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface CubeMeasureInfo {
+  name: string;
+  expression: string;
+  type: string;
+}
+
+export interface CubeDimensionInfo {
+  name: string;
+  expression: string;
+  type: string;
+}
+
+export interface CubeInfo {
+  name: string;
+  baseObject: string;
+  measures: CubeMeasureInfo[];
+  dimensions: CubeDimensionInfo[];
+  timeDimensions: CubeDimensionInfo[];
+  hierarchies: Record<string, string[]>;
+}
+
 export interface WrenEngineOptions {
   /**
    * WASM binary source. Accepts:
@@ -83,6 +157,33 @@ export class WrenEngine {
    */
   async query(sql: string): Promise<Record<string, unknown>[]> {
     const jsonStr = await this.engine.query(sql);
+    if (!jsonStr) return [];
+    return JSON.parse(jsonStr);
+  }
+
+  /**
+   * Execute a structured cube query against the loaded MDL.
+   *
+   * Translates the CubeQuery to SQL via wren-core, then executes the SQL
+   * through the same path as `query()`. Requires `loadMDL` first.
+   *
+   * Prefer this over hand-written SQL for aggregation queries — the cube
+   * layer assembles `GROUP BY`, `DATE_TRUNC`, and `WHERE` clauses for you.
+   */
+  async cubeQuery(query: CubeQueryInput): Promise<Record<string, unknown>[]> {
+    const jsonStr = await this.engine.cubeQuery(JSON.stringify(query));
+    if (!jsonStr) return [];
+    return JSON.parse(jsonStr);
+  }
+
+  /**
+   * List the cubes defined in the loaded MDL.
+   *
+   * Useful for an agent to discover what's queryable before calling
+   * `cubeQuery`. Requires `loadMDL` first.
+   */
+  listCubes(): CubeInfo[] {
+    const jsonStr = this.engine.listCubes();
     if (!jsonStr) return [];
     return JSON.parse(jsonStr);
   }

--- a/core/wren-core-wasm/sdk/src/wren_core_wasm.d.ts
+++ b/core/wren-core-wasm/sdk/src/wren_core_wasm.d.ts
@@ -12,6 +12,8 @@ export class WrenEngine {
   registerParquet(table_name: string, data: Uint8Array): Promise<void>;
   loadMDL(mdl_json: string, source: string): Promise<void>;
   query(sql: string): Promise<string>;
+  cubeQuery(cube_query_json: string): Promise<string>;
+  listCubes(): string;
 }
 
 export type InitInput =

--- a/core/wren-core-wasm/sdk/tests/index.test.mjs
+++ b/core/wren-core-wasm/sdk/tests/index.test.mjs
@@ -349,6 +349,7 @@ function cubeMDL() {
         columns: [
           { name: "amount", type: "DOUBLE" },
           { name: "status", type: "VARCHAR" },
+          { name: "created_at", type: "DATE" },
         ],
       },
     ],
@@ -366,8 +367,10 @@ function cubeMDL() {
         dimensions: [
           { name: "status", expression: "status", type: "VARCHAR" },
         ],
-        timeDimensions: [],
-        hierarchies: {},
+        timeDimensions: [
+          { name: "created_at", expression: "created_at", type: "DATE" },
+        ],
+        hierarchies: { time_drill: ["created_at"] },
       },
     ],
   };
@@ -385,7 +388,11 @@ describe("cubeQuery + listCubes", () => {
     assert.equal(cubes[0].baseObject, "orders");
     assert.equal(cubes[0].measures.length, 2);
     assert.equal(cubes[0].measures[0].name, "total");
+    assert.equal(cubes[0].dimensions.length, 1);
     assert.equal(cubes[0].dimensions[0].name, "status");
+    assert.equal(cubes[0].timeDimensions.length, 1);
+    assert.equal(cubes[0].timeDimensions[0].name, "created_at");
+    assert.deepEqual(cubes[0].hierarchies, { time_drill: ["created_at"] });
     engine.free();
   });
 
@@ -440,6 +447,67 @@ describe("cubeQuery + listCubes", () => {
       () => engine.listCubes(),
       /No MDL loaded/i,
     );
+    engine.free();
+  });
+
+  it("cubeQuery applies dimension filters", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    await engine.registerJson("orders", [
+      { amount: 10, status: "open", created_at: "2024-01-15" },
+      { amount: 25, status: "open", created_at: "2024-02-20" },
+      { amount: 7, status: "closed", created_at: "2024-01-05" },
+      { amount: 5, status: "cancelled", created_at: "2024-02-10" },
+    ]);
+    await engine.loadMDL(cubeMDL(), { source: "" });
+
+    const rows = await engine.cubeQuery({
+      cube: "order_metrics",
+      measures: ["total"],
+      dimensions: ["status"],
+      filters: [
+        { dimension: "status", operator: "in", value: ["open", "closed"] },
+      ],
+    });
+
+    assert.equal(rows.length, 2);
+    const byStatus = Object.fromEntries(rows.map((r) => [r.status, r.total]));
+    assert.equal(byStatus.open, 35);
+    assert.equal(byStatus.closed, 7);
+    assert.equal(byStatus.cancelled, undefined);
+    engine.free();
+  });
+
+  it("cubeQuery bucketizes a time dimension with date range", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    await engine.registerJson("orders", [
+      { amount: 10, status: "open", created_at: "2024-01-15" },
+      { amount: 25, status: "open", created_at: "2024-01-20" },
+      { amount: 7, status: "closed", created_at: "2024-02-05" },
+      // Outside the dateRange window — excluded.
+      { amount: 1000, status: "open", created_at: "2025-01-15" },
+    ]);
+    await engine.loadMDL(cubeMDL(), { source: "" });
+
+    const rows = await engine.cubeQuery({
+      cube: "order_metrics",
+      measures: ["total"],
+      timeDimensions: [
+        {
+          dimension: "created_at",
+          granularity: "month",
+          dateRange: ["2024-01-01", "2025-01-01"],
+        },
+      ],
+    });
+
+    assert.equal(rows.length, 2);
+    // Buckets are exposed as `<dim>__<granularity>` columns.
+    const bucketCol = "created_at__month";
+    assert.ok(bucketCol in rows[0], `expected ${bucketCol} column in ${JSON.stringify(rows[0])}`);
+    const totals = Object.fromEntries(rows.map((r) => [r[bucketCol], r.total]));
+    // Two distinct months — Jan totals 35, Feb totals 7.
+    const values = Object.values(totals).sort((a, b) => a - b);
+    assert.deepEqual(values, [7, 35]);
     engine.free();
   });
 });

--- a/core/wren-core-wasm/sdk/tests/index.test.mjs
+++ b/core/wren-core-wasm/sdk/tests/index.test.mjs
@@ -333,3 +333,113 @@ describe("free", () => {
     // No assertion needed — just verify it doesn't throw
   });
 });
+
+// =========================================================================
+// cubeQuery + listCubes
+// =========================================================================
+
+function cubeMDL() {
+  return {
+    catalog: "wren",
+    schema: "public",
+    models: [
+      {
+        name: "orders",
+        tableReference: { table: "orders" },
+        columns: [
+          { name: "amount", type: "DOUBLE" },
+          { name: "status", type: "VARCHAR" },
+        ],
+      },
+    ],
+    relationships: [],
+    metrics: [],
+    views: [],
+    cubes: [
+      {
+        name: "order_metrics",
+        baseObject: "orders",
+        measures: [
+          { name: "total", expression: "SUM(amount)", type: "DOUBLE" },
+          { name: "order_count", expression: "COUNT(*)", type: "BIGINT" },
+        ],
+        dimensions: [
+          { name: "status", expression: "status", type: "VARCHAR" },
+        ],
+        timeDimensions: [],
+        hierarchies: {},
+      },
+    ],
+  };
+}
+
+describe("cubeQuery + listCubes", () => {
+  it("listCubes returns cubes from the loaded MDL", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    await engine.registerJson("orders", [{ amount: 10, status: "open" }]);
+    await engine.loadMDL(cubeMDL(), { source: "" });
+
+    const cubes = engine.listCubes();
+    assert.equal(cubes.length, 1);
+    assert.equal(cubes[0].name, "order_metrics");
+    assert.equal(cubes[0].baseObject, "orders");
+    assert.equal(cubes[0].measures.length, 2);
+    assert.equal(cubes[0].measures[0].name, "total");
+    assert.equal(cubes[0].dimensions[0].name, "status");
+    engine.free();
+  });
+
+  it("cubeQuery aggregates by dimension", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    await engine.registerJson("orders", [
+      { amount: 10, status: "open" },
+      { amount: 25, status: "open" },
+      { amount: 7, status: "closed" },
+    ]);
+    await engine.loadMDL(cubeMDL(), { source: "" });
+
+    const rows = await engine.cubeQuery({
+      cube: "order_metrics",
+      measures: ["total", "order_count"],
+      dimensions: ["status"],
+    });
+
+    assert.equal(rows.length, 2);
+    const byStatus = Object.fromEntries(rows.map((r) => [r.status, r]));
+    assert.equal(byStatus.open.total, 35);
+    assert.equal(byStatus.open.order_count, 2);
+    assert.equal(byStatus.closed.total, 7);
+    assert.equal(byStatus.closed.order_count, 1);
+    engine.free();
+  });
+
+  it("cubeQuery rejects an unknown cube", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    await engine.registerJson("orders", [{ amount: 10, status: "open" }]);
+    await engine.loadMDL(cubeMDL(), { source: "" });
+
+    await assert.rejects(
+      () => engine.cubeQuery({ cube: "nonexistent", measures: ["total"] }),
+      /not found/i,
+    );
+    engine.free();
+  });
+
+  it("cubeQuery without loadMDL fails clearly", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    await assert.rejects(
+      () => engine.cubeQuery({ cube: "order_metrics", measures: ["total"] }),
+      /No MDL loaded/i,
+    );
+    engine.free();
+  });
+
+  it("listCubes without loadMDL fails clearly", async () => {
+    const engine = await WrenEngine.init({ wasmUrl: wasmBytes });
+    assert.throws(
+      () => engine.listCubes(),
+      /No MDL loaded/i,
+    );
+    engine.free();
+  });
+});

--- a/core/wren-core-wasm/src/lib.rs
+++ b/core/wren-core-wasm/src/lib.rs
@@ -32,11 +32,14 @@ use wasm_bindgen::prelude::*;
 
 /// Wren Engine WASM instance.
 ///
-/// Holds a DataFusion SessionContext and (in M3+) an AnalyzedWrenMDL.
-/// All query execution happens in-browser via DataFusion.
+/// Holds a DataFusion SessionContext and (after `loadMDL`) the analyzed
+/// MDL. `analyzed_mdl` is kept so the cube API (`cubeQuery`, `listCubes`)
+/// can read the manifest after `loadMDL` returns. All query execution
+/// happens in-browser via DataFusion.
 #[wasm_bindgen]
 pub struct WrenEngine {
     ctx: datafusion::execution::context::SessionContext,
+    analyzed_mdl: Option<std::sync::Arc<wren_core::mdl::AnalyzedWrenMDL>>,
 }
 
 #[wasm_bindgen]
@@ -59,7 +62,10 @@ impl WrenEngine {
 
         let ctx = datafusion::execution::context::SessionContext::new_with_config(config);
 
-        Ok(WrenEngine { ctx })
+        Ok(WrenEngine {
+            ctx,
+            analyzed_mdl: None,
+        })
     }
 
     /// Register an in-memory table from a JSON array of objects.
@@ -198,11 +204,19 @@ impl WrenEngine {
 
         let properties: Arc<HashMap<String, Option<String>>> = Arc::new(HashMap::new());
 
-        let new_ctx = apply_wren_on_ctx(&self.ctx, analyzed_mdl, properties, Mode::LocalRuntime)
-            .await
-            .map_err(|e| JsError::new(&format!("Failed to apply MDL rules: {e}")))?;
+        // Clone the Arc so `apply_wren_on_ctx` can take ownership while
+        // we keep a handle on `self` for cubeQuery/listCubes access.
+        let new_ctx = apply_wren_on_ctx(
+            &self.ctx,
+            Arc::clone(&analyzed_mdl),
+            properties,
+            Mode::LocalRuntime,
+        )
+        .await
+        .map_err(|e| JsError::new(&format!("Failed to apply MDL rules: {e}")))?;
 
         self.ctx = new_ctx;
+        self.analyzed_mdl = Some(analyzed_mdl);
         Ok(())
     }
 
@@ -483,6 +497,77 @@ impl WrenEngine {
             .map_err(|e| JsError::new(&format!("JSON writer finish error: {e}")))?;
 
         String::from_utf8(buf).map_err(|e| JsError::new(&format!("UTF-8 encoding error: {e}")))
+    }
+
+    /// Execute a structured CubeQuery against the loaded MDL.
+    ///
+    /// Takes a JSON-encoded `CubeQuery` (matching the camelCase shape used
+    /// by the Python binding), translates it to SQL via wren-core, and
+    /// runs the SQL through the existing `query()` path. Returns a JSON
+    /// array of result rows.
+    ///
+    /// Requires `loadMDL` to have been called first.
+    #[wasm_bindgen(js_name = cubeQuery)]
+    pub async fn cube_query(&self, cube_query_json: &str) -> Result<String, JsError> {
+        let analyzed = self
+            .analyzed_mdl
+            .as_ref()
+            .ok_or_else(|| JsError::new("No MDL loaded. Call loadMDL() first."))?;
+        let wren_mdl = analyzed.wren_mdl();
+        let manifest = &wren_mdl.manifest;
+
+        let query: wren_core::mdl::CubeQuery = serde_json::from_str(cube_query_json)
+            .map_err(|e| JsError::new(&format!("Invalid CubeQuery JSON: {e}")))?;
+
+        let sql = wren_core::mdl::cube_query_to_sql(&query, manifest)
+            .map_err(|e| JsError::new(&format!("CubeQuery error: {e}")))?;
+
+        self.query(&sql).await
+    }
+
+    /// List the cubes defined in the loaded MDL.
+    ///
+    /// Returns a JSON array of `{ name, baseObject, measures, dimensions,
+    /// timeDimensions, hierarchies }` records. Requires `loadMDL` to have
+    /// been called first.
+    #[wasm_bindgen(js_name = listCubes)]
+    pub fn list_cubes(&self) -> Result<String, JsError> {
+        let analyzed = self
+            .analyzed_mdl
+            .as_ref()
+            .ok_or_else(|| JsError::new("No MDL loaded. Call loadMDL() first."))?;
+        let wren_mdl = analyzed.wren_mdl();
+        let manifest = &wren_mdl.manifest;
+
+        let cubes: Vec<serde_json::Value> = manifest
+            .cubes
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "name": c.name,
+                    "baseObject": c.base_object,
+                    "measures": c.measures.iter().map(|m| serde_json::json!({
+                        "name": m.name,
+                        "expression": m.expression,
+                        "type": m.r#type,
+                    })).collect::<Vec<_>>(),
+                    "dimensions": c.dimensions.iter().map(|d| serde_json::json!({
+                        "name": d.name,
+                        "expression": d.expression,
+                        "type": d.r#type,
+                    })).collect::<Vec<_>>(),
+                    "timeDimensions": c.time_dimensions.iter().map(|td| serde_json::json!({
+                        "name": td.name,
+                        "expression": td.expression,
+                        "type": td.r#type,
+                    })).collect::<Vec<_>>(),
+                    "hierarchies": c.hierarchies,
+                })
+            })
+            .collect();
+
+        serde_json::to_string(&cubes)
+            .map_err(|e| JsError::new(&format!("Serialization error: {e}")))
     }
 }
 


### PR DESCRIPTION
## Summary

Phase F of the cube rollout (impl-cube-wasm.md): expose the cube translator to the browser through `@wrenai/wren-core-wasm`.

### F0 — store the analyzed MDL
- `WrenEngine` now holds `analyzed_mdl: Option<Arc<AnalyzedWrenMDL>>`.
- `loadMDL` `Arc::clone`s the analyzed manifest into the struct after `apply_wren_on_ctx`, so the cube API can read the manifest without re-analyzing.

### F1 — Rust wasm-bindgen API
- `cubeQuery(json) -> Promise<string>` — deserialize `CubeQuery` via serde, translate through `wren_core::mdl::cube_query_to_sql`, execute via the existing `query()` path. Curated re-export, not `wren_core::mdl::cube::*` (which is `pub(crate)` since PR #2276).
- `listCubes() -> string` — emit a JSON array of `{ name, baseObject, measures, dimensions, timeDimensions, hierarchies }`.
- Clean error messages when called before `loadMDL`.

### F2 + F5 — TypeScript SDK
- New exported types: `CubeQueryInput`, `TimeDimensionInput`, `CubeFilterInput`, `CubeInfo`, plus `Granularity` and `FilterOperator` string unions.
- `cubeQuery(query)` returns `Promise<Record<string, unknown>[]>`; `listCubes()` returns `CubeInfo[]`.
- Hand-maintained `wren_core_wasm.d.ts` mirror updated to match.

### F3 — Integration tests
- 5 new SDK tests under `sdk/tests/index.test.mjs`: `listCubes` shape, `cubeQuery` aggregation, unknown cube rejection, and "missing MDL" errors for both methods.

### F4 — AGENT_GUIDE
- New "Cube Query API" section with discovery, query, filter operators, and granularity reference.
- Bumped the unpkg CDN URL from `@0.1.0` to `@0.3.0` so the doc matches the current npm release.

## Test plan
- [x] `just build-wasm-dev` — WASM dev build compiles
- [x] `just build-dist` + `just typecheck` — TypeScript SDK builds and type-checks clean
- [x] `just test` — 19 SDK integration tests pass (5 new + 14 prior)
- [x] `cargo clippy --target wasm32-unknown-unknown -- -D warnings` — clean
- [ ] CI runs the release WASM build and the size check
- [ ] CI runs `cargo fmt --all -- --check` — note: there is a pre-existing fmt diff in `extract_bare_table_name` test on `feat/wasm-cube` HEAD that this PR doesn't introduce or touch; left alone to keep the diff minimal.

Phase G (skills wiring + npm release) is the last step before merging `feat/wasm-cube` into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Cube Query API with `cubeQuery()` and `listCubes()` methods for structured data querying, supporting measures, dimensions, filters, time bucketing, and granularity options.
  * Added interactive demo pages (Cube Quickstart and Cube Explorer) for exploring and querying cubes in the browser.

* **Documentation**
  * Updated Cube Query API documentation with usage examples, filter operators, and time dimension semantics.
  * Added Examples section to README with instructions for running demo applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2278)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->