### PR TITLE
docs(mdl-schema): align with Cube types (PR #1574 follow-up)

### DIFF
--- a/core/wren-mdl/mdl.schema.json
+++ b/core/wren-mdl/mdl.schema.json
@@ -454,6 +454,7 @@
             "type": "object",
             "additionalProperties": {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "type": "string",
                 "minLength": 1

--- a/core/wren-mdl/mdl.schema.json
+++ b/core/wren-mdl/mdl.schema.json
@@ -120,6 +120,75 @@
       },
       "required": ["name", "required"],
       "additionalProperties": false
+    },
+    "measure": {
+      "description": "A measure within a Cube — a named aggregation expression.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "the name of the measure",
+          "type": "string",
+          "minLength": 1
+        },
+        "expression": {
+          "description": "the SQL expression of the measure (typically an aggregation such as SUM, COUNT, AVG)",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "the data type of the measure result",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["name", "expression", "type"],
+      "additionalProperties": false
+    },
+    "cubeDimension": {
+      "description": "A grouping attribute within a Cube.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "the name of the dimension",
+          "type": "string",
+          "minLength": 1
+        },
+        "expression": {
+          "description": "the SQL expression of the dimension (typically a column reference)",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "the data type of the dimension",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["name", "expression", "type"],
+      "additionalProperties": false
+    },
+    "timeDimension": {
+      "description": "A time-based dimension within a Cube. Granularity is applied at query time via `wren cube query`, not declared here.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "the name of the time dimension",
+          "type": "string",
+          "minLength": 1
+        },
+        "expression": {
+          "description": "the SQL expression of the time dimension (typically a date/timestamp column reference)",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "description": "the data type of the time dimension (DATE, TIMESTAMP, …)",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["name", "expression", "type"],
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -128,6 +197,11 @@
       "description": "the schema of WrenMDL",
       "type": "string",
       "const": "https://raw.githubusercontent.com/Canner/WrenAI/main/wren-mdl/mdl.schema.json"
+    },
+    "layoutVersion": {
+      "description": "the MDL wire-format layout version (default 1)",
+      "type": "integer",
+      "minimum": 1
     },
     "catalog": {
       "description": "the catalog name of WrenMDL",
@@ -145,10 +219,50 @@
       "minLength": 1
     },
     "dataSource": {
-      "description": "the data source type (case insensitive). Valid values are: BIGQUERY, CLICKHOUSE, CANNER, TRINO, MSSQL, MYSQL, POSTGRES, SNOWFLAKE, DUCKDB, LOCAL_FILE, S3_FILE, GCS_FILE, MINIO_FILE, ORACLE, ATHENA, REDSHIFT",
+      "description": "the data source type. Canonical form is UPPERCASE; Rust serde also accepts lowercase aliases (and the wren CLI emits lowercase by default).",
       "type": "string",
-      "pattern": "^(?:[Bb][Ii][Gg][Qq][Uu][Ee][Rr][Yy]|[Cc][Ll][Ii][Cc][Kk][Hh][Oo][Uu][Ss][Ee]|[Cc][Aa][Nn][Nn][Ee][Rr]|[Tt][Rr][Ii][Nn][Oo]|[Mm][Ss][Ss][Qq][Ll]|[Mm][Yy][Ss][Qq][Ll]|[Pp][Oo][Ss][Tt][Gg][Rr][Ee][Ss]|[Ss][Nn][Oo][Ww][Ff][Ll][Aa][Kk][Ee]|[Dd][Uu][Cc][Kk][Dd][Bb]|[Ll][Oo][Cc][Aa][Ll]_[Ff][Ii][Ll][Ee]|[Ss]3_[Ff][Ii][Ll][Ee]|[Gg][Cc][Ss]_[Ff][Ii][Ll][Ee]|[Mm][Ii][Nn][Ii][Oo]_[Ff][Ii][Ll][Ee]|[Oo][Rr][Aa][Cc][Ll][Ee]|[Aa][Tt][Hh][Ee][Nn][Aa]|[Rr][Ee][Dd][Ss][Hh][Ii][Ff][Tt])$",
-      "minLength": 1
+      "enum": [
+        "BIGQUERY",
+        "CLICKHOUSE",
+        "CANNER",
+        "TRINO",
+        "MSSQL",
+        "MYSQL",
+        "DORIS",
+        "POSTGRES",
+        "SNOWFLAKE",
+        "DATAFUSION",
+        "DUCKDB",
+        "LOCAL_FILE",
+        "S3_FILE",
+        "GCS_FILE",
+        "MINIO_FILE",
+        "ORACLE",
+        "ATHENA",
+        "REDSHIFT",
+        "DATABRICKS",
+        "SPARK",
+        "bigquery",
+        "clickhouse",
+        "canner",
+        "trino",
+        "mssql",
+        "mysql",
+        "doris",
+        "postgres",
+        "snowflake",
+        "datafusion",
+        "duckdb",
+        "local_file",
+        "s3_file",
+        "gcs_file",
+        "minio_file",
+        "oracle",
+        "athena",
+        "redshift",
+        "databricks",
+        "spark"
+      ]
     },
     "models": {
       "description": "the list of models",
@@ -295,94 +409,60 @@
         "required": ["name", "models", "joinType", "condition"]
       }
     },
