### PR TITLE
chore(wren): separate SDK and local core install flows

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,10 +61,12 @@ Outputs a ~68 MB WASM binary; distributed via npm and unpkg (jsDelivr's 50 MB pe
 ### core/wren (SDK & CLI)
 ```bash
 cd core/wren
-just install              # build wren-core-py wheel + uv sync
+just install              # uv sync (locked prebuilt wren-core-py wheel from PyPI; no Rust build)
 just install-all          # with all optional extras (incl. memory)
 just install-extra <e>    # e.g. just install-extra postgres
 just install-memory       # memory extra (lancedb + sentence-transformers)
+just install-local        # engine dev: uv sync + build local wheel + overlay
+just use-local-core       # rebuild + re-overlay after Rust changes
 just dev                  # run `wren` CLI
 just test                 # pytest tests/
 just test-memory          # memory-specific tests

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -63,10 +63,10 @@ jobs:
           uv run --no-sync maturin build
       - name: Install dependencies
         run: |
-          uv lock --find-links ../wren-core-py/target/wheels/ --upgrade-package wren-core-py
-          uv sync --extra dev --find-links ../wren-core-py/target/wheels/
+          uv sync --locked
+          uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run unit tests
-        run: uv run pytest tests/unit/ -v -m unit
+        run: uv run --no-sync pytest tests/unit/ -v -m unit
 
   test-connector:
     name: ${{ matrix.datasource }} tests
@@ -116,10 +116,10 @@ jobs:
           uv run --no-sync maturin build
       - name: Install dependencies
         run: |
-          uv lock --find-links ../wren-core-py/target/wheels/ --upgrade-package wren-core-py
-          uv sync --extra ${{ matrix.extra }} --extra dev --find-links ../wren-core-py/target/wheels/
+          uv sync --locked --extra ${{ matrix.extra }}
+          uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run ${{ matrix.datasource }} tests
-        run: uv run pytest ${{ matrix.test_file }} -v -m ${{ matrix.marker }}
+        run: uv run --no-sync pytest ${{ matrix.test_file }} -v -m ${{ matrix.marker }}
 
   test-ui:
     name: ui tests
@@ -153,10 +153,10 @@ jobs:
           uv run --no-sync maturin build
       - name: Install dependencies
         run: |
-          uv lock --find-links ../wren-core-py/target/wheels/ --upgrade-package wren-core-py
-          uv sync --extra dev --extra ui --find-links ../wren-core-py/target/wheels/
+          uv sync --locked --extra ui
+          uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run UI tests
-        run: uv run pytest tests/test_profile_web.py tests/test_field_registry.py -v
+        run: uv run --no-sync pytest tests/test_profile_web.py tests/test_field_registry.py -v
 
   test-memory:
     name: memory tests
@@ -190,8 +190,8 @@ jobs:
           uv run --no-sync maturin build
       - name: Install dependencies
         run: |
-          uv lock --find-links ../wren-core-py/target/wheels/ --upgrade-package wren-core-py
-          uv sync --extra dev --extra memory --find-links ../wren-core-py/target/wheels/
+          uv sync --locked --extra memory
+          uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Cache sentence-transformers model
         uses: actions/cache@v4
         with:
@@ -200,4 +200,4 @@ jobs:
       - name: Run memory tests
         env:
           WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
-        run: uv run pytest tests/unit/test_memory.py -v
+        run: uv run --no-sync pytest tests/unit/test_memory.py -v

--- a/core/wren/.claude/CLAUDE.md
+++ b/core/wren/.claude/CLAUDE.md
@@ -20,7 +20,7 @@ just format           # ruff auto-fix (also aliased as `just fmt`)
 just build            # uv build (produces wheel)
 ```
 
-`install`, `install-all`, `install-extra`, and `install-memory` use the locked prebuilt engine wheel and do not require Rust (dev tools are in the default dependency group). Local engine testing is opt-in via `install-local`/`use-local-core`. Run recipes use `uv run --no-sync` so they don't revert an overlaid local wheel.
+`install`, `install-all`, `install-extra`, and `install-memory` use the locked prebuilt engine wheel and do not require Rust. Dev tools come from uv's default `dev` dependency group. Local engine testing is opt-in via `install-local`/`use-local-core`. Run recipes use `uv run --no-sync` so they don't revert an overlaid local wheel.
 
 Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend.
 
@@ -68,7 +68,7 @@ Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend.
 
 ## Optional Extras
 
-Install per data-source extras: `postgres`, `mysql`, `bigquery`, `snowflake`, `clickhouse`, `trino`, `mssql`, `databricks`, `redshift`, `spark`, `athena`, `oracle`, `memory`, `all`, `dev`.
+Install per data-source extras: `postgres`, `mysql`, `bigquery`, `snowflake`, `clickhouse`, `trino`, `mssql`, `databricks`, `redshift`, `spark`, `athena`, `oracle`, `memory`, `all`.
 
 On macOS, `mysql` extra needs:
 ```bash

--- a/core/wren/.claude/CLAUDE.md
+++ b/core/wren/.claude/CLAUDE.md
@@ -6,10 +6,12 @@ Python SDK and CLI for Wren Engine. Wraps `wren-core-py` (PyO3 bindings) + Ibis 
 
 ```bash
 cd wren
-just install          # build wren-core-py wheel + uv sync
+just install          # uv sync — prebuilt wren-core-py wheel from PyPI (no Rust build)
 just install-all      # with all optional extras (including memory)
 just install-extra <extra>   # e.g. just install-extra postgres
 just install-memory   # install memory extra (lancedb + sentence-transformers)
+just install-local    # engine dev: uv sync + build local wheel + overlay (needs Rust)
+just use-local-core   # rebuild + re-overlay local wheel after a Rust change
 just dev              # run `wren` CLI
 just test             # pytest tests/
 just test-memory      # memory-specific tests
@@ -17,6 +19,8 @@ just lint             # ruff format --check + ruff check
 just format           # ruff auto-fix (also aliased as `just fmt`)
 just build            # uv build (produces wheel)
 ```
+
+`install`, `install-all`, `install-extra`, and `install-memory` use the locked prebuilt engine wheel and do not require Rust (dev tools are in the default dependency group). Local engine testing is opt-in via `install-local`/`use-local-core`. Run recipes use `uv run --no-sync` so they don't revert an overlaid local wheel.
 
 Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend.
 
@@ -73,4 +77,9 @@ PKG_CONFIG_PATH="$(brew --prefix mysql-client)/lib/pkgconfig" just install-extra
 
 ## Dependency on wren-core-py
 
-`wren-core-py` wheel is built locally from `../wren-core-py/` and installed via `--find-links`. Run `just build-core` (or `just install`) to rebuild after Rust changes.
+By default the engine binding comes prebuilt from PyPI (pinned in `uv.lock`), so
+ordinary `just install` needs no Rust toolchain. To test against local Rust
+changes, `just use-local-core` builds the wheel from `../wren-core-py/` and
+overlays it into `.venv` (via `uv pip install --reinstall --no-index
+--find-links`). The run recipes use `uv run --no-sync` so a subsequent `uv run`
+won't revert that overlay to the locked PyPI version.

--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -213,11 +213,32 @@ with WrenEngine(manifest_str, DataSource.mysql, {"host": "...", ...}) as engine:
 
 ## Development
 
+Prerequisites: `just` and `uv`. (Rust + Cargo are only needed for the
+local-engine recipes below.)
+
+### Standard setup (no Rust toolchain)
+
 ```bash
-just install-dev    # Install with dev dependencies
+just install        # uv sync — pulls the prebuilt wren-core-py wheel from PyPI
 just lint           # Ruff format check + lint
 just format         # Auto-fix
 ```
+
+`just install` is a plain `uv sync`: it installs the locked prebuilt `wren-core-py` engine binding and the dev tools (pytest/ruff), which live in the default dependency group. No compilation required. This is enough for all Python-side development. Use `just install-extra <extra>` or `just install-all` for data-source extras.
+
+### Engine development (changing the Rust core)
+
+Only needed when you modify `../wren-core-py` (or `../wren-core`) and want
+`core/wren` to run against your local build. Requires Rust + Cargo.
+
+```bash
+just install-local    # uv sync + build the local wheel + overlay it into .venv
+just use-local-core   # rebuild + re-overlay after each subsequent Rust change
+```
+
+The run recipes (`just test*`, `just lint`, `just dev`) use `uv run --no-sync`,
+so they never revert a locally overlaid engine back to the lockfile version. If
+dependencies change, re-run an install recipe first.
 
 | Command | What it runs | Docker needed |
 |---------|-------------|---------------|
@@ -230,8 +251,8 @@ just format         # Auto-fix
 Profile web tests (`test_profile_web.py`) require `wrenai[ui]`:
 
 ```bash
-uv sync --extra dev --extra ui --find-links ../wren-core-py/target/wheels/
-uv run pytest tests/test_profile_web.py -v
+uv sync --extra ui
+uv run --no-sync pytest tests/test_profile_web.py -v
 ```
 
 ## Publishing

--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -224,7 +224,7 @@ just lint           # Ruff format check + lint
 just format         # Auto-fix
 ```
 
-`just install` is a plain `uv sync`: it installs the locked prebuilt `wren-core-py` engine binding and the dev tools (pytest/ruff), which live in the default dependency group. No compilation required. This is enough for all Python-side development. Use `just install-extra <extra>` or `just install-all` for data-source extras.
+`just install` is a plain `uv sync`: it installs the locked prebuilt `wren-core-py` engine binding and the development tools from uv's default `dev` dependency group. No compilation required. This is enough for all Python-side development. Use `just install-extra <extra>` or `just install-all` for data-source extras.
 
 ### Engine development (changing the Rust core)
 

--- a/core/wren/justfile
+++ b/core/wren/justfile
@@ -1,27 +1,19 @@
 default:
     @just --list
 
-build-core:
-    cd ../wren-core-py && just install && just build
-
 core-wheel-dir := "../wren-core-py/target/wheels/"
 
-install-core:
-    just build-core
+# ─── Install (light) ──────────────────────────────────────────────
+# Uses the locked prebuilt wren-core-py wheel. No Rust toolchain required.
+# Dev tools live in the default dependency group.
 
 install:
-    just build-core
-    uv sync --find-links {{ core-wheel-dir }}
-
-install-dev:
-    just build-core
-    uv sync --extra dev --find-links {{ core-wheel-dir }}
+    uv sync
 
 install-all:
-    just build-core
-    uv sync --all-extras --find-links {{ core-wheel-dir }}
+    uv sync --all-extras
 
-install-extra extra *flags:
+install-extra extra:
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "{{ extra }}" = "mysql" ]; then
@@ -30,66 +22,81 @@ install-extra extra *flags:
             export PKG_CONFIG_PATH="$mysql_prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
         fi
     fi
