### PR TITLE
docs: add China mainland mirror tips for pip and HuggingFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ pip install wrenai                      # core (DuckDB included)
 pip install "wrenai[postgres,memory]"   # add per-datasource and memory extras as needed
 ```
 
+> **Tip for users in mainland China:** If `pip install` is slow or fails, use the Tsinghua mirror:
+> ```bash
+> pip install wrenai -i https://pypi.tuna.tsinghua.edu.cn/simple
+> ```
+> If HuggingFace model downloads time out, add `export HF_ENDPOINT=https://hf-mirror.com` before running the CLI.
+```
+
 ### 2. Install the discovery stub for your AI client
 
 ```bash


### PR DESCRIPTION
  Add a tip for users in mainland China about using Tsinghua PyPI mirror and HuggingFace mirror.
  When installing from China, both `pip install` and HuggingFace model downloads can fail due to network restrictions. This tip saves new users from the troubleshooting we went through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart installation section with guidance for users in mainland China, including alternative PyPI mirror configuration and HuggingFace mirror endpoint settings to improve installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->