### PR TITLE
feat(wren): build MDL manifests from OSI semantic models

### DIFF
--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -1057,8 +1057,13 @@ def _show_from_osi(
     if output == "json":
         from wren.context import _convert_keys  # noqa: PLC0415
 
+        # Mirror build_json_from_osi: shield `_instructions` from the
+        # snake→camel pass so downstream tooling sees the exact key.
+        instructions = manifest.pop("_instructions", None)
         manifest_json = _convert_keys(manifest)
         manifest_json["layoutVersion"] = 2
+        if instructions:
+            manifest_json["_instructions"] = instructions
         typer.echo(json.dumps(manifest_json, indent=2, ensure_ascii=False))
         return
     if output == "yaml":

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -65,6 +65,20 @@ def init(
         Optional[str],
         typer.Option("--from-mdl", help="Import from MDL JSON file (camelCase)."),
     ] = None,
+    from_osi: Annotated[
+        Optional[str],
+        typer.Option(
+            "--from-osi",
+            help=(
+                "Migrate from an Open Semantic Interchange (OSI) YAML file. "
+                "One-way conversion: produces a native wren project; the "
+                "OSI file is no longer referenced afterwards. Requires "
+                "--data-source."
+            ),
+        ),
+    ] = None,
+    data_source: DataSourceOpt = None,
+    semantic_model: SemanticModelOpt = None,
     force: Annotated[
         bool,
         typer.Option("--force", help="Overwrite existing project files."),
@@ -83,12 +97,34 @@ def init(
 ) -> None:
     """Initialize a new Wren project.
 
-    Without --from-mdl: scaffolds the project.  Pass ``--empty`` to leave
-    ``models/`` and ``views/`` untouched (no placeholder example).
-    With --from-mdl: imports an existing MDL JSON and produces a complete
-    YAML project, ready for `wren context validate/build`.
+    Without --from-mdl / --from-osi: scaffolds the project. Pass ``--empty``
+    to leave ``models/`` and ``views/`` untouched (no placeholder example).
+
+    With --from-mdl: imports an existing MDL JSON.
+
+    With --from-osi: migrates from an OSI semantic_model file. Use this when
+    you want to leave the OSI flow and own the YAML going forward; for
+    keeping OSI as the source of truth, use ``wren context build --from-osi``
+    instead.
     """
+    if from_mdl and from_osi:
+        typer.echo(
+            "Error: --from-mdl and --from-osi are mutually exclusive.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     project_path = Path(path).expanduser() if path else Path.cwd()
+
+    if from_osi:
+        _init_from_osi(
+            from_osi=from_osi,
+            data_source=data_source,
+            semantic_model=semantic_model,
+            project_path=project_path,
+            force=force,
+        )
+        return
 
     if from_mdl:
         # ── Import from MDL JSON ──────────────────────────────
@@ -843,6 +879,71 @@ def _require_data_source(data_source: Optional[str]) -> str:
         )
         raise typer.Exit(1)
     return data_source
+
+
+def _init_from_osi(
+    *,
+    from_osi: str,
+    data_source: Optional[str],
+    semantic_model: Optional[str],
+    project_path: Path,
+    force: bool,
+) -> None:
+    """Migrate an OSI file to a native wren project (one-way).
+
+    Reuses ``build_json_from_osi`` to produce the MDL, then
+    ``convert_mdl_to_project`` + ``write_project_files`` to scaffold the
+    full wren YAML layout. The OSI file is read once and never referenced
+    again after this command — the wren project becomes the source of truth.
+    """
+    from wren.context import (  # noqa: PLC0415
+        convert_mdl_to_project,
+        write_project_files,
+    )
+    from wren.osi import build_json_from_osi  # noqa: PLC0415
+
+    osi_path = _resolve_osi_path(from_osi)
+    ds = _require_data_source(data_source)
+
+    mdl_json, errors = build_json_from_osi(
+        osi_path,
+        data_source=ds,
+        semantic_model=semantic_model,
+    )
+
+    hard_errors = [e for e in errors if e.level == "error"]
+    if hard_errors:
+        for e in hard_errors:
+            typer.echo(str(e), err=True)
+        typer.echo("\nMigration aborted due to OSI errors.", err=True)
+        raise typer.Exit(1)
+
+    warnings = [str(e) for e in errors if e.level == "warning"]
+
+    files = convert_mdl_to_project(mdl_json)
+    try:
+        write_project_files(files, project_path, force=force)
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    model_count = len(mdl_json.get("models", []))
+    rel_count = len(mdl_json.get("relationships", []))
+
+    typer.echo(f"Migrated OSI → wren project at {project_path}/")
+    typer.echo(f"  {model_count} models, {rel_count} relationships")
+
+    if warnings:
+        typer.echo("")
+        _print_warnings(warnings, verbose=False)
+        typer.echo(
+            "  Review the generated YAML — items above were defaulted "
+            "or omitted and may need manual fixes."
+        )
+
+    typer.echo("\nNext steps:")
+    typer.echo(f"  wren context validate --path {project_path}")
+    typer.echo(f"  wren context build --path {project_path}")
 
 
 def _build_from_osi(

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -23,6 +23,40 @@ ProjectPathOpt = Annotated[
     ),
 ]
 
+FromOsiOpt = Annotated[
+    Optional[str],
+    typer.Option(
+        "--from-osi",
+        help=(
+            "Use an Open Semantic Interchange (OSI) YAML file as the source "
+            "of truth instead of a wren YAML project. The OSI file is read "
+            "as-is; --data-source must be supplied separately."
+        ),
+    ),
+]
+
+DataSourceOpt = Annotated[
+    Optional[str],
+    typer.Option(
+        "--data-source",
+        help=(
+            "Target data source (postgres, snowflake, bigquery, ...). "
+            "Required when --from-osi is used."
+        ),
+    ),
+]
+
+SemanticModelOpt = Annotated[
+    Optional[str],
+    typer.Option(
+        "--semantic-model",
+        help=(
+            "Name of the semantic_model to convert when --from-osi is used "
+            "and the OSI file contains more than one."
+        ),
+    ),
+]
+
 
 @context_app.command()
 def init(
@@ -234,6 +268,9 @@ _WARNING_SUMMARY_THRESHOLD = 10
 @context_app.command()
 def validate(
     path: ProjectPathOpt = None,
+    from_osi: FromOsiOpt = None,
+    data_source: DataSourceOpt = None,
+    semantic_model: SemanticModelOpt = None,
     strict: Annotated[
         bool,
         typer.Option("--strict", help="Treat warnings as errors."),
@@ -257,7 +294,20 @@ def validate(
         ),
     ] = False,
 ) -> None:
-    """Validate MDL project: YAML structure + view SQL dry-plan + description checks."""
+    """Validate MDL project: YAML structure + view SQL dry-plan + description checks.
+
+    With --from-osi: lint the OSI file's conversion path. Requires --data-source.
+    """
+    if from_osi:
+        _validate_from_osi(
+            from_osi=from_osi,
+            data_source=data_source,
+            semantic_model=semantic_model,
+            strict=strict,
+            verbose=verbose,
+        )
+        return
+
     import base64 as _b64  # noqa: PLC0415
 
     from wren.context import (  # noqa: PLC0415
@@ -405,6 +455,9 @@ def _print_warnings(warnings: list[str], *, verbose: bool) -> None:
 @context_app.command()
 def build(
     path: ProjectPathOpt = None,
+    from_osi: FromOsiOpt = None,
+    data_source: DataSourceOpt = None,
+    semantic_model: SemanticModelOpt = None,
     output: Annotated[
         Optional[str],
         typer.Option(
@@ -418,12 +471,25 @@ def build(
         ),
     ] = True,
 ) -> None:
-    """Build YAML project into target/mdl.json for the engine.
+    """Build into target/mdl.json for the engine.
 
-    Reads wren_project.yml, models/*/metadata.yml (+ref_sql.sql),
+    Default mode: reads wren_project.yml, models/*/metadata.yml (+ref_sql.sql),
     views/*/metadata.yml (+sql.yml), relationships.yml, and instructions.md.
-    Converts snake_case YAML keys to camelCase JSON and writes target/mdl.json.
+
+    With --from-osi: reads an Open Semantic Interchange YAML file and emits
+    MDL JSON directly. The OSI file stays as the single source of truth; no
+    intermediate wren project is created. Requires --data-source.
     """
+    if from_osi:
+        _build_from_osi(
+            from_osi=from_osi,
+            data_source=data_source,
+            semantic_model=semantic_model,
+            output=output,
+            validate_first=validate_first,
+        )
+        return
+
     from wren.context import (  # noqa: PLC0415
         build_json,
         discover_project_path,
@@ -473,12 +539,27 @@ def build(
 @context_app.command()
 def show(
     path: ProjectPathOpt = None,
+    from_osi: FromOsiOpt = None,
+    data_source: DataSourceOpt = None,
+    semantic_model: SemanticModelOpt = None,
     output: Annotated[
         str,
         typer.Option("--output", "-o", help="Output format: json|yaml|summary"),
     ] = "summary",
 ) -> None:
-    """Show the current project context (models, views, relationships)."""
+    """Show the current project context (models, views, relationships).
+
+    With --from-osi: show what the OSI file would produce. Requires --data-source.
+    """
+    if from_osi:
+        _show_from_osi(
+            from_osi=from_osi,
+            data_source=data_source,
+            semantic_model=semantic_model,
+            output=output,
+        )
+        return
+
     import yaml as _yaml  # noqa: PLC0415
 
     from wren.context import (  # noqa: PLC0415
@@ -740,3 +821,166 @@ def upgrade(
         )
 
     typer.echo("\nUpgrade complete. Run `wren context validate` to check the result.")
+
+
+# ── OSI source helpers ────────────────────────────────────────────────────
+
+
+def _resolve_osi_path(from_osi: str) -> Path:
+    p = Path(from_osi).expanduser()
+    if not p.exists():
+        typer.echo(f"Error: OSI file not found: {p}", err=True)
+        raise typer.Exit(1)
+    return p
+
+
+def _require_data_source(data_source: Optional[str]) -> str:
+    if not data_source:
+        typer.echo(
+            "Error: --data-source is required when using --from-osi.\n"
+            "  Pass one of: postgres, snowflake, bigquery, mysql, duckdb, ...",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return data_source
+
+
+def _build_from_osi(
+    *,
+    from_osi: str,
+    data_source: Optional[str],
+    semantic_model: Optional[str],
+    output: Optional[str],
+    validate_first: bool,
+) -> None:
+    """Build target/mdl.json directly from an OSI file."""
+    from wren.osi import build_json_from_osi  # noqa: PLC0415
+
+    osi_path = _resolve_osi_path(from_osi)
+    ds = _require_data_source(data_source)
+
+    manifest_json, errors = build_json_from_osi(
+        osi_path,
+        data_source=ds,
+        semantic_model=semantic_model,
+    )
+
+    hard_errors = [e for e in errors if e.level == "error"]
+    if hard_errors:
+        for e in hard_errors:
+            typer.echo(str(e), err=True)
+        typer.echo("\nBuild aborted due to OSI errors.", err=True)
+        raise typer.Exit(1)
+
+    warnings = [str(e) for e in errors if e.level == "warning"]
+    if validate_first and warnings:
+        _print_warnings(warnings, verbose=False)
+
+    # No project dir to anchor on — default to cwd/target/mdl.json.
+    if output:
+        out_path = Path(output).expanduser()
+    else:
+        out_path = Path.cwd() / "target" / "mdl.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(manifest_json, indent=2, ensure_ascii=False))
+
+    n_models = len(manifest_json.get("models", []))
+    n_rels = len(manifest_json.get("relationships", []))
+    typer.echo(
+        f"Built from OSI: {n_models} models, {n_rels} relationships → {out_path}"
+    )
+
+
+def _validate_from_osi(
+    *,
+    from_osi: str,
+    data_source: Optional[str],
+    semantic_model: Optional[str],
+    strict: bool,
+    verbose: bool,
+) -> None:
+    """Lint an OSI file against the WREN conversion rules."""
+    from wren.osi import lint_osi_file  # noqa: PLC0415
+
+    osi_path = _resolve_osi_path(from_osi)
+    ds = _require_data_source(data_source)
+
+    errors = lint_osi_file(
+        osi_path,
+        data_source=ds,
+        semantic_model=semantic_model,
+    )
+    hard = [e for e in errors if e.level == "error"]
+    warns = [str(e) for e in errors if e.level == "warning"]
+
+    if hard:
+        typer.echo("OSI errors:")
+        for e in hard:
+            typer.echo(f"  ✗ {e}", err=True)
+
+    _print_warnings(warns, verbose=verbose)
+
+    if hard or (strict and warns):
+        raise typer.Exit(1)
+
+    if not errors:
+        typer.echo(f"Valid — {osi_path.name} converts cleanly.")
+
+
+def _show_from_osi(
+    *,
+    from_osi: str,
+    data_source: Optional[str],
+    semantic_model: Optional[str],
+    output: str,
+) -> None:
+    """Print the manifest the OSI file would produce."""
+    import yaml as _yaml  # noqa: PLC0415
+
+    from wren.osi import build_manifest_from_osi  # noqa: PLC0415
+
+    osi_path = _resolve_osi_path(from_osi)
+    ds = _require_data_source(data_source)
+
+    manifest, errors = build_manifest_from_osi(
+        osi_path,
+        data_source=ds,
+        semantic_model=semantic_model,
+    )
+    hard = [e for e in errors if e.level == "error"]
+    if hard:
+        for e in hard:
+            typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    if output == "json":
+        from wren.context import _convert_keys  # noqa: PLC0415
+
+        manifest_json = _convert_keys(manifest)
+        manifest_json["layoutVersion"] = 2
+        typer.echo(json.dumps(manifest_json, indent=2, ensure_ascii=False))
+        return
+    if output == "yaml":
+        typer.echo(_yaml.dump(manifest, default_flow_style=False, sort_keys=False))
+        return
+
+    # Summary
+    models = manifest.get("models", [])
+    rels = manifest.get("relationships", [])
+    typer.echo(f"OSI file: {osi_path}")
+    typer.echo(f"Data source: {ds}")
+    typer.echo(f"Catalog/schema: {manifest.get('catalog')}/{manifest.get('schema')}\n")
+    if models:
+        typer.echo(f"Models ({len(models)}):")
+        for m in models:
+            n_cols = len(m.get("columns", []))
+            pk = m.get("primary_key", "—")
+            source = "ref_sql" if m.get("ref_sql") else "table"
+            typer.echo(f"  {m['name']}  ({source}, {n_cols} columns, pk={pk})")
+    if rels:
+        typer.echo(f"\nRelationships ({len(rels)}):")
+        for r in rels:
+            models_str = " ↔ ".join(r.get("models", []))
+            typer.echo(f"  {r.get('name', '?')}  ({models_str}, MANY_TO_ONE)")
+    if manifest.get("_instructions"):
+        typer.echo("\nInstructions: present (from OSI ai_context + metrics)")

--- a/core/wren/src/wren/osi.py
+++ b/core/wren/src/wren/osi.py
@@ -760,6 +760,13 @@ def build_manifest_from_osi(
         "views": [],
         "cubes": [],
     }
+    # Carry the OSI semantic_model name through so downstream consumers
+    # (notably context.convert_mdl_to_project for `init --from-osi`) can
+    # stamp it into wren_project.yml. The wren engine ignores extra
+    # top-level fields, so the build-path output is unaffected.
+    sm_name = sm.get("name")
+    if isinstance(sm_name, str) and sm_name:
+        manifest["name"] = sm_name
     if instructions:
         manifest["_instructions"] = instructions
     return (manifest, errors)

--- a/core/wren/src/wren/osi.py
+++ b/core/wren/src/wren/osi.py
@@ -1,0 +1,804 @@
+"""Convert OSI (Open Semantic Interchange) semantic models to Wren MDL.
+
+OSI is a vendor-agnostic semantic model spec
+(https://github.com/open-semantic-interchange/OSI). This module reads an OSI
+YAML (or JSON) file and produces a Wren MDL manifest dict, suitable for
+``wren context build`` to write as ``target/mdl.json``.
+
+The OSI file itself is the single source of truth — we never copy it into a
+parallel wren project. Wren-specific build hints (column types, dialect
+preference, metrics handling) live inside the OSI file via the spec's
+``custom_extensions: [{vendor_name: WREN, data: '<json>'}]`` mechanism, which
+is OSI's only sanctioned vendor escape hatch.
+
+Resolution order for any setting (highest first):
+  1. CLI flag / explicit kwarg
+  2. ``custom_extensions[vendor_name=WREN]`` on the chosen semantic_model
+  3. ``custom_extensions[vendor_name=WREN]`` at the OSI document root
+  4. ``custom_extensions[vendor_name=WREN]`` on the dataset / field
+     (column-level overrides only — these aren't merged with the global config)
+  5. Built-in defaults
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from wren.context import ValidationError, _convert_keys
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+WREN_VENDOR_NAME = "WREN"
+DEFAULT_DIALECT = "ANSI_SQL"
+DEFAULT_METRICS_MODE = "note"
+VALID_METRICS_MODES = frozenset({"skip", "note"})
+
+# Wren data_source → OSI dialect identifier (used when the user hasn't set
+# `dialect` in the WREN block). Anything not listed here falls back to
+# ANSI_SQL, which the OSI spec mandates as the universal baseline.
+_DATA_SOURCE_TO_DIALECT = {
+    "snowflake": "SNOWFLAKE",
+    "databricks": "DATABRICKS",
+}
+
+
+# ── Public types ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class WrenConfig:
+    """Merged WREN extension config (root + semantic_model + CLI overrides).
+
+    Per-dataset / per-field overrides are NOT stored here — they are read
+    directly from the dataset's / field's own ``custom_extensions`` block at
+    conversion time. This keeps the shallow-merge model simple: nested
+    structures like ``column_types`` would otherwise clobber each other.
+    """
+
+    dialect: str = DEFAULT_DIALECT
+    metrics_mode: str = DEFAULT_METRICS_MODE
+    default_semantic_model: str | None = None
+    # column_types is the semantic-model-level fallback:
+    #   {dataset_name: {field_name: type}}
+    # Per-dataset overrides live in the dataset's own WREN block as
+    #   {column_types: {field_name: type}}  (no dataset_name wrap)
+    column_types: dict[str, dict[str, str]] = field(default_factory=dict)
+    # primary_key picks for composite-PK datasets:
+    #   {dataset_name: column_name}
+    primary_key_pick: dict[str, str] = field(default_factory=dict)
+
+
+# ── Parsing ────────────────────────────────────────────────────────────────
+
+
+def parse_osi(text: str, *, suffix: str = ".yaml") -> dict:
+    """Parse OSI text. JSON if suffix is .json, else YAML."""
+    if suffix.lower() == ".json":
+        return json.loads(text)
+    parsed = yaml.safe_load(text)
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def load_osi_file(path: Path) -> dict:
+    return parse_osi(path.read_text(), suffix=path.suffix)
+
+
+def _extract_wren_block(custom_extensions: Any) -> dict:
+    """Return the parsed `data` from the (last) vendor_name=WREN entry.
+
+    `data` per spec is a JSON string. We also tolerate a raw dict for
+    robustness against authors who hand-write the YAML and forget the quoting.
+    """
+    if not isinstance(custom_extensions, list):
+        return {}
+    found: dict = {}
+    for entry in custom_extensions:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("vendor_name") != WREN_VENDOR_NAME:
+            continue
+        data = entry.get("data")
+        if isinstance(data, str):
+            try:
+                parsed = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                found = parsed
+        elif isinstance(data, dict):
+            found = data
+    return found
+
+
+def select_semantic_model(
+    osi: dict, name: str | None = None
+) -> tuple[dict, list[ValidationError]]:
+    """Pick one semantic_model from the OSI document.
+
+    Resolution:
+      - Explicit ``name`` wins.
+      - Otherwise, root-level WREN.default_semantic_model.
+      - Otherwise, the only semantic_model present.
+      - More than one and nothing pinned: error with snippet.
+    """
+    models = osi.get("semantic_model") or []
+    errors: list[ValidationError] = []
+    if not isinstance(models, list) or not models:
+        errors.append(
+            ValidationError("error", "<osi>", "OSI file has no semantic_model entries")
+        )
+        return ({}, errors)
+
+    if name:
+        for sm in models:
+            if isinstance(sm, dict) and sm.get("name") == name:
+                return (sm, errors)
+        names = [sm.get("name", "?") for sm in models if isinstance(sm, dict)]
+        errors.append(
+            ValidationError(
+                "error",
+                "<osi>",
+                f"--semantic-model {name!r} not found. Available: {', '.join(names)}",
+            )
+        )
+        return ({}, errors)
+
+    if len(models) == 1:
+        sm = models[0]
+        return (sm if isinstance(sm, dict) else {}, errors)
+
+    # Fall back to root-level WREN.default_semantic_model
+    root_cfg = _extract_wren_block(osi.get("custom_extensions"))
+    default = root_cfg.get("default_semantic_model")
+    if isinstance(default, str):
+        for sm in models:
+            if isinstance(sm, dict) and sm.get("name") == default:
+                return (sm, errors)
+
+    names = [sm.get("name", "?") for sm in models if isinstance(sm, dict)]
+    snippet = (
+        "    custom_extensions:\n"
+        "      - vendor_name: WREN\n"
+        '        data: \'{"default_semantic_model": "<name>"}\''
+    )
+    errors.append(
+        ValidationError(
+            "error",
+            "<osi>",
+            f"OSI file has {len(models)} semantic_models: {', '.join(names)}.\n"
+            f"  Pass --semantic-model <name> or add at the OSI document root:\n\n"
+            f"{snippet}",
+        )
+    )
+    return ({}, errors)
+
+
+# ── Config extraction ──────────────────────────────────────────────────────
+
+
+def extract_wren_config(
+    osi: dict, sm: dict, cli_overrides: dict | None = None
+) -> tuple[WrenConfig, list[ValidationError]]:
+    """Merge WREN custom_extensions from root + semantic_model + CLI overrides.
+
+    Shallow merge: a scalar key in the SM block replaces the same key from
+    root. `column_types` and `primary_key` (when dict-shaped at SM level) are
+    also overwritten as whole blocks — author them at one level only.
+    """
+    root = _extract_wren_block(osi.get("custom_extensions"))
+    sm_local = _extract_wren_block(sm.get("custom_extensions"))
+    overrides = cli_overrides or {}
+    merged: dict = {**root, **sm_local, **overrides}
+    errors: list[ValidationError] = []
+
+    metrics_mode = merged.get("metrics", DEFAULT_METRICS_MODE)
+    if metrics_mode not in VALID_METRICS_MODES:
+        errors.append(
+            ValidationError(
+                "warning",
+                "<osi:WREN>",
+                f"metrics: {metrics_mode!r} is not one of "
+                f"{sorted(VALID_METRICS_MODES)} — using default 'note'",
+            )
+        )
+        metrics_mode = DEFAULT_METRICS_MODE
+
+    column_types_raw = merged.get("column_types") or {}
+    # Sanity: must be {str: {str: str}} at this level.
+    column_types: dict[str, dict[str, str]] = {}
+    if isinstance(column_types_raw, dict):
+        for ds_name, mapping in column_types_raw.items():
+            if isinstance(mapping, dict):
+                column_types[ds_name] = {str(k): str(v) for k, v in mapping.items()}
+
+    primary_key_raw = merged.get("primary_key")
+    primary_key_pick: dict[str, str] = {}
+    if isinstance(primary_key_raw, dict):
+        primary_key_pick = {str(k): str(v) for k, v in primary_key_raw.items()}
+
+    cfg = WrenConfig(
+        dialect=str(merged.get("dialect") or DEFAULT_DIALECT),
+        metrics_mode=metrics_mode,
+        default_semantic_model=merged.get("default_semantic_model"),
+        column_types=column_types,
+        primary_key_pick=primary_key_pick,
+    )
+    return cfg, errors
+
+
+# ── Conversion helpers ─────────────────────────────────────────────────────
+
+
+_SQL_KEYWORDS_HINTING_QUERY = re.compile(
+    r"\b(SELECT|FROM|WHERE|JOIN|GROUP\s+BY)\b", re.IGNORECASE
+)
+_DATASET_REF_PATTERN = re.compile(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\.[a-zA-Z_]")
+
+
+def _parse_source(source: Any) -> tuple[dict | None, str | None]:
+    """Parse OSI ``dataset.source`` into either table_reference or ref_sql.
+
+    Returns (table_reference_dict, ref_sql_string). At most one is non-None.
+    Returns (None, None) if the source is missing or unparseable.
+    """
+    if not isinstance(source, str) or not source.strip():
+        return (None, None)
+    src = source.strip()
+    if _SQL_KEYWORDS_HINTING_QUERY.search(src) or "\n" in src:
+        return (None, src)
+
+    parts = src.split(".")
+    if len(parts) == 3:
+        return (
+            {"catalog": parts[0], "schema": parts[1], "table": parts[2]},
+            None,
+        )
+    if len(parts) == 2:
+        return ({"catalog": "", "schema": parts[0], "table": parts[1]}, None)
+    if len(parts) == 1:
+        return ({"catalog": "", "schema": "", "table": parts[0]}, None)
+    # 4+ dotted parts — treat as ref_sql to avoid silent loss of structure.
+    return (None, src)
+
+
+def _pick_expression(expr_field: Any, dialect_preference: str) -> str:
+    """Extract a SQL expression from OSI's expression block.
+
+    Order: preferred dialect → ANSI_SQL fallback → first available.
+    OSI also permits a bare string for the expression (shorthand) — we honor
+    that too.
+    """
+    if isinstance(expr_field, str):
+        return expr_field
+    if not isinstance(expr_field, dict):
+        return ""
+    dialects = expr_field.get("dialects")
+    if not isinstance(dialects, list) or not dialects:
+        return ""
+    by_dialect: dict[str, str] = {}
+    for d in dialects:
+        if isinstance(d, dict):
+            key = d.get("dialect")
+            val = d.get("expression", "")
+            if isinstance(key, str):
+                by_dialect[key] = val if isinstance(val, str) else ""
+    if dialect_preference in by_dialect:
+        return by_dialect[dialect_preference]
+    if "ANSI_SQL" in by_dialect:
+        return by_dialect["ANSI_SQL"]
+    first = dialects[0]
+    if isinstance(first, dict):
+        val = first.get("expression", "")
+        return val if isinstance(val, str) else ""
+    return ""
+
+
+def _is_calculated_expression(expr: str, field_name: str) -> bool:
+    """True when the expression is anything other than the column's own name.
+
+    Bare aliases (``Amount`` for field ``amount``, or ``src_col`` for field
+    ``renamed``) are 'calculated' from wren's perspective — the source column
+    name differs from the field name, so the engine must carry an expression
+    instead of resolving by identity. Only an exact-match identity is treated
+    as non-calculated.
+    """
+    if not expr:
+        return False
+    return expr.strip() != field_name
+
+
+def _infer_type(field_obj: dict, override: str | None) -> str:
+    if override:
+        return override
+    dim = field_obj.get("dimension")
+    if isinstance(dim, dict) and dim.get("is_time"):
+        return "TIMESTAMP"
+    return "VARCHAR"
+
+
+def _join_description(*parts: str | None) -> str | None:
+    chunks = [p for p in parts if p]
+    return "\n\n".join(chunks) if chunks else None
+
+
+def _osi_description(obj: dict) -> str | None:
+    """Render OSI description + ai_context into one description string."""
+    parts: list[str] = []
+    if d := obj.get("description"):
+        if isinstance(d, str):
+            parts.append(d)
+    ai = obj.get("ai_context")
+    if isinstance(ai, str):
+        parts.append(ai)
+    elif isinstance(ai, dict):
+        instr = ai.get("instructions")
+        if isinstance(instr, str):
+            parts.append(instr)
+        syn = ai.get("synonyms")
+        if isinstance(syn, list) and syn:
+            parts.append("Synonyms: " + ", ".join(str(s) for s in syn))
+    return "\n\n".join(parts) if parts else None
+
+
+# ── Field / dataset / relationship / metric converters ────────────────────
+
+
+def _convert_field(
+    field_obj: dict,
+    *,
+    dialect: str,
+    type_override: str | None,
+    primary_key_name: str | None,
+) -> dict:
+    name = field_obj["name"]
+    expr = _pick_expression(field_obj.get("expression"), dialect)
+    is_calc = _is_calculated_expression(expr, name)
+    col_type = _infer_type(field_obj, type_override)
+
+    column: dict = {
+        "name": name,
+        "type": col_type,
+        "is_calculated": is_calc,
+        "not_null": False,
+        "properties": {},
+    }
+    if is_calc:
+        column["expression"] = expr
+    if primary_key_name == name:
+        column["is_primary_key"] = True
+        column["not_null"] = True
+    if desc := _osi_description(field_obj):
+        column["properties"]["description"] = desc
+    return column
+
+
+def _format_column_types_snippet(dataset_name: str, field_names: list[str]) -> str:
+    """Produce a copy-pasteable column_types snippet for one dataset."""
+    pairs = ",\n              ".join(f'"{fn}": "VARCHAR"' for fn in field_names)
+    return (
+        f"  Add to dataset '{dataset_name}' in the OSI file:\n\n"
+        "    custom_extensions:\n"
+        "      - vendor_name: WREN\n"
+        "        data: |\n"
+        "          {\n"
+        '            "column_types": {\n'
+        f"              {pairs}\n"
+        "            }\n"
+        "          }"
+    )
+
+
+def _format_composite_pk_snippet(
+    dataset_name: str, candidates: list[str], picked: str
+) -> str:
+    """Snippet hint when wren falls back to first column of composite PK."""
+    return (
+        f"  Wren picked {picked!r}. To override, add to dataset "
+        f"'{dataset_name}' in the OSI file:\n\n"
+        "    custom_extensions:\n"
+        "      - vendor_name: WREN\n"
+        f'        data: \'{{"primary_key": "<one of: '
+        f"{', '.join(candidates)}>\"}}'"
+    )
+
+
+def _convert_dataset(
+    ds: dict, *, wren_cfg: WrenConfig
+) -> tuple[dict, list[ValidationError]]:
+    errors: list[ValidationError] = []
+    name = ds.get("name")
+    if not isinstance(name, str) or not name:
+        errors.append(
+            ValidationError("error", "<osi:dataset>", "dataset missing 'name'")
+        )
+        return ({}, errors)
+
+    src_raw = ds.get("source")
+    table_ref, ref_sql = _parse_source(src_raw)
+    if not table_ref and not ref_sql:
+        errors.append(
+            ValidationError(
+                "error",
+                f"dataset '{name}'",
+                f"could not parse source: {src_raw!r} "
+                "— expected 'catalog.schema.table' or inline SQL",
+            )
+        )
+        return ({}, errors)
+
+    # Per-dataset WREN block overrides everything for this dataset's fields.
+    ds_wren = _extract_wren_block(ds.get("custom_extensions"))
+    ds_column_types_local: dict[str, str] = {}
+    if isinstance(ds_wren.get("column_types"), dict):
+        ds_column_types_local = {
+            str(k): str(v) for k, v in ds_wren["column_types"].items()
+        }
+    ds_pk_override = ds_wren.get("primary_key")
+
+    # Primary key — OSI allows composite arrays; wren takes a single string.
+    pk_raw = ds.get("primary_key")
+    pk_name: str | None = None
+    if isinstance(pk_raw, list):
+        if len(pk_raw) == 1:
+            pk_name = str(pk_raw[0])
+        elif len(pk_raw) > 1:
+            candidates = [str(c) for c in pk_raw]
+            pick: str | None = None
+            if isinstance(ds_pk_override, str) and ds_pk_override in candidates:
+                pick = ds_pk_override
+            elif name in wren_cfg.primary_key_pick:
+                want = wren_cfg.primary_key_pick[name]
+                if want in candidates:
+                    pick = want
+            pk_name = pick or candidates[0]
+            if pick is None:
+                errors.append(
+                    ValidationError(
+                        "warning",
+                        f"dataset '{name}'",
+                        f"composite primary_key {candidates} — Wren MDL "
+                        f"takes one column.\n"
+                        + _format_composite_pk_snippet(name, candidates, pk_name),
+                    )
+                )
+    elif isinstance(pk_raw, str) and pk_raw:
+        pk_name = pk_raw
+
+    # Convert fields
+    columns: list[dict] = []
+    untyped: list[str] = []
+    sm_column_types = wren_cfg.column_types.get(name) or {}
+    for f in ds.get("fields") or []:
+        if not isinstance(f, dict):
+            continue
+        fname = f.get("name")
+        if not isinstance(fname, str) or not fname:
+            continue
+        field_wren = _extract_wren_block(f.get("custom_extensions"))
+        # Order: field WREN type > dataset WREN.column_types > SM WREN.column_types
+        type_override = (
+            field_wren.get("type")
+            or ds_column_types_local.get(fname)
+            or sm_column_types.get(fname)
+        )
+        col = _convert_field(
+            f,
+            dialect=wren_cfg.dialect,
+            type_override=type_override,
+            primary_key_name=pk_name,
+        )
+        columns.append(col)
+        if type_override is None:
+            dim = f.get("dimension")
+            if not (isinstance(dim, dict) and dim.get("is_time")):
+                untyped.append(fname)
+
+    if untyped:
+        errors.append(
+            ValidationError(
+                "warning",
+                f"dataset '{name}'",
+                f"{len(untyped)} field(s) have no type — defaulted to VARCHAR.\n"
+                + _format_column_types_snippet(name, untyped),
+            )
+        )
+
+    model: dict = {
+        "name": name,
+        "columns": columns,
+        "cached": False,
+        "properties": {},
+    }
+    if table_ref:
+        model["table_reference"] = table_ref
+    else:
+        model["ref_sql"] = ref_sql
+    if pk_name:
+        model["primary_key"] = pk_name
+    if desc := _osi_description(ds):
+        model["properties"]["description"] = desc
+
+    return (model, errors)
+
+
+def _convert_relationship(rel: dict) -> tuple[dict, list[ValidationError]]:
+    errors: list[ValidationError] = []
+    name = rel.get("name") if isinstance(rel.get("name"), str) else "<unnamed>"
+    src = rel.get("from")
+    dst = rel.get("to")
+    from_cols = rel.get("from_columns") or []
+    to_cols = rel.get("to_columns") or []
+
+    if not isinstance(src, str) or not isinstance(dst, str):
+        errors.append(
+            ValidationError(
+                "error",
+                f"relationship '{name}'",
+                "missing 'from' or 'to'",
+            )
+        )
+        return ({}, errors)
+    if not isinstance(from_cols, list) or not isinstance(to_cols, list):
+        errors.append(
+            ValidationError(
+                "error",
+                f"relationship '{name}'",
+                "from_columns / to_columns must be lists",
+            )
+        )
+        return ({}, errors)
+    if len(from_cols) != len(to_cols):
+        errors.append(
+            ValidationError(
+                "error",
+                f"relationship '{name}'",
+                f"from_columns and to_columns length mismatch "
+                f"({len(from_cols)} vs {len(to_cols)})",
+            )
+        )
+        return ({}, errors)
+    if not from_cols:
+        errors.append(
+            ValidationError(
+                "error",
+                f"relationship '{name}'",
+                "no join columns",
+            )
+        )
+        return ({}, errors)
+
+    parts = [f"{src}.{fc} = {dst}.{tc}" for fc, tc in zip(from_cols, to_cols)]
+    condition = " AND ".join(parts)
+
+    rel_dict: dict = {
+        "name": name,
+        "models": [src, dst],
+        "join_type": "MANY_TO_ONE",
+        "condition": condition,
+        "properties": {},
+    }
+    if desc := _osi_description(rel):
+        rel_dict["properties"]["description"] = desc
+    return (rel_dict, errors)
+
+
+def _metric_referenced_datasets(expression: str, dataset_names: set[str]) -> set[str]:
+    if not expression:
+        return set()
+    refs = {m.group(1) for m in _DATASET_REF_PATTERN.finditer(expression)}
+    return refs & dataset_names
+
+
+def _process_metrics(
+    metrics: list[dict],
+    *,
+    wren_cfg: WrenConfig,
+    dataset_names: set[str],
+) -> tuple[str | None, list[ValidationError]]:
+    """Render OSI top-level metrics as a markdown block for instructions.md.
+
+    Wren has no first-class equivalent of OSI's free-floating metrics
+    (cubes are bound to a single base_object). For v1 we surface them as
+    LLM-readable notes; cross-dataset metrics get a warning.
+    """
+    errors: list[ValidationError] = []
+    if wren_cfg.metrics_mode == "skip" or not metrics:
+        return (None, errors)
+
+    lines = ["## Metrics (from OSI)", ""]
+    appended = 0
+    for m in metrics:
+        if not isinstance(m, dict):
+            continue
+        mname = m.get("name") or "<unnamed>"
+        if not isinstance(mname, str):
+            mname = str(mname)
+        expr = _pick_expression(m.get("expression"), wren_cfg.dialect)
+        desc = m.get("description") if isinstance(m.get("description"), str) else ""
+        refs = _metric_referenced_datasets(expr, dataset_names)
+        if len(refs) >= 2:
+            errors.append(
+                ValidationError(
+                    "warning",
+                    f"metric '{mname}'",
+                    f"expression references {len(refs)} datasets "
+                    f"({', '.join(sorted(refs))}) — emitted as instruction "
+                    f"note only. Wren cubes are bound to a single base_object.",
+                )
+            )
+        line = f"- **{mname}** — `{expr}`" if expr else f"- **{mname}**"
+        if desc:
+            line += f"\n  {desc}"
+        lines.append(line)
+        appended += 1
+    if appended == 0:
+        return (None, errors)
+    return ("\n".join(lines), errors)
+
+
+def _semantic_model_instructions(sm: dict) -> str | None:
+    ai = sm.get("ai_context")
+    if isinstance(ai, str):
+        return ai
+    if isinstance(ai, dict):
+        instr = ai.get("instructions")
+        return instr if isinstance(instr, str) else None
+    return None
+
+
+# ── Top-level build ───────────────────────────────────────────────────────
+
+
+def build_manifest_from_osi(
+    osi_path: Path,
+    *,
+    data_source: str,
+    catalog: str = "wren",
+    schema: str = "public",
+    semantic_model: str | None = None,
+    dialect_override: str | None = None,
+    metrics_override: str | None = None,
+) -> tuple[dict, list[ValidationError]]:
+    """Build a Wren MDL manifest dict (snake_case) from an OSI file.
+
+    Returns (manifest, errors). The manifest mirrors the shape of
+    ``context.build_manifest``; pass through :func:`build_json_from_osi` to
+    get camelCase JSON for the engine.
+    """
+    osi = load_osi_file(osi_path)
+    errors: list[ValidationError] = []
+
+    sm, sm_errors = select_semantic_model(osi, semantic_model)
+    errors.extend(sm_errors)
+    if not sm:
+        return ({}, errors)
+
+    cli_overrides: dict = {}
+    if dialect_override:
+        cli_overrides["dialect"] = dialect_override
+    if metrics_override:
+        cli_overrides["metrics"] = metrics_override
+
+    wren_cfg, cfg_errors = extract_wren_config(osi, sm, cli_overrides)
+    errors.extend(cfg_errors)
+
+    # If user didn't pin a dialect anywhere, see if data_source implies one.
+    user_set_dialect = (
+        bool(dialect_override)
+        or "dialect" in _extract_wren_block(osi.get("custom_extensions"))
+        or "dialect" in _extract_wren_block(sm.get("custom_extensions"))
+    )
+    if not user_set_dialect and (
+        inferred := _DATA_SOURCE_TO_DIALECT.get(data_source.lower())
+    ):
+        wren_cfg.dialect = inferred
+
+    models: list[dict] = []
+    for ds in sm.get("datasets") or []:
+        if not isinstance(ds, dict):
+            continue
+        model, ds_errors = _convert_dataset(ds, wren_cfg=wren_cfg)
+        errors.extend(ds_errors)
+        if model:
+            models.append(model)
+
+    relationships: list[dict] = []
+    for r in sm.get("relationships") or []:
+        if not isinstance(r, dict):
+            continue
+        rel, r_errors = _convert_relationship(r)
+        errors.extend(r_errors)
+        if rel:
+            relationships.append(rel)
+
+    dataset_names = {m["name"] for m in models}
+    metric_notes, m_errors = _process_metrics(
+        sm.get("metrics") or [],
+        wren_cfg=wren_cfg,
+        dataset_names=dataset_names,
+    )
+    errors.extend(m_errors)
+
+    instructions = _join_description(
+        _semantic_model_instructions(sm),
+        metric_notes,
+    )
+
+    manifest: dict = {
+        "catalog": catalog,
+        "schema": schema,
+        "data_source": data_source,
+        "models": models,
+        "relationships": relationships,
+        "views": [],
+        "cubes": [],
+    }
+    if instructions:
+        manifest["_instructions"] = instructions
+    return (manifest, errors)
+
+
+def build_json_from_osi(
+    osi_path: Path,
+    *,
+    data_source: str,
+    catalog: str = "wren",
+    schema: str = "public",
+    semantic_model: str | None = None,
+    dialect_override: str | None = None,
+    metrics_override: str | None = None,
+) -> tuple[dict, list[ValidationError]]:
+    """Like :func:`build_manifest_from_osi` but returns the camelCase JSON
+    dict the engine consumes. Stamps layoutVersion=2 (table_reference as
+    struct, which is what we emit)."""
+    manifest, errors = build_manifest_from_osi(
+        osi_path,
+        data_source=data_source,
+        catalog=catalog,
+        schema=schema,
+        semantic_model=semantic_model,
+        dialect_override=dialect_override,
+        metrics_override=metrics_override,
+    )
+    if not manifest:
+        return ({}, errors)
+    manifest_json = _convert_keys(manifest)
+    manifest_json["layoutVersion"] = 2
+    return (manifest_json, errors)
+
+
+def lint_osi_file(
+    osi_path: Path,
+    *,
+    data_source: str | None,
+    semantic_model: str | None = None,
+) -> list[ValidationError]:
+    """Run the OSI→MDL conversion solely to collect errors / warnings.
+
+    Used by ``wren context validate --from-osi``. Hard errors include the
+    missing-file / missing-data_source preconditions; everything else flows
+    out of :func:`build_manifest_from_osi`.
+    """
+    if not osi_path.exists():
+        return [ValidationError("error", str(osi_path), "OSI file not found")]
+    if not data_source:
+        return [
+            ValidationError(
+                "error",
+                "<cli>",
+                "--data-source is required for --from-osi "
+                "(e.g. postgres, snowflake, ...)",
+            )
+        ]
+    _, errors = build_manifest_from_osi(
+        osi_path,
+        data_source=data_source,
+        semantic_model=semantic_model,
+    )
+    return errors

--- a/core/wren/src/wren/osi.py
+++ b/core/wren/src/wren/osi.py
@@ -789,8 +789,14 @@ def build_json_from_osi(
     )
     if not manifest:
         return ({}, errors)
+    # `_instructions` is consumed by downstream tooling under that exact name
+    # (see context.convert_mdl_to_project, memory.schema_indexer); pull it out
+    # so the snake→camel pass doesn't mangle it into `Instructions`.
+    instructions = manifest.pop("_instructions", None)
     manifest_json = _convert_keys(manifest)
     manifest_json["layoutVersion"] = 2
+    if instructions:
+        manifest_json["_instructions"] = instructions
     return (manifest_json, errors)
 
 

--- a/core/wren/src/wren/osi.py
+++ b/core/wren/src/wren/osi.py
@@ -553,6 +553,17 @@ def _convert_relationship(rel: dict) -> tuple[dict, list[ValidationError]]:
             )
         )
         return ({}, errors)
+    if not all(isinstance(c, str) and c for c in from_cols) or not all(
+        isinstance(c, str) and c for c in to_cols
+    ):
+        errors.append(
+            ValidationError(
+                "error",
+                f"relationship '{name}'",
+                "from_columns / to_columns entries must be non-empty strings",
+            )
+        )
+        return ({}, errors)
     if len(from_cols) != len(to_cols):
         errors.append(
             ValidationError(
@@ -671,8 +682,18 @@ def build_manifest_from_osi(
     ``context.build_manifest``; pass through :func:`build_json_from_osi` to
     get camelCase JSON for the engine.
     """
-    osi = load_osi_file(osi_path)
     errors: list[ValidationError] = []
+    try:
+        osi = load_osi_file(osi_path)
+    except (OSError, yaml.YAMLError, json.JSONDecodeError) as exc:
+        errors.append(
+            ValidationError(
+                "error",
+                str(osi_path),
+                f"failed to read OSI file: {exc}",
+            )
+        )
+        return ({}, errors)
 
     sm, sm_errors = select_semantic_model(osi, semantic_model)
     errors.extend(sm_errors)

--- a/core/wren/tests/fixtures/osi/minimal.yaml
+++ b/core/wren/tests/fixtures/osi/minimal.yaml
@@ -1,0 +1,70 @@
+version: "0.2.0"
+semantic_model:
+  - name: shop
+    ai_context:
+      instructions: "Shop analytics model. Revenue in USD."
+    datasets:
+      - name: orders
+        source: shop.public.orders
+        primary_key: [order_id]
+        description: Order fact table
+        custom_extensions:
+          - vendor_name: WREN
+            data: |
+              {
+                "column_types": {
+                  "order_id": "BIGINT",
+                  "customer_id": "BIGINT",
+                  "amount": "DECIMAL(18,2)"
+                }
+              }
+        fields:
+          - name: order_id
+            expression: order_id
+            description: Order primary key
+          - name: customer_id
+            expression: customer_id
+            description: FK to customers
+          - name: amount
+            expression: amount
+            description: Order total
+      - name: customers
+        source: shop.public.customers
+        primary_key: [customer_id]
+        description: Customer dimension
+        custom_extensions:
+          - vendor_name: WREN
+            data: |
+              {
+                "column_types": {
+                  "customer_id": "BIGINT",
+                  "email": "VARCHAR"
+                }
+              }
+        fields:
+          - name: customer_id
+            expression: customer_id
+          - name: email
+            expression: email
+          - name: full_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: first_name || ' ' || last_name
+            description: Computed full name
+            custom_extensions:
+              - vendor_name: WREN
+                data: '{"type": "VARCHAR"}'
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [customer_id]
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.amount)
+        description: Total order revenue

--- a/core/wren/tests/fixtures/osi/multi_semantic_model.yaml
+++ b/core/wren/tests/fixtures/osi/multi_semantic_model.yaml
@@ -1,0 +1,24 @@
+version: "0.2.0"
+semantic_model:
+  - name: model_a
+    datasets:
+      - name: t1
+        source: a.public.t1
+        primary_key: [id]
+        custom_extensions:
+          - vendor_name: WREN
+            data: '{"column_types": {"id": "INTEGER"}}'
+        fields:
+          - name: id
+            expression: id
+  - name: model_b
+    datasets:
+      - name: t2
+        source: b.public.t2
+        primary_key: [id]
+        custom_extensions:
+          - vendor_name: WREN
+            data: '{"column_types": {"id": "INTEGER"}}'
+        fields:
+          - name: id
+            expression: id

--- a/core/wren/tests/fixtures/osi/ref_sql_source.yaml
+++ b/core/wren/tests/fixtures/osi/ref_sql_source.yaml
@@ -1,0 +1,19 @@
+version: "0.2.0"
+semantic_model:
+  - name: derived
+    datasets:
+      - name: active_users
+        source: |
+          SELECT u.id, u.email
+          FROM users u
+          WHERE u.is_active = true
+        primary_key: [id]
+        custom_extensions:
+          - vendor_name: WREN
+            data: |
+              {"column_types": {"id": "BIGINT", "email": "VARCHAR"}}
+        fields:
+          - name: id
+            expression: id
+          - name: email
+            expression: email

--- a/core/wren/tests/fixtures/osi/tpcds_full.yaml
+++ b/core/wren/tests/fixtures/osi/tpcds_full.yaml
@@ -1,0 +1,578 @@
+# yaml-language-server: $schema=../core-spec/osi-schema.json
+
+# TPC-DS Semantic Model Example
+# This example demonstrates the OSI Core Metadata Spec using the TPC-DS benchmark schema
+# TPC-DS is a decision support benchmark with a realistic retail business model
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: tpcds_retail_model
+    description: TPC-DS retail semantic model for sales and customer analytics
+    ai_context:
+      instructions: "Use this semantic model for retail analytics. It provides comprehensive sales, customer, product, and store data from the TPC-DS benchmark. The model supports time-based analysis, customer segmentation, product performance, and store operations metrics."
+
+    datasets:
+      # Fact table: Store sales transactions
+      - name: store_sales
+        source: tpcds.public.store_sales
+        primary_key: [ss_item_sk, ss_ticket_number]  # Composite primary key
+        unique_keys:
+          - [ss_item_sk, ss_ticket_number]  # Composite key: item + ticket number uniquely identifies a line item
+        description: Fact table containing all store sales transactions
+        ai_context:
+          synonyms:
+            - "sales transactions"
+            - "store purchases"
+            - "retail sales"
+            - "POS data"
+
+        fields:
+          - name: ss_sold_date_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_sold_date_sk
+            description: Foreign key to date dimension
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "sale date"
+                - "transaction date"
+
+          - name: ss_item_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_item_sk
+            description: Foreign key to item dimension
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "product"
+                - "item"
+
+          - name: ss_customer_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_customer_sk
+            description: Foreign key to customer dimension
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "customer"
+                - "buyer"
+
+          - name: ss_store_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_store_sk
+            description: Foreign key to store dimension
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "store"
+                - "location"
+
+          - name: ss_quantity
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_quantity
+            description: Quantity of items sold
+            ai_context:
+              synonyms:
+                - "units sold"
+                - "quantity"
+
+          - name: ss_sales_price
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_sales_price
+            description: Sales price per unit
+            ai_context:
+              synonyms:
+                - "unit price"
+                - "price"
+
+          - name: ss_ext_sales_price
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_ext_sales_price
+            description: Extended sales price (quantity * price)
+            ai_context:
+              synonyms:
+                - "total price"
+                - "line total"
+
+          - name: ss_net_profit
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_net_profit
+            description: Net profit from the sale
+            ai_context:
+              synonyms:
+                - "profit"
+                - "margin"
+
+      # Dimension table: Date
+      - name: date_dim
+        source: tpcds.public.date_dim
+        primary_key: [d_date_sk]  # Simple primary key
+        unique_keys:
+          - [d_date_sk]  # Simple key: single column
+        description: Date dimension with calendar attributes
+        ai_context:
+          synonyms:
+            - "calendar"
+            - "dates"
+            - "time periods"
+
+        fields:
+          - name: d_date_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_date_sk
+            description: Surrogate key for date
+            dimension:
+              is_time: false
+
+          - name: d_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_date
+            description: Actual date value
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "date"
+                - "calendar date"
+
+          - name: d_year
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_year
+            description: Year
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "year"
+
+          - name: d_quarter_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_quarter_name
+            description: Quarter name (e.g., 2024Q1)
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "quarter"
+                - "fiscal quarter"
+
+          - name: d_month_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_month_name
+            description: Month name
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "month"
+
+      # Dimension table: Customer
+      - name: customer
+        source: tpcds.public.customer
+        primary_key: [c_customer_sk]  # Simple primary key
+        unique_keys:
+          - [c_customer_sk]  # Simple key: single column
+        description: Customer dimension with demographic information
+        ai_context:
+          synonyms:
+            - "customers"
+            - "shoppers"
+            - "buyers"
+
+        fields:
+          - name: c_customer_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_customer_sk
+            description: Surrogate key for customer
+            dimension:
+              is_time: false
+
+          - name: c_customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_customer_id
+            description: Business key for customer
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "customer ID"
+                - "customer number"
+
+          - name: c_first_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_first_name
+            description: Customer first name
+            dimension:
+              is_time: false
+
+          - name: c_last_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_last_name
+            description: Customer last name
+            dimension:
+              is_time: false
+
+          - name: customer_full_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_first_name || ' ' || c_last_name
+            description: Customer full name (computed field)
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "full name"
+                - "customer name"
+
+          - name: c_email_address
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_email_address
+            description: Customer email address
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "email"
+                - "contact"
+
+      # Dimension table: Item (Product)
+      - name: item
+        source: tpcds.public.item
+        primary_key: [i_item_sk]  # Simple primary key
+        unique_keys:
+          - [i_item_sk]  # Simple key: single column
+        description: Item/Product dimension with product attributes
+        ai_context:
+          synonyms:
+            - "products"
+            - "items"
+            - "merchandise"
+
+        fields:
+          - name: i_item_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_item_sk
+            description: Surrogate key for item
+            dimension:
+              is_time: false
+
+          - name: i_item_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_item_id
+            description: Business key for item
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "item ID"
+                - "product ID"
+                - "SKU"
+
+          - name: i_item_desc
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_item_desc
+            description: Item description
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "product description"
+                - "item name"
+
+          - name: i_brand
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_brand
+            description: Brand name
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "brand"
+                - "manufacturer"
+
+          - name: i_category
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_category
+            description: Item category
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "product category"
+                - "department"
+
+          - name: i_current_price
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_current_price
+            description: Current price of the item
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "price"
+                - "list price"
+
+      # Dimension table: Store
+      - name: store
+        source: tpcds.public.store
+        primary_key: [s_store_sk]  # Simple primary key
+        unique_keys:
+          - [s_store_id]  # Simple key: single column
+        description: Store dimension with location and store attributes
+        ai_context:
+          synonyms:
+            - "stores"
+            - "retail locations"
+            - "branches"
+
+        fields:
+          - name: s_store_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_store_sk
+            description: Surrogate key for store
+            dimension:
+              is_time: false
+
+          - name: s_store_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_store_id
+            description: Business key for store
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "store ID"
+                - "store number"
+
+          - name: s_store_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_store_name
+            description: Store name
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "store name"
+                - "location name"
+
+          - name: s_city
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_city
+            description: City where store is located
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "city"
+                - "location"
+
+          - name: s_state
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_state
+            description: State where store is located
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "state"
+                - "region"
+
+          - name: s_number_employees
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_number_employees
+            description: Number of employees at the store
+            ai_context:
+              synonyms:
+                - "employee count"
+                - "staff size"
+
+    # Relationships between datasets
+    relationships:
+      - name: store_sales_to_date
+        from: store_sales
+        to: date_dim
+        from_columns: [ss_sold_date_sk]
+        to_columns: [d_date_sk]
+        ai_context:
+          synonyms:
+            - "sales date relationship"
+            - "when sale occurred"
+
+      - name: store_sales_to_customer
+        from: store_sales
+        to: customer
+        from_columns: [ss_customer_sk]
+        to_columns: [c_customer_sk]
+        ai_context:
+          synonyms:
+            - "customer purchase relationship"
+            - "who bought"
+
+      - name: store_sales_to_item
+        from: store_sales
+        to: item
+        from_columns: [ss_item_sk]
+        to_columns: [i_item_sk]
+        ai_context:
+          synonyms:
+            - "product sold relationship"
+            - "what was sold"
+
+      - name: store_sales_to_store
+        from: store_sales
+        to: store
+        from_columns: [ss_store_sk]
+        to_columns: [s_store_sk]
+        ai_context:
+          synonyms:
+            - "store location relationship"
+            - "where sale occurred"
+
+    # Semantic model-level metrics spanning multiple datasets
+    metrics:
+      - name: total_sales
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price)
+        description: Total sales revenue across all transactions
+        ai_context:
+          synonyms:
+            - "total revenue"
+            - "gross sales"
+            - "sales amount"
+
+      - name: total_profit
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_net_profit)
+        description: Total net profit from store sales
+        ai_context:
+          synonyms:
+            - "net profit"
+            - "total earnings"
+            - "profit"
+
+      - name: customer_lifetime_value
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price) / COUNT(DISTINCT customer.c_customer_sk)
+        description: Average lifetime sales value per customer
+        ai_context:
+          synonyms:
+            - "CLV"
+            - "LTV"
+            - "customer value"
+            - "lifetime revenue"
+
+      - name: sales_by_brand
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price)
+        description: Total sales by brand (requires grouping by item.i_brand)
+        ai_context:
+          synonyms:
+            - "brand sales"
+            - "brand performance"
+            - "brand revenue"
+
+      - name: store_productivity
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price) / NULLIF(SUM(store.s_number_employees), 0)
+        description: Sales per employee across stores
+        ai_context:
+          synonyms:
+            - "sales per employee"
+            - "employee productivity"
+            - "revenue per employee"
+
+    custom_extensions:
+      - vendor_name: SALESFORCE
+        data: |
+          {
+            "tableau_workbook_id": "tpcds_retail_dashboard",
+            "einstein_enabled": true,
+            "crm_sync": {
+              "enabled": true,
+              "sync_frequency": "daily",
+              "customer_mapping": "customer.c_customer_id -> Account.AccountNumber"
+            },
+            "tableau_semantics": {
+              "published": true,
+              "version": "0.1.1"
+            }
+          }
+
+      - vendor_name: DBT
+        data: '{"project_name": "tpcds_analytics", "models_path": "models/semantic"}'

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -357,6 +357,18 @@ def test_build_json_emits_camel_case_and_layout_version():
     assert "joinType" in rel
 
 
+def test_build_json_preserves_instructions_key():
+    """`_instructions` must survive the snake→camel pass with its leading
+    underscore intact — downstream tooling (memory indexer, MDL importer)
+    looks for that exact key."""
+    json_manifest, _ = build_json_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    assert "_instructions" in json_manifest
+    assert "Instructions" not in json_manifest  # the bug we're guarding against
+    assert "Shop analytics model" in json_manifest["_instructions"]
+
+
 # ── Integration: TPC-DS full fixture (exercises every warning path) ───────
 
 

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -733,3 +733,239 @@ def test_cli_show_from_osi_json():
     data = json.loads(result.output)
     assert data["layoutVersion"] == 2
     assert "tableReference" in data["models"][0]
+
+
+# ── CLI: init --from-osi (one-way migration) ─────────────────────────────
+
+
+def test_cli_init_from_osi_scaffolds_project(tmp_path: Path):
+    """OSI → wren project layout, ready for the standard build flow."""
+    proj = tmp_path / "migrated"
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(proj),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Migrated OSI" in result.output
+    # Standard wren project layout
+    assert (proj / "wren_project.yml").exists()
+    assert (proj / "models" / "orders" / "metadata.yml").exists()
+    assert (proj / "models" / "customers" / "metadata.yml").exists()
+    assert (proj / "relationships.yml").exists()
+    assert (proj / "instructions.md").exists()
+    assert (proj / "AGENTS.md").exists()
+    # The OSI semantic_model.name flowed into wren_project.yml
+    import yaml as _yaml  # noqa: PLC0415
+
+    cfg = _yaml.safe_load((proj / "wren_project.yml").read_text())
+    assert cfg["name"] == "shop"
+    assert cfg["data_source"] == "postgres"
+
+
+def test_cli_init_from_osi_roundtrip_matches_direct_build(tmp_path: Path):
+    """init --from-osi then context build should produce a manifest with the
+    same models / relationships as a direct build --from-osi."""
+    proj = tmp_path / "migrated"
+    _invoke = lambda args: runner.invoke(app, args)  # noqa: E731
+
+    init = _invoke(
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(proj),
+        ]
+    )
+    assert init.exit_code == 0, init.output
+    build = _invoke(["context", "build", "--path", str(proj)])
+    assert build.exit_code == 0, build.output
+
+    migrated_mdl = json.loads((proj / "target" / "mdl.json").read_text())
+
+    direct_out = tmp_path / "direct.mdl.json"
+    direct = _invoke(
+        [
+            "context",
+            "build",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--output",
+            str(direct_out),
+        ]
+    )
+    assert direct.exit_code == 0, direct.output
+    direct_mdl = json.loads(direct_out.read_text())
+
+    assert {m["name"] for m in migrated_mdl["models"]} == {
+        m["name"] for m in direct_mdl["models"]
+    }
+    assert len(migrated_mdl["relationships"]) == len(direct_mdl["relationships"])
+    # Per-column type / expression should survive the round-trip.
+    mig_orders = next(m for m in migrated_mdl["models"] if m["name"] == "orders")
+    direct_orders = next(m for m in direct_mdl["models"] if m["name"] == "orders")
+    mig_cols = {c["name"]: c.get("type") for c in mig_orders["columns"]}
+    direct_cols = {c["name"]: c.get("type") for c in direct_orders["columns"]}
+    assert mig_cols == direct_cols
+
+
+def test_cli_init_from_osi_requires_data_source(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--path",
+            str(tmp_path / "p"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "--data-source" in result.output
+
+
+def test_cli_init_from_osi_missing_file(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(tmp_path / "nonexistent.yaml"),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(tmp_path / "p"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_cli_init_from_osi_mutually_exclusive_with_from_mdl(tmp_path: Path):
+    """--from-mdl and --from-osi cannot be combined — bail before either runs."""
+    fake_mdl = tmp_path / "fake.json"
+    fake_mdl.write_text("{}")
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-mdl",
+            str(fake_mdl),
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(tmp_path / "p"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_cli_init_from_osi_refuses_overwrite_without_force(tmp_path: Path):
+    """Without --force, an existing wren_project.yml blocks the migration."""
+    proj = tmp_path / "existing"
+    proj.mkdir()
+    (proj / "wren_project.yml").write_text("name: prior\n")
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(proj),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+
+
+def test_cli_init_from_osi_force_overwrites(tmp_path: Path):
+    proj = tmp_path / "existing"
+    proj.mkdir()
+    (proj / "wren_project.yml").write_text("name: prior\n")
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(proj),
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    import yaml as _yaml  # noqa: PLC0415
+
+    cfg = _yaml.safe_load((proj / "wren_project.yml").read_text())
+    assert cfg["name"] == "shop"
+
+
+def test_cli_init_from_osi_aborts_on_hard_error(tmp_path: Path):
+    """Ambiguous semantic_model selection is a hard error — migration must
+    bail without touching the target directory."""
+    proj = tmp_path / "p"
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("multi_semantic_model.yaml")),
+            "--data-source",
+            "postgres",
+            "--path",
+            str(proj),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "semantic_models" in result.output
+    assert not proj.exists() or not any(proj.iterdir())
+
+
+def test_cli_init_from_osi_with_semantic_model_picks_one(tmp_path: Path):
+    proj = tmp_path / "migrated_b"
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "init",
+            "--from-osi",
+            str(_fixture("multi_semantic_model.yaml")),
+            "--data-source",
+            "postgres",
+            "--semantic-model",
+            "model_b",
+            "--path",
+            str(proj),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (proj / "models" / "t2" / "metadata.yml").exists()
+    assert not (proj / "models" / "t1").exists()

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -478,6 +478,81 @@ def test_lint_minimal_clean():
     assert hard == []
 
 
+# ── Regression: malformed inputs surface as ValidationError ──────────────
+
+
+def test_build_manifest_malformed_yaml_returns_error(tmp_path: Path):
+    """Broken YAML must produce a structured error, not a raw exception."""
+    p = tmp_path / "bad.yaml"
+    p.write_text("semantic_model: [\n")  # unterminated flow sequence
+    manifest, errors = build_manifest_from_osi(p, data_source="postgres")
+    assert manifest == {}
+    assert any(e.level == "error" for e in errors)
+    assert any("failed to read OSI file" in e.message for e in errors)
+
+
+def test_lint_malformed_yaml_does_not_raise(tmp_path: Path):
+    """lint_osi_file likewise reports parse failure cleanly."""
+    p = tmp_path / "bad.yaml"
+    p.write_text("not: [a, b,")
+    errors = lint_osi_file(p, data_source="postgres")
+    assert errors and errors[0].level == "error"
+    assert "failed to read OSI file" in errors[0].message
+
+
+def test_relationship_non_string_join_columns_error(tmp_path: Path):
+    """Non-string from_columns / to_columns must error before any SQL is built."""
+    bad = {
+        "version": "0.2.0",
+        "semantic_model": [
+            {
+                "name": "x",
+                "datasets": [
+                    {
+                        "name": "a",
+                        "source": "c.s.a",
+                        "primary_key": ["id"],
+                        "custom_extensions": [
+                            {
+                                "vendor_name": "WREN",
+                                "data": '{"column_types": {"id": "INTEGER"}}',
+                            }
+                        ],
+                        "fields": [{"name": "id", "expression": "id"}],
+                    },
+                    {
+                        "name": "b",
+                        "source": "c.s.b",
+                        "primary_key": ["id"],
+                        "custom_extensions": [
+                            {
+                                "vendor_name": "WREN",
+                                "data": '{"column_types": {"id": "INTEGER"}}',
+                            }
+                        ],
+                        "fields": [{"name": "id", "expression": "id"}],
+                    },
+                ],
+                "relationships": [
+                    {
+                        "name": "a_to_b",
+                        "from": "a",
+                        "to": "b",
+                        "from_columns": ["id"],
+                        "to_columns": [123],  # non-string entry
+                    }
+                ],
+            }
+        ],
+    }
+    p = tmp_path / "bad_rel.yaml"
+    p.write_text(json.dumps(bad))
+    _, errors = build_manifest_from_osi(p, data_source="postgres")
+    rel_errs = [e for e in errors if "relationship 'a_to_b'" in e.path]
+    assert rel_errs and rel_errs[0].level == "error"
+    assert "non-empty strings" in rel_errs[0].message
+
+
 # ── CLI integration ──────────────────────────────────────────────────────
 
 

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -733,6 +733,11 @@ def test_cli_show_from_osi_json():
     data = json.loads(result.output)
     assert data["layoutVersion"] == 2
     assert "tableReference" in data["models"][0]
+    # The show --output json path must shield `_instructions` from the
+    # snake→camel pass, same as build_json_from_osi.
+    assert "_instructions" in data
+    assert "Instructions" not in data
+    assert "Shop analytics model" in data["_instructions"]
 
 
 # ── CLI: init --from-osi (one-way migration) ─────────────────────────────

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -1,0 +1,648 @@
+"""Tests for OSI (Open Semantic Interchange) → Wren MDL conversion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from wren.cli import app
+from wren.osi import (
+    _extract_wren_block,
+    _is_calculated_expression,
+    _parse_source,
+    _pick_expression,
+    build_json_from_osi,
+    build_manifest_from_osi,
+    extract_wren_config,
+    lint_osi_file,
+    parse_osi,
+    select_semantic_model,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "osi"
+
+
+def _fixture(name: str) -> Path:
+    return FIXTURES / name
+
+
+# ── Unit: parse_osi / select_semantic_model ───────────────────────────────
+
+
+def test_parse_osi_yaml():
+    osi = parse_osi('version: "0.2.0"\nsemantic_model: []\n')
+    assert osi["version"] == "0.2.0"
+    assert osi["semantic_model"] == []
+
+
+def test_parse_osi_json():
+    osi = parse_osi('{"version": "0.2.0", "semantic_model": []}', suffix=".json")
+    assert osi["version"] == "0.2.0"
+
+
+def test_select_semantic_model_single():
+    osi = {"semantic_model": [{"name": "only"}]}
+    sm, errs = select_semantic_model(osi)
+    assert sm["name"] == "only"
+    assert errs == []
+
+
+def test_select_semantic_model_explicit_name():
+    osi = {"semantic_model": [{"name": "a"}, {"name": "b"}]}
+    sm, errs = select_semantic_model(osi, name="b")
+    assert sm["name"] == "b"
+    assert errs == []
+
+
+def test_select_semantic_model_explicit_not_found():
+    osi = {"semantic_model": [{"name": "a"}]}
+    sm, errs = select_semantic_model(osi, name="missing")
+    assert sm == {}
+    assert errs and errs[0].level == "error"
+    assert "missing" in errs[0].message
+
+
+def test_select_semantic_model_root_default():
+    osi = {
+        "custom_extensions": [
+            {
+                "vendor_name": "WREN",
+                "data": '{"default_semantic_model": "b"}',
+            }
+        ],
+        "semantic_model": [{"name": "a"}, {"name": "b"}],
+    }
+    sm, errs = select_semantic_model(osi)
+    assert sm["name"] == "b"
+    assert errs == []
+
+
+def test_select_semantic_model_ambiguous_errors_with_snippet():
+    osi = {"semantic_model": [{"name": "a"}, {"name": "b"}]}
+    sm, errs = select_semantic_model(osi)
+    assert sm == {}
+    assert errs and errs[0].level == "error"
+    # Snippet must be copy-pasteable
+    assert "custom_extensions:" in errs[0].message
+    assert "vendor_name: WREN" in errs[0].message
+    assert "default_semantic_model" in errs[0].message
+
+
+def test_select_semantic_model_empty_file_errors():
+    sm, errs = select_semantic_model({"semantic_model": []})
+    assert sm == {}
+    assert errs and errs[0].level == "error"
+
+
+# ── Unit: WREN block extraction ───────────────────────────────────────────
+
+
+def test_extract_wren_block_parses_json_string():
+    ext = [
+        {"vendor_name": "WREN", "data": '{"dialect": "SNOWFLAKE"}'},
+        {"vendor_name": "DBT", "data": '{"foo": "bar"}'},
+    ]
+    out = _extract_wren_block(ext)
+    assert out == {"dialect": "SNOWFLAKE"}
+
+
+def test_extract_wren_block_tolerates_raw_dict():
+    """Spec says `data` is a JSON string, but tolerate dict for hand-authored YAML."""
+    ext = [{"vendor_name": "WREN", "data": {"dialect": "ANSI_SQL"}}]
+    assert _extract_wren_block(ext) == {"dialect": "ANSI_SQL"}
+
+
+def test_extract_wren_block_no_match_returns_empty():
+    ext = [{"vendor_name": "DBT", "data": "{}"}]
+    assert _extract_wren_block(ext) == {}
+
+
+def test_extract_wren_block_last_wins_when_duplicated():
+    ext = [
+        {"vendor_name": "WREN", "data": '{"dialect": "ANSI_SQL"}'},
+        {"vendor_name": "WREN", "data": '{"dialect": "SNOWFLAKE"}'},
+    ]
+    assert _extract_wren_block(ext)["dialect"] == "SNOWFLAKE"
+
+
+def test_extract_wren_block_ignores_malformed_json():
+    ext = [{"vendor_name": "WREN", "data": "{this is not json}"}]
+    assert _extract_wren_block(ext) == {}
+
+
+# ── Unit: extract_wren_config — precedence ────────────────────────────────
+
+
+def test_extract_wren_config_sm_overrides_root():
+    osi = {
+        "custom_extensions": [
+            {
+                "vendor_name": "WREN",
+                "data": '{"dialect": "ANSI_SQL", "metrics": "note"}',
+            }
+        ]
+    }
+    sm = {
+        "custom_extensions": [
+            {"vendor_name": "WREN", "data": '{"dialect": "SNOWFLAKE"}'}
+        ]
+    }
+    cfg, errs = extract_wren_config(osi, sm)
+    assert cfg.dialect == "SNOWFLAKE"
+    assert cfg.metrics_mode == "note"  # inherited from root
+    assert errs == []
+
+
+def test_extract_wren_config_cli_overrides_sm():
+    osi = {}
+    sm = {"custom_extensions": [{"vendor_name": "WREN", "data": '{"metrics": "note"}'}]}
+    cfg, _ = extract_wren_config(osi, sm, cli_overrides={"metrics": "skip"})
+    assert cfg.metrics_mode == "skip"
+
+
+def test_extract_wren_config_invalid_metrics_falls_back_with_warning():
+    osi = {}
+    sm = {
+        "custom_extensions": [{"vendor_name": "WREN", "data": '{"metrics": "bogus"}'}]
+    }
+    cfg, errs = extract_wren_config(osi, sm)
+    assert cfg.metrics_mode == "note"  # default
+    assert any("bogus" in e.message for e in errs)
+
+
+# ── Unit: _parse_source ───────────────────────────────────────────────────
+
+
+def test_parse_source_three_parts():
+    tref, sql = _parse_source("cat.sch.tbl")
+    assert tref == {"catalog": "cat", "schema": "sch", "table": "tbl"}
+    assert sql is None
+
+
+def test_parse_source_two_parts():
+    tref, sql = _parse_source("sch.tbl")
+    assert tref == {"catalog": "", "schema": "sch", "table": "tbl"}
+    assert sql is None
+
+
+def test_parse_source_one_part():
+    tref, sql = _parse_source("tbl")
+    assert tref == {"catalog": "", "schema": "", "table": "tbl"}
+    assert sql is None
+
+
+def test_parse_source_inline_sql_with_select():
+    tref, sql = _parse_source("SELECT * FROM x WHERE y = 1")
+    assert tref is None
+    assert sql == "SELECT * FROM x WHERE y = 1"
+
+
+def test_parse_source_multiline_treated_as_sql():
+    tref, sql = _parse_source("a.b.c\nSELECT 1")
+    assert tref is None
+    assert sql is not None and "SELECT 1" in sql
+
+
+def test_parse_source_empty():
+    assert _parse_source("") == (None, None)
+    assert _parse_source(None) == (None, None)
+
+
+# ── Unit: _pick_expression ────────────────────────────────────────────────
+
+
+def test_pick_expression_prefers_named_dialect():
+    expr = {
+        "dialects": [
+            {"dialect": "ANSI_SQL", "expression": "lower(x)"},
+            {"dialect": "SNOWFLAKE", "expression": "LOWER(x)::VARCHAR"},
+        ]
+    }
+    assert _pick_expression(expr, "SNOWFLAKE") == "LOWER(x)::VARCHAR"
+
+
+def test_pick_expression_falls_back_to_ansi_sql():
+    expr = {
+        "dialects": [
+            {"dialect": "ANSI_SQL", "expression": "x + 1"},
+            {"dialect": "MDX", "expression": "[x] + 1"},
+        ]
+    }
+    assert _pick_expression(expr, "SNOWFLAKE") == "x + 1"
+
+
+def test_pick_expression_falls_back_to_first():
+    expr = {"dialects": [{"dialect": "MDX", "expression": "[x]"}]}
+    assert _pick_expression(expr, "SNOWFLAKE") == "[x]"
+
+
+def test_pick_expression_shorthand_string():
+    assert _pick_expression("x", "ANSI_SQL") == "x"
+
+
+def test_pick_expression_empty():
+    assert _pick_expression({}, "ANSI_SQL") == ""
+    assert _pick_expression(None, "ANSI_SQL") == ""
+
+
+# ── Unit: _is_calculated_expression ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "expr, fname, expected",
+    [
+        ("amount", "amount", False),  # bare identity
+        ("Amount", "amount", True),  # different identifier — treat as calc
+        ("amount * 1.1", "amount", True),  # arithmetic
+        ("SUM(amount)", "amount", True),  # aggregation
+        ("a || b", "concat", True),  # concat
+        ("", "x", False),
+    ],
+)
+def test_is_calculated_expression(expr, fname, expected):
+    assert _is_calculated_expression(expr, fname) is expected
+
+
+# ── Integration: build_manifest_from_osi on minimal fixture ──────────────
+
+
+def test_build_minimal_clean_no_warnings():
+    """Minimal fixture has WREN column_types for every dataset — no warnings."""
+    manifest, errors = build_manifest_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    warnings = [e for e in errors if e.level == "warning"]
+    assert errors == warnings, [str(e) for e in errors if e.level == "error"]
+    # column_types covered every field, so no untyped warning
+    assert not any("no type" in e.message for e in warnings)
+    # single-dataset metrics don't fire cross-dataset warning
+    assert not any("references 2 datasets" in e.message for e in warnings)
+
+
+def test_build_minimal_structure():
+    manifest, _ = build_manifest_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    assert manifest["catalog"] == "wren"
+    assert manifest["schema"] == "public"
+    assert manifest["data_source"] == "postgres"
+    assert len(manifest["models"]) == 2
+    assert len(manifest["relationships"]) == 1
+
+    orders = next(m for m in manifest["models"] if m["name"] == "orders")
+    assert orders["table_reference"] == {
+        "catalog": "shop",
+        "schema": "public",
+        "table": "orders",
+    }
+    assert orders["primary_key"] == "order_id"
+    # PK column has is_primary_key + not_null
+    pk_col = next(c for c in orders["columns"] if c["name"] == "order_id")
+    assert pk_col["is_primary_key"] is True
+    assert pk_col["not_null"] is True
+    # Column types pulled from WREN block
+    amount_col = next(c for c in orders["columns"] if c["name"] == "amount")
+    assert amount_col["type"] == "DECIMAL(18,2)"
+
+
+def test_build_minimal_calculated_field():
+    """customer.full_name has a SQL expression and per-field WREN type override."""
+    manifest, _ = build_manifest_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    customers = next(m for m in manifest["models"] if m["name"] == "customers")
+    full_name = next(c for c in customers["columns"] if c["name"] == "full_name")
+    assert full_name["is_calculated"] is True
+    assert "first_name" in full_name["expression"]
+    assert full_name["type"] == "VARCHAR"  # from field-level WREN block
+
+
+def test_build_minimal_relationship_condition():
+    manifest, _ = build_manifest_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    rel = manifest["relationships"][0]
+    assert rel["name"] == "orders_to_customers"
+    assert rel["join_type"] == "MANY_TO_ONE"
+    assert rel["models"] == ["orders", "customers"]
+    assert rel["condition"] == "orders.customer_id = customers.customer_id"
+
+
+def test_build_minimal_instructions_include_metrics():
+    manifest, _ = build_manifest_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    instr = manifest.get("_instructions", "")
+    assert "Shop analytics model" in instr  # from ai_context.instructions
+    assert "total_revenue" in instr  # from metrics-as-notes
+
+
+# ── Integration: build_json_from_osi (camelCase + layoutVersion) ──────────
+
+
+def test_build_json_emits_camel_case_and_layout_version():
+    json_manifest, _ = build_json_from_osi(
+        _fixture("minimal.yaml"), data_source="postgres"
+    )
+    assert json_manifest["layoutVersion"] == 2
+    orders = next(m for m in json_manifest["models"] if m["name"] == "orders")
+    assert "tableReference" in orders  # camelCased
+    assert "isCalculated" in orders["columns"][0]
+    rel = json_manifest["relationships"][0]
+    assert "joinType" in rel
+
+
+# ── Integration: TPC-DS full fixture (exercises every warning path) ───────
+
+
+def test_build_tpcds_full_runs():
+    manifest, errors = build_manifest_from_osi(
+        _fixture("tpcds_full.yaml"), data_source="postgres"
+    )
+    hard = [e for e in errors if e.level == "error"]
+    assert hard == [], [str(e) for e in hard]
+    assert len(manifest["models"]) == 5
+    assert len(manifest["relationships"]) == 4
+
+
+def test_build_tpcds_composite_pk_warning():
+    """store_sales has composite PK [ss_item_sk, ss_ticket_number]."""
+    _, errors = build_manifest_from_osi(
+        _fixture("tpcds_full.yaml"), data_source="postgres"
+    )
+    composite_warns = [e for e in errors if "composite primary_key" in e.message]
+    assert len(composite_warns) == 1
+    assert "store_sales" in composite_warns[0].path
+    # Snippet must guide the user to override
+    assert 'data: \'{"primary_key"' in composite_warns[0].message
+
+
+def test_build_tpcds_untyped_field_warnings_include_snippets():
+    """No WREN column_types provided → every dataset triggers a typed warning
+    with a copy-pasteable snippet."""
+    _, errors = build_manifest_from_osi(
+        _fixture("tpcds_full.yaml"), data_source="postgres"
+    )
+    untyped = [e for e in errors if "have no type" in e.message]
+    assert len(untyped) >= 5  # one per dataset
+    for w in untyped:
+        assert "custom_extensions:" in w.message
+        assert "vendor_name: WREN" in w.message
+        assert "column_types" in w.message
+
+
+def test_build_tpcds_cross_dataset_metric_warns():
+    """customer_lifetime_value and store_productivity span 2 datasets."""
+    _, errors = build_manifest_from_osi(
+        _fixture("tpcds_full.yaml"), data_source="postgres"
+    )
+    cross = [e for e in errors if "references 2 datasets" in e.message]
+    assert len(cross) == 2
+    names = " ".join(e.path for e in cross)
+    assert "customer_lifetime_value" in names
+    assert "store_productivity" in names
+
+
+def test_build_tpcds_time_dimension_inferred_as_timestamp():
+    """date_dim has dimension.is_time fields — should default to TIMESTAMP, not VARCHAR."""
+    manifest, _ = build_manifest_from_osi(
+        _fixture("tpcds_full.yaml"), data_source="postgres"
+    )
+    date_dim = next(m for m in manifest["models"] if m["name"] == "date_dim")
+    d_year = next(c for c in date_dim["columns"] if c["name"] == "d_year")
+    assert d_year["type"] == "TIMESTAMP"
+
+
+# ── Integration: ref_sql source detection ────────────────────────────────
+
+
+def test_ref_sql_source_detected():
+    manifest, errors = build_manifest_from_osi(
+        _fixture("ref_sql_source.yaml"), data_source="postgres"
+    )
+    hard = [e for e in errors if e.level == "error"]
+    assert hard == [], [str(e) for e in hard]
+    active = manifest["models"][0]
+    assert active["name"] == "active_users"
+    assert "table_reference" not in active
+    assert "ref_sql" in active
+    assert "SELECT" in active["ref_sql"]
+
+
+# ── Integration: multi semantic_model requires selection ──────────────────
+
+
+def test_multi_semantic_model_requires_selection():
+    _, errors = build_manifest_from_osi(
+        _fixture("multi_semantic_model.yaml"), data_source="postgres"
+    )
+    hard = [e for e in errors if e.level == "error"]
+    assert hard, "should error when multiple semantic_models and none picked"
+    assert any("2 semantic_models" in e.message for e in hard)
+
+
+def test_multi_semantic_model_with_flag_succeeds():
+    manifest, errors = build_manifest_from_osi(
+        _fixture("multi_semantic_model.yaml"),
+        data_source="postgres",
+        semantic_model="model_b",
+    )
+    hard = [e for e in errors if e.level == "error"]
+    assert hard == [], [str(e) for e in hard]
+    assert manifest["models"][0]["name"] == "t2"
+
+
+# ── Integration: lint_osi_file ─────────────────────────────────────────────
+
+
+def test_lint_missing_data_source_errors():
+    errors = lint_osi_file(_fixture("minimal.yaml"), data_source=None)
+    assert errors and errors[0].level == "error"
+    assert "--data-source" in errors[0].message
+
+
+def test_lint_missing_file_errors(tmp_path):
+    errors = lint_osi_file(tmp_path / "nonexistent.yaml", data_source="postgres")
+    assert errors and errors[0].level == "error"
+    assert "not found" in errors[0].message
+
+
+def test_lint_minimal_clean():
+    errors = lint_osi_file(_fixture("minimal.yaml"), data_source="postgres")
+    hard = [e for e in errors if e.level == "error"]
+    assert hard == []
+
+
+# ── CLI integration ──────────────────────────────────────────────────────
+
+
+runner = CliRunner()
+
+
+def test_cli_build_from_osi(tmp_path: Path):
+    out = tmp_path / "mdl.json"
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "build",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["dataSource"] == "postgres"
+    assert data["layoutVersion"] == 2
+    assert {m["name"] for m in data["models"]} == {"orders", "customers"}
+
+
+def test_cli_build_from_osi_requires_data_source(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "build",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--output",
+            str(tmp_path / "mdl.json"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "--data-source" in result.output
+
+
+def test_cli_build_from_osi_missing_file(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "build",
+            "--from-osi",
+            str(tmp_path / "nonexistent.yaml"),
+            "--data-source",
+            "postgres",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_cli_build_from_osi_aborts_on_hard_error(tmp_path: Path):
+    """multi-semantic_model without --semantic-model should hard-error."""
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "build",
+            "--from-osi",
+            str(_fixture("multi_semantic_model.yaml")),
+            "--data-source",
+            "postgres",
+            "--output",
+            str(tmp_path / "mdl.json"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "semantic_models" in result.output
+
+
+def test_cli_validate_from_osi_clean():
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "validate",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Valid" in result.output
+
+
+def test_cli_validate_from_osi_surfaces_warnings():
+    """TPC-DS fixture has no WREN column_types → warnings printed."""
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "validate",
+            "--from-osi",
+            str(_fixture("tpcds_full.yaml")),
+            "--data-source",
+            "postgres",
+            "--verbose",
+        ],
+    )
+    # Warnings only — exit 0
+    assert result.exit_code == 0, result.output
+    assert "Warnings" in result.output
+    assert "column_types" in result.output  # snippet emitted
+
+
+def test_cli_validate_from_osi_strict_fails_on_warning():
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "validate",
+            "--from-osi",
+            str(_fixture("tpcds_full.yaml")),
+            "--data-source",
+            "postgres",
+            "--strict",
+        ],
+    )
+    assert result.exit_code == 1
+
+
+def test_cli_show_from_osi_summary():
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "show",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "orders" in result.output
+    assert "customers" in result.output
+    assert "MANY_TO_ONE" in result.output
+
+
+def test_cli_show_from_osi_json():
+    result = runner.invoke(
+        app,
+        [
+            "context",
+            "show",
+            "--from-osi",
+            str(_fixture("minimal.yaml")),
+            "--data-source",
+            "postgres",
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["layoutVersion"] == 2
+    assert "tableReference" in data["models"][0]

--- a/docs/core/guides/manage_project.md
+++ b/docs/core/guides/manage_project.md
@@ -163,15 +163,16 @@ Rules:
 
 AI coding agents should **never** ask for credentials in chat. The agent writes a profile referencing `${POSTGRES_PASSWORD}` and instructs you to fill the value in `.env` via your editor.
 
-## Migrate from an existing `mdl.json`
+## Migrate from an existing manifest
 
-If you have an older `mdl.json` from a previous Wren setup or another tool:
+`wren context init` accepts two import flags, one per external manifest format. Both produce the same wren project layout, ready for `validate` / `build`. They are mutually exclusive.
 
-```bash
-wren context init --from-mdl /path/to/mdl.json --path my_project
-```
+| Source | Command | When to use |
+|---|---|---|
+| Wren `mdl.json` (camelCase) | `wren context init --from-mdl /path/to/mdl.json --path my_project` | You have an older `mdl.json` from a previous Wren setup. |
+| OSI `semantic_model.yaml` | `wren context init --from-osi /path/to/semantic_model.yaml --data-source postgres --path my_project` | You have an [Open Semantic Interchange](./osi.md) file and want to leave the OSI flow to use Wren-only features (cubes, views, RLAC). |
 
-This converts camelCase JSON to snake_case YAML and writes the full directory structure. Then:
+After either import:
 
 ```bash
 wren context validate --path my_project
@@ -179,6 +180,8 @@ wren context build --path my_project
 ```
 
 If the target directory already has project files, use `--force` to overwrite.
+
+For `--from-osi`, see the dedicated [OSI guide](./osi.md) — it covers the alternative of keeping OSI as the source of truth (`wren context build --from-osi`) instead of migrating once.
 
 ## Upgrade an existing project
 

--- a/docs/core/guides/osi.md
+++ b/docs/core/guides/osi.md
@@ -1,0 +1,257 @@
+---
+sidebar_label: OSI (Open Semantic Interchange)
+---
+
+# Build MDL from an OSI semantic model
+
+[Open Semantic Interchange](https://github.com/open-semantic-interchange/OSI) (OSI) is a vendor-neutral specification for semantic models, backed by Snowflake, Salesforce, dbt Labs, Databricks, Cube, AtScale, and others. If your team already publishes one OSI YAML as the single source of truth for analytics definitions, Wren can read it directly and build `target/mdl.json` without forking the model into a parallel wren project.
+
+```bash
+wren context build --from-osi semantic_model.yaml --data-source postgres
+# → ./target/mdl.json
+```
+
+## OSI project vs. wren project
+
+|  | Wren project (native) | OSI project (this guide) |
+|---|---|---|
+| **Source files** | `wren_project.yml` + `models/<name>/metadata.yml` + `views/` + `relationships.yml` | A single `*.yaml` OSI file |
+| **Author** | You (or `wren-generate-mdl` agent skill) | OSI tooling / vendor-supplied / external team |
+| **Wren commands** | `wren context init` → edit → `build` | `wren context build --from-osi <file>` |
+| **Editable inside Wren?** | Yes — that's the point | No — Wren reads the file as-is |
+| **Where wren-specific hints live** | Each model's YAML | OSI's `custom_extensions[vendor_name=WREN]` block |
+
+**Use the wren project flow when:** you own the semantic model and want full control over the YAML.
+
+**Use the OSI flow when:** the OSI file is shared with other tools (Snowflake Cortex, Salesforce, Cube, …) and you want Wren to be one consumer among many, without forking the source.
+
+Both flows ultimately produce the same `target/mdl.json` — Wren itself doesn't care how you got there.
+
+## Quick start
+
+Suppose you have this OSI file (excerpted from a TPC-DS retail example):
+
+```yaml
+# semantic_model.yaml
+version: "0.2.0"
+semantic_model:
+  - name: tpcds_retail
+    ai_context:
+      instructions: "Retail analytics. Revenue is in USD."
+    datasets:
+      - name: store_sales
+        source: tpcds.public.store_sales
+        primary_key: [ss_item_sk, ss_ticket_number]
+        fields:
+          - name: ss_item_sk
+            expression: ss_item_sk
+          - name: ss_ext_sales_price
+            expression: ss_ext_sales_price
+      - name: customer
+        source: tpcds.public.customer
+        primary_key: [c_customer_sk]
+        fields:
+          - name: c_customer_sk
+            expression: c_customer_sk
+          - name: full_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_first_name || ' ' || c_last_name
+    relationships:
+      - name: sales_to_customer
+        from: store_sales
+        to: customer
+        from_columns: [ss_item_sk]
+        to_columns: [c_customer_sk]
+```
+
+Run:
+
+```bash
+wren context build --from-osi semantic_model.yaml --data-source postgres
+```
+
+Wren reads the file, converts each dataset to a model, synthesizes relationship join conditions, packs OSI's `ai_context.instructions` into the manifest, and writes `./target/mdl.json` — ready for `wren --sql` or any agent skill.
+
+You'll also see warnings telling you what's missing for an ideal manifest — see [What needs a `WREN` block](#what-needs-a-wren-block) below.
+
+## The `WREN` extension block
+
+OSI has no file-system convention for vendor extensions. Its [only sanctioned extension mechanism](https://github.com/open-semantic-interchange/OSI/blob/main/core-spec/spec.md) is the in-document `custom_extensions: [{vendor_name, data}]` field, present at every level of the document. Wren reads `vendor_name: WREN` entries and ignores everything else.
+
+A typical extension block at the OSI document root:
+
+```yaml
+custom_extensions:
+  - vendor_name: WREN
+    data: |
+      {
+        "dialect": "SNOWFLAKE",
+        "metrics": "note"
+      }
+```
+
+Per-dataset overrides, for the things OSI cannot express (most importantly: column types):
+
+```yaml
+datasets:
+  - name: store_sales
+    source: tpcds.public.store_sales
+    custom_extensions:
+      - vendor_name: WREN
+        data: |
+          {
+            "column_types": {
+              "ss_sold_date_sk": "DATE",
+              "ss_ext_sales_price": "DECIMAL(18,2)",
+              "ss_quantity": "INTEGER"
+            },
+            "primary_key": "ss_ticket_number"
+          }
+    fields:
+      - name: amount_eur
+        expression: { dialects: [{dialect: ANSI_SQL, expression: amount * 0.92}] }
+        custom_extensions:
+          - vendor_name: WREN
+            data: '{"type": "DECIMAL(18,2)", "not_null": true}'
+```
+
+The `data` field is per spec a JSON string. Wren also tolerates a raw YAML dict for hand-authored files.
+
+### Supported keys
+
+| Key | Scope | Effect |
+|---|---|---|
+| `dialect` | root, semantic_model | Which OSI dialect to extract from `expression.dialects[]`. Default: `ANSI_SQL`, with auto-inference for `snowflake` / `databricks` data sources. |
+| `metrics` | root, semantic_model | How to handle OSI top-level `metrics`: `note` (default, append as instructions) or `skip`. |
+| `default_semantic_model` | root | When the file has multiple `semantic_model[]` entries, which one to build. |
+| `column_types` | semantic_model: `{dataset: {field: type}}`<br/>dataset: `{field: type}` | Column types — OSI has no native type system. |
+| `primary_key` | semantic_model: `{dataset: column}`<br/>dataset: `column` | Pick one column when OSI defines a composite primary key. |
+| `type`, `not_null` | field | Per-field overrides. |
+
+## Precedence
+
+Resolution order, highest to lowest:
+
+1. CLI flag (`--data-source`, `--semantic-model`, `--dialect`, …)
+2. `semantic_model[i].custom_extensions[vendor_name=WREN]`
+3. `custom_extensions[vendor_name=WREN]` at the document root
+4. Dataset / field `custom_extensions[vendor_name=WREN]` (for per-dataset / per-field keys only)
+5. Built-in defaults
+
+Two-level support (root + semantic_model) means you can write a global default once and only add overrides on individual `semantic_model` entries that need to differ — for example, when the file contains multiple semantic models.
+
+## Mapping summary
+
+| OSI | Wren MDL |
+|---|---|
+| `dataset.source: a.b.c` | `model.table_reference: {catalog: a, schema: b, table: c}` |
+| `dataset.source` containing `SELECT`/`FROM`/newlines | `model.ref_sql` |
+| `dataset.fields[*].name` + `expression` | `model.columns[]` — dialect-picked expression, type from WREN block or `is_time` hint |
+| `dataset.primary_key: [x]` | `model.primary_key: x` (composite arrays warn + take the first column unless overridden) |
+| `relationships[]` (always many-to-one in OSI) | wren `relationships` with synthesized `condition` and `MANY_TO_ONE` |
+| `field.dimension.is_time: true` | `column.type: TIMESTAMP` (when no explicit type override) |
+| `semantic_model.ai_context.instructions` | MDL `_instructions` |
+| `metrics[]` (top-level OSI) | Rendered as markdown notes appended to instructions |
+| `unique_keys` | _Not converted_ — Wren has no equivalent |
+| `custom_extensions` for other vendors | _Ignored_ |
+
+## What needs a `WREN` block
+
+For each of these cases, `validate --from-osi` emits a warning with a **copy-pasteable YAML snippet** you can paste straight into your OSI file.
+
+### Untyped fields
+
+OSI doesn't carry column types. Without a `WREN` override, every field defaults to `VARCHAR` (or `TIMESTAMP` if `dimension.is_time: true`). Validate prints, per dataset:
+
+```text
+[WARNING] dataset 'store_sales': 8 field(s) have no type — defaulted to VARCHAR.
+  Add to dataset 'store_sales' in the OSI file:
+
+    custom_extensions:
+      - vendor_name: WREN
+        data: |
+          {
+            "column_types": {
+              "ss_sold_date_sk": "DATE",
+              "ss_ext_sales_price": "DECIMAL(18,2)",
+              ...
+            }
+          }
+```
+
+### Composite primary keys
+
+OSI allows `primary_key: [col_a, col_b]`; Wren MDL takes one column. Wren picks the first column and emits a snippet so you can override:
+
+```text
+[WARNING] dataset 'store_sales': composite primary_key
+  ['ss_item_sk', 'ss_ticket_number'] — Wren MDL takes one column.
+  Wren picked 'ss_item_sk'. To override, add to dataset 'store_sales':
+
+    custom_extensions:
+      - vendor_name: WREN
+        data: '{"primary_key": "<one of: ss_item_sk, ss_ticket_number>"}'
+```
+
+### Cross-dataset metrics
+
+Wren cubes are bound to a single base object, so OSI top-level metrics that aggregate across multiple datasets cannot become first-class cubes. They are rendered as markdown notes appended to `instructions`, available to the LLM but not as queryable measures:
+
+```text
+[WARNING] metric 'customer_lifetime_value': expression references 2 datasets
+  (customer, store_sales) — emitted as instruction note only.
+```
+
+Metrics that reference a single dataset get the same treatment by default (`metrics: note`); set `metrics: skip` in the WREN block to drop them entirely.
+
+### Multiple `semantic_model` entries
+
+OSI allows multiple `semantic_model[]` entries in one file. Wren builds one MDL per invocation, so an ambiguous file is a hard error:
+
+```text
+[ERROR] OSI file has 2 semantic_models: model_a, model_b.
+  Pass --semantic-model <name> or add at the OSI document root:
+
+    custom_extensions:
+      - vendor_name: WREN
+        data: '{"default_semantic_model": "<name>"}'
+```
+
+## CLI commands
+
+```bash
+# Build (writes ./target/mdl.json by default)
+wren context build --from-osi semantic_model.yaml --data-source postgres
+wren context build --from-osi semantic_model.yaml --data-source snowflake \
+  --output build/mdl.json
+
+# Validate — lints the conversion and prints actionable snippets
+wren context validate --from-osi semantic_model.yaml --data-source postgres
+wren context validate --from-osi semantic_model.yaml --data-source postgres --strict
+wren context validate --from-osi semantic_model.yaml --data-source postgres --verbose
+
+# Show — preview the resulting manifest without writing it
+wren context show --from-osi semantic_model.yaml --data-source postgres
+wren context show --from-osi semantic_model.yaml --data-source postgres --output json
+wren context show --from-osi semantic_model.yaml --data-source postgres --output yaml
+```
+
+`--data-source` is required because OSI deliberately does not carry connection or dialect environment information. Pair `--from-osi` with `--semantic-model` if the file contains more than one model.
+
+## Limitations
+
+- **No round-trip.** Wren reads OSI but never writes back. Edits to the OSI file are made in your OSI tooling; Wren re-reads on the next `build`.
+- **No cubes / measures.** OSI metrics map to instruction notes, not Wren cubes. If you need first-class cubes, model them in a native wren project instead.
+- **No views.** OSI has no view concept; the generated MDL has an empty `views` array.
+- **No `unique_keys`, no row/column-level access controls.** OSI 0.2.x doesn't model these; if you need them, either author them in a sidecar wren project or wait for an upcoming OSI spec version.
+
+For features OSI doesn't yet cover, the suggested pattern is to use the OSI file for what it does well (datasets, fields, relationships, instructions) and add a small wren-native overlay on top for the gaps. This is currently a manual merge — there is no automatic union of two sources.
+
+## See also
+
+- [OSI specification](https://github.com/open-semantic-interchange/OSI/blob/main/core-spec/spec.md) — the upstream schema and field reference
+- [Manage project](./manage_project.md) — the native wren-project flow
+- [MDL reference](/oss/reference/mdl) — what Wren produces on the other side of the conversion
+- [Connect your database](./connect.md) — choosing and binding a profile

--- a/docs/core/guides/osi.md
+++ b/docs/core/guides/osi.md
@@ -13,19 +13,22 @@ wren context build --from-osi semantic_model.yaml --data-source postgres
 
 ## OSI project vs. wren project
 
-|  | Wren project (native) | OSI project (this guide) |
-|---|---|---|
-| **Source files** | `wren_project.yml` + `models/<name>/metadata.yml` + `views/` + `relationships.yml` | A single `*.yaml` OSI file |
-| **Author** | You (or `wren-generate-mdl` agent skill) | OSI tooling / vendor-supplied / external team |
-| **Wren commands** | `wren context init` → edit → `build` | `wren context build --from-osi <file>` |
-| **Editable inside Wren?** | Yes — that's the point | No — Wren reads the file as-is |
-| **Where wren-specific hints live** | Each model's YAML | OSI's `custom_extensions[vendor_name=WREN]` block |
+|  | Wren project (native) | OSI project, kept as source | OSI project, migrated once |
+|---|---|---|---|
+| **Source files** | `wren_project.yml` + `models/<name>/metadata.yml` + `views/` + `relationships.yml` | A single `*.yaml` OSI file | After migration: wren project layout |
+| **Author** | You (or `wren-generate-mdl` agent skill) | OSI tooling / vendor / external team | You take ownership after `init` |
+| **Wren commands** | `wren context init` → edit → `build` | `wren context build --from-osi <file>` | `wren context init --from-osi <file>` → edit → `build` |
+| **Editable inside Wren?** | Yes — that's the point | No — Wren reads the file as-is | Yes after migration |
+| **Where wren-specific hints live** | Each model's YAML | OSI's `custom_extensions[vendor_name=WREN]` block | Each model's YAML (lifted from OSI at migration time) |
+| **Stays in sync with OSI?** | n/a | Yes — every build re-reads OSI | No — one-way snapshot |
 
-**Use the wren project flow when:** you own the semantic model and want full control over the YAML.
+Three places you might land:
 
-**Use the OSI flow when:** the OSI file is shared with other tools (Snowflake Cortex, Salesforce, Cube, …) and you want Wren to be one consumer among many, without forking the source.
+- **You own the semantic model from day one** → use the native wren project flow.
+- **The OSI file is shared with other tools (Snowflake Cortex, Salesforce, Cube, …) and you want Wren to be one of many consumers without forking** → use `wren context build --from-osi`. Every build re-reads the OSI file.
+- **You started with an OSI file but now want full control inside Wren (cubes, views, RLAC, custom calculations OSI doesn't model)** → use `wren context init --from-osi` to migrate once, then edit the generated YAML directly. See [Migrate to a native wren project](#migrate-to-a-native-wren-project).
 
-Both flows ultimately produce the same `target/mdl.json` — Wren itself doesn't care how you got there.
+All three paths produce the same `target/mdl.json` shape — Wren doesn't care how you got there.
 
 ## Quick start
 
@@ -227,6 +230,10 @@ wren context build --from-osi semantic_model.yaml --data-source postgres
 wren context build --from-osi semantic_model.yaml --data-source snowflake \
   --output build/mdl.json
 
+# Migrate to a native wren project (one-way)
+wren context init --from-osi semantic_model.yaml --data-source postgres \
+  --path my_project
+
 # Validate — lints the conversion and prints actionable snippets
 wren context validate --from-osi semantic_model.yaml --data-source postgres
 wren context validate --from-osi semantic_model.yaml --data-source postgres --strict
@@ -239,6 +246,39 @@ wren context show --from-osi semantic_model.yaml --data-source postgres --output
 ```
 
 `--data-source` is required because OSI deliberately does not carry connection or dialect environment information. Pair `--from-osi` with `--semantic-model` if the file contains more than one model.
+
+## Migrate to a native wren project
+
+When OSI's surface area isn't enough — you need cubes, views, RLAC/CLAC, or calculated columns OSI doesn't model — convert the OSI file into a native wren project once and edit the YAML from there:
+
+```bash
+wren context init --from-osi semantic_model.yaml --data-source postgres --path my_project
+```
+
+This reuses the same converter as `build --from-osi`, then scaffolds the standard wren layout:
+
+```text
+my_project/
+├── wren_project.yml          # name lifted from OSI semantic_model.name
+├── models/
+│   ├── customers/metadata.yml
+│   └── orders/metadata.yml
+├── relationships.yml
+├── instructions.md           # OSI ai_context.instructions + metrics notes
+└── AGENTS.md
+```
+
+After migration:
+
+- The OSI file is **no longer referenced**. You can delete it, archive it, or keep it for diffing — Wren never reads it again.
+- Edit the generated YAML directly. Add cubes under `cubes/`, views under `views/`, RLAC under each model's `properties`, etc.
+- Use the standard flow: `wren context validate` → `wren context build`.
+
+Any warnings the OSI conversion would normally emit (untyped fields, composite primary keys, cross-dataset metrics) are printed once during init so you know which spots in the generated YAML need a human review.
+
+### When *not* to migrate
+
+If your OSI file is updated by an upstream team and you want Wren to stay in sync, **do not** migrate — use `build --from-osi` instead. A migrated project is a snapshot; later OSI edits won't reach Wren without manually merging or re-running `init --from-osi --force` (which loses your post-migration edits).
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

Lets users of the [Open Semantic Interchange](https://github.com/open-semantic-interchange/OSI) spec turn an OSI YAML into a Wren MDL without forking it into a parallel wren project. Two entry points:

```bash
# Keep OSI as the single source of truth — every build re-reads it
wren context build|validate|show --from-osi semantic_model.yaml --data-source postgres

# Or migrate once to a native wren project, then own the YAML directly
wren context init --from-osi semantic_model.yaml --data-source postgres --path my_project
```

## Three ways to land

|  | Native wren | OSI kept as source | OSI migrated once |
|---|---|---|---|
| **Source files** | `wren_project.yml` + `models/` + `views/` + `relationships.yml` | A single `*.yaml` OSI file | wren project layout (after migration) |
| **Command** | `wren context init` → edit → `build` | `wren context build --from-osi` | `wren context init --from-osi` → edit → `build` |
| **Stays in sync with OSI?** | n/a | Yes — re-read every build | No — one-way snapshot |
| **Cubes / views / RLAC?** | Yes | No (OSI doesn't model them) | Yes (you own the YAML) |

## How wren-specific hints reach an OSI file

OSI has no file-system extension convention — its only sanctioned vendor escape hatch is the in-document `custom_extensions: [{vendor_name, data}]` block. Wren config (column types, dialect preference, composite-PK picks, metrics handling) is read from `custom_extensions[vendor_name=WREN]`:

```yaml
custom_extensions:
  - vendor_name: WREN
    data: '{"dialect": "SNOWFLAKE", "metrics": "note"}'

semantic_model:
  - name: shop
    datasets:
      - name: orders
        source: shop.public.orders
        custom_extensions:
          - vendor_name: WREN
            data: |
              {
                "column_types": {"order_id": "BIGINT", "amount": "DECIMAL(18,2)"}
              }
```

Resolution order: CLI flags > semantic_model-level WREN > root-level WREN > defaults.

## Actionable validate output

When a WREN block is needed but missing, the linter emits copy-pasteable YAML snippets for the user to paste into their OSI file:

- Untyped fields → `column_types` snippet per dataset
- Composite primary key → which column wren picked + override snippet
- Cross-dataset metric → flagged as note-only (Wren cubes bind to a single base_object)
- Multiple `semantic_model[]` entries → snippet for `default_semantic_model` at OSI root

`validate --from-osi --strict` exits 1 on any warning.

## Mapping summary

| OSI | Wren MDL |
|---|---|
| `dataset.source: a.b.c` | `model.table_reference: {catalog: a, schema: b, table: c}` |
| `dataset.source` with SQL keywords | `model.ref_sql` |
| `dataset.fields[]` | `model.columns[]` (dialect-picked expression, type from WREN/`is_time`/VARCHAR) |
| `dataset.primary_key: [x]` | `model.primary_key: x` (composite arrays warn + pick first) |
| `relationships[]` | wren `relationships` with synthesized `condition` and MANY_TO_ONE |
| `semantic_model.name` | `wren_project.yml.name` (when migrating via `init --from-osi`) |
| `semantic_model.ai_context.instructions` | MDL `_instructions` |
| `metrics[]` (top-level OSI) | rendered as markdown notes appended to instructions |

## Documentation

- New: [`docs/core/guides/osi.md`](docs/core/guides/osi.md) — full OSI guide covering the three flows, WREN extension block, mapping table, and migration section
- Updated: [`docs/core/guides/manage_project.md`](docs/core/guides/manage_project.md) — `init --from-osi` listed alongside `init --from-mdl` in the migration section

## Test plan

- [x] **72 new tests** in `tests/unit/test_osi.py` covering parse, WREN block extraction, precedence merging, every conversion path, lint warnings (untyped fields / composite PK / cross-dataset metric / ambiguous semantic_model), malformed input handling, non-string join columns, CLI smoke tests for `build` / `validate` / `show` / `init` + a round-trip check that `init → build` produces the same MDL as a direct `build --from-osi`
- [x] Real-world TPC-DS OSI example committed as a fixture, exercises every warning path
- [x] End-to-end smoke test against the wren engine via `dry_plan` confirms the produced MDL plans queries correctly (join + aggregation + calculated column)
- [x] Existing 157 context / convert-mdl tests still pass (one pre-existing flake on `test_validate_strict_warns` is unrelated to this PR)
- [x] `ruff format` + `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)