### PR TITLE
feat(wren): query MDL views in the SDK rewriter and strict mode

### DIFF
--- a/core/wren/src/wren/connector/duckdb.py
+++ b/core/wren/src/wren/connector/duckdb.py
@@ -75,7 +75,7 @@ class DuckDBConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
             sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
-        return self.connection.execute(sql).to_arrow_table()
+        return self.connection.execute(sql).fetch_arrow_table()
 
     def dry_run(self, sql: str) -> None:
         self.connection.execute(f"EXPLAIN {sql}")

--- a/core/wren/src/wren/engine.py
+++ b/core/wren/src/wren/engine.py
@@ -173,12 +173,17 @@ class WrenEngine:
 
             manifest_json = json.loads(base64.b64decode(self.manifest_str))
             model_names = {m["name"] for m in manifest_json.get("models", [])}
+            view_names = {v["name"] for v in manifest_json.get("views", [])}
+            # Views are MDL-defined objects too. Strict mode gates access to
+            # objects *outside* the manifest, so a view reference is allowed;
+            # ``extract_by`` scopes the view (and the models it joins) in.
+            queryable_names = model_names | view_names
 
             # Policy validation: check tables and functions before execution.
             if self._config.strict_mode or self._config.denied_functions:
-                validate_sql_policy(ast, model_names, self._config)
+                validate_sql_policy(ast, queryable_names, self._config)
 
-            # Resolve table refs to canonical manifest model names so that
+            # Resolve table refs to canonical manifest names so that
             # ``extract_by`` (case-sensitive in Rust) finds them under SQL's
             # case-sensitivity rules: quoted identifiers match exactly,
             # unquoted fall back to a case-insensitive scan.
@@ -189,7 +194,7 @@ class WrenEngine:
                 quoted = (
                     bool(t.this.quoted) if isinstance(t.this, exp.Identifier) else False
                 )
-                resolved = resolve_model_name(t.name, quoted, model_names)
+                resolved = resolve_model_name(t.name, quoted, queryable_names)
                 tables.append(resolved if resolved is not None else t.name)
 
             extractor = get_manifest_extractor(self.manifest_str)

--- a/core/wren/src/wren/mdl/cte_rewriter.py
+++ b/core/wren/src/wren/mdl/cte_rewriter.py
@@ -1,9 +1,14 @@
 """CTE-based SQL rewriter.
 
 Parses user SQL with sqlglot, uses ``qualify_columns`` to fully resolve
-all column references, then calls wren-core
-``transform_sql`` once per model with a simple ``SELECT col1, col2 FROM
-model`` and injects each expanded result as a CTE into the original query.
+all column references, then calls wren-core ``transform_sql`` once per model
+with a simple ``SELECT col1, col2 FROM model`` and injects each expanded
+result as a CTE into the original query.
+
+A referenced view is handled differently: its ``statement`` is native SQL
+that references models, so it is injected as a CTE **verbatim** (never sent
+to wren-core), and the models it references are emitted as model CTEs before
+it. This keeps the view as the executable SQL it was authored as.
 """
 
 from __future__ import annotations
@@ -100,11 +105,24 @@ class CTERewriter:
             self.schema.add_table(schema_name, cols, dialect=self.dialect)
             self._col_orig_name[name] = orig
 
+        # A view's ``statement`` is native-dialect SQL that references models.
+        # It is NOT expanded by wren-core — it becomes a CTE kept verbatim,
+        # preceded by model CTEs for the models it references. view_dict maps
+        # name → the view object so the statement can be emitted as-is.
+        self.view_dict: dict[str, dict] = {
+            view["name"]: view for view in self.manifest.get("views", [])
+        }
+        self.view_names: set[str] = set(self.view_dict)
+
     def rewrite(self, sql: str) -> str:
-        """Rewrite *sql* by injecting model CTEs.
+        """Rewrite *sql* by injecting model and view CTEs.
+
+        Models are expanded by wren-core. A referenced view is emitted as a
+        CTE holding its native-SQL ``statement`` verbatim; the models that
+        statement references are expanded as model CTEs placed before it.
 
         Returns the transformed SQL string in the target sqlglot dialect.
