### PR TITLE
ci(release): sync wrenai version in uv.lock

### DIFF
--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -3296,7 +3296,7 @@ wheels = [
 
 [[package]]
 name = "wrenai"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,11 @@
       "release-type": "python",
       "bump-minor-pre-major": true,
       "extra-files": [
-        "src/wren/__init__.py"
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wrenai')].version"
+        }
       ]
     },
     "core/wren-core-wasm": {


### PR DESCRIPTION
## Summary

Release Please already bumps `core/wren/pyproject.toml` and `core/wren/CHANGELOG.md` for `wrenai` releases, but the editable `wrenai` entry in `core/wren/uv.lock` was left behind at `0.8.0` after the `0.9.0` release.

This PR keeps the lockfile metadata in sync by adding `uv.lock` to the `core/wren` release-please `extra-files` config. It also removes the stale `src/wren/__init__.py` extra-file entry, since `__version__` now comes from package metadata via `importlib.metadata.version("wrenai")`.

## Changes

- Sync `core/wren/uv.lock` `wrenai` version from `0.8.0` to `0.9.0`
- Add a TOML jsonpath extra-file entry for `uv.lock`
- Remove the no-op `src/wren/__init__.py` extra-file entry

## Test plan

- Verified `core/wren/pyproject.toml` and `core/wren/uv.lock` both show `0.9.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to improve version management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->