### PR TITLE
chore(wren): rebrand PyPI description to Wren AI

### DIFF
--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "wrenai"
 version = "0.7.0"
-description = "Wren Engine CLI and Python SDK — semantic SQL layer for 20+ data sources"
+description = "Wren AI CLI and Python SDK — semantic SQL layer for 20+ data sources"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- Update `core/wren/pyproject.toml` description from "Wren Engine CLI and Python SDK …" to "Wren AI CLI and Python SDK …" so the PyPI project page matches the Wren AI rebrand.

## Test plan
- [ ] Confirm description renders correctly on PyPI after next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package description from "Wren Engine" to "Wren AI"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->