### PR TITLE
docs: align skill install docs with the discovery-stub model (#2341)

### DIFF
--- a/docs/core/concepts/agent_learning.md
+++ b/docs/core/concepts/agent_learning.md
@@ -16,9 +16,9 @@ The difference is that an agent forgets between sessions unless your tooling sto
 
 Wren AI runs the agent through two beats whenever you set up a new project.
 
-**Beat 1 — Scaffold fast.** The `wren-generate-mdl` skill drives the agent through schema discovery, type normalization, and an initial MDL project. The agent can already query through that modeled layer in a few minutes. The MDL is rough but functional — it covers what the database can tell you about itself.
+**Beat 1 — Scaffold fast.** The `generate-mdl` guide drives the agent through schema discovery, type normalization, and an initial MDL project. The agent can already query through that modeled layer in a few minutes. The MDL is rough but functional — it covers what the database can tell you about itself.
 
-**Beat 2 — Enrich deep.** Structure is only the start. The hard business meaning lives in docs, decks, Slack threads, and analyst SQL. The `wren-enrich-context` workflow brings that meaning in through two modes:
+**Beat 2 — Enrich deep.** Structure is only the start. The hard business meaning lives in docs, decks, Slack threads, and analyst SQL. The `enrich-context` workflow brings that meaning in through two modes:
 
 - **Grill mode** — the agent asks one focused question at a time ("which is the canonical `orders` table?", "what does `status = 4` mean?", "should `active customer` exclude internal users?"). You answer; the agent patches MDL, `instructions.md`, `queries.yml`, or memory.
 - **Auto-pilot mode** — drop PDFs, glossaries, handbooks, and SQL history into `<project>/raw/`. The agent reads them, proposes context changes with evidence, and waits for review.
@@ -40,7 +40,7 @@ The agent reads from all four when it gathers context for a new question. The fi
 
 ## The query workflow in practice
 
-The `wren-usage` skill orchestrates the day-to-day pattern:
+The `usage` guide orchestrates the day-to-day pattern:
 
 ```text
 User asks a business question

--- a/docs/core/concepts/stack_position.md
+++ b/docs/core/concepts/stack_position.md
@@ -50,7 +50,7 @@ Three things sit above Wren AI: the **agents** that ask questions. Three things 
 
 ### You have no semantic layer
 
-Wren AI can be your first one. The `wren-generate-mdl` skill scaffolds an MDL project from your warehouse schema in a few minutes. Enrich it over time with the grill / auto-pilot workflow.
+Wren AI can be your first one. The `generate-mdl` guide scaffolds an MDL project from your warehouse schema in a few minutes. Enrich it over time with the grill / auto-pilot workflow.
 
 ### You have a transformation pipeline (dbt, Coalesce, in-house)
 

--- a/docs/core/concepts/what_is_mdl.md
+++ b/docs/core/concepts/what_is_mdl.md
@@ -89,7 +89,7 @@ See [Manage project](/oss/guides/manage_project) for the project structure and l
 
 ## From raw schema to trusted context
 
-MDL usually starts with scaffolding. The `wren-generate-mdl` skill can inspect a database, normalize types, detect structure, and generate an initial project so the agent can query through a modeled layer quickly.
+MDL usually starts with scaffolding. The `generate-mdl` guide can inspect a database, normalize types, detect structure, and generate an initial project so the agent can query through a modeled layer quickly.
 
 That first pass is useful, but it is only the beginning. The deeper value comes when your team enriches the model:
 

--- a/docs/core/get_started/installation.md
+++ b/docs/core/get_started/installation.md
@@ -6,18 +6,18 @@ sidebar_label: Installation
 
 Get Wren AI running. Your AI coding agent does the rest.
 
-## 1. Install the skill bundle
+## 1. Install the skill
 
-Skills are workflow guides that teach AI coding agents (Claude Code, Openclaw, Hermes, Codex, etc.) how to drive the Wren CLI for you:
+This installs a single **discovery stub** (`wren`) that teaches AI coding agents (Claude Code, Openclaw, Hermes, Codex, etc.) how to drive the Wren CLI for you:
 
 ```bash
-npx skills add Canner/WrenAI --skill '*'
+npx skills add Canner/WrenAI
 ```
 
-Have multiple AI coding agents installed and want the skills available in all of them? Pass `--agent '*'`:
+Have multiple AI coding agents installed and want the stub available in all of them? Pass `--agent '*'`:
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent '*'
+npx skills add Canner/WrenAI --agent '*'
 ```
 
 Or via the install script:
@@ -26,13 +26,13 @@ Or via the install script:
 curl -fsSL https://raw.githubusercontent.com/Canner/WrenAI/main/skills/install.sh | bash
 ```
 
-> See the [Skills reference](/oss/reference/skills) for the full list of skills installed and what each one does.
+> **Only one skill is installed** — `wren` (at `~/.claude/skills/wren/SKILL.md` for Claude Code). This is expected. Since Wren `0.8`, the workflow guides (`onboarding`, `usage`, `generate-mdl`, `dlt-connector`, `enrich-context`) no longer install as separate skills; they live inside the `wren` CLI and the stub fetches them on demand with `wren skills get <name>`. See the [Skills reference](/oss/reference/skills) for the full delivery model and what each guide does.
 
 ## 2. Ask your agent to set things up
 
 **Start a new agent session** (skills load at session start), open your project directory, and ask:
 
-Use the `/wren-onboarding` skill to install and set up Wren AI.
+Use the `/wren` skill to install and set up Wren AI.
 
 The agent will check your environment, install Python dependencies, create a connection profile for your data source, scaffold the project, and run a first query — all in one flow.
 

--- a/docs/core/get_started/quickstart-with-agent/adal.md
+++ b/docs/core/get_started/quickstart-with-agent/adal.md
@@ -13,7 +13,7 @@ A lightweight coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent adal
+npx skills add Canner/WrenAI --agent adal
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in AdaL, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/aider-desk.md
+++ b/docs/core/get_started/quickstart-with-agent/aider-desk.md
@@ -13,7 +13,7 @@ A desktop UI for the Aider coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent aider-desk
+npx skills add Canner/WrenAI --agent aider-desk
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Launch the AiderDesk app, then `File → Open Folder...` to open your project an
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/amp.md
+++ b/docs/core/get_started/quickstart-with-agent/amp.md
@@ -13,7 +13,7 @@ Sourcegraph's coding agent. Uses the shared `.agents/skills/` directory.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent amp
+npx skills add Canner/WrenAI --agent amp
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ amp
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/antigravity.md
+++ b/docs/core/get_started/quickstart-with-agent/antigravity.md
@@ -14,7 +14,7 @@ Google's AI development workspace.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent antigravity
+npx skills add Canner/WrenAI --agent antigravity
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project folder in Antigravity, then start a new agent session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/augment.md
+++ b/docs/core/get_started/quickstart-with-agent/augment.md
@@ -14,7 +14,7 @@ Augment Code coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent augment
+npx skills add Canner/WrenAI --agent augment
 ```
 
 ## Run onboarding
@@ -28,7 +28,7 @@ auggie
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/bob.md
+++ b/docs/core/get_started/quickstart-with-agent/bob.md
@@ -14,7 +14,7 @@ IBM watsonx coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent bob
+npx skills add Canner/WrenAI --agent bob
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project folder in IBM Bob (watsonx Code Assistant), then start a new c
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/claude-code.md
+++ b/docs/core/get_started/quickstart-with-agent/claude-code.md
@@ -13,7 +13,7 @@ Anthropic's official terminal coding assistant.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent claude-code
+npx skills add Canner/WrenAI --agent claude-code
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ claude
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/cline.md
+++ b/docs/core/get_started/quickstart-with-agent/cline.md
@@ -13,7 +13,7 @@ Open-source autonomous coding agent for VS Code.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent cline
+npx skills add Canner/WrenAI --agent cline
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in VS Code with the Cline extension installed, then cli
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/codearts-agent.md
+++ b/docs/core/get_started/quickstart-with-agent/codearts-agent.md
@@ -14,7 +14,7 @@ Huawei Cloud CodeArts Doer.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent codearts-agent
+npx skills add Canner/WrenAI --agent codearts-agent
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project in CodeArts IDE, then open the CodeArts Agent panel.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/codebuddy.md
+++ b/docs/core/get_started/quickstart-with-agent/codebuddy.md
@@ -13,7 +13,7 @@ Tencent CodeBuddy coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent codebuddy
+npx skills add Canner/WrenAI --agent codebuddy
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project in CodeBuddy IDE (or the VS Code extension), then open the Cod
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/codemaker.md
+++ b/docs/core/get_started/quickstart-with-agent/codemaker.md
@@ -13,7 +13,7 @@ Codemaker AI coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent codemaker
+npx skills add Canner/WrenAI --agent codemaker
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Codemaker, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/codestudio.md
+++ b/docs/core/get_started/quickstart-with-agent/codestudio.md
@@ -13,7 +13,7 @@ OPPO/Heytap coding IDE.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent codestudio
+npx skills add Canner/WrenAI --agent codestudio
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Code Studio, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/codex.md
+++ b/docs/core/get_started/quickstart-with-agent/codex.md
@@ -14,7 +14,7 @@ OpenAI Codex CLI.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent codex
+npx skills add Canner/WrenAI --agent codex
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ codex
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/command-code.md
+++ b/docs/core/get_started/quickstart-with-agent/command-code.md
@@ -13,7 +13,7 @@ Command Code agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent command-code
+npx skills add Canner/WrenAI --agent command-code
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ cmd
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/continue.md
+++ b/docs/core/get_started/quickstart-with-agent/continue.md
@@ -13,7 +13,7 @@ Open-source IDE coding assistant.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent continue
+npx skills add Canner/WrenAI --agent continue
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in VS Code or a JetBrains IDE with the Continue extensi
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/cortex.md
+++ b/docs/core/get_started/quickstart-with-agent/cortex.md
@@ -14,7 +14,7 @@ Snowflake Cortex coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent cortex
+npx skills add Canner/WrenAI --agent cortex
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project in Snowflake's Cortex Code interface, then start a new agent s
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/crush.md
+++ b/docs/core/get_started/quickstart-with-agent/crush.md
@@ -13,7 +13,7 @@ Charm's TUI coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent crush
+npx skills add Canner/WrenAI --agent crush
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ crush
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/cursor.md
+++ b/docs/core/get_started/quickstart-with-agent/cursor.md
@@ -13,7 +13,7 @@ The Cursor IDE.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent cursor
+npx skills add Canner/WrenAI --agent cursor
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Cursor (`File → Open Folder...` or `⌘O` / `Ctrl+
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/deepagents.md
+++ b/docs/core/get_started/quickstart-with-agent/deepagents.md
@@ -14,7 +14,7 @@ LangChain Deep Agents framework.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent deepagents
+npx skills add Canner/WrenAI --agent deepagents
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ dcode
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/devin.md
+++ b/docs/core/get_started/quickstart-with-agent/devin.md
@@ -14,7 +14,7 @@ Cognition Devin CLI.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent devin
+npx skills add Canner/WrenAI --agent devin
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ devin
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/dexto.md
+++ b/docs/core/get_started/quickstart-with-agent/dexto.md
@@ -13,7 +13,7 @@ Dexto coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent dexto
+npx skills add Canner/WrenAI --agent dexto
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Dexto, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/droid.md
+++ b/docs/core/get_started/quickstart-with-agent/droid.md
@@ -14,7 +14,7 @@ Factory AI Droid CLI.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent droid
+npx skills add Canner/WrenAI --agent droid
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ droid
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/firebender.md
+++ b/docs/core/get_started/quickstart-with-agent/firebender.md
@@ -14,7 +14,7 @@ Android JetBrains coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent firebender
+npx skills add Canner/WrenAI --agent firebender
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project in a JetBrains IDE with the Firebender plugin installed, then 
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/forgecode.md
+++ b/docs/core/get_started/quickstart-with-agent/forgecode.md
@@ -13,7 +13,7 @@ Forge AI coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent forgecode
+npx skills add Canner/WrenAI --agent forgecode
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ forge
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/gemini-cli.md
+++ b/docs/core/get_started/quickstart-with-agent/gemini-cli.md
@@ -14,7 +14,7 @@ Google's official Gemini CLI.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent gemini-cli
+npx skills add Canner/WrenAI --agent gemini-cli
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ gemini
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/github-copilot.md
+++ b/docs/core/get_started/quickstart-with-agent/github-copilot.md
@@ -14,7 +14,7 @@ GitHub Copilot CLI / Coding Agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent github-copilot
+npx skills add Canner/WrenAI --agent github-copilot
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project folder in VS Code (or another supported IDE) with GitHub Copil
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/goose.md
+++ b/docs/core/get_started/quickstart-with-agent/goose.md
@@ -13,7 +13,7 @@ Block's open-source coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent goose
+npx skills add Canner/WrenAI --agent goose
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ goose session
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/hermes-agent.md
+++ b/docs/core/get_started/quickstart-with-agent/hermes-agent.md
@@ -13,7 +13,7 @@ Hermes coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent hermes-agent
+npx skills add Canner/WrenAI --agent hermes-agent
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Hermes Agent, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/iflow-cli.md
+++ b/docs/core/get_started/quickstart-with-agent/iflow-cli.md
@@ -14,7 +14,7 @@ iFlow CLI agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent iflow-cli
+npx skills add Canner/WrenAI --agent iflow-cli
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ iflow
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/junie.md
+++ b/docs/core/get_started/quickstart-with-agent/junie.md
@@ -14,7 +14,7 @@ JetBrains Junie.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent junie
+npx skills add Canner/WrenAI --agent junie
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project in a JetBrains IDE with the Junie plugin installed, then open 
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/kilo.md
+++ b/docs/core/get_started/quickstart-with-agent/kilo.md
@@ -13,7 +13,7 @@ VS Code coding agent (fork of Roo Code).
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent kilo
+npx skills add Canner/WrenAI --agent kilo
 ```
 
 ## Run onboarding
@@ -27,7 +27,7 @@ kilo
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/kimi-cli.md
+++ b/docs/core/get_started/quickstart-with-agent/kimi-cli.md
@@ -14,7 +14,7 @@ Moonshot Kimi CLI. Uses the shared `.agents/skills/` directory.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent kimi-cli
+npx skills add Canner/WrenAI --agent kimi-cli
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ kimi
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/kiro-cli.md
+++ b/docs/core/get_started/quickstart-with-agent/kiro-cli.md
@@ -14,7 +14,7 @@ AWS Kiro CLI.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent kiro-cli
+npx skills add Canner/WrenAI --agent kiro-cli
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ kiro
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/kode.md
+++ b/docs/core/get_started/quickstart-with-agent/kode.md
@@ -13,7 +13,7 @@ shareAI Kode coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent kode
+npx skills add Canner/WrenAI --agent kode
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ kode
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/mcpjam.md
+++ b/docs/core/get_started/quickstart-with-agent/mcpjam.md
@@ -13,7 +13,7 @@ MCPJam development tool.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent mcpjam
+npx skills add Canner/WrenAI --agent mcpjam
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in MCPJam, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/mistral-vibe.md
+++ b/docs/core/get_started/quickstart-with-agent/mistral-vibe.md
@@ -14,7 +14,7 @@ Mistral's Vibe coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent mistral-vibe
+npx skills add Canner/WrenAI --agent mistral-vibe
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ vibe
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/mux.md
+++ b/docs/core/get_started/quickstart-with-agent/mux.md
@@ -13,7 +13,7 @@ Mux coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent mux
+npx skills add Canner/WrenAI --agent mux
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Mux, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/neovate.md
+++ b/docs/core/get_started/quickstart-with-agent/neovate.md
@@ -13,7 +13,7 @@ Neovate coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent neovate
+npx skills add Canner/WrenAI --agent neovate
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ neovate
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/openclaw.md
+++ b/docs/core/get_started/quickstart-with-agent/openclaw.md
@@ -14,7 +14,7 @@ OpenClaw coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent openclaw
+npx skills add Canner/WrenAI --agent openclaw
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ openclaw
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/opencode.md
+++ b/docs/core/get_started/quickstart-with-agent/opencode.md
@@ -13,7 +13,7 @@ SST's open-source coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent opencode
+npx skills add Canner/WrenAI --agent opencode
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ opencode
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/openhands.md
+++ b/docs/core/get_started/quickstart-with-agent/openhands.md
@@ -14,7 +14,7 @@ All-Hands open-source coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent openhands
+npx skills add Canner/WrenAI --agent openhands
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ openhands
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/pi.md
+++ b/docs/core/get_started/quickstart-with-agent/pi.md
@@ -13,7 +13,7 @@ Pi Mono coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent pi
+npx skills add Canner/WrenAI --agent pi
 ```
 
 ## Run onboarding
@@ -25,7 +25,7 @@ pi
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/pochi.md
+++ b/docs/core/get_started/quickstart-with-agent/pochi.md
@@ -13,7 +13,7 @@ Pochi coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent pochi
+npx skills add Canner/WrenAI --agent pochi
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Pochi, then start a new chat session.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/qoder.md
+++ b/docs/core/get_started/quickstart-with-agent/qoder.md
@@ -14,7 +14,7 @@ Qoder coding IDE.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent qoder
+npx skills add Canner/WrenAI --agent qoder
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project folder in Qoder IDE, then open the Qoder chat panel.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/qwen-code.md
+++ b/docs/core/get_started/quickstart-with-agent/qwen-code.md
@@ -14,7 +14,7 @@ Alibaba Qwen Code CLI.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent qwen-code
+npx skills add Canner/WrenAI --agent qwen-code
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ qwen
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/roo.md
+++ b/docs/core/get_started/quickstart-with-agent/roo.md
@@ -13,7 +13,7 @@ Open-source VS Code coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent roo
+npx skills add Canner/WrenAI --agent roo
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in VS Code with the Roo Code extension installed, then 
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/rovodev.md
+++ b/docs/core/get_started/quickstart-with-agent/rovodev.md
@@ -14,7 +14,7 @@ Atlassian Rovo Dev.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent rovodev
+npx skills add Canner/WrenAI --agent rovodev
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ acli rovodev run
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/tabnine-cli.md
+++ b/docs/core/get_started/quickstart-with-agent/tabnine-cli.md
@@ -14,7 +14,7 @@ Tabnine CLI coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent tabnine-cli
+npx skills add Canner/WrenAI --agent tabnine-cli
 ```
 
 ## Run onboarding
@@ -26,7 +26,7 @@ tabnine
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/trae-cn.md
+++ b/docs/core/get_started/quickstart-with-agent/trae-cn.md
@@ -14,7 +14,7 @@ Trae (China region).
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent trae-cn
+npx skills add Canner/WrenAI --agent trae-cn
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project folder in Trae CN IDE (`File → Open Folder...`), then open t
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/trae.md
+++ b/docs/core/get_started/quickstart-with-agent/trae.md
@@ -13,7 +13,7 @@ ByteDance Trae IDE.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent trae
+npx skills add Canner/WrenAI --agent trae
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Trae IDE (`File → Open Folder...`), then open the 
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/warp.md
+++ b/docs/core/get_started/quickstart-with-agent/warp.md
@@ -14,7 +14,7 @@ Warp terminal coding agent. Uses the shared `.agents/skills/` directory.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent warp
+npx skills add Canner/WrenAI --agent warp
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open Warp, then press `⌘I` / `Ctrl+I` to enter Agent Mode.
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/windsurf.md
+++ b/docs/core/get_started/quickstart-with-agent/windsurf.md
@@ -13,7 +13,7 @@ Codeium Windsurf IDE.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent windsurf
+npx skills add Canner/WrenAI --agent windsurf
 ```
 
 ## Run onboarding
@@ -23,7 +23,7 @@ Open your project folder in Windsurf (`File → Open Folder...`), then open the 
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart-with-agent/zencoder.md
+++ b/docs/core/get_started/quickstart-with-agent/zencoder.md
@@ -14,7 +14,7 @@ Zencoder coding agent.
 ## Install Wren skills
 
 ```bash
-npx skills add Canner/WrenAI --skill '*' --agent zencoder
+npx skills add Canner/WrenAI --agent zencoder
 ```
 
 ## Run onboarding
@@ -24,7 +24,7 @@ Open your project folder in VS Code or a JetBrains IDE with the Zencoder extensi
 Then ask:
 
 ```text
-Use the /wren-onboarding skill to install and set up Wren AI.
+Use the /wren skill to install and set up Wren AI.
 ```
 
 The skill walks the agent through environment checks, profile creation, project scaffolding, and a first query.

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -13,7 +13,7 @@ This guide drops three things on you in the first few steps. Skim before you sta
 - **Wren CLI (`wren`)** — the Python CLI that runs all of this. Connects to a database, holds your modeling files, executes SQL through the semantic layer, manages a local memory index. ([CLI reference →](/oss/reference/cli))
 - **MDL (Modeling Definition Language)** — YAML files under `models/`, `views/`, and `relationships.yml` that describe your tables, columns, and joins in business terms. The agent reads MDL instead of guessing from raw schema. ([MDL concept →](/oss/concepts/what_is_mdl) · [Wren project guide →](/oss/reference/mdl))
 - **jaffle_shop** — a public sample database from dbt Labs. We use it so you do not need to bring your own database to follow this quickstart. It is a fictional ecommerce business with `customers`, `orders`, `products`, and `supplies`. *(Want to skip jaffle_shop and use your own database? Finish the install in step 2 then jump to [Connect your database](/oss/guides/connect).)*
-- **Skills** — markdown workflow guides that tell an AI coding agent (Claude Code, Openclaw, Hermes, Codex, etc.) how to operate the CLI. Two skills drive this quickstart: `wren-generate-mdl` (one-time scaffolding) and `wren-usage` (day-to-day querying). ([Skills concept →](/oss/reference/skills))
+- **Skills** — markdown workflow guides that tell an AI coding agent (Claude Code, Openclaw, Hermes, Codex, etc.) how to operate the CLI. You install one `wren` discovery stub; it fetches the guides from the CLI on demand. Two guides drive this quickstart: `generate-mdl` (one-time scaffolding) and `usage` (day-to-day querying). ([Skills concept →](/oss/reference/skills))
 
 ---
 
@@ -88,26 +88,26 @@ wren version
 
 ---
 
-## Step 3 — Install CLI skills
+## Step 3 — Install the CLI skill
 
-Skills are workflow guides that tell your AI coding agent how to use the Wren CLI effectively. Install the skill bundle:
+Skills are workflow guides that tell your AI coding agent how to use the Wren CLI effectively. Install the discovery stub — it fetches the guides from the CLI on demand:
 
 ```bash
-npx skills add Canner/WrenAI --skill '*'
+npx skills add Canner/WrenAI
 # or:
 curl -fsSL https://raw.githubusercontent.com/Canner/WrenAI/main/skills/install.sh | bash
 ```
 
-The CLI auto-detects your installed agent. To target a specific one, add `--agent <name>` (e.g., `claude-code`, `cursor`, `windsurf`, `cline`).
+The CLI auto-detects your installed agent. To target a specific one, add `--agent <name>` (e.g., `claude-code`, `cursor`, `windsurf`, `cline`). Only one skill (`wren`) is installed; the workflow guides below are served on demand with `wren skills get <name>`.
 
-This quickstart uses two of the installed skills:
+This quickstart uses two of those guides:
 
-| Skill | Purpose |
+| Guide | Purpose |
 |-------|---------|
-| **wren-usage** | Day-to-day workflow — gather context, recall past queries, write SQL, store results |
-| **wren-generate-mdl** | One-time setup — explore database schema and generate the MDL project |
+| **usage** | Day-to-day workflow — gather context, recall past queries, write SQL, store results |
+| **generate-mdl** | One-time setup — explore database schema and generate the MDL project |
 
-For the full skill list (including `wren-onboarding` and `wren-dlt-connector`), see the [Skills reference](/oss/reference/skills).
+For the full guide list (including `onboarding` and `dlt-connector`), see the [Skills reference](/oss/reference/skills).
 
 ---
 
@@ -218,9 +218,11 @@ claude
 Then ask:
 
 ```
-Use the wren-generate-mdl skill to explore the jaffle_shop database
+Use the /wren skill to explore the jaffle_shop database
 and generate the MDL for all tables. The data source is DuckDB.
 ```
+
+The `wren` skill recognizes this as a scaffolding task and pulls in the `generate-mdl` guide (`wren skills get generate-mdl`) to drive it.
 
 Claude Code will:
 
@@ -258,7 +260,7 @@ What are the top 5 products by total revenue?
 Show me the monthly order count trend.
 ```
 
-Behind the scenes, Claude Code uses the **wren-usage** skill to:
+Behind the scenes, Claude Code uses the **usage** guide to:
 
 1. **Fetch context** (`wren memory fetch`) — find relevant tables and columns for your question
 2. **Recall examples** (`wren memory recall`) — find similar past queries

--- a/docs/core/guides/connect.md
+++ b/docs/core/guides/connect.md
@@ -9,12 +9,12 @@ Wren AI talks to your database through a **profile** — credentials and connect
 The flow is the same regardless of which database you use:
 
 1. **Install the connector extra** for your data source.
-2. **Create a profile** with `wren profile add` (or let the `wren-onboarding` skill do it).
+2. **Create a profile** with `wren profile add` (or let the `onboarding` guide do it).
 3. **Bind the profile** to your project with `wren context set-profile`.
-4. **Generate the MDL** with the `wren-generate-mdl` skill (or manually).
+4. **Generate the MDL** with the `generate-mdl` guide (or manually).
 5. **Start querying.**
 
-If you have an AI coding agent installed, the `wren-onboarding` skill drives the whole thing — see [Installation](/oss/get_started/installation).
+If you have an AI coding agent installed, the `/wren` skill drives the whole thing — see [Installation](/oss/get_started/installation).
 
 ## Supported data sources
 

--- a/docs/core/guides/model.md
+++ b/docs/core/guides/model.md
@@ -17,7 +17,7 @@ Turn your warehouse schema into an agent-readable MDL project that captures your
 
 1. **Connect your data source.** See [Connect your data](./connect.md) for profile setup.
 2. **Open your agent in a fresh project directory and ask:**
-   > Use the `wren-generate-mdl` skill to scaffold an MDL project for this database.
+   > Use the `/wren` skill to scaffold an MDL project for this database.
 3. **Review the scaffold.** The agent introspects schema, normalizes types, detects relationships, and writes one model per table. It will ask one focused question whenever it cannot decide alone — naming, canonical tables, ambiguous foreign keys.
 4. **Build and index.** The skill finishes with:
    ```bash

--- a/docs/core/guides/osi.md
+++ b/docs/core/guides/osi.md
@@ -16,7 +16,7 @@ wren context build --from-osi semantic_model.yaml --data-source postgres
 |  | Wren project (native) | OSI project, kept as source | OSI project, migrated once |
 |---|---|---|---|
 | **Source files** | `wren_project.yml` + `models/<name>/metadata.yml` + `views/` + `relationships.yml` | A single `*.yaml` OSI file | After migration: wren project layout |
-| **Author** | You (or `wren-generate-mdl` agent skill) | OSI tooling / vendor / external team | You take ownership after `init` |
+| **Author** | You (or the `generate-mdl` agent guide) | OSI tooling / vendor / external team | You take ownership after `init` |
 | **Wren commands** | `wren context init` → edit → `build` | `wren context build --from-osi <file>` | `wren context init --from-osi <file>` → edit → `build` |
 | **Editable inside Wren?** | Yes — that's the point | No — Wren reads the file as-is | Yes after migration |
 | **Where wren-specific hints live** | Each model's YAML | OSI's `custom_extensions[vendor_name=WREN]` block | Each model's YAML (lifted from OSI at migration time) |

--- a/docs/core/guides/refine.md
+++ b/docs/core/guides/refine.md
@@ -32,7 +32,7 @@ Without the `memory` extra, the memory commands below will not be available.
 
 ## The flow today
 
-The day-to-day refinement loop runs on the `wren-usage` skill plus a few `wren memory` and `instructions.md` edits. When you need to go deeper than incremental edits — backfilling enum meanings, units, default filters, synonyms, or named metrics across a whole project — reach for the [`wren-enrich-context`](#wren-enrich-context) skill described below.
+The day-to-day refinement loop runs on the `usage` guide plus a few `wren memory` and `instructions.md` edits. When you need to go deeper than incremental edits — backfilling enum meanings, units, default filters, synonyms, or named metrics across a whole project — reach for the [`enrich-context`](#enrich-context) guide described below.
 
 ### 1. Capture business rules in `instructions.md`
 
@@ -53,9 +53,9 @@ The day-to-day refinement loop runs on the `wren-usage` skill plus a few `wren m
 
 Organize by topic with `##` headings — each heading and its body becomes a retrievable chunk in memory. Edit by hand, or have your agent propose changes when it spots a recurring confusion.
 
-### 2. Let `wren-usage` compound from every confirmed answer
+### 2. Let `usage` compound from every confirmed answer
 
-The day-to-day `wren-usage` skill stores confirmed answers automatically:
+The day-to-day `usage` guide stores confirmed answers automatically:
 
 ```text
 User asks a question
@@ -108,16 +108,16 @@ Three commands to keep memory tidy:
 
 See the [CLI reference](/oss/reference/cli) for the full memory command surface.
 
-## `wren-enrich-context`
+## `enrich-context`
 
-The `wren-enrich-context` skill goes deeper than incremental `instructions.md` edits. It reads everything you drop into `<project>/raw/` (PDFs, glossaries, handbooks, analyst SQL, data dictionaries), compares it against the current MDL / `instructions.md` / `queries.yml` / memory, and fills the gaps — writing back only to reviewable, version-controlled artifacts. It works from a ten-category gap catalog: enum value meanings, units, NULL semantics, magic sentinels, default filters, synonyms, time conventions, cross-system identifiers, currency rules, and canonical-table preferences. Named aggregation metrics (ARR, churn, DAU) are proposed as cubes.
+The `enrich-context` guide goes deeper than incremental `instructions.md` edits. It reads everything you drop into `<project>/raw/` (PDFs, glossaries, handbooks, analyst SQL, data dictionaries), compares it against the current MDL / `instructions.md` / `queries.yml` / memory, and fills the gaps — writing back only to reviewable, version-controlled artifacts. It works from a ten-category gap catalog: enum value meanings, units, NULL semantics, magic sentinels, default filters, synonyms, time conventions, cross-system identifiers, currency rules, and canonical-table preferences. Named aggregation metrics (ARR, churn, DAU) are proposed as cubes.
 
 Pick one of two modes at session start:
 
 - **Grill mode** — the agent walks each gap one question at a time and asks focused questions ("Which of `customers`, `customers_v3`, `loyalty_v3` is canonical?", "What does `status = 4` mean?"). You answer in plain language; the agent drafts the change and patches MDL, `instructions.md`, `queries.yml`, or memory based on the answer category. With your OK, it can also sample low-cardinality columns from the live DB to discover enum and sentinel values.
 - **Auto-pilot mode** — drop docs, glossaries, SQL history, or a metric handbook into `<project>/raw/` and the agent reads them, applies its best inferences directly, and escalates to grill only on raw-vs-MDL conflicts and high-blast-radius additions (new cubes / views / relationships). It hands you a confidence-tagged audit at the end.
 
-Both modes only **add** — they never modify an existing field; contradictions are surfaced on a "please fix manually" list. Install it with the other skills (`npx skills add Canner/WrenAI --skill wren-enrich-context`) and trigger it by saying "enrich context" or "grill me on this project". See the [skills reference](/oss/reference/skills#wren-enrich-context) for the full breakdown.
+Both modes only **add** — they never modify an existing field; contradictions are surfaced on a "please fix manually" list. With the `wren` skill installed (`npx skills add Canner/WrenAI`), trigger it by saying "enrich context" or "grill me on this project" — the stub fetches the guide with `wren skills get enrich-context`. See the [skills reference](/oss/reference/skills#enrich-context) for the full breakdown.
 
 ## See also
 

--- a/docs/core/introduction.mdx
+++ b/docs/core/introduction.mdx
@@ -83,7 +83,7 @@ The open core includes:
 - **[MDL (Modeling Definition Language)](/oss/concepts/what_is_mdl)** — the semantic contract. MDL defines models, relationships, calculated fields, views, and agent-oriented metadata in files you can read, review, version, and fork.
 - **Rust semantic engine** — powered by Apache DataFusion. It plans and executes modeled SQL across supported data sources such as PostgreSQL, MySQL, BigQuery, Snowflake, DuckDB, ClickHouse, Trino, SQL Server, Databricks, Redshift, Oracle, Athena, Apache Spark, and more.
 - **[`wren` CLI](/oss/reference/cli)** — commands for querying, planning, validating, building context, profiling data, and managing memory.
-- **[Skills](/oss/reference/skills)** — structured workflows such as `wren-generate-mdl` and `wren-onboarding` that let AI coding agents operate Wren AI safely and reproducibly.
+- **[Skills](/oss/reference/skills)** — structured workflows such as `generate-mdl` and `onboarding`, served on demand from the `wren` CLI, that let AI coding agents operate Wren AI safely and reproducibly.
 - **Framework SDKs** — [LangChain](/oss/sdk/langchain) and [Pydantic AI](/oss/sdk/pydantic) integrations for attaching a Wren project to agent frameworks.
 - **[wren-core-wasm](/oss/sdk/wasm)** — the semantic engine compiled to WebAssembly, so MDL-aware SQL can run in the browser.
 


### PR DESCRIPTION
## Problem

Fixes #2341. After following the [installation docs](https://docs.getwren.ai/oss/get_started/installation), users see only a single `wren` skill (`~/.claude/skills/wren/SKILL.md`) and assume the install failed, because the docs still tell them to invoke `/wren-onboarding` and describe `wren-onboarding`, `wren-usage`, etc. as separately installed skills.

## Root cause

Since Wren 0.8 (#2329), the skill delivery model changed: only **one discovery stub** (`wren`) is installed. The workflow guides (`onboarding`, `usage`, `generate-mdl`, `dlt-connector`, `enrich-context`) now live inside the `wren` CLI and are served on demand via `wren skills get <name>`. Seeing one skill is the **expected** behavior — `docs/core/reference/skills.md` already documents this, but the get-started and concept docs were never updated.

This is a docs-only fix; the install behavior itself is already correct.

## Changes (63 files)

- Replace the obsolete `/wren-onboarding` trigger with `/wren` across `installation.md` and all 53 `quickstart-with-agent/*` guides.
- Drop the misleading `--skill '*'` flag from every `npx skills add` command (the bundle ships a single stub).
- Add an explicit note in `installation.md`: only the `wren` stub is installed, and guides are fetched on demand.
- Reframe `wren-<name>` skill references as CLI-served `<name>` guides across the quickstart, guides (`connect`, `refine`, `model`, `osi`), and concepts (`agent_learning`, `stack_position`, `what_is_mdl`) docs; fix the stale `#wren-enrich-context` anchor.

## Verification

- No remaining `wren-onboarding|wren-usage|wren-generate-mdl|wren-dlt-connector|wren-enrich-context` references in `docs/`.
- No remaining `--skill` flags or stale `#wren-*` anchors.
- No code or test changes (served-content guard tests cover CLI content, not `docs/core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across all agent quickstart guides to use the simplified `Canner/WrenAI` skill installation command with agent-specific flags
  * Renamed workflow references: `wren-generate-mdl` → `generate-mdl`, `wren-usage` → `usage`, `wren-onboarding` → `/wren`
  * Updated onboarding commands to use the unified `/wren` skill entrypoint
  * Introduced the "single discovery stub" delivery model in installation documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->