-    dev_flag=""
-    for flag in {{ flags }}; do
-        if [ "$flag" = "--dev" ]; then
-            dev_flag="--extra dev"
-        fi
-    done
-    uv sync --extra {{ extra }} $dev_flag --find-links {{ core-wheel-dir }}
-
-dev:
-    uv run wren
-
-test:
-    uv run pytest tests/ -v
-
-test-unit:
-    uv run pytest tests/unit/ -v -m unit
-
-test-datafusion:
-    uv run pytest tests/connectors/test_datafusion.py -v -m datafusion
-
-test-duckdb:
-    uv run pytest tests/connectors/test_duckdb.py -v -m duckdb
-
-test-postgres:
-    uv run pytest tests/connectors/test_postgres.py -v -m postgres
-
-test-mysql:
-    uv run pytest tests/connectors/test_mysql.py tests/connectors/test_mysql_connector.py -v -m mysql
-
-test-snowflake:
-    uv run pytest tests/connectors/test_snowflake.py -v -m snowflake
-
-test-canner:
-    uv run pytest tests/connectors/test_canner.py -v -m canner
-
-test-clickhouse:
-    uv run pytest tests/connectors/test_clickhouse.py -v -m clickhouse
-
-test-trino:
-    uv run pytest tests/connectors/test_trino.py -v -m trino
-
-test-connector marker:
-    uv run pytest tests/connectors/ -v -m {{ marker }}
+    uv sync --extra {{ extra }}
 
 install-memory:
