### PR TITLE
docs(wren): document macOS memory first-run scan

### DIFF
--- a/core/wren/docs/cli.md
+++ b/core/wren/docs/cli.md
@@ -82,6 +82,8 @@ pip install 'wrenai[main]'   # includes memory, interactive, ui
 
 All `memory` subcommands accept `--path DIR` to override the default storage location (`~/.wren/memory/`).
 
+> **Note:** The `memory` extra bundles ~800MB of large unsigned native libraries (lancedb plus sentence-transformers/torch). On macOS, the first command that loads the memory stack can trigger a one-time XProtect/Gatekeeper scan and pause for up to about a minute before it finishes; this is normal macOS behavior, not a Wren error, and happens once per install or fresh virtual environment. With lazy memory loading, lightweight non-`memory` commands are unaffected — the scan is deferred to your first real memory use, not eliminated.
+
 ### Hybrid strategy: full text vs. embedding search
 
 When providing schema context to an LLM, there is a trade-off:

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -235,6 +235,8 @@ Claude Code will:
 7. **Validate and build** — `wren context validate` → `wren context build`
 8. **Index memory** — `wren memory index` (generates seed NL-SQL examples)
 
+> **Tip:** If `wren memory index` (the indexing step above) seems to hang for tens of seconds on macOS — it hasn't. That first `wren memory` command loads large unsigned native libraries (lancedb and torch, ~800MB), and macOS runs a one-time XProtect security scan the first time they execute. This is expected macOS behavior, not a Wren problem, and it's a one-off — every later `wren memory` command runs at normal speed. To avoid the pause during a live demo, run any `wren memory` command once right after install and let it finish.
+
 After completion, verify the project:
 
 ```bash

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -124,6 +124,8 @@ pip install 'wrenai[memory,main]'
 
 All `memory` subcommands accept `--path DIR` to override the default storage location (`~/.wren/memory/`).
 
+> **Note:** The `memory` extra bundles ~800MB of large unsigned native libraries (lancedb plus sentence-transformers/torch). On macOS, the first command that loads the memory stack can trigger a one-time XProtect/Gatekeeper scan and pause for up to about a minute before it finishes; this is normal macOS behavior, not a Wren error, and happens once per install or fresh virtual environment. With lazy memory loading, lightweight non-`memory` commands are unaffected — the scan is deferred to your first real memory use, not eliminated.
+
 ### Hybrid strategy: full text vs. embedding search
 
 When providing schema context to an LLM, there is a trade-off:


### PR DESCRIPTION
## Summary
- Document the one-time macOS XProtect/Gatekeeper scan that can happen when the memory stack is first loaded.
- Add a quickstart tip so users do not mistake the first `wren memory index` pause for a hang.
- Clarify that this is expected macOS first-run behavior after a fresh install or rebuilt virtual environment.

## Background
In a fresh macOS virtual environment with `wrenai[main,memory]`, the first command path that loaded the memory stack took noticeably longer than later runs:

| Run | Command | Wall time | CPU | XProtect activity |
|---|---:|---:|---:|---|
| First run | `uv run wren --version` | 59.7s | 15% | `XprotectService` repeatedly at 60-83% CPU |
| Second run | `uv run wren --version` | 3.8s | 85% | 0 XProtect samples |

The memory extra installs large native dependencies: 314 `.dylib` / `.so` files totaling about 836MB. The largest files include `libtorch_cpu.dylib` at 240MB, `wren_core.abi3.so` at 129MB, and LanceDB’s native extension at 112MB.

This explains why the first memory-related command can appear to pause for tens of seconds on macOS, while subsequent runs return to normal speed.

## After #2352

After #2352, lightweight CLI commands no longer load the memory stack, so the macOS first-run scan is no longer triggered by commands such as `wren --version` or `wren --help`.

The scan still happens when the memory stack is first used. In other words, the one-time cost is deferred to the first real memory command rather than removed.

Measured on macOS with fresh virtual environments installed with `wrenai[main,memory]`:

| Scenario | Result |
|---|---:|
| Fresh first `wren --version` before #2352 | ~48s, with XProtect activity |
| Fresh first `wren --version` after #2352 | ~5s, only core native library scan |
| First explicit memory-stack load after #2352, `python -c "import lancedb"` | ~9s, with XProtect activity again |
| XprotectService peak during first explicit memory-stack load | 96.2% CPU |

The `~9s` memory-stack measurement is not a universal upper bound; XProtect timing depends on machine state and system-level scan caching. The important behavior is that XProtect activity moves from lightweight CLI startup to the first command that actually loads memory dependencies, such as `wren memory index`, `wren memory status`, or an equivalent LanceDB import path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that installing the memory feature on macOS may trigger a one-time security scan, potentially pausing the first memory-related command for up to one minute—this is expected behavior.
  * Added guidance to run memory commands immediately after installation to prevent delays during live demonstrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->