### PR TITLE
docs(skills): quote pip install wrenai[…] consistently

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -90,7 +90,7 @@ Run `bash skills/check-versions.sh` to verify parity before merging.
 
 ## Requirements
 
-- `wren` CLI installed (`pip install wrenai` or `pip install wrenai[<datasource>]`)
+- `wren` CLI installed (`pip install "wrenai"` or `pip install "wrenai[<datasource>]"`)
 - A database connection (configured via `wren profile add` or `~/.wren/connection_info.json`)
 - An AI client that supports skills (Claude Code, Cline, Cursor, etc.)
 

--- a/skills/wren-generate-mdl/SKILL.md
+++ b/skills/wren-generate-mdl/SKILL.md
@@ -37,7 +37,7 @@ For memory and query workflows after setup, see the **wren-usage** skill.
 
 ## Prerequisites
 
-- `wren` CLI installed (`pip install wrenai[<datasource>]`)
+- `wren` CLI installed (`pip install "wrenai[<datasource>]"`)
 - A working database connection (credentials available to the agent)
 - A wren profile configured (`wren profile add`) or connection info ready
 


### PR DESCRIPTION
## Summary

Two leftover skill files used unquoted `pip install wrenai[<extra>]` inside backticks. On zsh (the default macOS shell) the unquoted `[…]` is parsed as a glob pattern and the command fails with `zsh: no matches found`. Every other skill wraps the spec in double quotes; this PR brings the stragglers in line.

| File | Change |
|------|--------|
| `skills/README.md` | `pip install wrenai` / `pip install wrenai[<datasource>]` → quoted |
| `skills/wren-generate-mdl/SKILL.md` | `pip install wrenai[<datasource>]` → quoted |

This is the follow-up to #2317 — same theme, two stragglers that didn't get touched there.

## Test plan

- [ ] `grep -rnE 'pip install [^"]?wrenai\[' skills/` returns no hits.
- [ ] On a fresh zsh shell, `pip install "wrenai[memory]"` runs without `zsh: no matches found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated pip installation instructions to ensure proper command formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->