+    uv sync --extra memory
+
+# ─── Local engine (opt-in; requires Rust + Cargo) ─────────────────
+# Use only when testing core/wren against local Rust changes.
+
+# Low-level helper: builds the wheel only; does not modify .venv.
+build-core:
+    cd ../wren-core-py && just install && just build
+
+# Rebuild and overlay the local wheel into the current .venv.
+use-local-core:
     just build-core
-    uv sync --extra memory --extra dev --find-links {{ core-wheel-dir }}
+    uv pip install --reinstall --no-index --find-links {{ core-wheel-dir }} wren-core-py
+
+# First-time setup for engine development: light sync + local overlay.
+install-local:
+    just install
+    just use-local-core
+
+# ─── Run (read-only; assumes dependencies are installed) ──────────
+# --no-sync preserves any local core overlay. Re-run an install recipe
+# after dependency changes.
+
+dev:
+    uv run --no-sync wren
+
+test:
+    uv run --no-sync pytest tests/ -v
+
+test-unit:
+    uv run --no-sync pytest tests/unit/ -v -m unit
+
+test-datafusion:
+    uv run --no-sync pytest tests/connectors/test_datafusion.py -v -m datafusion
+
+test-duckdb:
+    uv run --no-sync pytest tests/connectors/test_duckdb.py -v -m duckdb
+
+test-postgres:
+    uv run --no-sync pytest tests/connectors/test_postgres.py -v -m postgres
+
+test-mysql:
+    uv run --no-sync pytest tests/connectors/test_mysql.py tests/connectors/test_mysql_connector.py -v -m mysql
+
+test-snowflake:
+    uv run --no-sync pytest tests/connectors/test_snowflake.py -v -m snowflake
+
+test-canner:
+    uv run --no-sync pytest tests/connectors/test_canner.py -v -m canner
+
+test-clickhouse:
+    uv run --no-sync pytest tests/connectors/test_clickhouse.py -v -m clickhouse
+
+test-trino:
+    uv run --no-sync pytest tests/connectors/test_trino.py -v -m trino
+
+test-connector marker:
+    uv run --no-sync pytest tests/connectors/ -v -m {{ marker }}
 
 test-memory:
