### PR TITLE
fix(skills): refresh stale docs URLs and wren-engine repo references

### DIFF
--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://www.getwren.ai/"
   },
   "homepage": "https://www.getwren.ai/",
-  "repository": "https://github.com/Canner/wren-engine",
+  "repository": "https://github.com/Canner/WrenAI",
   "license": "Apache-2.0",
   "keywords": [
     "wren",

--- a/skills/index.json
+++ b/skills/index.json
@@ -2,13 +2,13 @@
   "name": "wren-engine",
   "description": "AI agent skills for Wren Engine CLI — semantic SQL layer for 22+ data sources.",
   "homepage": "https://wren.ai",
-  "repository": "https://github.com/Canner/wren-engine",
+  "repository": "https://github.com/Canner/WrenAI",
   "license": "Apache-2.0",
   "skills": [
     {
       "name": "wren-onboarding",
       "version": "2.1",
-      "description": "Onboard a user to Wren Engine end-to-end. Walks the user through environment checks, .env configuration, connection profile creation, project scaffolding, binding the profile to the project, and first query. Defers procedural details, per-datasource notes, and the troubleshooting playbook to docs/core/get_started/connect.md so the skill stays focused on agent-side rules and routing. Use when the user wants to install Wren Engine, set up a new data source connection, or bootstrap a new project from scratch.",
+      "description": "Onboard a user to Wren Engine end-to-end. Walks the user through environment checks, .env configuration, connection profile creation, project scaffolding, binding the profile to the project, and first query. Defers procedural details, per-datasource notes, and the troubleshooting playbook to docs/core/guides/connect.md so the skill stays focused on agent-side rules and routing. Use when the user wants to install Wren Engine, set up a new data source connection, or bootstrap a new project from scratch.",
       "tags": [
         "wren",
         "onboarding",
@@ -21,7 +21,7 @@
       "dependencies": [
         "wren-generate-mdl"
       ],
-      "repository": "https://github.com/Canner/wren-engine/tree/main/skills/wren-onboarding"
+      "repository": "https://github.com/Canner/WrenAI/tree/main/skills/wren-onboarding"
     },
     {
       "name": "wren-dlt-connector",
@@ -42,7 +42,7 @@
       "dependencies": [
         "wren-generate-mdl"
       ],
-      "repository": "https://github.com/Canner/wren-engine/tree/main/skills/wren-dlt-connector"
+      "repository": "https://github.com/Canner/WrenAI/tree/main/skills/wren-dlt-connector"
     },
     {
       "name": "wren-generate-mdl",
@@ -61,7 +61,7 @@
         "clickhouse",
         "trino"
       ],
-      "repository": "https://github.com/Canner/wren-engine/tree/main/skills/wren-generate-mdl"
+      "repository": "https://github.com/Canner/WrenAI/tree/main/skills/wren-generate-mdl"
     },
     {
       "name": "wren-usage",
@@ -82,7 +82,7 @@
       "dependencies": [
         "wren-generate-mdl"
       ],
-      "repository": "https://github.com/Canner/wren-engine/tree/main/skills/wren-usage"
+      "repository": "https://github.com/Canner/WrenAI/tree/main/skills/wren-usage"
     }
   ]
 }

--- a/skills/wren-generate-mdl/SKILL.md
+++ b/skills/wren-generate-mdl/SKILL.md
@@ -11,14 +11,14 @@ metadata:
 
 ## Version check
 
-Silently fetch `https://raw.githubusercontent.com/Canner/wren-engine/main/skills/versions.json`.
+Silently fetch `https://raw.githubusercontent.com/Canner/WrenAI/main/skills/versions.json`.
 Compare the `wren-generate-mdl` key with this skill's version (from the frontmatter above).
 If the remote version is newer, notify the user before proceeding:
 
 > A newer version of the **wren-generate-mdl** skill is available.
 > Update with:
 > ```
-> npx skills add Canner/wren-engine --skill wren-generate-mdl
+> npx skills add Canner/WrenAI --skill wren-generate-mdl
 > ```
 > The CLI auto-detects your installed agent. To target a specific one, add `--agent <name>` (e.g., `claude-code`, `cursor`, `windsurf`, `cline`).
 

--- a/skills/wren-onboarding/SKILL.md
+++ b/skills/wren-onboarding/SKILL.md
@@ -18,12 +18,12 @@ Reference docs (the skill points to these — never duplicate their content):
 
 ## Version check
 
-Silently fetch `https://raw.githubusercontent.com/Canner/wren-engine/main/skills/versions.json`. Compare the `wren-onboarding` key with this skill's version (from the frontmatter above). If the remote version is newer, notify the user:
+Silently fetch `https://raw.githubusercontent.com/Canner/WrenAI/main/skills/versions.json`. Compare the `wren-onboarding` key with this skill's version (from the frontmatter above). If the remote version is newer, notify the user:
 
 > A newer version of the **wren-onboarding** skill is available.
 > Update with:
 > ```
-> npx skills add Canner/wren-engine --skill wren-onboarding
+> npx skills add Canner/WrenAI --skill wren-onboarding
 > ```
 
 Continue regardless of update status.