-    "metrics": {
-      "description": "(WIP) the list of metrics",
+    "cubes": {
+      "description": "the list of cubes (pre-aggregation semantic objects on top of a Model or View)",
       "type": "array",
       "unevaluatedItems": false,
       "items": {
-        "description": "(WIP) the metric",
+        "description": "a cube — measures + dimensions + time dimensions + optional hierarchies over a baseObject",
         "type": "object",
         "properties": {
           "name": {
-            "description": "the name of the metric",
+            "description": "the name of the cube",
             "type": "string",
             "minLength": 1
           },
           "baseObject": {
-            "description": "the base object of the metric",
+            "description": "the base object of the cube (must reference a defined Model or View)",
             "type": "string",
             "minLength": 1
           },
-          "dimension": {
-            "description": "the list of dimensions",
+          "measures": {
+            "description": "the list of measures (aggregation expressions)",
             "type": "array",
             "items": {
-                "$ref": "#/$defs/column"
-            }
-          },
-          "measure": {
-            "description": "the list of measures",
-            "type": "array",
-            "items": {
-                "$ref": "#/$defs/column"
+              "$ref": "#/$defs/measure"
             },
             "minItems": 1
           },
-          "timeGrain": {
-            "description": "the time grain fields of the metric",
+          "dimensions": {
+            "description": "the list of dimensions (grouping attributes)",
             "type": "array",
-            "unevaluatedItems": false,
             "items": {
-              "description": "the time grain field. It's should belong to the dimension fields",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "description": "the name of the time grain field",
-                  "type": "string",
-                  "minLength": 1
-                },
-                "refColumn": {
-                  "description": "the reference column name of the time grain field",
-                  "type": "string",
-                  "minLength": 1
-                },
-                "dateParts": {
-                  "description": "the acceptable time units of the time grain field",
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "YEAR",
-                      "QUARTER",
-                      "MONTH",
-                      "WEEK",
-                      "DAY",
-                      "HOUR",
-                      "MINUTE",
-                      "SECOND"
-                    ]
-                  }
-                }
-              },
-              "required": ["name", "refColumn", "dateParts"]
+              "$ref": "#/$defs/cubeDimension"
             }
           },
-          "cached": {
-            "type": "boolean"
+          "timeDimensions": {
+            "description": "the list of time-based dimensions; granularity is applied at query time",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/timeDimension"
+            }
           },
-          "refreshTime": {
-            "type": "string",
-            "description": "the cache refresh time of the metric",
-            "pattern": "^\\s*(\\d+(?:\\.\\d+)?)\\s*([a-zA-Z]+)\\s*$"
-          },
-          "properties": {
+          "hierarchies": {
+            "description": "drill-down paths — map of hierarchy name → ordered list of dimension or timeDimension names (coarsest to finest)",
             "type": "object",
             "additionalProperties": {
-              "type": ["string", "number", "boolean", "object", "array", "null"]
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         },
-        "required": ["name", "baseObject", "dimension", "measure"]
+        "required": ["name", "baseObject", "measures"],
+        "additionalProperties": false
       }
     },
     "views": {


### PR DESCRIPTION
The published JSON schema at `core/wren-mdl/mdl.schema.json` still described the pre-PR #1574 "metric" shape. Now that the whole cube line (PRs #1574, #2264, #2265, #2276, #2277, #2278, #2280) has landed, this aligns the schema with the current Rust `Manifest` / `Cube` types so external editors and validators don't flag the documented `cubes:` YAML as invalid.

## Changes (single file: `core/wren-mdl/mdl.schema.json`)

- **`metrics` → `cubes`** (top-level field rename, reshape). Old `metric` used singular `dimension`/`measure` + `timeGrain.dateParts` UPPERCASE enum; the new `cube` shape uses plural `measures`/`dimensions`/`timeDimensions` and adds `hierarchies`.
- **New `$defs`:** `measure`, `cubeDimension`, `timeDimension` — three simple `{ name, expression, type }` types (the old metric reused `column` with many irrelevant fields like `relationship`, `isCalculated`, `columnLevelAccessControl`).
- **`layoutVersion`** added at top level. Rust serializes this on every manifest produced by `wren context build`; the schema was missing it, so any real built `mdl.json` was already failing strict validation against `additionalProperties: false`.
- **`dataSource` regex → enum.** Adds 4 missing values (`DATAFUSION`, `DORIS`, `DATABRICKS`, `SPARK`) and lists both UPPERCASE and lowercase forms so it matches Rust serde aliases (which the wren CLI's snake_case YAML output relies on — `data_source: postgres` round-trips to `"dataSource": "postgres"`, lowercase).

## Migration

This is a **hard rename**. `metrics:` has been silently dropped by Rust serde since PR #1574, so there's no working `metrics:` user to migrate. External editors / validators pinned to the schema's `$id` URL pick up the new shape automatically.

## Validation

Six checks all green:

1. JSON syntax + Draft 2020-12 meta-schema
2. A `wren-core-py` `test_cube.py`-shaped cube manifest passes
3. **End-to-end:** the real `wren context build` output for a v3 project with a cube validates (this is what caught the missing-`layoutVersion` and lowercase-`dataSource` gaps in the original plan)
4. Old `metrics:`-shaped manifest is correctly rejected
5. All 20 `dataSource` values accepted in both UPPERCASE and lowercase
6. Bogus `dataSource` (e.g. `FAKE_DB`) still rejected

No internal consumer reads the schema (`grep mdl.schema.json` across `*.rs` / `*.py` / `*.ts` / `*.toml` returns zero hits), so no Rust / Python / TS regression is possible.

## Not in this PR (follow-up issues)

- `(WIP)` annotations on `refSql`, `baseObject`, `enumDefinitions`, `cached`, `refreshTime` are still there — separate staleness audit.
- Versioned schema URL (`mdl.schema.v1.json`) — separate breaking-change discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cube pre-aggregations with customizable measures, dimensions, time dimensions, and hierarchies
  * Introduced layoutVersion field to track manifest versions
  * Enhanced dataSource validation with explicit enum-based configuration for improved reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2281)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->