-    uv run pytest tests/unit/test_memory.py -v
+    uv run --no-sync pytest tests/unit/test_memory.py -v
 
 lint:
-    uv run ruff format --check src/
-    uv run ruff check src/
+    uv run --no-sync ruff format --check src/
+    uv run --no-sync ruff check src/
 
 format:
-    uv run ruff format src/
-    uv run ruff check --fix src/
+    uv run --no-sync ruff format src/
+    uv run --no-sync ruff check --fix src/
 
 build:
     uv build
 
 alias fmt := format
+alias install-dev := install

--- a/core/wren/justfile
+++ b/core/wren/justfile
@@ -5,7 +5,7 @@ core-wheel-dir := "../wren-core-py/target/wheels/"
 
 # ─── Install (light) ──────────────────────────────────────────────
 # Uses the locked prebuilt wren-core-py wheel. No Rust toolchain required.
-# Dev tools live in the default dependency group.
+# Dev tools come from uv's default dev dependency group.
 
 install:
     uv sync

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -63,13 +63,6 @@ main = ["wrenai[interactive,ui]"]
 all = [
   "wrenai[postgres,mysql,bigquery,snowflake,clickhouse,trino,mssql,databricks,redshift,athena,oracle,spark,main,memory]",
 ]
-dev = [
-  "pytest>=8",
-  "ruff>=0.4",
-  "orjson>=3",
-  "testcontainers[postgres,mysql]>=4",
-  "httpx>=0.27",
-]
 
 [project.scripts]
 wren = "wren.cli:app"

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "wren-core-py>=0.1",
+  "wren-core-py>=0.6",
   "duckdb>=1.0",
   "sqlglot>=27",
   "typer>=0.12",
