### PR TITLE
fix(mysql): handle brackets in connection URLs

### DIFF
--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -459,13 +459,46 @@ def _build_mysql_column(values: list, arrow_type: pa.DataType) -> pa.Array:
 # ---------------------------------------------------------------------------
 
 
+def _parse_mysql_connection_url(url: str):
+    """Parse a MySQL URL after escaping raw brackets in userinfo only.
+
+    ``urllib.parse.urlparse`` treats ``[`` / ``]`` anywhere in the netloc as
+    IPv6 host delimiters. That is correct for hosts like ``mysql://[::1]/db``
+    but it breaks on raw credentials such as ``mysql://user:p[a]ss@host/db``.
+    Sanitise only the userinfo segment so valid IPv6 hosts still parse.
+    """
+    from urllib.parse import urlparse  # noqa: PLC0415
+
+    scheme_idx = url.find("://")
+    if scheme_idx == -1:
+        return urlparse(url)
+
+    prefix = url[: scheme_idx + 3]
+    rest = url[scheme_idx + 3 :]
+
+    authority_end = len(rest)
+    for separator in "/?#":
+        idx = rest.find(separator)
+        if idx != -1:
+            authority_end = min(authority_end, idx)
+
+    authority = rest[:authority_end]
+    if "@" not in authority:
+        return urlparse(url)
+
+    userinfo, hostinfo = authority.rsplit("@", 1)
+    sanitized_userinfo = userinfo.replace("[", "%5B").replace("]", "%5D")
+    sanitized_url = f"{prefix}{sanitized_userinfo}@{hostinfo}{rest[authority_end:]}"
+    return urlparse(sanitized_url)
+
+
 def _build_mysql_connect_kwargs(connection_info) -> dict:
     """Translate ``MySqlConnectionInfo`` / ``ConnectionUrl`` into MySQLdb kwargs."""
-    from urllib.parse import parse_qsl, unquote_plus, urlparse  # noqa: PLC0415
+    from urllib.parse import parse_qsl, unquote  # noqa: PLC0415
 
     if hasattr(connection_info, "connection_url"):
         url = connection_info.connection_url.get_secret_value()
