### PR TITLE
docs(wren): rebrand README to Wren AI and expand rename migration note

### DIFF
--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -6,7 +6,7 @@
 
 Wren AI CLI and Python SDK — semantic SQL layer for 20+ data sources.
 
-Translate natural SQL queries through an [MDL (Modeling Definition Language)](https://docs.getwren.ai/) semantic layer and execute them against your database. Powered by [Apache DataFusion](https://datafusion.apache.org/) and [Ibis](https://ibis-project.org/).
+Translate natural SQL queries through an [MDL (Modeling Definition Language)](https://docs.getwren.ai/) semantic layer and execute them against your database. Powered by [Apache DataFusion](https://datafusion.apache.org/).
 
 ## Installation
 

--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/wrenai.svg)](https://pypi.org/project/wrenai/)
 [![License](https://img.shields.io/pypi/l/wrenai.svg)](https://github.com/Canner/WrenAI/blob/main/LICENSE)
 
-Wren Engine CLI and Python SDK — semantic SQL layer for 20+ data sources.
+Wren AI CLI and Python SDK — semantic SQL layer for 20+ data sources.
 
 Translate natural SQL queries through an [MDL (Modeling Definition Language)](https://docs.getwren.ai/) semantic layer and execute them against your database. Powered by [Apache DataFusion](https://datafusion.apache.org/) and [Ibis](https://ibis-project.org/).
 
@@ -225,21 +225,33 @@ uv run pytest tests/test_profile_web.py -v
 
 ## Package rename: `wren-engine` → `wrenai`
 
-Starting with the 0.7.0 release, this package is published on PyPI as
-[`wrenai`](https://pypi.org/project/wrenai/). The legacy
-[`wren-engine`](https://pypi.org/project/wren-engine/) project on PyPI is
-frozen at 0.6.x and no longer receives updates.
+Starting with the 0.7.0 release, this PyPI distribution is renamed from
+[`wren-engine`](https://pypi.org/project/wren-engine/) to
+[`wrenai`](https://pypi.org/project/wrenai/) to align with the **Wren AI**
+brand. The legacy `wren-engine` project on PyPI is frozen at 0.6.x and
+will not receive further updates.
 
-Nothing about the Python API or the CLI changes — `import wren`, the
-`wren` command, and every subcommand stay the same. Only the
-distribution name on PyPI is different.
+### What stays the same
 
-To migrate:
+- The Python import path: `import wren` (and submodules under `wren.*`)
+- The `wren` CLI entrypoint and every subcommand (`wren query`,
+  `wren context`, `wren profile`, `wren memory`, …)
+- All extras (`postgres`, `mysql`, `bigquery`, …, `memory`, `ui`, `main`,
+  `all`)
+- Configuration files under `~/.wren/` (profiles, memory, config)
+
+Only the name you type after `pip install` is different.
+
+### Migration
 
 ```bash
 pip uninstall wren-engine
-pip install wrenai            # or: pip install "wrenai[<extras>]"
+pip install wrenai                  # or: pip install "wrenai[<extras>]"
+wren --version                      # should print: wrenai X.Y.Z
 ```
+
+If your project pinned `wren-engine` in a `requirements.txt`,
+`pyproject.toml`, or lockfile, replace it with `wrenai` and re-lock.
 
 ## License
 


### PR DESCRIPTION
## Summary

Follow-up to #2315 (PyPI rename `wren-engine` → `wrenai`). Polishes `core/wren/README.md`:

- **Rebrand tagline**: \"Wren Engine CLI and Python SDK\" → \"Wren AI CLI and Python SDK\" to align with the unified **Wren AI** brand
- **Expand the rename migration section** that was added in #2315:
  - Lead with the **why** (brand alignment)
  - Add a \"What stays the same\" list (import path, CLI, extras, `~/.wren/` config) so users can scan and confirm their code doesn't need touching
  - Migration block now includes a `wren --version` sanity check + a note for projects pinning `wren-engine` in lockfiles or `requirements.txt`

PyPI distribution names (`wren-engine` / `wrenai`) are kept verbatim wherever they appear in install / uninstall commands — the rebrand only swaps the human-readable brand name.

## Test plan

- [ ] Render the README on GitHub and visually check the new section
- [ ] Confirm no other `Wren Engine` brand references remain in `core/wren/README.md` (only PyPI distribution name `wren-engine` should remain, in migration commands)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated branding to "Wren AI CLI" and adjusted the "Powered by" attribution to reference Apache DataFusion.
  * Clarified package rename to "wrenai" starting with 0.7.0 and noted legacy project freeze at 0.6.x.
  * Expanded migration guidance (check CLI version and re-lock any pinned dependencies) and listed what remains unchanged during the transition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->