### PR TITLE
fix(wren): support Databricks catalog

### DIFF
--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -11,6 +11,16 @@ from wren.model import (
 )
 
 
+def _connection_kwargs(connection_info: DatabricksConnectionUnion) -> dict[str, str]:
+    kwargs = {
+        "server_hostname": connection_info.server_hostname,
+        "http_path": connection_info.http_path,
+    }
+    if connection_info.catalog:
+        kwargs["catalog"] = connection_info.catalog
+    return kwargs
+
+
 class DatabricksConnector(ConnectorABC):
     def __init__(self, connection_info: DatabricksConnectionUnion):
         from databricks import sql as dbsql  # noqa: PLC0415
@@ -19,8 +29,7 @@ class DatabricksConnector(ConnectorABC):
 
         if isinstance(connection_info, DatabricksTokenConnectionInfo):
             self.connection = dbsql.connect(
-                server_hostname=connection_info.server_hostname,
-                http_path=connection_info.http_path,
+                **_connection_kwargs(connection_info),
                 access_token=connection_info.access_token.get_secret_value(),
             )
         elif isinstance(connection_info, DatabricksServicePrincipalConnectionInfo):
@@ -36,8 +45,7 @@ class DatabricksConnector(ConnectorABC):
                 return oauth_service_principal(DbConfig(**kwargs))
 
             self.connection = dbsql.connect(
-                server_hostname=connection_info.server_hostname,
-                http_path=connection_info.http_path,
+                **_connection_kwargs(connection_info),
                 credentials_provider=credential_provider,
             )
 

--- a/core/wren/src/wren/dbt.py
+++ b/core/wren/src/wren/dbt.py
@@ -520,22 +520,21 @@ def convert_dbt_target_to_wren_profile(target: DbtTarget) -> dict[str, Any]:
         )
 
     if datasource == "databricks":
+        payload = {
+            "databricks_type": "token",
+            "server_hostname": str(
+                _require_output_field(output, "server_hostname", "host")
+            ),
+            "http_path": str(_require_output_field(output, "http_path", "httpPath")),
+            "access_token": str(
+                _require_output_field(output, "token", "access_token", "accessToken")
+            ),
+        }
+        if output.get("catalog"):
+            payload["catalog"] = str(output["catalog"])
         return _build_wren_profile(
             "databricks",
-            {
-                "databricks_type": "token",
-                "server_hostname": str(
-                    _require_output_field(output, "server_hostname", "host")
-                ),
-                "http_path": str(
-                    _require_output_field(output, "http_path", "httpPath")
-                ),
-                "access_token": str(
-                    _require_output_field(
-                        output, "token", "access_token", "accessToken"
-                    )
-                ),
-            },
+            payload,
         )
 
     if datasource == "bigquery":

--- a/core/wren/src/wren/model/__init__.py
+++ b/core/wren/src/wren/model/__init__.py
@@ -208,6 +208,7 @@ class DatabricksTokenConnectionInfo(BaseConnectionInfo):
         alias="serverHostname", examples=["dbc-xxx.cloud.databricks.com"]
     )
     http_path: str = Field(alias="httpPath", examples=["/sql/1.0/warehouses/xxx"])
+    catalog: str | None = Field(default=None, examples=["main"])
     access_token: SecretStr = Field(alias="accessToken", examples=["dapi..."])
 
 
@@ -215,6 +216,7 @@ class DatabricksServicePrincipalConnectionInfo(BaseConnectionInfo):
     databricks_type: Literal["service_principal"] = "service_principal"
     server_hostname: str = Field(alias="serverHostname")
     http_path: str = Field(alias="httpPath")
+    catalog: str | None = Field(default=None, examples=["main"])
     client_id: SecretStr = Field(alias="clientId")
     client_secret: SecretStr = Field(alias="clientSecret")
     azure_tenant_id: str | None = Field(alias="azureTenantId", default=None)

--- a/core/wren/tests/test_field_registry.py
+++ b/core/wren/tests/test_field_registry.py
@@ -181,6 +181,19 @@ def test_hidden_discriminator_fields():
     assert db_fields["databricks_type"].default == "token"
 
 
+def test_databricks_catalog_field_is_optional():
+    """Databricks catalog should be available without making old configs invalid."""
+    token_fields = {f.name: f for f in get_fields("databricks", variant="token")}
+    assert token_fields["catalog"].required is False
+    assert token_fields["catalog"].label == "Catalog"
+
+    sp_fields = {
+        f.name: f for f in get_fields("databricks", variant="service_principal")
+    }
+    assert sp_fields["catalog"].required is False
+    assert sp_fields["catalog"].label == "Catalog"
+
+
 def test_fields_match_mcp_web_ui_postgres():
     """Regression: generated postgres fields cover all fields in old DATASOURCE_FIELDS."""
     expected_names = {"host", "port", "database", "user", "password"}