-        parsed = urlparse(url)
+        parsed = _parse_mysql_connection_url(url)
         if parsed.scheme not in {"mysql", "mysql+pymysql", "mysql+mysqldb"}:
             raise WrenError(
                 ErrorCode.INVALID_CONNECTION_INFO,
@@ -483,9 +516,9 @@ def _build_mysql_connect_kwargs(connection_info) -> dict:
         out: dict = {
             "host": host,
             "port": int(parsed.port) if parsed.port else 3306,
-            "user": parsed.username,
-            "passwd": unquote_plus(parsed.password) if parsed.password else "",
-            "db": parsed.path.lstrip("/") if parsed.path else None,
+            "user": unquote(parsed.username) if parsed.username else None,
+            "passwd": unquote(parsed.password) if parsed.password else "",
+            "db": unquote(parsed.path.lstrip("/")) if parsed.path else None,
             "charset": "utf8mb4",
             "use_unicode": True,
             "autocommit": True,

--- a/core/wren/tests/unit/test_mysql_helpers.py
+++ b/core/wren/tests/unit/test_mysql_helpers.py
@@ -14,6 +14,7 @@ from wren.connector.mysql import (
     _apply_limit,
     _arrow_decimal_from_mysql_field,
     _build_mysql_column,
+    _build_mysql_connect_kwargs,
     _coerce_limit,
     _mysql_blob_codes,
     _mysql_decimal_codes,
@@ -21,8 +22,23 @@ from wren.connector.mysql import (
     _mysql_string_codes,
     _mysql_unsigned_variant_map,
 )
+from wren.model.error import ErrorCode, WrenError
 
 pytestmark = pytest.mark.unit
+
+
+class _FakeConnUrl:
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    def get_secret_value(self) -> str:
+        return self._url
+
+
+class _FakeConnInfoFromUrl:
+    def __init__(self, url: str, kwargs: dict[str, str] | None = None) -> None:
+        self.connection_url = _FakeConnUrl(url)
+        self.kwargs = kwargs
 
 
 # ── _coerce_limit ─────────────────────────────────────────────────────────
@@ -71,6 +87,78 @@ def test_apply_limit_strips_trailing_semicolon() -> None:
 def test_apply_limit_zero() -> None:
     out = _apply_limit("SELECT a FROM t", 0)
     assert out.endswith("LIMIT 0")
+
+
+# ── URL connection kwargs ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("scheme", ["mysql", "mysql+pymysql", "mysql+mysqldb"])
+def test_mysql_url_allows_raw_brackets_in_password(scheme: str) -> None:
+    out = _build_mysql_connect_kwargs(
+        _FakeConnInfoFromUrl(f"{scheme}://user:p[a]ss@db.example.com:3306/test")
+    )
+
+    assert out["host"] == "db.example.com"
+    assert out["port"] == 3306
+    assert out["user"] == "user"
+    assert out["passwd"] == "p[a]ss"
+    assert out["db"] == "test"
+
+
+def test_mysql_url_decodes_user_password_and_database() -> None:
+    out = _build_mysql_connect_kwargs(
+        _FakeConnInfoFromUrl(
+            "mysql://us%40er:p%40ss%20word@db.example.com:3306/my%20db"
+            "?charset=utf8mb4"
+        )
+    )
+
+    assert out["user"] == "us@er"
+    assert out["passwd"] == "p@ss word"
+    assert out["db"] == "my db"
+    assert out["charset"] == "utf8mb4"
+
+
+def test_mysql_url_preserves_literal_plus_in_userinfo() -> None:
+    out = _build_mysql_connect_kwargs(
+        _FakeConnInfoFromUrl("mysql://svc+etl:p+wd@db.example.com:3306/test")
+    )
+
+    assert out["user"] == "svc+etl"
+    assert out["passwd"] == "p+wd"
+
+
+def test_mysql_url_preserves_ipv6_host_parsing() -> None:
+    out = _build_mysql_connect_kwargs(
+        _FakeConnInfoFromUrl("mysql://user:p[a]ss@[::1]:3306/test")
+    )
+
+    assert out["host"] == "::1"
+    assert out["port"] == 3306
+    assert out["passwd"] == "p[a]ss"
+    assert out["db"] == "test"
+
+
+def test_mysql_url_kwargs_override_query_params() -> None:
+    out = _build_mysql_connect_kwargs(
+        _FakeConnInfoFromUrl(
+            "mysql://user:pw@db.example.com:3306/test"
+            "?charset=latin1&connect_timeout=10",
+            kwargs={"charset": "utf8mb4"},
+        )
+    )
+
+    assert out["charset"] == "utf8mb4"
+    assert out["connect_timeout"] == "10"
+
+
+def test_mysql_url_invalid_scheme_raises() -> None:
+    with pytest.raises(WrenError) as exc:
+        _build_mysql_connect_kwargs(
+            _FakeConnInfoFromUrl("postgres://user:pw@db.example.com:5432/test")
+        )
+
+    assert exc.value.error_code == ErrorCode.INVALID_CONNECTION_INFO
 
 
 # ── _arrow_decimal_from_mysql_field ──────────────────────────────────────


### PR DESCRIPTION
  ## Summary

  Fix MySQL `connectionUrl` parsing when the password contains raw `[` or `]`.

  Before this change, URL-based MySQL connections could fail during parsing with an invalid IPv6 URL error because `urllib.parse.urlparse()` treated brackets in the password as host
  delimiters.

  ## Root cause

  The MySQL connector passed the raw connection URL directly to `urlparse()`. A URL like:

  ```text
  mysql://user:p[a]ss@host:3306/db
```
  fails before any connection attempt because urlparse() interprets [ / ] in the netloc as IPv6 syntax.

  There was also an adjacent decoding issue: MySQL URL userinfo was decoded with unquote_plus, which incorrectly turns literal + into a space.

  ## Changes

  - add a MySQL-specific URL parse helper that percent-encodes raw [ / ] in userinfo before calling urlparse()
  - only sanitize the userinfo segment, so valid IPv6 hosts like [::1] still parse correctly
  - switch MySQL URL decoding from unquote_plus to unquote for:
      - username
      - password
      - database path

  - keep existing scheme validation and kwarg precedence unchanged

  ## Tests

  Added unit coverage for:

  - raw bracketed passwords in MySQL URLs
  - all supported MySQL URL schemes
  - percent-decoding of username, password, and database name
  - preserving literal + in userinfo
  - preserving valid IPv6 host parsing
  - kwargs overriding query-string params
  - invalid scheme raising INVALID_CONNECTION_INFO

  ## Issue

  Closes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MySQL connection URL parsing to correctly handle special characters and encoded components in credentials; improved IPv6 address support.

* **Tests**
  * Added comprehensive test coverage for MySQL connection URL parsing with various credential formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->