### PR TITLE
fix(wren-core): preserve composite-key predicates in relationship joins

### DIFF
--- a/core/wren-core/core/src/logical_plan/analyze/relation_chain.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/relation_chain.rs
@@ -9,10 +9,10 @@ use crate::logical_plan::utils::{
 use crate::mdl::context::SessionPropertiesRef;
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::JoinType;
-use crate::mdl::utils::{qualify_name_from_column_name, quoted};
+use crate::mdl::utils::{collect_join_keys, qualify_name_from_column_name, quoted};
 use crate::mdl::Dataset;
 use crate::mdl::{AnalyzedWrenMDL, SessionStateRef};
-use crate::{mdl, DataFusionError};
+use crate::DataFusionError;
 use datafusion::common::alias::AliasGenerator;
 use datafusion::common::{internal_err, plan_err, DFSchema, DFSchemaRef, Result};
 use datafusion::common::{plan_datafusion_err, TableReference};
@@ -148,31 +148,39 @@ impl RelationChain {
                     return plan_err!("Nil relation chain");
                 };
 
-                let join_keys: Vec<Expr> = mdl::utils::collect_identifiers(condition)?
-                    .iter()
-                    .map(|c| col(qualify_name_from_column_name(c)))
-                    .collect();
-
-                // The right key should be rebased if the right table has a generated alias
-                let join_keys = join_keys
-                    .into_iter()
-                    .map(|expr| match expr {
-                        Expr::Column(c) => {
-                            if c.relation
-                                .clone()
-                                .map(|r| r.table() != left_alias)
-                                .unwrap_or(false)
-                            {
-                                if let Some(right_alias) = &right_alias {
-                                    return rebase_column(&Expr::Column(c), right_alias);
-                                }
+                // Parse the relationship condition as a conjunction of column equalities.
+                // Composite keys (e.g. `a.x = b.x AND a.y = b.y`) produce one pair per
+                // equality; we rebase each column to the right alias when needed and AND
+                // the equalities back together to form the final join predicate.
+                let key_pairs = collect_join_keys(condition)?;
+                let right_alias_ref = right_alias.as_deref();
+                let rebase_key = |column: &datafusion::common::Column| -> Result<Expr> {
+                    let expr = col(qualify_name_from_column_name(column));
+                    if let Expr::Column(c) = &expr {
+                        let needs_rebase = c
+                            .relation
+                            .as_ref()
+                            .map(|r| r.table() != left_alias)
+                            .unwrap_or(false);
+                        if needs_rebase {
+                            if let Some(right_alias) = right_alias_ref {
+                                return rebase_column(&expr, right_alias);
                             }
-                            Ok::<_, DataFusionError>(Expr::Column(c))
                         }
-                        _ => Ok::<_, DataFusionError>(expr),
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                let join_condition = join_keys[0].clone().eq(join_keys[1].clone());
+                    }
+                    Ok::<_, DataFusionError>(expr)
+                };
+                let join_condition = key_pairs
+                    .iter()
+                    .map(|(l, r)| Ok(rebase_key(l)?.eq(rebase_key(r)?)))
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .reduce(|acc, eq| acc.and(eq))
+                    .ok_or_else(|| {
+                        plan_datafusion_err!(
+                            "Join condition `{condition}` produced no equality predicates"
+                        )
+                    })?;
                 let mut required_exprs = BTreeSet::new();
                 // collect the output calculated fields
                 match plan {

--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -4231,4 +4231,85 @@ mod test {
 
         Ok(())
     }
+
+    /// Verify that a relationship `condition` containing a conjunction of equalities
+    /// (composite-key join) propagates ALL equality predicates into the generated SQL,
+    /// instead of silently dropping any beyond the first pair.
+    #[tokio::test]
+    async fn test_composite_key_relationship() -> Result<()> {
+        let ctx = create_wren_ctx(None, None);
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("part")
+                    .table_reference("part")
+                    .column(ColumnBuilder::new("p_partkey", "int").build())
+                    .column(ColumnBuilder::new("p_suppkey", "int").build())
+                    .column(ColumnBuilder::new("p_brand", "string").build())
+                    .primary_key("p_partkey")
+                    .build(),
+            )
+            .model(
+                ModelBuilder::new("partsupp")
+                    .table_reference("partsupp")
+                    .column(ColumnBuilder::new("ps_partkey", "int").build())
+                    .column(ColumnBuilder::new("ps_suppkey", "int").build())
+                    .column(ColumnBuilder::new("ps_availqty", "int").build())
+                    .column(
+                        ColumnBuilder::new_relationship("part", "part", "partsupp_part")
+                            .build(),
+                    )
+                    .column(
+                        ColumnBuilder::new_calculated("part_brand", "string")
+                            .expression("part.p_brand")
+                            .build(),
+                    )
+                    .primary_key("ps_partkey")
+                    .build(),
+            )
+            .relationship(
+                RelationshipBuilder::new("partsupp_part")
+                    .model("partsupp")
+                    .model("part")
+                    .join_type(JoinType::ManyToOne)
+                    .condition(
+                        "partsupp.ps_partkey = part.p_partkey AND \
+                         partsupp.ps_suppkey = part.p_suppkey",
+                    )
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let sql = "SELECT part_brand FROM partsupp";
+        let transformed = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &[],
+            Arc::new(HashMap::default()),
+            sql,
+        )
+        .await?;
+        // Both join predicates must appear in the generated SQL, AND-ed together —
+        // the second pair (ps_suppkey/p_suppkey) was silently dropped before
+        // composite-key support landed.
+        let pk_pair = transformed.contains(r#""part".p_partkey = partsupp.ps_partkey"#)
+            || transformed.contains(r#"partsupp.ps_partkey = "part".p_partkey"#);
+        let sk_pair = transformed.contains(r#""part".p_suppkey = partsupp.ps_suppkey"#)
+            || transformed.contains(r#"partsupp.ps_suppkey = "part".p_suppkey"#);
+        assert!(pk_pair, "partkey predicate missing: {transformed}");
+        assert!(
+            sk_pair,
+            "suppkey predicate missing — composite key dropped: {transformed}"
+        );
+        assert!(
+            transformed.contains(" AND "),
+            "composite predicates should be conjoined with AND: {transformed}"
+        );
+        Ok(())
+    }
 }

--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -4286,29 +4286,12 @@ mod test {
             Mode::Unparse,
         )?);
         let sql = "SELECT part_brand FROM partsupp";
-        let transformed = transform_sql_with_ctx(
-            &ctx,
-            Arc::clone(&analyzed_mdl),
-            &[],
-            Arc::new(HashMap::default()),
-            sql,
-        )
-        .await?;
-        // Both join predicates must appear in the generated SQL, AND-ed together —
+        // The ON clause must carry BOTH equality predicates joined by AND —
         // the second pair (ps_suppkey/p_suppkey) was silently dropped before
         // composite-key support landed.
-        let pk_pair = transformed.contains(r#""part".p_partkey = partsupp.ps_partkey"#)
-            || transformed.contains(r#"partsupp.ps_partkey = "part".p_partkey"#);
-        let sk_pair = transformed.contains(r#""part".p_suppkey = partsupp.ps_suppkey"#)
-            || transformed.contains(r#"partsupp.ps_suppkey = "part".p_suppkey"#);
-        assert!(pk_pair, "partkey predicate missing: {transformed}");
-        assert!(
-            sk_pair,
-            "suppkey predicate missing — composite key dropped: {transformed}"
-        );
-        assert!(
-            transformed.contains(" AND "),
-            "composite predicates should be conjoined with AND: {transformed}"
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], Arc::new(HashMap::default()), sql).await?,
+            @r#"SELECT partsupp.part_brand FROM (SELECT __relation__1.p_brand AS part_brand FROM (SELECT "part".p_brand, "part".p_partkey, "part".p_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey FROM (SELECT "part".p_brand, "part".p_partkey, "part".p_suppkey FROM (SELECT "part".p_brand, "part".p_partkey, "part".p_suppkey FROM (SELECT __source.p_brand AS p_brand, __source.p_partkey AS p_partkey, __source.p_suppkey AS p_suppkey FROM "part" AS __source) AS "part") AS "part") AS "part" RIGHT OUTER JOIN (SELECT __source.ps_partkey AS ps_partkey, __source.ps_suppkey AS ps_suppkey FROM partsupp AS __source) AS partsupp ON "part".p_partkey = partsupp.ps_partkey AND "part".p_suppkey = partsupp.ps_suppkey) AS __relation__1) AS partsupp"#
         );
         Ok(())
     }

--- a/core/wren-core/core/src/mdl/utils.rs
+++ b/core/wren-core/core/src/mdl/utils.rs
@@ -63,6 +63,85 @@ pub fn collect_identifiers(expr: &str) -> Result<BTreeSet<Column>> {
     Ok(visited)
 }
 
+/// Parse a relationship join condition into a list of `(left, right)` column pairs in AST
+/// order. The condition must be a conjunction (`AND`) of equality (`=`) predicates over
+/// column references — for example `a.x = b.x AND a.y = b.y`. Each equality contributes one
+/// pair; pairs are preserved in source order so that callers can build a structurally
+/// correct multi-key join condition.
+///
+/// Returns an error if the condition contains non-equality predicates, disjunctions, or
+/// non-column operands.
+pub fn collect_join_keys(expr: &str) -> Result<Vec<(Column, Column)>> {
+    let parsed = match Parser::new(&GenericDialect {}).try_with_sql(expr) {
+        Ok(p) => p,
+        Err(e) => return plan_err!("Error parsing join condition `{expr}`: {e}"),
+    }
+    .parse_expr();
+    let parsed = match parsed {
+        Ok(e) => e,
+        Err(e) => return plan_err!("Error parsing join condition `{expr}`: {e}"),
+    };
+
+    let mut pairs = Vec::new();
+    collect_join_keys_inner(&parsed, &mut pairs)?;
+    if pairs.is_empty() {
+        return plan_err!(
+            "Join condition `{expr}` must contain at least one equality predicate"
+        );
+    }
+    Ok(pairs)
+}
+
+fn collect_join_keys_inner(
+    expr: &datafusion::sql::sqlparser::ast::Expr,
+    out: &mut Vec<(Column, Column)>,
+) -> Result<()> {
+    use datafusion::sql::sqlparser::ast::{BinaryOperator, Expr as SqlExpr};
+    match expr {
+        SqlExpr::Nested(inner) => collect_join_keys_inner(inner, out),
+        SqlExpr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => {
+            collect_join_keys_inner(left, out)?;
+            collect_join_keys_inner(right, out)
+        }
+        SqlExpr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            let l = column_from_sql_expr(left)?;
+            let r = column_from_sql_expr(right)?;
+            out.push((l, r));
+            Ok(())
+        }
+        other => plan_err!(
+            "Join condition must be a conjunction of column equalities, got: {other}"
+        ),
+    }
+}
+
+fn column_from_sql_expr(expr: &datafusion::sql::sqlparser::ast::Expr) -> Result<Column> {
+    use datafusion::sql::sqlparser::ast::Expr as SqlExpr;
+    match expr {
+        SqlExpr::Identifier(id) => Ok(Column::new_unqualified(id.value.clone())),
+        SqlExpr::CompoundIdentifier(ids) => {
+            let name = ids
+                .iter()
+                .map(|id| id.value.clone())
+                .collect::<Vec<String>>()
+                .join(".");
+            Ok(Column::new_unqualified(name))
+        }
+        SqlExpr::Nested(inner) => column_from_sql_expr(inner),
+        other => {
+            plan_err!("Expected column reference in join condition, got: {other}")
+        }
+    }
+}
+
 /// Provide a qualified name from a [Column] name.
 ///
 /// Example: if a column name is `"orders.customer.name"`, the qualified name would be `"orders"."customer"."name"`.
@@ -360,6 +439,79 @@ mod tests {
         assert!(result.contains(&super::Column::new_unqualified("City")));
         assert!(result.contains(&super::Column::new_unqualified("State")));
         Ok(())
+    }
+
+    #[test]
+    fn test_collect_join_keys_single() -> Result<()> {
+        let pairs = super::collect_join_keys("a.x = b.x")?;
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, super::Column::new_unqualified("a.x"));
+        assert_eq!(pairs[0].1, super::Column::new_unqualified("b.x"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_join_keys_composite() -> Result<()> {
+        let pairs = super::collect_join_keys("a.x = b.x AND a.y = b.y")?;
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, super::Column::new_unqualified("a.x"));
+        assert_eq!(pairs[0].1, super::Column::new_unqualified("b.x"));
+        assert_eq!(pairs[1].0, super::Column::new_unqualified("a.y"));
+        assert_eq!(pairs[1].1, super::Column::new_unqualified("b.y"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_join_keys_composite_three() -> Result<()> {
+        let pairs = super::collect_join_keys("a.x = b.x AND a.y = b.y AND a.z = b.z")?;
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[2].0, super::Column::new_unqualified("a.z"));
+        assert_eq!(pairs[2].1, super::Column::new_unqualified("b.z"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_join_keys_parenthesized() -> Result<()> {
+        let pairs = super::collect_join_keys("(a.x = b.x) AND (a.y = b.y)")?;
+        assert_eq!(pairs.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_join_keys_quoted() -> Result<()> {
+        let pairs =
+            super::collect_join_keys(r#""a"."X" = "b"."X" AND "a"."Y" = "b"."Y""#)?;
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, super::Column::new_unqualified("a.X"));
+        assert_eq!(pairs[0].1, super::Column::new_unqualified("b.X"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_join_keys_rejects_non_eq() {
+        let err = super::collect_join_keys("a.x > b.x").unwrap_err();
+        assert!(
+            err.to_string().contains("conjunction of column equalities"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collect_join_keys_rejects_disjunction() {
+        let err = super::collect_join_keys("a.x = b.x OR a.y = b.y").unwrap_err();
+        assert!(
+            err.to_string().contains("conjunction of column equalities"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collect_join_keys_rejects_literal() {
+        let err = super::collect_join_keys("a.x = 1").unwrap_err();
+        assert!(
+            err.to_string().contains("Expected column reference"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `RelationChain::plan` extracted all identifiers from a relationship `condition` and then used only the first two — so `a.x = b.x AND a.y = b.y` lost the second equality, breaking composite-key joins. The TPCH partsupp fixture in this repo already carries a TODO noting the gap (`// ps_partkey and ps_suppkey should be composite primary key`).
- Add `collect_join_keys` (new helper in `mdl/utils.rs`) that parses the condition expression and returns equality pairs in AST order, rejecting non-equality / disjunction / non-column shapes with a clear error.
- `relation_chain.rs` now rebases each column to the right alias (same logic as before) and ANDs the per-pair equalities into the final join predicate.
- This is the Phase 1 prerequisite for declarative composite primary keys (separate follow-up); on its own it already unlocks composite-join `condition` strings, which were previously expressible in MDL but silently truncated.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUST_MIN_STACK=8388608 cargo test --lib --tests --bins --release` — 133 passed (8 new helper tests + 1 new e2e composite-key test)
- [x] sqllogictest suites (`view.slt`, `model.slt`, `tpch/tpch.slt`, `type.slt`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support composite relationship keys: joins can be defined by multiple column equalities.

* **Bug Fixes**
  * Preserve multi-column join predicates during SQL transformation so all key equalities are included.

* **Tests**
  * Added unit and integration tests validating single- and multi-key join conditions, error cases, and snapshot coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->