--- a/core/wren/tests/unit/test_databricks_connector.py
+++ b/core/wren/tests/unit/test_databricks_connector.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from wren.connector.databricks import DatabricksConnector
+from wren.model import (
+    DatabricksServicePrincipalConnectionInfo,
+    DatabricksTokenConnectionInfo,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def databricks_connect_calls(monkeypatch):
+    calls = []
+
+    def connect(**kwargs):
+        calls.append(kwargs)
+        return MagicMock()
+
+    databricks_module = types.ModuleType("databricks")
+    sql_module = types.ModuleType("databricks.sql")
+    sql_module.connect = connect
+    databricks_module.sql = sql_module
+
+    sdk_module = types.ModuleType("databricks.sdk")
+    core_module = types.ModuleType("databricks.sdk.core")
+
+    class Config:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def oauth_service_principal(config):
+        return ("oauth", config.kwargs)
+
+    core_module.Config = Config
+    core_module.oauth_service_principal = oauth_service_principal
+    sdk_module.core = core_module
+
+    monkeypatch.setitem(sys.modules, "databricks", databricks_module)
+    monkeypatch.setitem(sys.modules, "databricks.sql", sql_module)
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk_module)
+    monkeypatch.setitem(sys.modules, "databricks.sdk.core", core_module)
+
+    return calls
+
+
+def test_token_connection_passes_catalog(databricks_connect_calls):
+    info = DatabricksTokenConnectionInfo(
+        server_hostname="dbc.example.cloud.databricks.com",
+        http_path="/sql/1.0/warehouses/abc",
+        catalog="main",
+        access_token=SecretStr("dapi-token"),
+    )
+
+    DatabricksConnector(info)
+
+    assert databricks_connect_calls[-1] == {
+        "server_hostname": "dbc.example.cloud.databricks.com",
+        "http_path": "/sql/1.0/warehouses/abc",
+        "catalog": "main",
+        "access_token": "dapi-token",
+    }
+
+
+def test_token_connection_omits_empty_catalog(databricks_connect_calls):
+    info = DatabricksTokenConnectionInfo(
+        server_hostname="dbc.example.cloud.databricks.com",
+        http_path="/sql/1.0/warehouses/abc",
+        catalog="",
+        access_token=SecretStr("dapi-token"),
+    )
+
+    DatabricksConnector(info)
+
+    assert "catalog" not in databricks_connect_calls[-1]
+
+
+def test_service_principal_connection_passes_catalog(databricks_connect_calls):
+    info = DatabricksServicePrincipalConnectionInfo(
+        server_hostname="dbc.example.cloud.databricks.com",
+        http_path="/sql/1.0/warehouses/abc",
+        catalog="analytics",
+        client_id=SecretStr("client-id"),
+        client_secret=SecretStr("client-secret"),
+        azure_tenant_id="tenant-id",
+    )
+
+    DatabricksConnector(info)
+
+    call = databricks_connect_calls[-1]
+    assert call["server_hostname"] == "dbc.example.cloud.databricks.com"
+    assert call["http_path"] == "/sql/1.0/warehouses/abc"
+    assert call["catalog"] == "analytics"
+
+    credentials = call["credentials_provider"]()
+    assert credentials == (
+        "oauth",
+        {
+            "host": "dbc.example.cloud.databricks.com",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "azure_tenant_id": "tenant-id",
+        },
+    )

--- a/core/wren/tests/unit/test_dbt.py
+++ b/core/wren/tests/unit/test_dbt.py
@@ -279,6 +279,32 @@ class TestConvertDbtTargetToWrenProfile:
         assert profile["dataset_id"] == "analytics"
         assert profile["credentials"]
 
+    def test_convert_databricks_profile_preserves_catalog(self, tmp_path):
+        project_dir, profiles_path = _write_basic_dbt_project(tmp_path)
+        profiles_path.write_text(
+            "jaffle_shop:\n"
+            "  target: dev\n"
+            "  outputs:\n"
+            "    dev:\n"
+            "      type: databricks\n"
+            "      host: dbc.example.cloud.databricks.com\n"
+            "      http_path: /sql/1.0/warehouses/abc\n"
+            "      token: dapi-token\n"
+            "      catalog: main\n"
+        )
+        target = resolve_dbt_target(project_dir, profiles_path=profiles_path)
+
+        profile = convert_dbt_target_to_wren_profile(target)
+
+        assert profile == {
+            "datasource": "databricks",
+            "databricks_type": "token",
+            "server_hostname": "dbc.example.cloud.databricks.com",
+            "http_path": "/sql/1.0/warehouses/abc",
+            "access_token": "dapi-token",
+            "catalog": "main",
+        }
+
     def test_convert_profile_missing_required_field(self, tmp_path):
         project_dir, profiles_path = _write_basic_dbt_project(tmp_path)
         profiles_path.write_text(


### PR DESCRIPTION
## Summary

- Add optional `catalog` support to Databricks token and service principal connection info.
- Pass `catalog` through to `databricks.sql.connect()` when it is provided.
- Preserve Databricks `catalog` from dbt targets when generating Wren profiles.
- Add focused unit coverage for connector wiring, field registry exposure, and dbt profile conversion.

## Why

In Unity Catalog workspaces with multiple catalogs, Databricks SQL cannot always resolve unqualified `INFORMATION_SCHEMA` references without a selected catalog. This gives users a way to set the catalog through Wren's Databricks connection profile.

Fixes #2177.

## Testing

```bash
PYTHONPATH=src .venv/bin/python -m pytest tests/unit/test_databricks_connector.py tests/unit/test_dbt.py::TestConvertDbtTargetToWrenProfile::test_convert_databricks_profile_preserves_catalog tests/test_field_registry.py

.venv/bin/python -m ruff check src/wren/connector/databricks.py src/wren/model/__init__.py src/wren/dbt.py tests/unit/test_databricks_connector.py tests/test_field_registry.py tests/unit/test_dbt.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `catalog` parameter support for Databricks connections (both token-based and service-principal authentication methods). Existing configurations without catalog remain fully compatible.

* **Tests**
  * Added regression and unit tests to verify catalog field is optional and that connection parameters are correctly passed to Databricks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->