### PR TITLE
docs(wren): fix cube quickstart and align YAML/CLI examples with implementation

### DIFF
--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -109,8 +109,8 @@ then query them with a structured input instead of writing `GROUP BY` SQL by han
 
 ```bash
 wren cube list
-wren cube describe order_metrics
-wren cube query --cube order_metrics --measures revenue --time-dimension "created_at:month"
+wren cube describe revenue
+wren cube query --cube revenue --measures total --time-dimension "order_date:month"
 ```
 
 The translator produces `DATE_TRUNC` / `GROUP BY` / `WHERE` clauses for you and

--- a/core/wren/src/wren/skills_content/enrich-context/references/cube_proposals.md
+++ b/core/wren/src/wren/skills_content/enrich-context/references/cube_proposals.md
@@ -72,10 +72,9 @@ dimensions:
     expression: <column>      # column on base_object
     type: VARCHAR             # use the column's actual type
 time_dimensions:
-  - name: <td_name>           # e.g. "month"
+  - name: <td_name>           # e.g. "order_date" — semantic column name, not the grain
     expression: <ts_column>   # e.g. "created_at"
-    grain: month              # one of: day | week | month | quarter | year
-    type: TIMESTAMP
+    type: TIMESTAMP           # granularity (day/week/month/…) is set at query time via --time-dimension
 hierarchies:
   - name: time
     levels: [year, quarter, month]   # only if multiple time grains are declared
@@ -169,7 +168,7 @@ Action: skip the cube proposal. Add to `queries.yml`:
   sql: |
     -- via cube
     SELECT day, dau FROM (
-      <result of: wren cube query --cube daily_engagement --measures dau --time-dimension day:day:LAST_7_DAYS>
+      <result of: wren cube query --cube daily_engagement --measures dau --time-dimension "day:day:2024-01-01,2024-01-08">
     )
   source: enrich
 ```

--- a/core/wren/src/wren/skills_content/usage/SKILL.md
+++ b/core/wren/src/wren/skills_content/usage/SKILL.md
@@ -333,9 +333,9 @@ time dimensions, and hierarchies.
 
 | User phrase | Maps to |
 |---|---|
-| "total revenue" | `--measures revenue` |
-| "by month" | `--time-dimension "created_at:month"` |
-| "in 2024" | `--time-dimension "created_at:month:2024-01-01,2025-01-01"` |
+| "total revenue" | `--measures total` |
+| "by month" | `--time-dimension "order_date:month"` |
+| "in 2024" | `--time-dimension "order_date:month:2024-01-01,2025-01-01"` |
 | "for completed orders" | `--filter "status:eq:completed"` |
 | "top N customers" | `--dimensions customer --limit N` |
 
@@ -345,9 +345,9 @@ CLI flags:
 
 ```bash
 wren cube query \
-  --cube order_metrics \
-  --measures revenue,order_count \
-  --time-dimension "created_at:month:2024-01-01,2025-01-01" \
+  --cube revenue \
+  --measures total,order_count \
+  --time-dimension "order_date:month:2024-01-01,2025-01-01" \
   --filter "status:eq:completed" \
   --limit 100
 ```
@@ -355,7 +355,7 @@ wren cube query \
 JSON input (good for agent-generated structured queries):
 
 ```bash
-echo '{"cube":"order_metrics","measures":["revenue"]}' | wren cube query --from -
+echo '{"cube":"revenue","measures":["total"]}' | wren cube query --from -
 ```
 
 Add `--sql-only` to print the generated SQL without executing — useful for

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -29,6 +29,7 @@ def _make_mdl(tmp_path: Path) -> Path:
                 "columns": [
                     {"name": "o_totalprice", "type": "double"},
                     {"name": "o_orderstatus", "type": "varchar"},
+                    {"name": "o_orderdate", "type": "date"},
                 ],
             }
         ],
@@ -53,6 +54,13 @@ def _make_mdl(tmp_path: Path) -> Path:
                         "name": "status",
                         "expression": "o_orderstatus",
                         "type": "VARCHAR",
+                    }
+                ],
+                "timeDimensions": [
+                    {
+                        "name": "order_date",
+                        "expression": "o_orderdate",
+                        "type": "DATE",
                     }
                 ],
             }
@@ -134,6 +142,29 @@ def test_cube_query_sql_only(tmp_path):
     assert "o_orderstatus AS status" in result.output
     assert "FROM orders" in result.output
     assert "GROUP BY" in result.output
+
+
+def test_cube_query_sql_only_time_dimension(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--time-dimension",
+            "order_date:month",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "DATE_TRUNC('month', o_orderdate)" in result.output
+    assert "SUM(o_totalprice) AS revenue" in result.output
 
 
 def test_cube_query_sql_only_filter(tmp_path):

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -182,6 +182,7 @@ This creates:
 ├── wren_project.yml        # project metadata
 ├── models/                 # one folder per table
 ├── views/                  # reusable SQL views
+├── cubes/                  # pre-aggregation metrics
 ├── relationships.yml       # table join definitions
 └── instructions.md         # business rules for the AI
 ```