@@ -100,5 +100,10 @@ ignore = [
 
 [dependency-groups]
 dev = [
-    "duckdb>=1.5.0",
+    "pytest>=8",
+    "ruff>=0.4",
+    "orjson>=3",
+    "testcontainers[postgres,mysql]>=4",
+    "httpx>=0.27",
+    "duckdb>=1.0",
 ]

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "wren-core-py>=0.6",
-  "duckdb>=1.0",
+  "duckdb>=1.5.0",
   "sqlglot>=27",
   "typer>=0.12",
   "pydantic>=2",
@@ -105,5 +105,5 @@ dev = [
     "orjson>=3",
     "testcontainers[postgres,mysql]>=4",
     "httpx>=0.27",
-    "duckdb>=1.0",
+    "duckdb>=1.5.0",
 ]

--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -3428,7 +3428,7 @@ requires-dist = [
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.8" },
     { name = "databricks-sdk", marker = "extra == 'databricks'" },
     { name = "databricks-sql-connector", marker = "extra == 'databricks'" },
-    { name = "duckdb", specifier = ">=1.0" },
+    { name = "duckdb", specifier = ">=1.5.0" },
     { name = "google-auth", marker = "extra == 'bigquery'" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.40,<4" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },

--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -3360,13 +3360,6 @@ databricks = [
     { name = "databricks-sdk" },
     { name = "databricks-sql-connector" },
 ]
-dev = [
-    { name = "httpx" },
-    { name = "orjson" },
-    { name = "pytest" },
-    { name = "ruff" },
-    { name = "testcontainers", extra = ["mysql"] },
-]
 interactive = [
     { name = "inquirerpy" },
 ]
@@ -3431,7 +3424,6 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "google-auth", marker = "extra == 'bigquery'" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.40,<4" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "inquirerpy", marker = "extra == 'interactive'", specifier = ">=0.3.4" },
     { name = "jinja2", marker = "extra == 'ui'", specifier = ">=3.1" },
     { name = "lancedb", marker = "extra == 'memory'", specifier = ">=0.6" },
@@ -3440,7 +3432,6 @@ requires-dist = [
     { name = "mysqlclient", marker = "extra == 'mysql'", specifier = ">=2.2" },
     { name = "opendal", specifier = ">=0.45" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=2" },
-    { name = "orjson", marker = "extra == 'dev'", specifier = ">=3" },
     { name = "pandas", specifier = ">=2" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3" },
     { name = "pyarrow", specifier = ">=14" },
@@ -3451,18 +3442,15 @@ requires-dist = [
     { name = "pyodbc", marker = "extra == 'mssql'", specifier = ">=5,<6" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "pyspark", marker = "extra == 'spark'", specifier = ">=3.5" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "python-multipart", marker = "extra == 'ui'", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "redshift-connector", marker = "extra == 'redshift'" },
     { name = "requests", specifier = ">=2.33.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "sentence-transformers", marker = "extra == 'memory'", specifier = ">=2.2" },
     { name = "snowflake-connector-python", extras = ["pandas"], marker = "extra == 'snowflake'", specifier = ">=3.10" },
     { name = "sqlglot", specifier = ">=27" },
     { name = "starlette", marker = "extra == 'ui'", specifier = ">=0.37" },
-    { name = "testcontainers", extras = ["postgres", "mysql"], marker = "extra == 'dev'", specifier = ">=4" },
     { name = "trino", marker = "extra == 'trino'", specifier = ">=0.333,<1" },
     { name = "typer", specifier = ">=0.12" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -3471,7 +3459,7 @@ requires-dist = [
     { name = "wrenai", extras = ["interactive", "ui"], marker = "extra == 'main'" },
     { name = "wrenai", extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "athena", "oracle", "spark", "main", "memory"], marker = "extra == 'all'" },
 ]
-provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "interactive", "ui", "main", "all", "dev"]
+provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "interactive", "ui", "main", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -3287,11 +3287,14 @@ wheels = [
 
 [[package]]
 name = "wren-core-py"
-version = "0.1.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/89/64d5a0a5b4e6e4d9f36d0e8856e358b78f8df537d754457a143c596ade68/wren_core_py-0.1.0.tar.gz", hash = "sha256:e1f85e4a76cd753850ab9750121c85788eff85ef9497481ac8c660bf92363e80", size = 173500, upload-time = "2026-03-31T13:51:59.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/38/b2cb577b44e0f167b1cd465f1f757d1e759f7d02b9156cc2d59da89f409c/wren_core_py-0.6.0.tar.gz", hash = "sha256:cb0c947d5201b6857b95395edd3ccfd5e40ec0f2789f14781a3efc79b68644a0", size = 183149, upload-time = "2026-05-15T09:26:06.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/37/02dae70f121c22cfb60dd0a0e16afd349d193e4bdca0e836e0b1952bb3c1/wren_core_py-0.1.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:51624141000c008cead7b330883d39fd36d2a1ffc10e18aedcf1a938df2ced6f", size = 31035179, upload-time = "2026-03-31T13:51:56.408Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/80/ea296d00ace9d68c8619b6b2f2d506d231d1003f392fe49612b1a87edc65/wren_core_py-0.6.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:65bab57150c475edf55b7aac5dc3548196e5bd5eeff0e1aff8f0b8be164394b6", size = 44663050, upload-time = "2026-05-15T09:25:52.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/cf/3238a3ee4cabafb35d9731547a5600a3664801270af6a337f8768b1605fe/wren_core_py-0.6.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:6d7b358778adc8a5bbaab3523f7021b060a4ba0b29527f0e917e8046574ef81e", size = 42638553, upload-time = "2026-05-15T09:25:56.621Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/2fae1e144252ab296df8fa5dcfb06b43c397028cb15a010b70709e76a04f/wren_core_py-0.6.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb3a453f7a86b8cd9325c2696585e3a6c042616e12fa3ed10b34e9a5793a9442", size = 47920325, upload-time = "2026-05-15T09:26:00.21Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9b/3a8e1d8b38567f0112af7d0faf540ff61799980e68a6f8a423f42567b534/wren_core_py-0.6.0-cp311-abi3-win_amd64.whl", hash = "sha256:b829a8faf28f44f58910bd73246e69a86bd01b14d45288cce52c712578ff8199", size = 41809570, upload-time = "2026-05-15T09:26:04.087Z" },
 ]
 
 [[package]]
@@ -3412,6 +3415,11 @@ ui = [
 [package.dev-dependencies]
 dev = [
     { name = "duckdb" },
+    { name = "httpx" },
+    { name = "orjson" },
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "testcontainers", extra = ["mysql"] },
 ]
 
 [package.metadata]
@@ -3459,14 +3467,21 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.29" },
-    { name = "wren-core-py", specifier = ">=0.1" },
+    { name = "wren-core-py", specifier = ">=0.6" },
     { name = "wrenai", extras = ["interactive", "ui"], marker = "extra == 'main'" },
     { name = "wrenai", extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "athena", "oracle", "spark", "main", "memory"], marker = "extra == 'all'" },
 ]
 provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "interactive", "ui", "main", "all", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "duckdb", specifier = ">=1.5.0" }]
+dev = [
+    { name = "duckdb", specifier = ">=1.5.0" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "orjson", specifier = ">=3" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.4" },
+    { name = "testcontainers", extras = ["postgres", "mysql"], specifier = ">=4" },
+]
 
 [[package]]
 name = "zstandard"


### PR DESCRIPTION
## Summary

This PR separates the default `core/wren` Python development setup from the local Rust engine development setup.

Previously, the `core/wren` install flow mixed Python dependency sync with building/resolving a local `wren-core-py` wheel from `core/wren-core-py`. That made the environment easy to drift: running `uv sync` or related `uv` commands could remove dev tools such as `pytest`, and `uv sync --find-links ...` mixed lockfile resolution with local wheel builds.

## What changed

- Move `core/wren` Python dev tools such as `pytest` and `ruff` from the published `dev` extra to uv's default `dev` dependency group.
- Make `just install` the standard Python development setup: a normal `uv sync` using the locked prebuilt `wren-core-py` wheel.
- Add explicit local engine commands for Rust/PyO3 work: `just install-local` and `just use-local-core`.
- Use `uv run --no-sync` for run/test/lint recipes so a locally overlaid `wren-core-py` wheel is not reverted during execution.
- Update `wren-ci.yml` to sync from the lockfile first, then overlay the locally built `wren-core-py` wheel, instead of running `uv lock --find-links ... --upgrade-package wren-core-py`.

## Development workflows

### Python development (`core/wren`)

Use this when working on the Python SDK, CLI, connectors, profiles, or tests under `core/wren`.

```bash
cd core/wren
just install
just test-unit
just lint
```

`just install` runs `uv sync`. It installs runtime dependencies, the locked prebuilt `wren-core-py` wheel, and Python dev tools such as `pytest` and `ruff`.

No Rust toolchain is required.

`just install-dev` remains available as an alias for `just install`.

### Local Rust engine development (`core/wren-core-py` / `core/wren-core`)

Use this when changing the Rust engine or Python binding and testing those changes through `core/wren`.

```bash
cd core/wren
just install-local
just test-unit
```

After subsequent Rust changes:

```bash
just use-local-core
just test-unit
```

`build-core` remains a low-level helper that only builds the local `wren-core-py` wheel. `use-local-core` rebuilds and overlays that wheel into the current `core/wren/.venv`.

## CI behavior

`wren-ci.yml` still validates `core/wren` against the local `wren-core-py` wheel built from the PR checkout, so changes to `core/wren-core-py` and `core/wren-core` remain covered.

The CI install sequence is now:

```bash
uv sync --locked ...
uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
uv run --no-sync pytest ...
```

This keeps CI aligned with the local engine workflow without rewriting lockfile resolution during CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Documentation**
  * Updated developer setup guidance with clear “standard” (no Rust toolchain) instructions and an opt-in local engine workflow using a locked, prebuilt wheel.
  * Refreshed command recipes for installs, tests, and UI-related test setup to avoid unwanted wheel reversion.

* **Chores**
  * Streamlined CI installs to use locked synchronization and reduce extra syncing during test runs.
  * Updated local engine overlay flow and adjusted automation defaults to “light” syncing.
  * Raised minimum runtime dependency versions and tightened dev dependency minimums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->