### PR TITLE
Fix vision paper link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Fast at first. Deep when you need it. Always reviewable and Git-friendly.
 - **Full governed execution** — audit logs, rate limits, approval workflow, data-flow inspector
 
 <!-- TODO: vision_paper_en.md is currently at .tmp/roadmap-discuss/vision_paper_en.md — move to a published path (e.g. docs/vision-paper.md or repo root) and update this link before publishing. -->
-Full roadmap and design notes: see the [vision paper](./vision_paper_en.md).
+Full roadmap and design notes: see the [vision paper](https://docs.getwren.ai/oss/introduction).
 
 ## Documentation
 


### PR DESCRIPTION
Updated the link to the vision paper in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the vision paper reference in README to point to the published documentation URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->