-        If no model references are found, falls back to
+        If no model or view references are found, falls back to
         ``session_context.transform_sql(sql)`` directly (when ``fallback``
         is ``True``); otherwise raises ``ValueError``.
         """
@@ -112,17 +130,23 @@ class CTERewriter:
 
         user_cte_names = self._collect_user_cte_names(ast)
         used_columns, user_table_refs = self._collect_model_columns(ast, user_cte_names)
+        view_refs = self._collect_view_refs(ast, user_cte_names)
 
-        # No model references detected — either fall back to the legacy
-        # whole-query transform, or raise so tests can catch the miss.
-        if not used_columns:
+        # A view's native-SQL statement references models; collect those so
+        # they get model CTEs placed before the (verbatim) view CTEs.
+        self._collect_view_model_usage(view_refs, used_columns, user_table_refs)
+
+        # No model or view references detected — either fall back to the
+        # legacy whole-query transform, or raise so tests can catch the miss.
+        if not used_columns and not view_refs:
             if self.fallback:
                 wren_sql = self.session_context.transform_sql(sql)
                 return sqlglot.transpile(wren_sql, read="wren", write=self.dialect)[0]
-            raise ValueError(f"No model references found in SQL: {sql}")
+            raise ValueError(f"No model or view references found in SQL: {sql}")
 
         model_ctes = self._build_model_ctes(used_columns, user_table_refs)
-        self._inject_ctes(ast, model_ctes)
+        view_ctes = self._build_view_ctes(view_refs)
+        self._inject_ctes(ast, model_ctes + view_ctes)
         # Oracle uppercases unquoted identifiers. Without forcing quoting
         # on output, the user's ``SELECT o_orderkey FROM orders`` would
         # land as ``SELECT O_ORDERKEY FROM ORDERS`` — both the table
@@ -241,6 +265,39 @@ class CTERewriter:
             user_table_refs.setdefault(model_name, (name, quoted))
         return alias_to_model, user_table_refs
 
+    def _collect_view_refs(
+        self, ast: exp.Expression, user_cte_names: set[str]
+    ) -> dict[str, tuple[str, bool]]:
+        """Map each referenced MDL view to the user-written ``(name, quoted)``.
+
+        Resolves table references against view names with the same
+        quoted/unquoted rules as models. The recorded identifier is used as
+        the injected CTE alias so dialects with case-folding bind the user's
+        ``FROM <view>`` to the CTE. Unlike ``_build_alias_map`` it does not
+        track SQL aliases, since a view is always expanded whole.
+        """
+        view_refs: dict[str, tuple[str, bool]] = {}
+        qualified = qualify_tables(ast.copy(), dialect=self.dialect)
+        for table in qualified.find_all(exp.Table):
+            name = table.name
+            if not name or name.lower() in user_cte_names:
+                continue
+            quoted = (
+                bool(table.this.quoted)
+                if isinstance(table.this, exp.Identifier)
+                else False
+            )
+            view_name = resolve_model_name(name, quoted, self.view_names)
+            if view_name is None:
+                continue
+            # A name defined as both a model and a view (malformed MDL) would
+            # otherwise emit two CTEs with the same name — invalid SQL. The
+            # model CTE wins; skip the view so output stays valid.
+            if resolve_model_name(name, quoted, self.model_dict) is not None:
+                continue
+            view_refs.setdefault(view_name, (name, quoted))
+        return view_refs
+
     # ------------------------------------------------------------------
     # CTE generation
     # ------------------------------------------------------------------
@@ -293,6 +350,70 @@ class CTERewriter:
             cte_name, cte_quoted = user_table_refs.get(model_name, (model_name, True))
             cte = exp.CTE(
                 this=expanded_ast,
+                alias=exp.TableAlias(
+                    this=exp.to_identifier(cte_name, quoted=cte_quoted)
+                ),
+            )
+            ctes.append(cte)
+        return ctes
+
+    def _collect_view_model_usage(
+        self,
+        view_refs: dict[str, tuple[str, bool]],
+        used_columns: dict[str, list[str] | None],
+        user_table_refs: dict[str, tuple[str, bool]],
+    ) -> None:
+        """Merge the models each referenced view's statement uses into
+        *used_columns* / *user_table_refs*, so those models get CTEs.
+
+        A view's statement is native SQL referencing models by name. Parsing
+        it through the same model-collection path captures which model columns
+        it needs. (Views referencing other views are not supported — the
+        manifest extractor does not scope nested views in, so they fail
+        earlier with a "table not found" planning error.)
+        """
+        for view_name in view_refs:
+            view_ast = parse_one(
+                self.view_dict[view_name]["statement"], dialect=self.dialect
+            )
+            view_cte_names = self._collect_user_cte_names(view_ast)
+            v_cols, v_refs = self._collect_model_columns(view_ast, view_cte_names)
+            self._merge_used_columns(used_columns, v_cols)
+            for model_name, ref in v_refs.items():
+                user_table_refs.setdefault(model_name, ref)
+
+    @staticmethod
+    def _merge_used_columns(
+        base: dict[str, list[str] | None], extra: dict[str, list[str] | None]
+    ) -> None:
+        """Merge *extra* model→columns into *base* in place.
+
+        ``None`` means ``SELECT *`` and wins over a specific column list;
+        otherwise column lists are unioned, preserving order.
+        """
+        for model, cols in extra.items():
+            if model not in base:
+                base[model] = cols
+            elif base[model] is None or cols is None:
+                base[model] = None
+            else:
+                seen = set(base[model])
+                base[model] = base[model] + [c for c in cols if c not in seen]
+
+    def _build_view_ctes(self, view_refs: dict[str, tuple[str, bool]]) -> list[exp.CTE]:
+        """Generate one CTE per view, holding the native-SQL statement as-is.
+
+        The statement is parsed/emitted with the target dialect (it is native
+        SQL) and references models by name, which resolve to the model CTEs
+        injected before it. wren-core is never asked to expand the view.
+        """
+        ctes: list[exp.CTE] = []
+        for view_name, (cte_name, cte_quoted) in view_refs.items():
+            body = parse_one(
+                self.view_dict[view_name]["statement"], dialect=self.dialect
+            )
+            cte = exp.CTE(
+                this=body,
                 alias=exp.TableAlias(
                     this=exp.to_identifier(cte_name, quoted=cte_quoted)
                 ),

--- a/core/wren/tests/unit/test_cte_rewriter.py
+++ b/core/wren/tests/unit/test_cte_rewriter.py
@@ -80,6 +80,23 @@ _MULTI_MODEL_MANIFEST = {
 }
 
 
+_VIEW_MANIFEST = {
+    "catalog": "wren",
+    "schema": "public",
+    "models": _MULTI_MODEL_MANIFEST["models"],
+    "relationships": _MULTI_MODEL_MANIFEST["relationships"],
+    "views": [
+        {
+            "name": "orders_with_customer",
+            "statement": (
+                "SELECT o.o_orderkey, o.o_orderstatus, c.c_name "
+                'FROM "orders" o JOIN "customer" c ON o.o_custkey = c.c_custkey'
+            ),
+        }
+    ],
+}
+
+
 def _b64(manifest: dict) -> str:
     return base64.b64encode(orjson.dumps(manifest)).decode()
 
@@ -264,9 +281,7 @@ class TestCTEEdgeCases:
         ast = sqlglot.parse_one(result, dialect="duckdb")
         with_clause = ast.args.get("with_")
         if with_clause:
-            cte_names = [
-                cte.args["alias"].this.name for cte in with_clause.expressions
-            ]
+            cte_names = [cte.args["alias"].this.name for cte in with_clause.expressions]
             orders_count = sum(1 for n in cte_names if n.lower() == "orders")
             assert orders_count <= 1, f"Duplicate 'orders' CTE: {result}"
 
@@ -325,6 +340,78 @@ class TestCorrelatedSubquery:
         )
         assert _has_cte(result, "orders")
         assert _has_cte(result, "customer")
+
+
+# ---------------------------------------------------------------------------
+# Tests: MDL views
+# ---------------------------------------------------------------------------
+
+
+class TestView:
+    def test_view_only_query(self):
+        """A view-only query expands the view as a verbatim CTE, plus the
+        model CTEs the view statement references."""
+        rw = _make_rewriter(_VIEW_MANIFEST)
+        result = rw.rewrite('SELECT o_orderkey FROM "orders_with_customer"')
+        assert _has_cte(result, "orders_with_customer")
+        assert _has_cte(result, "orders")
+        assert _has_cte(result, "customer")
+
+    def test_model_ctes_precede_view_cte(self):
+        """The models a view references must be defined before the view CTE."""
+        rw = _make_rewriter(_VIEW_MANIFEST)
+        result = rw.rewrite('SELECT c_name FROM "orders_with_customer"')
+        ast = sqlglot.parse_one(result, dialect="duckdb")
+        cte_names = [
+            cte.args["alias"].this.name for cte in ast.args["with_"].expressions
+        ]
+        view_idx = cte_names.index("orders_with_customer")
+        assert cte_names.index("orders") < view_idx
+        assert cte_names.index("customer") < view_idx
+
+    def test_view_body_kept_verbatim(self):
+        """The view CTE body is the native-SQL statement, not a wren-core
+        expansion — it still references the models by name and keeps the join."""
+        rw = _make_rewriter(_VIEW_MANIFEST)
+        result = rw.rewrite('SELECT c_name FROM "orders_with_customer"')
+        body = _cte_body_sql(result, "orders_with_customer")
+        assert body is not None
+        body_lower = body.lower()
+        assert "orders" in body_lower
+        assert "customer" in body_lower
+        assert "join" in body_lower
+
+    def test_view_select_star(self):
+        rw = _make_rewriter(_VIEW_MANIFEST)
+        result = rw.rewrite('SELECT * FROM "orders_with_customer"')
+        assert _has_cte(result, "orders_with_customer")
+        assert _has_cte(result, "orders")
+        assert _has_cte(result, "customer")
+
+    def test_view_join_model(self):
+        rw = _make_rewriter(_VIEW_MANIFEST)
+        result = rw.rewrite(
+            "SELECT v.c_name, o.o_orderstatus "
+            'FROM "orders_with_customer" v '
+            'JOIN "orders" o ON v.o_orderkey = o.o_orderkey'
+        )
+        assert _has_cte(result, "orders_with_customer")
+        assert _has_cte(result, "orders")
+        assert _has_cte(result, "customer")
+
+    def test_user_cte_references_view_and_model(self):
+        rw = _make_rewriter(_VIEW_MANIFEST)
+        result = rw.rewrite(
+            "WITH summary AS ("
+            "  SELECT v.c_name, o.o_orderkey "
+            '  FROM "orders_with_customer" v '
+            '  JOIN "orders" o ON v.o_orderkey = o.o_orderkey'
+            ") SELECT * FROM summary"
+        )
+        assert _has_cte(result, "orders_with_customer")
+        assert _has_cte(result, "orders")
+        assert _has_cte(result, "customer")
+        assert _has_cte(result, "summary")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A `View` is an MDL-defined object, so strict mode — which exists to block access to objects **outside** the manifest — should permit querying it. It didn't:

- **Policy:** `WrenEngine._plan` built its strict-mode validation/resolution set from `models` only. Any view reference was rejected with `MODEL_NOT_FOUND`.
- **Rewriter:** `CTERewriter` only expanded models, so a view-only query raised `No model references found`.

wren-core itself fully supports views; the SDK query path just never wired them in.

## Change

**Query MDL views in the SDK:**
- `engine.py`: include view names in the strict-mode policy set **and** the name-resolution set passed to `extract_by`.
- `cte_rewriter.py`: a view's `statement` is native-dialect SQL that references models. Emit it as a CTE **verbatim** (parsed by sqlglot, never sent to wren-core), and expand the models it references as model CTEs placed **before** it:

  ```sql
  WITH orders AS (<wren-core expansion>),
       customer AS (<wren-core expansion>),
       orders_with_customer AS (
         SELECT o.o_orderkey, o.o_orderstatus, c.c_name
         FROM orders o JOIN customer c ON o.o_custkey = c.c_custkey   -- verbatim
       )
  SELECT ... FROM orders_with_customer
  ```

  Benefits: the view stays the native SQL it was authored as, no double-expansion of models the outer query also references, flatter output.

**Drive-by fix (found while testing):**
- `connector/duckdb.py`: `execute().to_arrow_table()` → `fetch_arrow_table()`. `to_arrow_table` lives on `DuckDBPyRelation`, not the connection, so `WrenEngine.query()` raised `AttributeError` on duckdb 1.3.2.

## Tests

`tests/unit/test_cte_rewriter.py` — added a view to a TPCH-style manifest and cover: view-only, view⨝model join, `SELECT *`, model-CTE-precedes-view-CTE ordering, and a user CTE referencing both a view and a model.

Full unit suite: **287 passed, 38 skipped**. Lint clean.

## Limitations

A view referencing **another view** is not supported — the manifest extractor does not scope nested views into the session, so it fails earlier with a planning `table not found`. Access control on the underlying models is still enforced when accessed through a view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Views are now fully supported as queryable MDL objects alongside models, enabling queries against defined views and their dependent models.

* **Tests**
  * Added comprehensive test coverage for view queries and view-to-model interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canner/WrenAI/pull/2334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->