@@ -181,4 +181,4 @@ Don't carry an error playbook here — surface [`connect.md#troubleshooting`](ht
 If you hit something not in the playbook, tell the user:
 
 > "I hit an error I don't know how to fix: `<error>`.
-> See <https://docs.getwren.ai/oss/engine> or open an issue at <https://github.com/Canner/wren-engine/issues>."
+> See <https://docs.getwren.ai/oss/introduction> or open an issue at <https://github.com/Canner/WrenAI/issues>."

--- a/skills/wren-onboarding/SKILL.md
+++ b/skills/wren-onboarding/SKILL.md
@@ -12,9 +12,9 @@ metadata:
 This skill walks the agent through onboarding — environment checks, project scaffolding, profile creation, MDL generation, and first query. **Procedural details, per-datasource setup notes, and the troubleshooting playbook live in the docs**, not here. The skill's job is to enforce the agent-side rules (one step per turn, never ask for credentials in chat) and to dispatch the agent to the right doc / sibling skill at each step.
 
 Reference docs (the skill points to these — never duplicate their content):
-- [`docs/get_started/installation.md`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/installation.md) — CLI install + skill install
-- [`docs/get_started/connect.md`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/connect.md) — full connection procedure, **per-datasource setup notes, complete troubleshooting playbook**
-- [`docs/get_started/quickstart.md`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/quickstart.md) — bundled `jaffle_shop` demo
+- [`docs/core/get_started/installation.md`](https://github.com/Canner/WrenAI/blob/main/docs/core/get_started/installation.md) — CLI install + skill install
+- [`docs/core/guides/connect.md`](https://github.com/Canner/WrenAI/blob/main/docs/core/guides/connect.md) — full connection procedure, **per-datasource setup notes, complete troubleshooting playbook**
+- [`docs/core/get_started/quickstart.md`](https://github.com/Canner/WrenAI/blob/main/docs/core/get_started/quickstart.md) — bundled `jaffle_shop` demo
 
 ## Version check
 
@@ -54,7 +54,7 @@ Report findings as a 4-bullet list, then continue.
 
 > "Try the bundled `jaffle_shop` demo first (~30s, no DB needed), or connect your own database?"
 
-- **demo** → point at [`quickstart.md`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/quickstart.md) and stop this skill.
+- **demo** → point at [`quickstart.md`](https://github.com/Canner/WrenAI/blob/main/docs/core/get_started/quickstart.md) and stop this skill.
 - **own DB** → continue.
 
 ## Step 1 — Collect project name + database type
@@ -74,7 +74,7 @@ Side effects: creates `~/<project>/`, installs `wren-engine[<ds>,main]`, generat
 Run as a batch — report each command briefly, then end with one "please fill `.env`" ask:
 
 1. `mkdir -p ~/<project> && cd ~/<project>`.
-2. `pip install "wren-engine[<ds>,main]"`. For datasource-specific install gotchas (macOS mysql, etc.), see [`connect.md#per-datasource-setup-notes`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/connect.md).
+2. `pip install "wren-engine[<ds>,main]"`. For datasource-specific install gotchas (macOS mysql, etc.), see [`connect.md#per-datasource-setup-notes`](https://github.com/Canner/WrenAI/blob/main/docs/core/guides/connect.md).
 3. **Generate the `.env` template by introspecting the connector**:
 
    ```bash
@@ -91,7 +91,7 @@ Run as a batch — report each command briefly, then end with one "please fill `
    POSTGRES_PASSWORD=
    ```
 
-   Special encodings (BigQuery base64, Snowflake account format, Athena AWS creds, etc.) are documented in [`connect.md#per-datasource-setup-notes`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/connect.md). Surface the relevant section to the user verbatim — don't paraphrase.
+   Special encodings (BigQuery base64, Snowflake account format, Athena AWS creds, etc.) are documented in [`connect.md#per-datasource-setup-notes`](https://github.com/Canner/WrenAI/blob/main/docs/core/guides/connect.md). Surface the relevant section to the user verbatim — don't paraphrase.
 
 4. Add `.env` to `.gitignore` if the project is a git repo. Suggest `chmod 600 .env`.
 5. Tell the user: `.env` is at `<path>`, please fill every value and reply **"done"**.
@@ -118,7 +118,7 @@ wren profile add <project> --from-file /tmp/conn.yml
 Validation runs automatically. The CLI overwrites profiles silently — there is no `--force` flag.
 
 - ✓ **Success** → continue to Step 3.5.
-- ⚠ **Any warning** → consult [`connect.md#troubleshooting`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/connect.md) for the exact symptom (missing secret, driver auth failure, ValidationError, unreachable host, …) and tell the user what to fix.
+- ⚠ **Any warning** → consult [`connect.md#troubleshooting`](https://github.com/Canner/WrenAI/blob/main/docs/core/guides/connect.md) for the exact symptom (missing secret, driver auth failure, ValidationError, unreachable host, …) and tell the user what to fix.
 
 ## Step 3.5 — Scaffold the project
 
@@ -168,7 +168,7 @@ Suggest 2–3 NL questions based on the discovered tables (e.g. for an orders sc
 
 ## On error
 
-Don't carry an error playbook here — surface [`connect.md#troubleshooting`](https://github.com/Canner/wren-engine/blob/main/docs/get_started/connect.md) sections to the user. The doc covers:
+Don't carry an error playbook here — surface [`connect.md#troubleshooting`](https://github.com/Canner/WrenAI/blob/main/docs/core/guides/connect.md) sections to the user. The doc covers:
 
 - `wren: command not found`
 - `pip install … externally-managed-environment`

--- a/skills/wren-usage/SKILL.md
+++ b/skills/wren-usage/SKILL.md
@@ -11,14 +11,14 @@ metadata:
 
 ## Version check
 
-Silently fetch `https://raw.githubusercontent.com/Canner/wren-engine/main/skills/versions.json`.
+Silently fetch `https://raw.githubusercontent.com/Canner/WrenAI/main/skills/versions.json`.
 Compare the `wren-usage` key with this skill's version (from the frontmatter above).
 If the remote version is newer, notify the user before proceeding:
 
 > A newer version of the **wren-usage** skill is available.
 > Update with:
 > ```
-> npx skills add Canner/wren-engine --skill wren-usage
+> npx skills add Canner/WrenAI --skill wren-usage
 > ```
 > The CLI auto-detects your installed agent. To target a specific one, add `--agent <name>` (e.g., `claude-code`, `cursor`, `windsurf`, `cline`).
 
@@ -90,7 +90,7 @@ The CLI reads the active profile for connection info and datasource. Use `wren p
 
 For memory-specific decisions, see [references/memory.md](references/memory.md).
 For SQL syntax, CTE-based modeling, and error diagnosis, see [references/wren-sql.md](references/wren-sql.md).
-For project structure, MDL field definitions, and CLI workflow details, see the [documentation](https://github.com/Canner/wren-engine/tree/main/docs).
+For project structure, MDL field definitions, and CLI workflow details, see the [documentation](https://github.com/Canner/WrenAI/tree/main/docs/core).
 
 ---
 


### PR DESCRIPTION
## Summary

Cleans up two classes of stale references that survived the post-rebrand docs/repo reorg:

- **`Canner/wren-engine` → `Canner/WrenAI`** — top-level `skills/index.json` repository field + four per-skill `repository` fields, the Claude plugin manifest, the `raw.githubusercontent.com` Version-check URL in three SKILL.md files, the `npx skills add` command shown to users in those same three skills, the docs tree link in `wren-usage`, and the GitHub issues URL in the `wren-onboarding` error fallback.
- **Docs path fixes**:
  - `docs/get_started/{installation,quickstart}.md` → `docs/core/get_started/{installation,quickstart}.md`
  - `docs/get_started/connect.md` → `docs/core/guides/connect.md` (connect.md was relocated to `guides/`, not `get_started/`)
  - `wren-usage` doc tree link now points at `WrenAI/tree/main/docs/core`
  - `wren-onboarding` error-fallback hint now links to `docs.getwren.ai/oss/introduction` (the old `oss/engine` URL pattern no longer exists)
  - `index.json` wren-onboarding description text corrected to match the new connect.md path

After this PR, a repo-wide grep for `Canner/wren-engine`, `docs/get_started/`, and `docs/core/get_started/connect.md` inside `skills/` returns zero hits.

## Out of scope (kept for a separate decision)

- **Broken section anchors** in connect.md links (e.g. `#troubleshooting`, `#per-datasource-setup-notes`) — the new `docs/core/guides/connect.md` is slimmer and these anchors no longer exist; URLs degrade to page top. Treat as a content question rather than a URL fix.
- **wren-onboarding install flow gap** — separate `wren --version` "not installed" branch and the `pip install` step buried inside Step 2's batch can let agents skip installation; deferred to its own change.

## Test plan

- [ ] `grep -rnE 'Canner/wren-engine|docs/get_started/|docs\.getwren\.ai/oss/engine' skills/` returns no hits.
- [ ] Each updated URL resolves to a real page (installation.md, quickstart.md, connect.md, docs tree, intro page, issues page).
- [ ] `skills/index.json` still parses as valid JSON and `npx skills add Canner/WrenAI --skill wren-onboarding` runs against the renamed repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references and documentation links across skill configurations and documentation files to reflect organizational changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->