### PR TITLE
perf(cli): use find_spec instead of eager import to detect memory extra

### DIFF
--- a/core/wren/src/wren/cli.py
+++ b/core/wren/src/wren/cli.py
@@ -607,17 +607,14 @@ app.add_typer(cube_app)
 app.add_typer(utils_app)
 app.add_typer(skills_app)
 
-try:
-    import lancedb  # noqa: PLC0415, F401
-    import sentence_transformers  # noqa: PLC0415, F401
+from importlib.util import find_spec  # noqa: E402
 
+# Detect the optional `memory` extra without importing it: a real import would
+# eagerly pull lancedb (and the heavy ML stack it loads) into every CLI startup.
+if find_spec("lancedb") and find_spec("sentence_transformers"):
     from wren.memory.cli import memory_app  # noqa: PLC0415
 
     app.add_typer(memory_app)
-except ImportError:
-    # `memory` is installed on demand via `pip install "wrenai[memory]"`;
-    # until then the subcommand group simply isn't registered.
-    pass
 
 from wren.profile_cli import profile_app  # noqa: PLC0415, E402
 

--- a/core/wren/tests/test_cli_memory_detection.py
+++ b/core/wren/tests/test_cli_memory_detection.py
@@ -38,6 +38,7 @@ def test_import_cli_does_not_pull_heavy_ml_stack():
 
 @pytest.mark.skipif(not MEMORY_INSTALLED, reason="memory extra not installed")
 def test_memory_subcommand_registered_when_extra_present():
+    """The `memory` subcommand group is registered when the extra is installed."""
     cli = importlib.import_module("wren.cli")
     names = {g.typer_instance.info.name for g in cli.app.registered_groups}
     assert "memory" in names, "memory subcommand not registered despite extra installed"
@@ -45,6 +46,7 @@ def test_memory_subcommand_registered_when_extra_present():
 
 @pytest.mark.skipif(MEMORY_INSTALLED, reason="memory extra IS installed")
 def test_memory_subcommand_absent_when_extra_missing():
+    """The `memory` subcommand group is not registered when the extra is missing."""
     cli = importlib.import_module("wren.cli")
     names = {g.typer_instance.info.name for g in cli.app.registered_groups}
     assert "memory" not in names, "memory subcommand registered without the extra"

--- a/core/wren/tests/test_cli_memory_detection.py
+++ b/core/wren/tests/test_cli_memory_detection.py
@@ -1,0 +1,50 @@
+"""`wren.cli` must detect the optional `memory` extra without
+eagerly importing it (which would pull lancedb -> torch into every startup)."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+MEMORY_INSTALLED = bool(importlib.util.find_spec("lancedb")) and bool(
+    importlib.util.find_spec("sentence_transformers")
+)
+
+
+def _fresh_import_modules() -> dict[str, bool]:
+    """Import wren.cli in a clean subprocess and report loaded heavy modules."""
+    code = (
+        "import sys, importlib; importlib.import_module('wren.cli'); "
+        "print(int('torch' in sys.modules), int('lancedb' in sys.modules))"
+    )
+    out = subprocess.check_output([sys.executable, "-c", code], text=True).strip()
+    torch_loaded, lancedb_loaded = (bool(int(x)) for x in out.split())
+    return {
+        "torch": torch_loaded,
+        "lancedb": lancedb_loaded,
+    }
+
+
+def test_import_cli_does_not_pull_heavy_ml_stack():
+    """Importing the CLI must NOT load torch/lancedb, even when memory is installed."""
+    loaded = _fresh_import_modules()
+    assert loaded["torch"] is False, "torch leaked into CLI startup"
+    assert loaded["lancedb"] is False, "lancedb leaked into CLI startup"
+
+
+@pytest.mark.skipif(not MEMORY_INSTALLED, reason="memory extra not installed")
+def test_memory_subcommand_registered_when_extra_present():
+    cli = importlib.import_module("wren.cli")
+    names = {g.typer_instance.info.name for g in cli.app.registered_groups}
+    assert "memory" in names, "memory subcommand not registered despite extra installed"
+
+
+@pytest.mark.skipif(MEMORY_INSTALLED, reason="memory extra IS installed")
+def test_memory_subcommand_absent_when_extra_missing():
+    cli = importlib.import_module("wren.cli")
+    names = {g.typer_instance.info.name for g in cli.app.registered_groups}
+    assert "memory" not in names, "memory subcommand registered without the extra"


### PR DESCRIPTION
Non-memory CLI commands (`--version`, `--help`, `context`, `dry-run`, etc.) currently pay the startup cost of the optional memory stack because `wren/cli.py` eagerly imports `lancedb` and `sentence_transformers` at module load time just to detect whether the memory extra is installed.

That eager import pulls in the heavy ML stack (`lancedb -> sentence_transformers -> transformers/torch ...`) even when the user is not running a `wren memory` command. On macOS, a fresh install can also trigger XProtect scanning of the large native binaries on first run.

This PR replaces the try/import detection block with `importlib.util.find_spec`, so Wren checks package availability without executing package `__init__` files. `from wren.memory.cli import memory_app` remains cheap because the heavy memory imports are already lazy inside the memory command handlers.

## Measured impact

Warm startup, `wrenai[main,memory]`, invoked directly via `.venv/bin/wren` (N=15, mean ± σ):

| Command | Before (eager import) | After (`find_spec`) | Speedup |
| --- | ---: | ---: | ---: |
| `wren --version` | 2.82s ± 0.13 | 0.16s ± 0.002 | **~17.5x faster** |
| `wren --help` | 2.76s ± 0.10 | 0.19s ± 0.004 | **~14.3x faster** |

`torch`, `lancedb`, and `sentence_transformers` no longer enter `sys.modules` on non-memory startup — confirmed via `python -X importtime` and the regression test added below. (Invoked through `uv run` instead of the binary directly, both versions also carry uv's fixed ~0.25s wrapper overhead, so the "after" reads ~0.41s / ~6x there — the import-cost reduction is the same.)

### macOS first run

On a clean install, the first `wren --version` drops from **~48s to ~5s**. The eager import loads the ~800MB of ML native libraries (`libtorch_cpu.dylib` 240MB, lancedb, …), which macOS XProtect then scans on first execution — process sampling shows `XprotectService` pinned at ~95% CPU for the whole window. With `find_spec`, non-memory startup no longer loads those libraries, so the scan is not triggered. The one-time scan is *deferred* to the first real `wren memory` command, not eliminated.

## Test plan

- Added regression coverage that importing `wren.cli` does not load `torch` or `lancedb`
- Added coverage that `wren memory` is registered when the memory extra is installed
- Added coverage that `wren memory` is absent when the memory extra is not installed
- Ran `uv run pytest tests/test_cli_memory_detection.py tests/unit/test_version.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deferred registration of the optional memory subcommand so CLI startup is lighter when optional ML dependencies are not present.

* **Tests**
  * Added tests ensuring the CLI does not load heavy ML dependencies on import and that the memory subcommand is present only when its extras are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->