@@ -274,24 +275,36 @@ The more you ask, the smarter the system gets — each stored query improves fut
 
 ---
 
-## Step 8 — Query a cube (optional)
+## Step 8 — Add and query a cube (optional)
 
-If your MDL defines cubes, use the cube CLI for aggregation queries — agents
-don't have to hand-write `GROUP BY` / `DATE_TRUNC` SQL:
+A **cube** is a semantic aggregation object — a model plus declared measures, dimensions, and time grains. `generate-mdl` scaffolds tables and relationships but not cubes, so add one now with Claude Code.
+
+### Step 8a — Add a cube
+
+In Claude Code:
+
+```
+Use the /wren skill to add a cube named "revenue" over the orders model:
+total revenue as SUM(amount), an order count, broken down by status and
+monthly by order_date.
+```
+
+Claude Code drafts the cube YAML, confirms with you, writes it to `cubes/revenue/metadata.yml`, and rebuilds the manifest.
+
+> **Prefer to write it by hand?** See the [Cube guide](../guides/cubes.md) for the full YAML structure, then run `wren context build`.
+
+### Step 8b — Query the cube
 
 ```bash
 wren cube list
 
 wren cube query \
-  --cube order_metrics \
-  --measures revenue \
-  --time-dimension "created_at:month"
+  --cube revenue \
+  --measures total,order_count \
+  --time-dimension "order_date:month"
 ```
 
-Cube queries are the recommended path for aggregation when a cube covers the
-question. Lower error rate, especially on small / local models. See the
-[Cube guide](../guides/cubes.md) for the YAML structure and the
-[CLI reference](../reference/cli.md#wren-cube--pre-aggregation-queries) for all flags.
+`--time-dimension` takes `<name>:<granularity>`. Add `--dimensions status` or `--filter "status:eq:completed"` to slice further. See the [Cube guide](../guides/cubes.md) and [CLI reference](../reference/cli.md#wren-cube--pre-aggregation-queries) for all options.
 
 ---
 
@@ -312,6 +325,9 @@ After setup, your project directory looks like this:
 │   └── supplies/
 │       └── metadata.yml
 ├── views/
+├── cubes/                      # only if you did Step 8
+│   └── revenue/
+│       └── metadata.yml        # measures + dimensions for aggregation
 ├── relationships.yml           # e.g. orders → customers (many_to_one)
 ├── instructions.md             # your business rules
 ├── .wren/

--- a/docs/core/guides/cubes.md
+++ b/docs/core/guides/cubes.md
@@ -46,7 +46,6 @@ dimensions:
 time_dimensions:
   - name: order_date
     expression: order_date
-    grain: month
     type: DATE
 hierarchies:
   - name: time

--- a/docs/core/guides/cubes.md
+++ b/docs/core/guides/cubes.md
@@ -9,7 +9,7 @@ Cubes are pre-aggregated semantic objects: a base model or view plus declared me
 ## What you'll end up with
 
 - A `cubes/<name>/metadata.yml` per cube, declaring its measures and dimensions
-- A queryable cube name in MDL — `wren cube query --cube revenue --measures total --dimensions month`
+- A queryable cube name in MDL — `wren cube query --cube revenue --measures total --time-dimension "order_date:month"`
 - An agent that picks structured cube queries instead of inventing aggregation SQL
 
 ## Why this primitive matters
@@ -44,7 +44,7 @@ dimensions:
     expression: status
     type: VARCHAR
 time_dimensions:
-  - name: month
+  - name: order_date
     expression: order_date
     grain: month
     type: DATE
@@ -64,21 +64,14 @@ wren cube query \
   --cube revenue \
   --measures total,order_count \
   --dimensions status \
-  --time-dimension month \
-  --filter "status = 'completed'"
+  --time-dimension "order_date:month" \
+  --filter "status:eq:completed"
 ```
 
-Or from an agent SDK:
-
-```python
-result = wren.cube.query(
-  cube="revenue",
-  measures=["total"],
-  dimensions=["status"],
-  time_dimension="month",
-  filter="status = 'completed'"
-)
-```
+`--time-dimension` takes `<name>:<granularity>`, and `--filter` takes
+`<dimension>:<operator>:<value>`. See the
+[CLI reference](/oss/reference/cli#wren-cube--pre-aggregation-queries) for the
+full list of granularities and filter operators.
 
 No hand-written `GROUP BY`. No `DATE_TRUNC`. No join inference.
 

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -253,7 +253,7 @@ Pretty-print the full cube schema as JSON: `baseObject`, measures (with
 expressions), dimensions, time dimensions, hierarchies.
 
 ```bash
-wren cube describe order_metrics
+wren cube describe revenue
 ```
 
 ### `wren cube query`
@@ -265,10 +265,10 @@ the same path as `wren --sql`. Two input modes:
 
 ```bash
 wren cube query \
-  --cube order_metrics \
-  --measures revenue,order_count \
+  --cube revenue \
+  --measures total,order_count \
   --dimensions status \
-  --time-dimension "created_at:month:2024-01-01,2025-01-01" \
+  --time-dimension "order_date:month:2024-01-01,2025-01-01" \
   --filter "status:eq:completed" \
   --limit 100
 ```

--- a/docs/core/reference/mdl.md
+++ b/docs/core/reference/mdl.md
@@ -259,9 +259,8 @@ dimensions:
     expression: status
     type: VARCHAR
 time_dimensions:
-  - name: month
+  - name: order_date
     expression: order_date
-    grain: month
     type: DATE
 hierarchies:
   - name: time
@@ -274,7 +273,7 @@ hierarchies:
 | `base_object` | yes | Model or view this cube aggregates over. |
 | `measures[]` | yes | Aggregated values (`expression` + `type`). |
 | `dimensions[]` | no | Categorical group-bys. |
-| `time_dimensions[]` | no | Time-based group-bys with explicit grain. |
+| `time_dimensions[]` | no | Time-based group-bys. Granularity is applied at query time via `--time-dimension name:granularity` (see [CLI reference](/oss/reference/cli#wren-cube--pre-aggregation-queries)). |
 | `hierarchies[]` | no | Ordered levels for drill-down (year → quarter → month). |
 | `refresh_time` | no | Cache refresh interval. |
 | `properties` | no | Arbitrary metadata. |


### PR DESCRIPTION
## Problem

While following the quickstart literally, [Step 8 on main](https://docs.getwren.ai/oss/get_started/quickstart#step-8--query-a-cube-optional) does not have a cube available to query yet.

This PR updates the quickstart to include a **cube creation step** before querying it, so the flow becomes complete from setup to query execution.

While making this adjustment, I also noticed a few small mismatches in the current cube-related examples and aligned them with the actual schema and CLI behavior:

1. Example fields and cube names were not fully aligned with jaffle_shop.  
   The examples used `created_at` as the time dimension name, while jaffle_shop / the generated `orders` model uses `order_date`. The cube name `order_metrics` and the measure naming also did not match the cube that users would create in the updated quickstart (`revenue`, with measures `total` and `order_count`).

2. The YAML examples included a `grain:` field that is not part of the current schema.  
   `mdl.schema.json` defines `timeDimension` with only `name`, `expression`, and `type` (`additionalProperties: false`). Granularity is applied at query time via the CLI (`--time-dimension name:granularity`), not in YAML, so the existing `grain: month` examples could be confusing.

3. Some CLI examples did not match the current argument format.  
   `--time-dimension` expects `name:granularity`, and `--filter` expects `dim:op:value`.

If I misunderstood anything or missed some context here, please feel free to correct me. Thank you!

## Fix

### Quickstart

- Added a cube creation step before querying a cube.
- Split the original Step 8 flow into:
  - **8a** — add a cube using Claude Code and the `/wren` skill.
  - **8b** — query the cube after it exists.
- Updated the examples to use a consistent jaffle_shop `revenue` cube:
  - `SUM(amount)` as `total`
  - `order_count`
  - grouped by `status`
  - monthly by `order_date`

### Cube guide and CLI reference

- Updated CLI examples so they match the current parser behavior:
  - `--time-dimension "order_date:month"`
  - `--filter "status:eq:completed"`
- Removed the `wren.cube.query(...)` Python example, since that API does not currently exist.
- Aligned the CLI reference example with the same `revenue` cube used in the quickstart.

### MDL reference and skill template

- Removed `grain: month` from:
  - `docs/core/reference/mdl.md`
  - `docs/core/guides/cubes.md`
  - `enrich-context` skill template (`cube_proposals.md`)
- Updated the `time_dimensions[]` table description in `mdl.md` to clarify that granularity is applied at query time via `--time-dimension name:granularity`.
- Replaced the `LAST_7_DAYS` placeholder in the skill example with a concrete `start,end` date range format, since the CLI expects two concrete dates.

### README and usage skill

- Aligned `core/wren/README.md` and `usage/SKILL.md` cube examples with the same `revenue` / `order_date` / `total` naming used in the quickstart and cube guide.

### Tests

- Extended the `_make_mdl` fixture in `test_cube_cli.py` with:
  - an `o_orderdate` column
  - a `timeDimensions` entry
- Added `test_cube_query_sql_only_time_dimension` to verify that:
  - `--time-dimension order_date:month`
  - produces `DATE_TRUNC('month', o_orderdate)` in the generated SQL.

## Scope

This PR updates docs, skill content (`enrich-context` and `usage`), `core/wren/README.md`, and one test file.

It does not change engine logic, CLI argument parsing, or the YAML loader.

The updates were checked against the current source of truth:

- CLI flag behavior: `cube_cli.py` (`--time-dimension`, `--dimensions`, `--filter`)
- YAML schema: `mdl.schema.json` (`timeDimension` definition, `additionalProperties: false`)
- Rust struct: `TimeDimension` in `manifest-macro/src/lib.rs`
- Cube loading path: `context.py` `_load_cubes_v2` (`schema_version 3` → `cubes/<name>/metadata.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cube query examples to use `revenue` cube with refined time dimension syntax
  * Clarified that time granularity is applied at query time via CLI flag
  * Updated filter syntax examples to align with current conventions

* **Tests**
  * Added unit test coverage for cube query functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->