### PR TITLE
docs(core): rewrite GenBI guide around the agent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   </picture>
 </a>
 
-### The open context layer for AI agents over business data.
+### Open-source GenBI: generative BI for AI agents.
 
-*Your agent doesn't know what your data means. We fix that.*
+*Your agents generate, deploy, and govern dashboards from any database, grounded in a context layer they can actually trust.*
 
 [Docs](https://docs.getwren.ai) · [Discord](https://discord.gg/5DvshJqG8Z) · [Vision](https://www.getwren.ai/post/the-missing-context-layer-for-ai-agents-over-business-data) · [Blog](https://www.getwren.ai/blog)
 
@@ -25,42 +25,63 @@
 
 </div>
 
-> 📣 **2026-05-07** — Wren Engine has merged into this repo under [`core/`](./core). The previous `Canner/wren-engine` repo is archived. The previous WrenAI GenBI app is preserved on the [`legacy/v1`](https://github.com/Canner/WrenAI/tree/legacy/v1) branch (tag `v1-final`). [Read the announcement →](https://github.com/Canner/WrenAI/discussions/2205)
+> 📣 **2026-05-07**: Wren Engine has merged into this repo under [`core/`](./core). The previous `Canner/wren-engine` repo is archived. The previous WrenAI GenBI app (the Docker-based chat-first BI product) is preserved on the [`legacy/v1`](https://github.com/Canner/WrenAI/tree/legacy/v1) branch (tag `v1-final`) and is now **Wren GenBI Classic**; see [A note on the "GenBI" name](#a-note-on-the-genbi-name) below. [Read the announcement →](https://github.com/Canner/WrenAI/discussions/2205)
 
 <!--
   📺 HERO DEMO (place here)
   ─────────────────────────
-  Suggested: a 5–10 second silent loop showing:
-    1. Terminal: `wren skills get onboarding` (agent fetches the workflow guide from the CLI)
-    2. Agent walks the user through setup, then writes SQL via `wren query` — visible reasoning trace
-    3. Final result table
+  Suggested: a 10-second silent loop showing GenBI end to end:
+    1. User asks their agent (in plain language) for a dashboard
+    2. Agent writes governed SQL via the Wren context layer, builds the app
+    3. `wren genbi deploy` produces a live, shareable dashboard URL
   Format: .gif (≤2 MB) or .mp4 (autoplay-muted).
   Save under  /assets/wrenai-demo.gif  and use the line below:
 
-  <img src="./assets/wrenai-demo.gif" alt="Wren AI in action" width="820" />
+  <img src="./assets/wrenai-demo.gif" alt="Wren GenBI in action" width="820" />
 -->
 
 ---
 
 ## What WrenAI is
 
-WrenAI is the **open context layer** that gives your agents what schemas don't: business semantics, examples, memory, governance, and — soon — the unstructured corporate knowledge that lives in your docs, wikis, and chat threads. Built for the agent frameworks you already use. 
+WrenAI is the **open-source GenBI engine**: it lets AI agents **generate, deploy, and govern** business intelligence, from a SQL answer to a shareable dashboard, across 22+ data sources.
+
+What makes the output trustworthy is the layer underneath: an open **context layer** that gives agents what schemas don't. That means business semantics, approved definitions, examples, memory, and governance, plus the unstructured company knowledge that lives in your docs, wikis, and chat threads. Generative BI is only as good as the context it stands on, and Wren is that context, made reviewable and reusable by every agent you already run.
 
 ![Wren AI architecture](./misc/wren-ai-architecture.png)
 
+## GenBI in three beats: Generate · Deploy · Know
+
+- **Generate.** Your agent turns a business question into *governed* SQL and charts. Schema-aware retrieval, MDL planning, dry-plan validation, and structured errors keep it correct instead of confidently wrong.
+- **Deploy.** Turn any answer into a shareable, browser-side dashboard powered by [`wren-core-wasm`](https://docs.getwren.ai/oss/sdk/wasm) and ship it to your own Vercel or Cloudflare Pages account with one command.
+- **Know.** The knowledge that makes all of this correct lives in versionable, evidence-linked files: semantic models (MDL), company definitions (`instructions.md`), and a memory of what worked. Reviewable. Git-friendly. Never locked inside someone else's UI.
+
 ## Why agent builders pick WrenAI
 
-- **Open by default** — Open-sourced core, SDK, and skills through Apache-2.0 license.
-- **Built for AI agents** — Skills, agentic architecture, context retrieval are first-class. Ships as SDKs for the agent frameworks that engineers already use.
-- **Correctness as primitives** — rich schema retrieval, dry-plan validation, structured errors with hints, value profiling, eval runner. The agent orchestrates; the trace lives in the agent's reasoning.
-- **Reviewable, reproducible context** — every definition, example, and mapping is versionable and evidence-linked. Git-friendly.
-- **Sits on top of your existing stack** — warehouse, transformation pipelines, your existing semantic layer. Not another tool to maintain.
+- **Generative BI, end to end.** Not just text-to-SQL. Generate the answer, deploy the dashboard, share the URL, all driven by the agents you already use.
+- **Knowledge management built in.** Business meaning, approved definitions, and proven examples are captured as reviewable, version-controlled context, not buried in prompts.
+- **Open by default.** Open-sourced core, SDK, and skills under the Apache-2.0 license.
+- **Correctness as primitives.** Rich schema retrieval, dry-plan validation, structured errors with hints, value profiling, eval runner. The agent orchestrates; the trace lives in its reasoning.
+- **Sits on top of your existing stack.** Warehouse, transformation pipelines, your existing semantic layer. Not another tool to maintain.
 
-## With & Without Wren AI
+## How Wren compares
 
-Agents are everywhere. Claude Code, Cursor, ChatGPT, Aider, LangChain pipelines, Pydantic AI flows, in-house copilots, customer-facing apps. None of them should have to rediscover your business logic from scratch. With Wren AI, "the context layer," they query through a standalone, shared interface usable by every agent and person, not gated behind a single vendor's UI and architecture.
+|  | A raw LLM agent | A traditional BI tool | A bare semantic layer | **WrenAI** |
+|---|:---:|:---:|:---:|:---:|
+| Writes SQL for you | ✅ (often wrong) | ❌ | ❌ | ✅ governed |
+| Knows your business definitions | ❌ | partial, in-tool | ✅ (schema only) | ✅ + non-schema knowledge |
+| Generates & deploys dashboards | ❌ | ✅ (manual, in-tool) | ❌ | ✅ agent-driven |
+| Works through *your* agents (Claude Code, Cursor, MCP…) | ✅ | ❌ | ❌ | ✅ |
+| Open, reviewable, Git-friendly context | ❌ | ❌ | partial | ✅ |
+| Governed execution across 22+ sources | ❌ | per-connector | ✅ (definitions only) | ✅ |
 
-<img width="1445" height="758" alt="before & after" src="https://github.com/user-attachments/assets/d6ef8b73-b844-4e11-9586-b4f7ab6ae9dc" />
+## Wren is for you if…
+
+- You want **AI agents to produce trustworthy BI**, answers *and* dashboards, not just plausible SQL.
+- Your business logic (definitions, enums, units, approved joins) lives **outside the database** and your agents keep getting it wrong.
+- You want context that's **open, reviewable, and version-controlled**, usable by every agent and person, not gated behind one vendor's UI.
+
+**Skip Wren if** you only need a one-off chart from a single CSV, or you're happy letting an agent guess at SQL with no governance.
 
 ## Quickstart
 
@@ -81,7 +102,6 @@ pip install "wrenai[postgres,memory]"   # add per-datasource and memory extras a
 > pip install wrenai -i https://pypi.tuna.tsinghua.edu.cn/simple
 > ```
 > If HuggingFace model downloads time out, add `export HF_ENDPOINT=https://hf-mirror.com` before running the CLI.
-```
 
 ### 2. Install the discovery stub for your AI client
 
@@ -91,7 +111,7 @@ npx skills add Canner/WrenAI            # auto-detects Claude Code, Cursor, Clin
 
 The stub is ~50 lines. It teaches your agent to fetch workflow guides via
 `wren skills get <name>` and shaped prompts via
-`wren ask "<question>" --guided|--direct` — everything else lives in the CLI.
+`wren ask "<question>" --guided|--direct`, and everything else lives in the CLI.
 
 ### 3. Ask your agent to set things up
 
@@ -103,7 +123,7 @@ The agent runs `wren skills get onboarding`, follows the guide step-by-step,
 checks your environment, creates a connection profile, scaffolds the project,
 and runs a first query.
 
-### 4. (Optional) Enrich the project
+### 4. (Optional) Enrich the project: the *Know* beat
 
 Once onboarding finishes, ask:
 
@@ -112,25 +132,35 @@ Once onboarding finishes, ask:
 The agent runs `wren skills get enrich-context` and follows the guide in
 **grill** mode (one question at a time) or **auto-pilot** mode (agent reads
 `<project>/raw/` and proposes). Both modes write to MDL, instructions,
-queries, and memory — all reviewable, all Git-friendly.
+queries, and memory, all reviewable, all Git-friendly.
 
-### 5. Ask questions
+### 5. Ask questions: the *Generate* beat
 
 > "Who are our top 10 customers by sales this quarter?"
 
 Your agent fetches MDL context, recalls similar past queries, writes
 governed SQL, and executes via `wren query`.
 
+### 6. Build & deploy a dashboard: the *Deploy* beat
+
+> "Turn that into an interactive dashboard I can filter and share, and deploy it to Vercel."
+
+The agent runs `wren skills get genbi`, builds a browser-side GenBI app from
+your project's context, previews it locally, and ships it to your own Vercel
+or Cloudflare Pages account, returning a live, shareable URL. See the
+[Build & deploy a GenBI app guide](https://docs.getwren.ai/oss/guides/genbi).
+
 **Want to try it without your own database?** Ask your agent to use the
-bundled `jaffle_shop` sample dataset — same flow, querying a real warehouse
+bundled `jaffle_shop` sample dataset. Same flow, querying a real warehouse
 end-to-end in a couple of minutes.
 
-## Two beats: scaffold fast, enrich deep
+## Two beats first, then the third
 
 ```bash
-# Day 1 — agent-driven
-wren skills get onboarding         # workflow guide: set up project + first query
-wren skills get enrich-context     # workflow guide: add business context (cubes, units, enums)
+# Day 1 (agent-driven)
+wren skills get onboarding         # workflow guide: set up project + first query  (Generate)
+wren skills get enrich-context     # workflow guide: add business context           (Know)
+wren skills get genbi              # workflow guide: build & deploy a dashboard      (Deploy)
 
 # Day-to-day
 wren query --sql '...'             # query through the MDL semantic layer
@@ -140,54 +170,59 @@ wren ask "<question>" --direct     # wrap a question for a stronger agent
 
 Fast at first. Deep when you need it. Always reviewable and Git-friendly.
 
-<!--
-  📷 OPTIONAL: 2-up screenshot showing grill mode (left) vs auto-pilot mode (right).
-  Save under  /assets/two-beats.png
--->
-
 ## What's Included
 
-- **Modeling Definition Language (MDL)** — models, columns, relationships, views, cubes, metrics, row-level / column-level access control (RLAC / CLAC)
-- **Engine** — Apache DataFusion based, 22+ data sources
-- **Memory & examples** — LanceDB-backed, hybrid retrieval, versionable
-- **Agent SDK** — `wren-langchain` (LangChain / LangGraph), `wren-pydantic`; reference Python integration for other stacks
-- **Governed execution primitives** — functions, dry-plan, row limits, access control
+- **Modeling Definition Language (MDL)**: models, columns, relationships, views, cubes, metrics, row-level / column-level access control (RLAC / CLAC)
+- **Engine**: Apache DataFusion based, 22+ data sources
+- **GenBI dashboards**: agent-built, browser-side apps powered by [`wren-core-wasm`](https://docs.getwren.ai/oss/sdk/wasm), deployable to Vercel / Cloudflare Pages
+- **Knowledge & memory**: business meaning in version-controlled `instructions.md` and `queries.yml`, plus a local LanceDB memory index (hybrid retrieval) for recall
+- **Agent SDK**: `wren-langchain` (LangChain / LangGraph), `wren-pydantic`; reference Python integration for other stacks
+- **Governed execution primitives**: functions, dry-plan, row limits, access control
 
 ## What's next
 
-- **Context enrichment skill** — `/wren-enrich-context` (grill + auto-pilot modes) hardened across MDL, instructions, queries, and memory
-- **End-to-end correctness primitives** — value profiling, rich retrieval, structured errors, golden eval runner
-- **Agent-native distribution** — first-class SDKs across major agent frameworks; see [GitHub Discussions](https://github.com/Canner/WrenAI/discussions) for what's prioritized next
-- **Full governed execution** — audit logs, rate limits, approval workflow, data-flow inspector
+- **End-to-end correctness primitives**: value profiling, rich retrieval, structured errors, golden eval runner
+- **Agent-native distribution**: first-class SDKs across major agent frameworks; see [GitHub Discussions](https://github.com/Canner/WrenAI/discussions) for what's prioritized next
+- **Full governed execution**: audit logs, rate limits, approval workflow, data-flow inspector
 
-<!-- TODO: vision_paper_en.md is currently at .tmp/roadmap-discuss/vision_paper_en.md — move to a published path (e.g. docs/vision-paper.md or repo root) and update this link before publishing. -->
-Full roadmap and design notes: see the [vision paper](https://docs.getwren.ai/oss/introduction).
+Full roadmap and design notes: see the [introduction](https://docs.getwren.ai/oss/introduction).
+
+## A note on the "GenBI" name
+
+"GenBI" now refers to this open-source generative-BI capability: agents that
+**generate** governed answers and **deploy** dashboards on top of Wren's context
+layer. The earlier **Wren AI GenBI** app, the Docker-based chat-first BI
+product, is now **Wren GenBI Classic**, preserved on the
+[`legacy/v1`](https://github.com/Canner/WrenAI/tree/legacy/v1) branch (no new
+features or security fixes). For a maintained, hosted version of that classic
+experience, see [Wren AI Commercial](https://getwren.ai).
 
 ## Documentation
 
-- [Quickstart](https://docs.getwren.ai/oss/get_started/quickstart) — from skill install to first answer
-- [Concepts](https://docs.getwren.ai/oss/concepts/what_is_context) — what context is, what MDL is, how memory works
-- [Connect a database](https://docs.getwren.ai/oss/guides/connect/overview) — Postgres, BigQuery, Snowflake, DuckDB, and more
-- [Agent SDKs](https://docs.getwren.ai/oss/sdk/overview) — what's shipping today, what's next
+- [Quickstart](https://docs.getwren.ai/oss/get_started/quickstart): from skill install to first answer
+- [Build & deploy a GenBI app](https://docs.getwren.ai/oss/guides/genbi): generate a dashboard and ship it
+- [Concepts](https://docs.getwren.ai/oss/concepts/what_is_context): what context is, what MDL is, how memory works
+- [Connect a database](https://docs.getwren.ai/oss/guides/connect): Postgres, BigQuery, Snowflake, DuckDB, and more
+- [Agent SDKs](https://docs.getwren.ai/oss/sdk/overview): what's shipping today, what's next
 
 ## Community
 
-- 💬 [Discord](https://discord.gg/5DvshJqG8Z) — chat with the team and other builders
-- 🐙 [GitHub Discussions](https://github.com/Canner/WrenAI/discussions) — design conversations, RFCs, longer threads
-- 🐦 [Twitter / X](https://x.com/getwrenai) — release notes and short updates
-- 🗞 [Blog](https://www.getwren.ai/blog) — vision, post-mortems, deep dives
+- 💬 [Discord](https://discord.gg/5DvshJqG8Z): chat with the team and other builders
+- 🐙 [GitHub Discussions](https://github.com/Canner/WrenAI/discussions): design conversations, RFCs, longer threads
+- 🐦 [Twitter / X](https://x.com/getwrenai): release notes and short updates
+- 🗞 [Blog](https://www.getwren.ai/blog): vision, post-mortems, deep dives
 
 ## Contributing
 
-We build in the open. Issues, PRs, connector contributions, SDK integrations, docs fixes — all welcome.
+We build in the open. Issues, PRs, connector contributions, SDK integrations, docs fixes are all welcome.
 
 - [Contributor guide](./CONTRIBUTING.md)
-- [Connector ecosystem program](./docs/contributing-a-connector.md) — three-tier ownership: official, community-blessed, community-owned
-- [Architecture map](./docs/architecture.md) — find the right place to land your change
+- [Connector ecosystem program](./docs/contributing-a-connector.md): three-tier ownership (official, community-blessed, community-owned)
+- [Architecture map](./docs/architecture.md): find the right place to land your change
 - Looking for somewhere to start? Try the [`good first issue`](https://github.com/Canner/WrenAI/labels/good%20first%20issue) label.
 
 <details>
-<summary><strong>Project structure</strong> — click to expand</summary>
+<summary><strong>Project structure</strong> (click to expand)</summary>
 
 ```
 core/
@@ -220,9 +255,9 @@ Apache 2.0. See [LICENSE](./LICENSE).
 
 <div align="center">
 
-*Come build the context layer with us.*
+*Come build open GenBI with us.*
 
-**If WrenAI helps you, drop a ⭐ — it genuinely helps us grow!**
+**If WrenAI helps you, drop a ⭐, it genuinely helps us grow!**
 
 <p><a href="#top">⬆️ Back to top</a></p>
 

--- a/docs/core/concepts/agent_learning.md
+++ b/docs/core/concepts/agent_learning.md
@@ -4,24 +4,24 @@ sidebar_label: How does the agent learn from your context?
 
 # How does the agent learn from your context?
 
-> An agent that ships in production does not memorize your business — it reads structured context, recalls proven examples, and writes them back as it works. Wren AI is designed around that loop.
+> An agent that ships in production does not memorize your business. It reads structured context, recalls proven examples, and writes them back as it works. Wren AI is designed around that loop, and it is what lets the BI your agents generate get more correct over time.
 
 ## Why this matters
 
 A first-day analyst does not know which table is canonical. Neither does an agent. Both get better through the same path: a guided start, focused questions, and a record of what worked.
 
-The difference is that an agent forgets between sessions unless your tooling stores the learning somewhere reviewable. Wren AI captures that learning in four explicit places — MDL, instructions, memory, and skills — so the agent picks up where the team left off, every time.
+The difference is that an agent forgets between sessions unless your tooling stores the learning somewhere reviewable. Wren AI captures that learning in four explicit places (MDL, instructions, memory, and skills) so the agent picks up where the team left off, every time.
 
 ## The two beats: scaffold fast, enrich deep
 
 Wren AI runs the agent through two beats whenever you set up a new project.
 
-**Beat 1 — Scaffold fast.** The `generate-mdl` guide drives the agent through schema discovery, type normalization, and an initial MDL project. The agent can already query through that modeled layer in a few minutes. The MDL is rough but functional — it covers what the database can tell you about itself.
+**Beat 1: Scaffold fast.** The `generate-mdl` guide drives the agent through schema discovery, type normalization, and an initial MDL project. The agent can already query through that modeled layer in a few minutes. The MDL is rough but functional. It covers what the database can tell you about itself.
 
-**Beat 2 — Enrich deep.** Structure is only the start. The hard business meaning lives in docs, decks, Slack threads, and analyst SQL. The `enrich-context` workflow brings that meaning in through two modes:
+**Beat 2: Enrich deep.** Structure is only the start. The hard business meaning lives in docs, decks, Slack threads, and analyst SQL. The `enrich-context` workflow brings that meaning in through two modes:
 
-- **Grill mode** — the agent asks one focused question at a time ("which is the canonical `orders` table?", "what does `status = 4` mean?", "should `active customer` exclude internal users?"). You answer; the agent patches MDL, `instructions.md`, `queries.yml`, or memory.
-- **Auto-pilot mode** — drop PDFs, glossaries, handbooks, and SQL history into `<project>/raw/`. The agent reads them, proposes context changes with evidence, and waits for review.
+- **Grill mode**: the agent asks one focused question at a time ("which is the canonical `orders` table?", "what does `status = 4` mean?", "should `active customer` exclude internal users?"). You answer; the agent patches MDL, `instructions.md`, `queries.yml`, or memory.
+- **Auto-pilot mode**: drop PDFs, glossaries, handbooks, and SQL history into `<project>/raw/`. The agent reads them, proposes context changes with evidence, and waits for review.
 
 Both modes write to reviewable, version-controlled artifacts. Nothing is silently absorbed into a black box.
 
@@ -31,8 +31,8 @@ Four artifacts capture different layers of learning:
 
 | Artifact | What it stores | Updated by |
 |---|---|---|
-| **MDL** (`models/`, `views/`, `relationships.yml`) | Structural and semantic contract — what data exists, how it relates, which calculations are reusable | `wren context build`, manual edits, agent-proposed changes |
-| **`instructions.md`** | Operational guidance — preferred terminology, default filters, table selection rules, caveats | Manual edits or agent-proposed changes |
+| **MDL** (`models/`, `views/`, `relationships.yml`) | Structural and semantic contract: what data exists, how it relates, which calculations are reusable | `wren context build`, manual edits, agent-proposed changes |
+| **`instructions.md`** | Operational guidance: preferred terminology, default filters, table selection rules, caveats | Manual edits or agent-proposed changes |
 | **Memory** (`.wren/memory/`) | Retrieval index over MDL + instructions, plus a record of confirmed natural-language-to-SQL pairs | `wren memory index`, `wren memory store` |
 | **`queries.yml`** | Curated, committable seed of natural-language-to-SQL examples | `wren memory dump` from accumulated memory |
 
@@ -72,6 +72,6 @@ The agent is not getting smarter. The context layer it reads from is getting ric
 
 ## See also
 
-- [How does memory get smarter over time?](./memory_system.md) — the mechanics of recall and indexing.
-- [What does MDL do for the agent?](./what_is_mdl.md) — the semantic contract the agent reads.
-- [Refine answer quality](/oss/guides/refine) — the recipe for running the enrich loop.
+- [How does memory get smarter over time?](./memory_system.md): the mechanics of recall and indexing.
+- [What does MDL do for the agent?](./what_is_mdl.md): the semantic contract the agent reads.
+- [Refine answer quality](/oss/guides/refine): the recipe for running the enrich loop.

--- a/docs/core/concepts/correctness.md
+++ b/docs/core/concepts/correctness.md
@@ -4,7 +4,7 @@ sidebar_label: How does Wren AI keep agents from hallucinating?
 
 # How does Wren AI keep agents from hallucinating?
 
-Hallucinations on business data are rarely a "model is bad at SQL" problem. They are a missing-context problem — the agent writes a confident-looking query against data it does not actually understand.
+Hallucinations on business data are rarely a "model is bad at SQL" problem. They are a missing-context problem. The agent writes a confident-looking query against data it does not actually understand. In GenBI that risk compounds: a dashboard built on a wrong query looks authoritative, so correctness is the whole game.
 
 Wren AI's architecture is designed to **give the agent the context it needs at every step**, and to **fail loudly when the agent guesses**. Here is how the pieces fit.
 
@@ -26,7 +26,7 @@ Five layers sit between the agent's question and the database:
 | Layer | What it does | How it prevents hallucination |
 |---|---|---|
 | **Skills** | Encode the workflow the agent must follow | The agent cannot skip "check memory" or "validate before execute" |
-| **MDL** | Declare every table, column, and relationship the agent is allowed to use | The agent can only name modeled objects — undeclared columns and legacy tables are invisible |
+| **MDL** | Declare every table, column, and relationship the agent is allowed to use | The agent can only name modeled objects, so undeclared columns and legacy tables are invisible |
 | **Memory** | Index MDL + instructions + past NL-SQL pairs; retrieve only what matters per question | The agent reads the relevant slice, not a generic schema dump |
 | **Plan + validate** | Expand modeled SQL into the exact SQL that will run, before any DB call | Bad references fail at plan time with a clear error, not silently in production |
 | **Connectors** | Execute the planned SQL against the source | Type, dialect, and permission checks happen here |
@@ -37,7 +37,7 @@ Five layers sit between the agent's question and the database:
 
 Raw warehouses give the agent ambiguous joins, near-duplicate tables (`customers` vs `customers_v3` vs `loyalty_v3`), and columns that overlap across schemas. MDL collapses those problems into one canonical surface.
 
-If `email` is not in the `customers` model, the agent cannot query it — it does not exist in Wren AI's view of your data. If the canonical join between `orders` and `customers` is declared once in MDL, the agent does not have to invent it.
+If `email` is not in the `customers` model, the agent cannot query it. It does not exist in Wren AI's view of your data. If the canonical join between `orders` and `customers` is declared once in MDL, the agent does not have to invent it.
 
 ### Memory: targeted retrieval beats dumping the schema
 
@@ -46,11 +46,11 @@ Two common failure modes:
 - **Dump the whole schema** into the prompt → the model gets confused by irrelevant tables.
 - **Let the model guess** which tables are relevant → it picks the wrong one.
 
-Memory does neither. It indexes MDL + `instructions.md` + confirmed NL-SQL pairs, and retrieves only the slice that matches the question. The agent reads `customers`, `orders`, and the approved revenue calculation — not 500 tables.
+Memory does neither. It indexes MDL + `instructions.md` + confirmed NL-SQL pairs, and retrieves only the slice that matches the question. The agent reads `customers`, `orders`, and the approved revenue calculation, not 500 tables.
 
 ### Plan + validate: errors fail visibly
 
-`wren dry-plan` takes the agent's modeled SQL and expands it into the exact SQL that will run against the database. The agent — and you — see:
+`wren dry-plan` takes the agent's modeled SQL and expands it into the exact SQL that will run against the database. The agent, and you, see:
 
 - Catalog and schema resolution
 - Relationship joins inlined as CTEs
@@ -91,10 +91,10 @@ For a question like "top 5 customers by lifetime value this quarter", the loop r
    → next similar question gets this as a recall
 ```
 
-Every step is a primitive the agent calls. The trace stays in the agent's reasoning where you review its work — there is no separate "correctness dashboard" you have to trust.
+Every step is a primitive the agent calls. The trace stays in the agent's reasoning where you review its work. There is no separate "correctness dashboard" you have to trust.
 
 ## See also
 
-- [Architecture](/oss/reference/architecture) — the full technical breakdown
-- [How does the agent learn from your context?](/oss/concepts/agent_learning) — the memory + skills loop
-- [What does MDL do for the agent?](/oss/concepts/what_is_mdl) — why MDL is the canonical surface
+- [Architecture](/oss/reference/architecture): the full technical breakdown
+- [How does the agent learn from your context?](/oss/concepts/agent_learning): the memory + skills loop
+- [What does MDL do for the agent?](/oss/concepts/what_is_mdl): why MDL is the canonical surface

--- a/docs/core/concepts/knowledge_management.md
+++ b/docs/core/concepts/knowledge_management.md
@@ -1,0 +1,69 @@
+---
+sidebar_label: How Wren manages your business knowledge
+---
+
+# How Wren manages your business knowledge
+
+GenBI is only as good as what the agent knows. The *Generate* and *Deploy* beats
+produce trustworthy BI because of a third beat that runs underneath them, the
+**Know** beat: the way Wren captures, reviews, and reuses your business knowledge
+so agents stop rediscovering it from scratch.
+
+This page is the map of that knowledge: where each kind lives, how it gets in,
+and why it stays trustworthy.
+
+## The four places knowledge lives
+
+Wren keeps business knowledge in explicit, inspectable artifacts, not buried in
+a prompt or locked inside a UI:
+
+| Artifact | What it holds | Example |
+| --- | --- | --- |
+| **MDL** (semantic models) | Structure and semantics: models, columns, relationships, calculated fields, views, cubes | `loyalty_v3` is the canonical loyalty table; `revenue = price * qty - refunds` |
+| **`instructions.md`** | Business rules and operating policy the schema can't carry | "active customer excludes service accounts"; "always filter `is_deleted = false`" |
+| **Memory index** | Behavioral retrieval state: which schema items were relevant, which SQL answered a similar question, confirmed examples | local runtime state under `.wren/memory/`, usually gitignored |
+| **`queries.yml`** | Curated question→SQL pairs exported from memory to keep and share | the version-controlled surface for shared examples |
+
+MDL says what the data *means*. Instructions say how your team wants it *used*.
+Memory says what has *worked*. MDL, `instructions.md`, and `queries.yml` are
+version-controlled files in your repo; the memory index under `.wren/memory/` is
+local runtime state (usually gitignored), and you share what it learns by
+exporting curated pairs to `queries.yml`. Together they are the context layer the
+rest of the docs refer to. See [What does Wren AI mean by context?](/oss/concepts/what_is_context).
+
+## How knowledge gets in: scaffold fast, enrich deep
+
+You do not write all of this by hand. The agent builds it in two beats (the
+loop described in [How does the agent learn from your context?](/oss/concepts/agent_learning)):
+
+1. **Scaffold fast.** The `generate-mdl` skill introspects your database and
+   produces a working MDL: one model per table, normalized types, detected
+   relationships. Enough to start querying in minutes.
+2. **Enrich deep.** The `enrich-context` skill brings in the meaning that lives
+   *outside* the database: enum meanings, units, NULL semantics, default
+   filters, synonyms, currency rules, and named metrics (ARR, churn, DAU) as
+   cubes. It runs in **grill** mode (one question at a time) or **auto-pilot**
+   mode (reads everything you drop under `<project>/raw/`, such as PDFs,
+   glossaries, and handbooks, then proposes). See [Refine answer quality](/oss/guides/refine).
+
+This is the difference between a *semantic* layer and a *context* layer: Wren
+ingests the company know-how that dbt, Cube, and the warehouse structurally
+can't, because it doesn't live in the schema.
+
+## Why this knowledge stays trustworthy
+
+- **Reviewable.** Every definition, rule, and example is a file you can read in a
+  pull request. No black-box embeddings deciding what your metrics mean.
+- **Versioned and Git-friendly.** Knowledge evolves with your code, with full
+  history and the ability to fork, diff, and roll back.
+- **Evidence-linked.** Enrichment records *why* a mapping is true (the doc or
+  column it came from), so it can be re-validated when the business changes.
+- **Compounding.** Every confirmed answer can feed memory, so the next question,
+  and the next dashboard, starts further ahead.
+
+## Where to go next
+
+- [Refine answer quality](/oss/guides/refine): the hands-on enrichment recipe
+- [The memory system](/oss/concepts/memory_system): how behavioral knowledge works
+- [What does MDL do for the agent?](/oss/concepts/what_is_mdl): the semantic contract
+- [Build & deploy a GenBI app](/oss/guides/genbi): turn this knowledge into a dashboard

--- a/docs/core/concepts/memory_system.md
+++ b/docs/core/concepts/memory_system.md
@@ -4,7 +4,7 @@ Memory is the behavioral layer of Wren AI's context system.
 
 MDL tells an agent what your data means. Instructions tell it how your team wants that data used. Memory tells it what has worked before: which schema items were relevant, which SQL answered a similar question, and which examples your team has already confirmed.
 
-Without memory, every question starts from zero. With memory, each accepted answer can make the next answer easier to ground.
+Without memory, every question starts from zero. With memory, each accepted answer can make the next answer, and the next dashboard, easier to ground. It is one half of how Wren manages your business knowledge (see [How Wren manages your business knowledge](/oss/concepts/knowledge_management)).
 
 ## Why memory matters
 

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -8,6 +8,14 @@ Wren AI open source is the full engine: free, self-hosted, and driven by one eng
 
 Wren AI Commercial is the same engine built for a team. It runs as a hosted cloud service or as a self-hosted enterprise deployment, and it adds a web UI, accounts, managed access control, integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
 
+## Which one fits
+
+**Solo, in the terminal.** One engineer or an AI agent, working through the CLI, SDK, and Git. Open source is all you need.
+
+**A data team.** Several people need governed access with roles and SSO, and non-technical teammates want to ask questions in a browser, Slack, or Teams. This is where Commercial earns its place.
+
+**Analytics for your customers.** You put analytics inside your own product, and each customer must see only their own data. Commercial enterprise gives you per-user RLS/CLS and multi-tenant isolation.
+
 ## Feature comparison
 
 | Capability | Open source | Commercial |
@@ -26,13 +34,6 @@ Wren AI Commercial is the same engine built for a team. It runs as a hosted clou
 | RLS/CLS per user, session properties, audit log | ❌ | ✅ |
 | Evaluation, AI Advisor, feedback tracing | ❌ | ✅ |
 | Vendor support | ❌ | ✅ |
-
-## Consider Commercial when
-
-- A team needs accounts, roles, and SSO, or LDAP/SCIM from your identity provider.
-- Non-technical users want to ask in a browser, Slack, or Teams.
-- You need RLS/CLS enforced per real user, or multi-tenant isolation for your own customers.
-- You want a managed cloud, scheduled dashboards, or vendor support.
 
 ## Talk to us
 

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -6,33 +6,68 @@ sidebar_label: Open source vs Commercial
 
 Wren AI open source is the full engine: free, self-hosted, and driven by one engineer or agent through the CLI and SDK.
 
-Wren AI Commercial is the same engine built for a team. It runs as a hosted cloud service or as a self-hosted enterprise deployment, and it adds a web UI, accounts, managed access control, integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
+Wren AI Commercial is the same engine built for a team. It adds a web UI, accounts, managed access control, chat and API integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
 
-## Feature comparison
+:::info Two ways to run Commercial
+Commercial runs as a hosted cloud service, or as a self-hosted enterprise deployment. Identity features like SSO, LDAP, and SCIM are part of the enterprise tier.
+:::
+
+The tables below group the differences so you can jump to the part you care about.
+
+## How you run it
+
+Open source is yours to run end to end. Commercial can be fully hosted, or self-hosted on enterprise.
 
 | Capability | Open source | Commercial |
 | --- | :---: | :---: |
 | Free and fully self-hosted | ✅ | ✅ |
 | Fully managed cloud | ❌ | ✅ |
 | CLI and SDK for your own agents | ✅ | ✅ |
-| MCP server and hosted REST API | ❌ | ✅ |
-| Access control defined in MDL (RLAC/CLAC) | ✅ | ✅ |
-| GenBI dashboards | ✅ | ✅ |
+
+## Access for your team
+
+Open source is a single operator. Commercial brings accounts, identity, and the places your team already works.
+
+| Capability | Open source | Commercial |
+| --- | :---: | :---: |
 | Web UI for non-technical users | ❌ | ✅ |
-| Slack and Microsoft Teams | ❌ | ✅ |
-| Built-in agentic sandbox mode | ❌ | ✅ |
 | Accounts, roles, multi-user | ❌ | ✅ |
 | SSO, LDAP, SCIM provisioning | ❌ | ✅ |
+| Slack and Microsoft Teams | ❌ | ✅ |
+
+## Security and governance
+
+Both define access control in MDL. Commercial binds it to real users and keeps an audit trail.
+
+| Capability | Open source | Commercial |
+| --- | :---: | :---: |
+| Access control defined in MDL (RLAC/CLAC) | ✅ | ✅ |
 | RLS/CLS per user, session properties, audit log | ❌ | ✅ |
+
+## Build, query, and support
+
+Both query through the engine and ship GenBI dashboards. Commercial adds hosted access, agent modes, quality tooling, and support.
+
+| Capability | Open source | Commercial |
+| --- | :---: | :---: |
+| GenBI dashboards | ✅ | ✅ |
+| MCP server and hosted REST API | ❌ | ✅ |
+| Agentic and interactive answer modes (web UI, sandboxed) | ❌ | ✅ |
 | Evaluation, AI Advisor, feedback tracing | ❌ | ✅ |
 | Vendor support | ❌ | ✅ |
 
-## Consider Commercial when
-
+:::tip Consider Commercial when
 - A team needs accounts, roles, and SSO, or LDAP/SCIM from your identity provider.
 - Non-technical users want to ask in a browser, Slack, or Teams.
 - You need RLS/CLS enforced per real user, or multi-tenant isolation for your own customers.
 - You want a managed cloud, scheduled dashboards, or vendor support.
+:::
+
+:::note Stay on open source when
+- You are one developer or an agent in a CLI/SDK and Git workflow.
+- You want to own everything, self-hosted, with your context in your repo.
+- Definition-level RLAC/CLAC is enough and you have no identity or team needs.
+:::
 
 ## Talk to us
 

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -1,0 +1,39 @@
+---
+sidebar_label: Open source vs Commercial
+---
+
+# Open source vs Commercial
+
+Wren AI open source is the full engine: free, self-hosted, and driven by one engineer or agent through the CLI and SDK.
+
+Wren AI Commercial is the same engine built for a team. It runs as a hosted cloud service or as a self-hosted enterprise deployment, and it adds a web UI, accounts, managed access control, integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
+
+## Feature comparison
+
+| Capability | Open source | Commercial |
+| --- | :---: | :---: |
+| Free and fully self-hosted | ✅ | ✅ |
+| Fully managed cloud | ❌ | ✅ |
+| CLI and SDK for your own agents | ✅ | ✅ |
+| MCP server and hosted REST API | ❌ | ✅ |
+| Access control defined in MDL (RLAC/CLAC) | ✅ | ✅ |
+| GenBI dashboards | ✅ | ✅ |
+| Web UI for non-technical users | ❌ | ✅ |
+| Slack and Microsoft Teams | ❌ | ✅ |
+| Built-in agentic sandbox mode | ❌ | ✅ |
+| Accounts, roles, multi-user | ❌ | ✅ |
+| SSO, LDAP, SCIM provisioning | ❌ | ✅ |
+| RLS/CLS per user, session properties, audit log | ❌ | ✅ |
+| Evaluation, AI Advisor, feedback tracing | ❌ | ✅ |
+| Vendor support | ❌ | ✅ |
+
+## Consider Commercial when
+
+- A team needs accounts, roles, and SSO, or LDAP/SCIM from your identity provider.
+- Non-technical users want to ask in a browser, Slack, or Teams.
+- You need RLS/CLS enforced per real user, or multi-tenant isolation for your own customers.
+- You want a managed cloud, scheduled dashboards, or vendor support.
+
+## Talk to us
+
+See [Wren AI Commercial](/cp/overview) for details and to reach the team. Open source stays first-class either way.

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -6,68 +6,33 @@ sidebar_label: Open source vs Commercial
 
 Wren AI open source is the full engine: free, self-hosted, and driven by one engineer or agent through the CLI and SDK.
 
-Wren AI Commercial is the same engine built for a team. It adds a web UI, accounts, managed access control, chat and API integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
+Wren AI Commercial is the same engine built for a team. It runs as a hosted cloud service or as a self-hosted enterprise deployment, and it adds a web UI, accounts, managed access control, integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
 
-:::info Two ways to run Commercial
-Commercial runs as a hosted cloud service, or as a self-hosted enterprise deployment. Identity features like SSO, LDAP, and SCIM are part of the enterprise tier.
-:::
-
-The tables below group the differences so you can jump to the part you care about.
-
-## How you run it
-
-Open source is yours to run end to end. Commercial can be fully hosted, or self-hosted on enterprise.
+## Feature comparison
 
 | Capability | Open source | Commercial |
 | --- | :---: | :---: |
 | Free and fully self-hosted | ✅ | ✅ |
 | Fully managed cloud | ❌ | ✅ |
 | CLI and SDK for your own agents | ✅ | ✅ |
-
-## Access for your team
-
-Open source is a single operator. Commercial brings accounts, identity, and the places your team already works.
-
-| Capability | Open source | Commercial |
-| --- | :---: | :---: |
+| MCP server and hosted REST API | ❌ | ✅ |
+| Access control defined in MDL (RLAC/CLAC) | ✅ | ✅ |
+| GenBI dashboards | ✅ | ✅ |
 | Web UI for non-technical users | ❌ | ✅ |
+| Slack and Microsoft Teams | ❌ | ✅ |
+| Agentic and interactive answer modes (web UI, sandboxed) | ❌ | ✅ |
 | Accounts, roles, multi-user | ❌ | ✅ |
 | SSO, LDAP, SCIM provisioning | ❌ | ✅ |
-| Slack and Microsoft Teams | ❌ | ✅ |
-
-## Security and governance
-
-Both define access control in MDL. Commercial binds it to real users and keeps an audit trail.
-
-| Capability | Open source | Commercial |
-| --- | :---: | :---: |
-| Access control defined in MDL (RLAC/CLAC) | ✅ | ✅ |
 | RLS/CLS per user, session properties, audit log | ❌ | ✅ |
-
-## Build, query, and support
-
-Both query through the engine and ship GenBI dashboards. Commercial adds hosted access, agent modes, quality tooling, and support.
-
-| Capability | Open source | Commercial |
-| --- | :---: | :---: |
-| GenBI dashboards | ✅ | ✅ |
-| MCP server and hosted REST API | ❌ | ✅ |
-| Agentic and interactive answer modes (web UI, sandboxed) | ❌ | ✅ |
 | Evaluation, AI Advisor, feedback tracing | ❌ | ✅ |
 | Vendor support | ❌ | ✅ |
 
-:::tip Consider Commercial when
+## Consider Commercial when
+
 - A team needs accounts, roles, and SSO, or LDAP/SCIM from your identity provider.
 - Non-technical users want to ask in a browser, Slack, or Teams.
 - You need RLS/CLS enforced per real user, or multi-tenant isolation for your own customers.
 - You want a managed cloud, scheduled dashboards, or vendor support.
-:::
-
-:::note Stay on open source when
-- You are one developer or an agent in a CLI/SDK and Git workflow.
-- You want to own everything, self-hosted, with your context in your repo.
-- Definition-level RLAC/CLAC is enough and you have no identity or team needs.
-:::
 
 ## Talk to us
 

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -37,7 +37,14 @@ Wren AI Commercial is the same engine built for a team. It runs as a hosted clou
 
 ## What Commercial adds
 
-Open source already gives you the engine: governed SQL, your MDL context layer, and GenBI dashboards you deploy yourself. Commercial takes that same engine and makes it usable by a whole team without anyone having to run it. You get a hosted web UI so non-technical people can ask questions, real accounts with roles and SSO (plus LDAP and SCIM on enterprise), and access control tied to actual users instead of policies you maintain by hand. It also brings the tools people already work in, like Slack and Teams, a hosted API and MCP server, dashboards that refresh on their own, quality tooling to track accuracy, and a team to call when something breaks. Your MDL and context carry over unchanged, so moving up means adding a team layer, not rebuilding.
+Open source is the full engine. Commercial adds the team layer on top:
+
+- **Runs itself.** Hosted cloud, or self-hosted enterprise, so no one has to operate the stack.
+- **Built for people, not just agents.** A web UI plus Slack and Teams, so non-technical teammates can ask questions.
+- **Real identity and access.** Accounts, roles, SSO, LDAP, and SCIM, with access control tied to actual users.
+- **More ways in.** A hosted API and MCP server, and dashboards that refresh on their own.
+- **Confidence.** Accuracy tracking, feedback tracing, and a team to call when something breaks.
+- **No rebuild.** Your MDL and context carry over unchanged.
 
 ## Talk to us
 

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -35,6 +35,10 @@ Wren AI Commercial is the same engine built for a team. It runs as a hosted clou
 | Evaluation, AI Advisor, feedback tracing | ❌ | ✅ |
 | Vendor support | ❌ | ✅ |
 
+## What Commercial adds
+
+Open source already gives you the engine: governed SQL, your MDL context layer, and GenBI dashboards you deploy yourself. Commercial takes that same engine and makes it usable by a whole team without anyone having to run it. You get a hosted web UI so non-technical people can ask questions, real accounts with roles and SSO (plus LDAP and SCIM on enterprise), and access control tied to actual users instead of policies you maintain by hand. It also brings the tools people already work in, like Slack and Teams, a hosted API and MCP server, dashboards that refresh on their own, quality tooling to track accuracy, and a team to call when something breaks. Your MDL and context carry over unchanged, so moving up means adding a team layer, not rebuilding.
+
 ## Talk to us
 
 See [Wren AI Commercial](/cp/overview) for details and to reach the team. Open source stays first-class either way.

--- a/docs/core/concepts/stack_position.md
+++ b/docs/core/concepts/stack_position.md
@@ -4,7 +4,7 @@ sidebar_label: Where does Wren AI sit in my stack?
 
 # Where does Wren AI sit in my stack?
 
-> Wren AI does not replace your warehouse, your transformation pipeline, or your existing semantic layer. It sits **between** your data infrastructure and the agents querying it, providing the context they need to do it safely.
+> Wren AI does not replace your warehouse, your transformation pipeline, or your existing semantic layer. It sits **between** your data infrastructure and the agents querying it, providing the context they need to generate and deploy trustworthy BI safely.
 
 ## The short version
 
@@ -15,7 +15,7 @@ sidebar_label: Where does Wren AI sit in my stack?
                          │  ask questions, get context
                          ▼
 ┌──────────────────────────────────────────────────────┐
-│              Wren AI — open context layer            │
+│              Wren AI - open context layer            │
 │   MDL · Memory · Skills · Governed execution         │
 └────────────────────────┬─────────────────────────────┘
                          │  planned, governed SQL
@@ -32,7 +32,7 @@ Three things sit above Wren AI: the **agents** that ask questions. Three things 
 
 **Your data warehouse.** Wren AI does not store rows. Your warehouse keeps storing rows. Wren AI sends planned SQL there for execution.
 
-**Your transformation pipeline.** If you already model raw data into clean tables — dbt, custom Python, scheduled SQL — keep doing that. Wren AI reads the result, it does not own the upstream pipeline.
+**Your transformation pipeline.** If you already model raw data into clean tables (dbt, custom Python, scheduled SQL), keep doing that. Wren AI reads the result, it does not own the upstream pipeline.
 
 **Your existing semantic layer.** If you already have business-facing models, metrics, or a metric layer, Wren AI can layer on top to give agents the same definitions without rebuilding them. The MDL you author is the **agent-facing contract**; what you already have stays where it lives.
 
@@ -40,7 +40,7 @@ Three things sit above Wren AI: the **agents** that ask questions. Three things 
 
 ## What it does provide
 
-**The agent-facing context layer.** The five layers — structural, semantic, business, operational, behavioral — collected into one inspectable, version-controlled surface that any agent can query.
+**The agent-facing context layer.** The five layers (structural, semantic, business, operational, behavioral) collected into one inspectable, version-controlled surface that any agent can query.
 
 **A governed SQL plane.** The CLI plans modeled SQL into executable SQL, runs dry-plan / dry-run, applies access policies, and executes through your warehouse connectors. The agent does not need direct database credentials or unrestricted access.
 
@@ -54,7 +54,7 @@ Wren AI can be your first one. The `generate-mdl` guide scaffolds an MDL project
 
 ### You have a transformation pipeline (dbt, Coalesce, in-house)
 
-Keep it. Point Wren AI at the **output tables** of your pipeline. The MDL describes the agent-facing meaning of those tables — what columns to expose, which joins are approved, which calculations are reusable. The pipeline keeps owning ingestion and modeling logic. Wren AI owns the layer between modeled data and the agent.
+Keep it. Point Wren AI at the **output tables** of your pipeline. The MDL describes the agent-facing meaning of those tables: what columns to expose, which joins are approved, which calculations are reusable. The pipeline keeps owning ingestion and modeling logic. Wren AI owns the layer between modeled data and the agent.
 
 ### You have a semantic layer
 
@@ -74,11 +74,11 @@ Profiles separate connection credentials from project definitions. The same MDL 
 
 Replacing your stack to get an AI agent that queries it well is a fast way to make nobody happy. The pattern Wren AI was designed around is the inverse: **leave the existing stack in place, add one inspectable layer on top, give every agent the same governed surface**.
 
-That is also why Wren AI is open source. Business context is too important to lock inside a vendor product — your MDL, examples, query history, and mapping decisions should live in your repo, under your team's review.
+That is also why Wren AI is open source. Business context is too important to lock inside a vendor product. Your MDL, examples, query history, and mapping decisions should live in your repo, under your team's review.
 
 ## See also
 
-- [What does Wren AI mean by context?](./what_is_context.md) — the conceptual ground
-- [Architecture](/oss/reference/architecture) — the technical stack inside Wren AI
-- [Connect your data](/oss/guides/connect) — point Wren AI at your warehouse
-- [Manage project](/oss/guides/manage_project) — multi-environment profile workflow
+- [What does Wren AI mean by context?](./what_is_context.md): the conceptual ground
+- [Architecture](/oss/reference/architecture): the technical stack inside Wren AI
+- [Connect your data](/oss/guides/connect): point Wren AI at your warehouse
+- [Manage project](/oss/guides/manage_project): multi-environment profile workflow

--- a/docs/core/concepts/what_is_context.md
+++ b/docs/core/concepts/what_is_context.md
@@ -6,7 +6,7 @@ A schema tells an agent that a table has columns. Context tells it which table i
 
 That distinction matters because AI agents do not fail on business data only because they are not smart enough. They fail because the meaning they need is scattered across warehouses, dashboards, SQL files, docs, decks, Slack threads, and people's heads.
 
-Wren AI exists to turn that scattered meaning into an open, machine-readable context layer that humans, agents, dashboards, and applications can share.
+Wren AI exists to turn that scattered meaning into an open, machine-readable context layer that humans, agents, dashboards, and applications can share. It is the layer that makes **GenBI** (the answers and dashboards your agents generate) trustworthy instead of merely plausible.
 
 ## Why schema is not enough
 

--- a/docs/core/concepts/what_is_mdl.md
+++ b/docs/core/concepts/what_is_mdl.md
@@ -4,7 +4,7 @@ Modeling Definition Language (MDL) is the semantic contract at the center of Wre
 
 It is how you tell agents, applications, and humans what your business data means: which datasets exist, which fields are exposed, how entities relate, which calculations are reusable, and which query-shaped objects should be treated as stable interfaces.
 
-Raw schemas describe storage. MDL describes meaning.
+Raw schemas describe storage. MDL describes meaning. Every governed answer an agent generates is planned through this contract. So is every GenBI dashboard it deploys. That is why it sits at the center.
 
 ## Why MDL exists
 

--- a/docs/core/concepts/why_wren.md
+++ b/docs/core/concepts/why_wren.md
@@ -1,0 +1,69 @@
+---
+sidebar_label: Why Wren? (and how it compares)
+---
+
+# Why Wren? (and how it compares)
+
+Wren AI is the **open-source GenBI engine**: it lets AI agents generate, deploy,
+and govern business intelligence on top of a context layer they can trust. This
+page is the honest version: what Wren is for, what it is *not*, and how it
+differs from the tools it sits near.
+
+## The problem Wren solves
+
+Agents are everywhere: Claude Code, Cursor, ChatGPT, Aider, LangChain
+pipelines, in-house copilots. None of them know what your data *means*. Point one
+at a warehouse and it writes confident, plausible, wrong SQL, because the meaning
+it needs (canonical tables, approved definitions, units, join paths) lives
+outside the schema. Build a dashboard on top of that and you have shipped a
+trustworthy-looking lie.
+
+Wren gives every agent the same governed context, then lets them turn questions
+into answers and dashboards that are actually correct.
+
+## How Wren compares
+
+|  | A raw LLM agent | A traditional BI tool | A bare semantic layer | **Wren AI** |
+| --- | :---: | :---: | :---: | :---: |
+| Writes SQL for you | ✅ (often wrong) | ❌ | ❌ | ✅ governed |
+| Knows your business definitions | ❌ | partial, in-tool | ✅ (schema-derived) | ✅ + non-schema knowledge |
+| Generates **and** deploys dashboards | ❌ | ✅ (manual, in-tool) | ❌ | ✅ agent-driven |
+| Works through *your* agents (Claude Code, Cursor, MCP…) | ✅ | ❌ | ❌ | ✅ |
+| Open, reviewable, Git-friendly context | ❌ | ❌ | partial | ✅ |
+| Governed execution across 22+ sources | ❌ | per-connector | ✅ (definitions only) | ✅ |
+
+A few distinctions worth being precise about:
+
+- **vs. a raw LLM agent:** Wren is the governance and knowledge the agent is
+  missing. Same agent, correct answers.
+- **vs. a traditional BI tool:** BI tools render dashboards a human builds by
+  hand, in their UI. Wren has agents *generate* them from your context and
+  deploy them to your own hosting.
+- **vs. a bare semantic layer** (dbt Semantic Layer, Cube): those define metrics
+  from the schema. Wren adds the company knowledge that isn't in the schema
+  (enum meanings, units, policy, proven examples) and a generative-BI output on
+  top. See [How Wren manages your business knowledge](/oss/concepts/knowledge_management).
+
+## Wren is for you if…
+
+- You want **AI agents to produce trustworthy BI** (answers *and* dashboards),
+  not just plausible SQL.
+- Your business logic lives **outside the database** and your agents keep
+  getting it wrong.
+- You want context that's **open, reviewable, and version-controlled**, usable
+  by every agent and person, not gated behind one vendor's UI.
+- You query **many sources** (Postgres, BigQuery, Snowflake, DuckDB, and 18+
+  more) and want one governed surface across them.
+
+## Skip Wren if…
+
+- You only need a one-off chart from a single CSV.
+- You're happy letting an agent guess at SQL with no governance.
+- You want a fully hosted, click-to-build BI product with no setup. In that
+  case look at [Wren AI Commercial](https://getwren.ai).
+
+## Where to go next
+
+- [Install](/oss/get_started/installation) and the [Quickstart](/oss/get_started/quickstart)
+- [What does Wren AI mean by context?](/oss/concepts/what_is_context): the idea underneath GenBI
+- [Build & deploy a GenBI app](/oss/guides/genbi): see the payoff

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start: Wren CLI with jaffle_shop
 
-Ask natural-language questions of the **jaffle_shop** dataset using **Wren AI CLI** and **Claude Code** — no cloud database, no Docker, no extra infrastructure.
+Ask natural-language questions of the **jaffle_shop** dataset using **Wren AI CLI** and **Claude Code**. No cloud database, no Docker, no extra infrastructure.
 
 > **Time:** ~15 minutes
 >
@@ -10,23 +10,23 @@ Ask natural-language questions of the **jaffle_shop** dataset using **Wren AI CL
 
 This guide drops three things on you in the first few steps. Skim before you start:
 
-- **Wren CLI (`wren`)** — the Python CLI that runs all of this. Connects to a database, holds your modeling files, executes SQL through the semantic layer, manages a local memory index. ([CLI reference →](/oss/reference/cli))
-- **MDL (Modeling Definition Language)** — YAML files under `models/`, `views/`, and `relationships.yml` that describe your tables, columns, and joins in business terms. The agent reads MDL instead of guessing from raw schema. ([MDL concept →](/oss/concepts/what_is_mdl) · [Wren project guide →](/oss/reference/mdl))
-- **jaffle_shop** — a public sample database from dbt Labs. We use it so you do not need to bring your own database to follow this quickstart. It is a fictional ecommerce business with `customers`, `orders`, `products`, and `supplies`. *(Want to skip jaffle_shop and use your own database? Finish the install in step 2 then jump to [Connect your database](/oss/guides/connect).)*
-- **Skills** — markdown workflow guides that tell an AI coding agent (Claude Code, Openclaw, Hermes, Codex, etc.) how to operate the CLI. You install one `wren` discovery stub; it fetches the guides from the CLI on demand. Two guides drive this quickstart: `generate-mdl` (one-time scaffolding) and `usage` (day-to-day querying). ([Skills concept →](/oss/reference/skills))
+- **Wren CLI (`wren`)**: the Python CLI that runs all of this. Connects to a database, holds your modeling files, executes SQL through the semantic layer, manages a local memory index. ([CLI reference →](/oss/reference/cli))
+- **MDL (Modeling Definition Language)**: YAML files under `models/`, `views/`, and `relationships.yml` that describe your tables, columns, and joins in business terms. The agent reads MDL instead of guessing from raw schema. ([MDL concept →](/oss/concepts/what_is_mdl) · [Wren project guide →](/oss/reference/mdl))
+- **jaffle_shop**: a public sample database from dbt Labs. We use it so you do not need to bring your own database to follow this quickstart. It is a fictional ecommerce business with `customers`, `orders`, `products`, and `supplies`. *(Want to skip jaffle_shop and use your own database? Finish the install in step 2 then jump to [Connect your database](/oss/guides/connect).)*
+- **Skills**: markdown workflow guides that tell an AI coding agent (Claude Code, Openclaw, Hermes, Codex, etc.) how to operate the CLI. You install one `wren` discovery stub; it fetches the guides from the CLI on demand. Two guides drive this quickstart: `generate-mdl` (one-time scaffolding) and `usage` (day-to-day querying). ([Skills concept →](/oss/reference/skills))
 
 ---
 
 ## Prerequisites
 
-- **Claude Code** — installed and authenticated ([install guide](https://docs.anthropic.com/en/docs/claude-code/overview))
+- **Claude Code**: installed and authenticated ([install guide](https://docs.anthropic.com/en/docs/claude-code/overview))
 - **Python 3.11+**
-- **Node.js / npm** — required if using `npx` to install skills (see Step 3)
+- **Node.js / npm**: required if using `npx` to install skills (see Step 3)
 - **Git**
 
 ---
 
-## Step 0 — Create a Python virtual environment
+## Step 0: Create a Python virtual environment
 
 Create and activate a virtual environment before installing any packages. This keeps dbt and wrenai dependencies isolated from your system Python:
 
@@ -39,7 +39,7 @@ source ~/.venvs/wren/bin/activate
 
 ---
 
-## Step 1 — Seed the jaffle_shop dataset
+## Step 1: Seed the jaffle_shop dataset
 
 Clone the dbt jaffle\_shop project and build the DuckDB database:
 
@@ -56,7 +56,7 @@ Verify the database file was created:
 ls jaffle_shop.duckdb
 ```
 
-Note the **absolute path** to this directory — you'll need it when setting up the profile:
+Note the **absolute path** to this directory. You'll need it when setting up the profile:
 
 ```bash
 pwd
@@ -65,7 +65,7 @@ pwd
 
 ---
 
-## Step 2 — Install wrenai Python package
+## Step 2: Install wrenai Python package
 
 For this quickstart, install with **DuckDB + memory + UI + interactive prompts**:
 
@@ -73,12 +73,12 @@ For this quickstart, install with **DuckDB + memory + UI + interactive prompts**
 pip install "wrenai[memory,main]"
 ```
 
-DuckDB is included by default — no extra needed. For other data sources, append the connector extra (e.g. `pip install "wrenai[memory,main,postgres]"`).
+DuckDB is included by default, so no extra is needed. For other data sources, append the connector extra (e.g. `pip install "wrenai[memory,main,postgres]"`).
 
 > **Available extras:**
-> - `postgres`, `mysql`, `bigquery`, `snowflake`, `clickhouse`, `trino`, `mssql`, `databricks`, `redshift`, `athena`, `oracle`, `spark` — data source connectors
-> - `memory` — LanceDB-backed semantic memory (NL-SQL recall, embedding retrieval). **Optional** but recommended for the quickstart.
-> - `main` — interactive prompts + browser-based profile UI
+> - `postgres`, `mysql`, `bigquery`, `snowflake`, `clickhouse`, `trino`, `mssql`, `databricks`, `redshift`, `athena`, `oracle`, `spark`: data source connectors
+> - `memory`: LanceDB-backed semantic memory (NL-SQL recall, embedding retrieval). **Optional** but recommended for the quickstart.
+> - `main`: interactive prompts + browser-based profile UI
 
 Verify the installation:
 
@@ -88,9 +88,9 @@ wren version
 
 ---
 
-## Step 3 — Install the CLI skill
+## Step 3: Install the CLI skill
 
-Skills are workflow guides that tell your AI coding agent how to use the Wren CLI effectively. Install the discovery stub — it fetches the guides from the CLI on demand:
+Skills are workflow guides that tell your AI coding agent how to use the Wren CLI effectively. Install the discovery stub. It fetches the guides from the CLI on demand:
 
 ```bash
 npx skills add Canner/WrenAI
@@ -104,14 +104,14 @@ This quickstart uses two of those guides:
 
 | Guide | Purpose |
 |-------|---------|
-| **usage** | Day-to-day workflow — gather context, recall past queries, write SQL, store results |
-| **generate-mdl** | One-time setup — explore database schema and generate the MDL project |
+| **usage** | Day-to-day workflow: gather context, recall past queries, write SQL, store results |
+| **generate-mdl** | One-time setup: explore database schema and generate the MDL project |
 
 For the full guide list (including `onboarding` and `dlt-connector`), see the [Skills reference](/oss/reference/skills).
 
 ---
 
-## Step 4 — Set up a profile
+## Step 4: Set up a profile
 
 A profile stores your database connection info (like dbt profiles). Create one for the jaffle\_shop DuckDB database:
 
@@ -124,7 +124,7 @@ wren profile add jaffle-shop --ui
 This opens a browser form. Fill in:
 
 - **Data source:** `duckdb`
-- **Database path:** `/Users/you/jaffle_shop_duckdb` — the **directory** containing `.duckdb` files, not the `.duckdb` file itself (your absolute path from Step 1)
+- **Database path:** `/Users/you/jaffle_shop_duckdb`, the **directory** containing `.duckdb` files, not the `.duckdb` file itself (your absolute path from Step 1)
 
 ### Option B: Interactive CLI
 
@@ -166,7 +166,7 @@ wren profile debug
 
 ---
 
-## Step 5 — Initialize a Wren project
+## Step 5: Initialize a Wren project
 
 Create a new directory for your project and scaffold the project structure:
 
@@ -189,7 +189,7 @@ This creates:
 
 The generated `wren_project.yml` contains default values for `catalog` and `schema`:
 
-> **Note:** `catalog` and `schema` in `wren_project.yml` define the **Wren AI namespace** — they have nothing to do with your database's catalog or schema. Keep the defaults (`wren` / `public`). The actual database location of each table is specified per-model in the `table_reference` section.
+> **Note:** `catalog` and `schema` in `wren_project.yml` define the **Wren AI namespace**. They have nothing to do with your database's catalog or schema. Keep the defaults (`wren` / `public`). The actual database location of each table is specified per-model in the `table_reference` section.
 
 Bind the profile you just created to this project:
 
@@ -197,13 +197,13 @@ Bind the profile you just created to this project:
 wren context set-profile jaffle-shop
 ```
 
-This writes `profile: jaffle-shop` and `data_source: duckdb` into `wren_project.yml`, locking this project to its connection. Future commands (and the SDK) use the bound profile regardless of which profile is globally active — so `wren profile switch` elsewhere can't accidentally redirect this project's queries.
+This writes `profile: jaffle-shop` and `data_source: duckdb` into `wren_project.yml`, locking this project to its connection. Future commands (and the SDK) use the bound profile regardless of which profile is globally active, so `wren profile switch` elsewhere can't accidentally redirect this project's queries.
 
 ---
 
-## Step 6 — Generate MDL with Claude Code
+## Step 6: Generate MDL with Claude Code
 
-First, remove the example model and view that `wren context init` created — they are placeholders and will be replaced by the generated models:
+First, remove the example model and view that `wren context init` created. They are placeholders and will be replaced by the generated models:
 
 ```bash
 rm -rf models/example_model views/example_view
@@ -227,16 +227,16 @@ The `wren` skill recognizes this as a scaffolding task and pulls in the `generat
 
 Claude Code will:
 
-1. **Discover tables** — `customers`, `orders`, `products`, `supplies`, etc.
-2. **Introspect columns and types** — using SQLAlchemy or `information_schema`
-3. **Normalize types** — via `wren utils parse-type`
-4. **Write model YAML files** — one folder per table under `models/`
-5. **Infer relationships** — from foreign keys and naming conventions
-6. **Add descriptions** — Claude may ask you to describe key tables/columns
-7. **Validate and build** — `wren context validate` → `wren context build`
-8. **Index memory** — `wren memory index` (generates seed NL-SQL examples)
+1. **Discover tables**: `customers`, `orders`, `products`, `supplies`, etc.
+2. **Introspect columns and types** using SQLAlchemy or `information_schema`
+3. **Normalize types** via `wren utils parse-type`
+4. **Write model YAML files**, one folder per table under `models/`
+5. **Infer relationships** from foreign keys and naming conventions
+6. **Add descriptions**: Claude may ask you to describe key tables/columns
+7. **Validate and build**: `wren context validate` → `wren context build`
+8. **Index memory**: `wren memory index` (generates seed NL-SQL examples)
 
-> **Tip:** If `wren memory index` (the indexing step above) seems to hang for tens of seconds on macOS — it hasn't. That first `wren memory` command loads large unsigned native libraries (lancedb and torch, ~800MB), and macOS runs a one-time XProtect security scan the first time they execute. This is expected macOS behavior, not a Wren problem, and it's a one-off — every later `wren memory` command runs at normal speed. To avoid the pause during a live demo, run any `wren memory` command once right after install and let it finish.
+> **Tip:** If `wren memory index` (the indexing step above) seems to hang for tens of seconds on macOS, it hasn't. That first `wren memory` command loads large unsigned native libraries (lancedb and torch, ~800MB), and macOS runs a one-time XProtect security scan the first time they execute. This is expected macOS behavior, not a Wren problem, and it's a one-off: every later `wren memory` command runs at normal speed. To avoid the pause during a live demo, run any `wren memory` command once right after install and let it finish.
 
 After completion, verify the project:
 
@@ -247,7 +247,7 @@ wren memory status
 
 ---
 
-## Step 7 — Start asking questions
+## Step 7: Start asking questions
 
 You're ready to go. In Claude Code, just ask questions in natural language:
 
@@ -265,21 +265,21 @@ Show me the monthly order count trend.
 
 Behind the scenes, Claude Code uses the **usage** guide to:
 
-1. **Fetch context** (`wren memory fetch`) — find relevant tables and columns for your question
-2. **Recall examples** (`wren memory recall`) — find similar past queries
-3. **Write SQL** — using the semantic layer (model names, not raw table names)
-4. **Execute** (`wren --sql "..."`) — run through the Wren engine
-5. **Store** (`wren memory store`) — save successful NL-SQL pairs for future recall
+1. **Fetch context** (`wren memory fetch`): find relevant tables and columns for your question
+2. **Recall examples** (`wren memory recall`): find similar past queries
+3. **Write SQL** using the semantic layer (model names, not raw table names)
+4. **Execute** (`wren --sql "..."`): run through the Wren engine
+5. **Store** (`wren memory store`): save successful NL-SQL pairs for future recall
 
-The more you ask, the smarter the system gets — each stored query improves future recall accuracy.
+The more you ask, the smarter the system gets. Each stored query improves future recall accuracy.
 
 ---
 
-## Step 8 — Add and query a cube (optional)
+## Step 8: Add and query a cube (optional)
 
-A **cube** is a semantic aggregation object — a model plus declared measures, dimensions, and time grains. `generate-mdl` scaffolds tables and relationships but not cubes, so add one now with Claude Code.
+A **cube** is a semantic aggregation object: a model plus declared measures, dimensions, and time grains. `generate-mdl` scaffolds tables and relationships but not cubes, so add one now with Claude Code.
 
-### Step 8a — Add a cube
+### Step 8a: Add a cube
 
 In Claude Code:
 
@@ -293,7 +293,7 @@ Claude Code drafts the cube YAML, confirms with you, writes it to `cubes/revenue
 
 > **Prefer to write it by hand?** See the [Cube guide](../guides/cubes.md) for the full YAML structure, then run `wren context build`.
 
-### Step 8b — Query the cube
+### Step 8b: Query the cube
 
 ```bash
 wren cube list
@@ -308,6 +308,51 @@ wren cube query \
 
 ---
 
+## Step 9: Build and deploy a GenBI dashboard (optional)
+
+You have answers. Now turn one into a shareable report. GenBI builds a
+browser-side dashboard from your project's context and deploys it to your own
+Vercel or Cloudflare Pages account. You drive the whole thing through the agent.
+
+In Claude Code:
+
+```
+Use the /wren skill to build a GenBI dashboard from the revenue cube:
+monthly revenue and order count, filterable by status. Then preview it locally.
+```
+
+The `wren` skill pulls in the `genbi` guide (`wren skills get genbi`) and drives
+the build:
+
+1. **Build the instruction** (`wren genbi build`) hydrates the app spec with your MDL and the pinned `wren-core-wasm` version.
+2. **Author the app** writes a self-contained app under `apps/<name>/`, choosing charts that answer the question.
+3. **Snapshot the data** exports what the dashboard needs (default snapshot mode), so the app runs fully client-side with no backend.
+4. **Verify and preview** (`wren genbi verify`, then `wren genbi open`) runs preflight checks and serves the app locally.
+
+Open the preview URL the agent prints (for example `http://127.0.0.1:8848/`) and
+click through it. Refine in plain language ("make it a bar chart", "drop the
+status filter") and the agent rebuilds.
+
+When it looks right, ask the agent to deploy:
+
+```
+Deploy the dashboard to Vercel.
+```
+
+You supply the deploy token: add `VERCEL_TOKEN` (or `CLOUDFLARE_API_TOKEN` plus
+`CLOUDFLARE_ACCOUNT_ID`) to `~/.wren/.env`, then tell the agent to continue. It
+runs `wren genbi deploy` and returns a shareable URL. Deploys go to a preview
+URL by default; say "ship it to production" to promote it.
+
+> **Heads-up:** new Vercel projects return HTTP 401 to logged-out visitors by
+> default. The deploy still succeeded; to make the URL public, disable Vercel
+> Authentication once at Project → Settings → Deployment Protection → Vercel
+> Authentication → Disabled.
+
+For the full walkthrough, see [Build and deploy a GenBI app](../guides/genbi.md).
+
+---
+
 ## What's in the project
 
 After setup, your project directory looks like this:
@@ -317,7 +362,7 @@ After setup, your project directory looks like this:
 ├── wren_project.yml
 ├── models/
 │   ├── customers/
-│   │   └── metadata.yml        # table schema + descriptions
+│   │   └── metadata.yml        # table schema and descriptions
 │   ├── orders/
 │   │   └── metadata.yml
 │   ├── products/
@@ -338,7 +383,7 @@ After setup, your project directory looks like this:
 
 Key files to customize:
 
-- **`instructions.md`** — Add business rules, naming conventions, or query guidelines. Use `##` headings to organize by topic. Example:
+- **`instructions.md`**: Add business rules, naming conventions, or query guidelines. Use `##` headings to organize by topic. Example:
 
   ```markdown
   ## Naming Conventions
@@ -349,9 +394,9 @@ Key files to customize:
   - Always use order_date for time-based filtering, not created_at
   ```
 
-- **`models/*/metadata.yml`** — Add or refine `properties.description` on models and columns. Better descriptions = better memory search.
+- **`models/*/metadata.yml`**: Add or refine `properties.description` on models and columns. Better descriptions = better memory search.
 
-- **`relationships.yml`** — Add or fix join conditions. Wrong relationships cause silent query errors.
+- **`relationships.yml`**: Add or fix join conditions. Wrong relationships cause silent query errors.
 
 After editing any file, rebuild and re-index:
 
@@ -385,5 +430,5 @@ wren memory index
 
 ## Next steps
 
-- **Add views** for frequently asked questions — views with good descriptions become high-quality recall examples
+- **Add views** for frequently asked questions. Views with good descriptions become high-quality recall examples
 - **Refine instructions** as you discover query patterns the AI gets wrong

--- a/docs/core/guides/genbi.md
+++ b/docs/core/guides/genbi.md
@@ -5,12 +5,12 @@ sidebar_label: Build & deploy a GenBI app
 # Build & deploy a GenBI app
 
 GenBI turns your project's context layer into a shareable, browser-side
-dashboard — powered by [`wren-core-wasm`](../sdk/wasm.md) — and ships it to your
+dashboard, powered by [`wren-core-wasm`](../sdk/wasm.md), and ships it to your
 own Vercel or Cloudflare Pages account. You never type the `wren genbi`
 commands yourself: you describe the dashboard you want in plain language, and
 your agent drives the CLI to produce a public URL.
 
-This guide shows how to **talk to your agent** to get there — how to ask for a
+This guide shows how to **talk to your agent** to get there: how to ask for a
 dashboard and how to ask it to deploy. For the underlying commands and every
 flag, see the [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps).
 
@@ -18,9 +18,9 @@ flag, see the [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build
 
 You need two things:
 
-- **A Wren project** — the context layer the dashboard reads from. If you don't
+- **A Wren project**: the context layer the dashboard reads from. If you don't
   have one yet, [connect a data source](connect.md) first.
-- **An agent with the `wren` CLI** — any coding agent that can run shell
+- **An agent with the `wren` CLI**: any coding agent that can run shell
   commands. The agent loads its own GenBI playbook on demand via
   `wren skills get genbi`, so you don't have to teach it the workflow.
 
@@ -29,25 +29,26 @@ That's it. From here on you just have a conversation.
 ## Create a dashboard
 
 Describe what you want in natural language. The agent figures out the queries,
-picks the charts, and assembles the app — iterate with it the same way you'd
+picks the charts, and assembles the app. Iterate with it the same way you would
 iterate with a teammate:
 
 ```text
-U: My project is in ~/forecast — show me last week's forecast by product.
-U: And the 8-week trend.
-U: Turn this into an interactive dashboard I can filter by product and OSAT, and share.
-A: Built it and ran the checks. Want to preview locally or deploy?
-U: Preview first.            → A: http://127.0.0.1:8848/
-U: Make the OSAT chart a share-of-total, and lighten the palette.
-A: Updated — refresh the preview.
+User:  My project is in ~/forecast. Show me last week's forecast by product.
+User:  And the 8-week trend.
+User:  Turn this into an interactive dashboard I can filter by product and OSAT, then share.
+Agent: Built it and ran the checks. Want to preview locally or deploy?
+User:  Preview first.
+Agent: Serving at http://127.0.0.1:8848/
+User:  Make the OSAT chart a share-of-total, and lighten the palette.
+Agent: Updated. Refresh the preview.
 ```
 
-Behind each turn, the agent is doing the deterministic work for you — you don't
+Behind each turn, the agent is doing the deterministic work for you. You do not
 have to run any of it:
 
 - **Gets the authoritative build instruction** from the CLI (it knows your live
   project facts and the pinned wasm version).
-- **Authors the app** under `apps/<name>/`, following that instruction —
+- **Authors the app** under `apps/<name>/`, following that instruction,
   choosing the charts and layout that answer your question.
 - **Records and checks the app** so it's deploy-ready, including a secret scan
   that refuses to ship inlined credentials.
@@ -59,12 +60,12 @@ If you want to see exactly which commands these map to, they're all in the
 
 ## Snapshot vs live data
 
-This is the one real choice you'll make in the conversation — tell the agent
+This is the one real choice you'll make in the conversation. Tell the agent
 which you want (it defaults to **snapshot**):
 
 | Mode | Where the data lives | Use it for |
 |------|----------------------|------------|
-| **snapshot** (default) | Bundled with the app and queried client-side via wasm | Demos, reports, small data, dlt-pipeline output — fully serverless |
+| **snapshot** (default) | Bundled with the app and queried client-side via wasm | Demos, reports, small data, dlt-pipeline output, fully serverless |
 | **live** | The app calls back to your warehouse/API at view time | Production-scale or always-fresh data; needs a CORS-enabled endpoint and **never** inlined credentials |
 
 A snapshot freezes the numbers at build time, so it's perfect for a report you
@@ -75,25 +76,27 @@ hand off. Pick live when the dashboard has to stay current.
 Just ask:
 
 ```text
-U: Preview it locally.
-A: http://127.0.0.1:8848/
+User:  Preview it locally.
+Agent: Serving at http://127.0.0.1:8848/
 ```
 
 The agent serves the built app on your machine so you can click through it
-before deploying anything. Refine in the same breath — "make this a bar chart",
-"drop the OSAT filter" — and the agent rebuilds.
+before deploying anything. Refine in the same breath ("make this a bar chart",
+"drop the OSAT filter") and the agent rebuilds.
 
 ## Deploy it
 
-GenBI ships to your own **Vercel** or **Cloudflare Pages** account — those are
-the two providers supported today (Vercel is the default). When you're happy,
-ask the agent to ship it:
+GenBI ships to your own **Vercel** or **Cloudflare Pages** account, the two
+providers supported today (Vercel is the default). When you're happy, ask the
+agent to ship it:
 
 ```text
-U: Deploy it to Vercel.
-A: I need a VERCEL_TOKEN — add it to ~/.wren/.env, then tell me.
-U: Done.                     → A: Deployed <preview-url>
-U: Ship it to production.    → A: <production-url>
+User:  Deploy it to Vercel.
+Agent: I need a VERCEL_TOKEN. Add it to ~/.wren/.env, then tell me.
+User:  Done.
+Agent: Deployed to <preview-url>
+User:  Ship it to production.
+Agent: Promoted to <production-url>
 ```
 
 A few things worth knowing so the conversation goes smoothly:
@@ -105,13 +108,13 @@ A few things worth knowing so the conversation goes smoothly:
 - **Preview vs production.** Deploys go to a preview URL by default; say "ship
   it to production" when you want the agent to promote it.
 - **The deploy target is a public static host.** Anyone with the URL can read
-  every file the app ships, so never let the agent inline secrets — the
+  every file the app ships, so never let the agent inline secrets. The
   pre-deploy secret scan is a safety net, not a guarantee.
 
 ### The Vercel 401 trap
 
 New Vercel projects ship with **Vercel Authentication** turned on, so every
-deployment — preview *and* production — returns **HTTP 401** to anyone who
+deployment, preview *and* production, returns **HTTP 401** to anyone who
 isn't logged into your Vercel account. The deploy succeeded; the URL is just
 gated. To make the dashboard publicly shareable, disable it once in the Vercel
 dashboard: **Project → Settings → Deployment Protection → Vercel
@@ -120,7 +123,7 @@ leave it on.
 
 ## See also
 
-- [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps) — every subcommand and flag
-- [`genbi` skill](../reference/skills.md#genbi) — the agent's workflow playbook
-- [`dlt-connector` skill](../reference/skills.md#dlt-connector) — load SaaS data before you build
-- [wren-core-wasm](../sdk/wasm.md) — the in-browser engine that powers the app
+- [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps): every subcommand and flag
+- [`genbi` skill](../reference/skills.md#genbi): the agent's workflow playbook
+- [`dlt-connector` skill](../reference/skills.md#dlt-connector): load SaaS data before you build
+- [wren-core-wasm](../sdk/wasm.md): the in-browser engine that powers the app

--- a/docs/core/guides/genbi.md
+++ b/docs/core/guides/genbi.md
@@ -4,151 +4,123 @@ sidebar_label: Build & deploy a GenBI app
 
 # Build & deploy a GenBI app
 
-`wren genbi` turns a project's context layer into a shareable, browser-side
-GenBI web app — powered by [`wren-core-wasm`](../sdk/wasm.md) — and deploys it
-to the user's Vercel or Cloudflare Pages account. The whole flow runs through
-an AI agent: the user describes the dashboard they want in natural language,
-and the agent drives the CLI to produce a public URL.
+GenBI turns your project's context layer into a shareable, browser-side
+dashboard — powered by [`wren-core-wasm`](../sdk/wasm.md) — and ships it to your
+own Vercel or Cloudflare Pages account. You never type the `wren genbi`
+commands yourself: you describe the dashboard you want in plain language, and
+your agent drives the CLI to produce a public URL.
 
-## The CLI ↔ agent split
+This guide shows how to **talk to your agent** to get there — how to ask for a
+dashboard and how to ask it to deploy. For the underlying commands and every
+flag, see the [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps).
 
-GenBI deliberately divides the work:
+## Before you start
 
-- **The CLI owns the deterministic parts** — the authoritative build
-  instruction (it knows the live project facts and the pinned wasm version),
-  the app index (`.wren/apps.yml`), `verify`, and `deploy`.
-- **The agent owns authoring** — it writes the app code by following the build
-  instruction, choosing the charts and layout that actually answer the user's
-  question.
+You need two things:
 
-`.wren/apps.yml` is always machine-written via `wren genbi register/remove` —
-never edited by hand.
+- **A Wren project** — the context layer the dashboard reads from. If you don't
+  have one yet, [connect a data source](connect.md) first.
+- **An agent with the `wren` CLI** — any coding agent that can run shell
+  commands. The agent loads its own GenBI playbook on demand via
+  `wren skills get genbi`, so you don't have to teach it the workflow.
 
-The matching agent workflow guide is served by the CLI: `wren skills get
-genbi`. For the full command/flag reference see the
+That's it. From here on you just have a conversation.
+
+## Create a dashboard
+
+Describe what you want in natural language. The agent figures out the queries,
+picks the charts, and assembles the app — iterate with it the same way you'd
+iterate with a teammate:
+
+```text
+U: My project is in ~/forecast — show me last week's forecast by product.
+U: And the 8-week trend.
+U: Turn this into an interactive dashboard I can filter by product and OSAT, and share.
+A: Built it and ran the checks. Want to preview locally or deploy?
+U: Preview first.            → A: http://127.0.0.1:8848/
+U: Make the OSAT chart a share-of-total, and lighten the palette.
+A: Updated — refresh the preview.
+```
+
+Behind each turn, the agent is doing the deterministic work for you — you don't
+have to run any of it:
+
+- **Gets the authoritative build instruction** from the CLI (it knows your live
+  project facts and the pinned wasm version).
+- **Authors the app** under `apps/<name>/`, following that instruction —
+  choosing the charts and layout that answer your question.
+- **Records and checks the app** so it's deploy-ready, including a secret scan
+  that refuses to ship inlined credentials.
+- **Previews it locally** when you ask, so you can see it before anyone else
+  does.
+
+If you want to see exactly which commands these map to, they're all in the
 [CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps).
 
-## Data modes
+## Snapshot vs live data
 
-Pick one at build time:
+This is the one real choice you'll make in the conversation — tell the agent
+which you want (it defaults to **snapshot**):
 
 | Mode | Where the data lives | Use it for |
 |------|----------------------|------------|
-| **snapshot** (default) | Bundled with the app as `data/*.parquet`, queried client-side via wasm | Demos, reports, small data, dlt-pipeline output — fully serverless |
+| **snapshot** (default) | Bundled with the app and queried client-side via wasm | Demos, reports, small data, dlt-pipeline output — fully serverless |
 | **live** | The app calls back to your warehouse/API at view time | Production-scale or always-fresh data; needs a CORS-enabled endpoint and **never** inlined credentials |
 
-## The conversational flow
+A snapshot freezes the numbers at build time, so it's perfect for a report you
+hand off. Pick live when the dashboard has to stay current.
 
-The user never has to know the `wren genbi` commands — they describe intent and
-the agent translates it. A typical end-to-end conversation:
+## Preview before you share
+
+Just ask:
 
 ```text
-U: My project is in ~/forecast — last week's forecast by product?
-U: And the 8-week trend?
-U: Turn this into an interactive dashboard I can filter by product/OSAT and share.
-A: (build → author → register → verify) Done — preview locally or deploy?
-U: Preview first.            → A: http://127.0.0.1:8848/
-U: Make the OSAT chart a share-of-total; lighten the palette.
+U: Preview it locally.
+A: http://127.0.0.1:8848/
+```
+
+The agent serves the built app on your machine so you can click through it
+before deploying anything. Refine in the same breath — "make this a bar chart",
+"drop the OSAT filter" — and the agent rebuilds.
+
+## Deploy it
+
+GenBI ships to your own **Vercel** or **Cloudflare Pages** account — those are
+the two providers supported today (Vercel is the default). When you're happy,
+ask the agent to ship it:
+
+```text
 U: Deploy it to Vercel.
 A: I need a VERCEL_TOKEN — add it to ~/.wren/.env, then tell me.
 U: Done.                     → A: Deployed <preview-url>
-A: Heads-up: the URL returns 401 — Vercel Deployment Protection is on.
-   Disable it at Project → Settings → Deployment Protection to make it public.
-U: Disabled.                 → A: Confirmed public ✅
-U: Ship it to production.    → A: (--prod) <production-url>
+U: Ship it to production.    → A: <production-url>
 ```
 
-What the agent runs behind each turn:
+A few things worth knowing so the conversation goes smoothly:
 
-### 1. Build — get the instruction
+- **You supply the deploy token, not the agent.** Add `VERCEL_TOKEN` (or
+  `CLOUDFLARE_API_TOKEN` plus `CLOUDFLARE_ACCOUNT_ID`) to your environment or a
+  `.env` file. Tokens are never passed on the command line, so they can't leak
+  into shell history.
+- **Preview vs production.** Deploys go to a preview URL by default; say "ship
+  it to production" when you want the agent to promote it.
+- **The deploy target is a public static host.** Anyone with the URL can read
+  every file the app ships, so never let the agent inline secrets — the
+  pre-deploy secret scan is a safety net, not a guarantee.
 
-```bash
-wren genbi build forecast-dashboard --prompt "<the user's request, verbatim>" --data-mode snapshot
-```
+### The Vercel 401 trap
 
-Prints the authoritative build instruction (wasm wiring with the pinned
-`wren-core-wasm` version, the project's model/column inventory, data-mode
-guidance, acceptance criteria, and the target folder). It writes no app files;
-it only compiles `target/mdl.json` first if it's missing. Use `--prompt-file`
-or `--prompt -` for long prompts.
-
-### 2. Author the app
-
-The agent writes everything under `apps/<name>/`, following the instruction:
-
-- copy the compiled MDL in as `apps/<name>/mdl.json`;
-- load `wren-core-wasm` from the CDN in the instruction (never bundle the
-  ~68 MB binary);
-- **snapshot:** export the data the dashboard needs to `apps/<name>/data/` as
-  parquet. A DuckDB-backed project (including anything loaded by the
-  [`dlt-connector`](../reference/skills.md#dlt-connector) skill) exports
-  trivially:
-
-  ```bash
-  python - <<'PY'
-  import duckdb
-  con = duckdb.connect("<db>.duckdb", read_only=True)
-  con.execute(
-      "COPY (SELECT * FROM <table>) "
-      "TO 'apps/<name>/data/<table>.parquet' (FORMAT parquet)"
-  )
-  PY
-  ```
-
-- **live:** write an endpoint-only connection config — never inline
-  credentials.
-
-### 3. Register & verify
-
-```bash
-wren genbi register forecast-dashboard --data-mode snapshot
-wren genbi verify forecast-dashboard
-```
-
-`verify` is a deterministic, no-browser preflight: required files exist,
-`mdl.json` parses, snapshot apps ship a `.parquet`/`.duckdb` asset, and a
-**default-deny secret scan** flags inlined credentials (and refuses any
-`.env*` file outright). `deploy` gates on `verify`.
-
-> The secret scan is best-effort defense-in-depth, **not** a guarantee — the
-> real rule is *never inline secrets into app files*. The deploy target is a
-> public static host: anyone with the URL can read every shipped file.
-
-### 4. Preview locally
-
-```bash
-wren genbi open forecast-dashboard --port 8848
-```
-
-### 5. Deploy
-
-```bash
-wren genbi deploy forecast-dashboard --provider vercel        # or cloudflare
-wren genbi deploy forecast-dashboard --provider vercel --prod # confirm with the user first
-```
-
-- **Preview by default;** `--prod` ships to production.
-- **Tokens** are discovered from the environment or `.env` files
-  (`VERCEL_TOKEN` / `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID`) —
-  never passed as CLI flags (they'd leak into shell history).
-- **Cloudflare** shells out to the [`wrangler`](https://developers.cloudflare.com/workers/wrangler/)
-  CLI (`npm install -g wrangler`, or have `npx` available) — Pages has no
-  single inline-upload REST endpoint.
-
-## Vercel Deployment Protection (the 401 trap)
-
-New Vercel projects ship with **Vercel Authentication** on by default, so every
-deployment — preview *and* production — returns **HTTP 401** to anyone not
-logged into the owning account. The deploy itself succeeded; the URL is just
-gated. To make the app publicly shareable, disable it in the Vercel dashboard:
-**Project → Settings → Deployment Protection → Vercel Authentication →
-Disabled**. This is a one-time per-project toggle, not controllable from
-`wren genbi deploy`. If you only need a private link (viewable while logged
-into your account), leaving it on is fine.
+New Vercel projects ship with **Vercel Authentication** turned on, so every
+deployment — preview *and* production — returns **HTTP 401** to anyone who
+isn't logged into your Vercel account. The deploy succeeded; the URL is just
+gated. To make the dashboard publicly shareable, disable it once in the Vercel
+dashboard: **Project → Settings → Deployment Protection → Vercel
+Authentication → Disabled**. If you only need a private link for yourself,
+leave it on.
 
 ## See also
 
-- [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps)
-- [`genbi` skill](../reference/skills.md#genbi)
-- [`dlt-connector` skill](../reference/skills.md#dlt-connector) — load SaaS data first
+- [`wren genbi` CLI reference](../reference/cli.md#wren-genbi--build--deploy-genbi-apps) — every subcommand and flag
+- [`genbi` skill](../reference/skills.md#genbi) — the agent's workflow playbook
+- [`dlt-connector` skill](../reference/skills.md#dlt-connector) — load SaaS data before you build
 - [wren-core-wasm](../sdk/wasm.md) — the in-browser engine that powers the app

--- a/docs/core/guides/model.md
+++ b/docs/core/guides/model.md
@@ -4,21 +4,21 @@ sidebar_label: Model your business
 
 # Model your business
 
-Turn your warehouse schema into an agent-readable MDL project that captures your business logic.
+Turn your warehouse schema into an agent-readable MDL project that captures your business logic. This is the foundation every generated answer and GenBI dashboard is planned through.
 
 ## What you'll end up with
 
 - A Wren project directory with `wren_project.yml`, `models/`, `views/`, `relationships.yml`, and `instructions.md`
 - A compiled `target/mdl.json` ready for the engine
 - A memory index over the modeled schema, so agents can fetch relevant context per question
-- A first query that runs through MDL — not against raw tables
+- A first query that runs through MDL, not against raw tables
 
 ## The flow
 
 1. **Connect your data source.** See [Connect your data](./connect.md) for profile setup.
 2. **Open your agent in a fresh project directory and ask:**
    > Use the `/wren` skill to scaffold an MDL project for this database.
-3. **Review the scaffold.** The agent introspects schema, normalizes types, detects relationships, and writes one model per table. It will ask one focused question whenever it cannot decide alone — naming, canonical tables, ambiguous foreign keys.
+3. **Review the scaffold.** The agent introspects schema, normalizes types, detects relationships, and writes one model per table. It will ask one focused question whenever it cannot decide alone: naming, canonical tables, ambiguous foreign keys.
 4. **Build and index.** The skill finishes with:
    ```bash
    wren context build
@@ -49,18 +49,18 @@ The hard meaning lives outside the database. Scaffolding cannot tell you:
 - Whether `active customer` excludes service accounts
 - That "Project Lighthouse" maps to `campaign_id = 4172`
 
-Bring those in with [Refine answer quality](./refine.md) — the grill / auto-pilot loop that fills the semantic gaps.
+Bring those in with [Refine answer quality](./refine.md), the grill / auto-pilot loop that fills the semantic gaps.
 
 ## Enrich as you go
 
 Once you have a baseline, add depth incrementally:
 
-- **Descriptions and business names** on models and columns — memory uses these for retrieval
+- **Descriptions and business names** on models and columns, which memory uses for retrieval
 - **Calculated fields** for metrics the team agrees on (`revenue = net_total - refunds`)
 - **Relationship columns** so agents can write `orders.customer.first_name` without manual joins
 - **Views** for stable, pre-built query shapes (`completed_orders`, `monthly_revenue`)
-- **Cubes** for governed aggregations — see [Pre-aggregate with cubes](./cubes.md)
-- **Selective column exposure** to keep PII columns invisible to agents — omit them from the model and they cannot be queried
+- **Cubes** for governed aggregations (see [Pre-aggregate with cubes](./cubes.md))
+- **Selective column exposure** to keep PII columns invisible to agents. Omit them from the model and they cannot be queried
 
 Each time you edit, rebuild and re-index:
 
@@ -78,6 +78,6 @@ wren memory index
 
 ## See also
 
-- [MDL schema reference](/oss/reference/mdl) — every field accepted in MDL files
-- [Refine answer quality](./refine.md) — close the loop with memory and instructions
-- [What does MDL do for the agent?](/oss/concepts/what_is_mdl) — the design idea behind MDL
+- [MDL schema reference](/oss/reference/mdl): every field accepted in MDL files
+- [Refine answer quality](./refine.md): close the loop with memory and instructions
+- [What does MDL do for the agent?](/oss/concepts/what_is_mdl): the design idea behind MDL

--- a/docs/core/guides/refine.md
+++ b/docs/core/guides/refine.md
@@ -4,7 +4,7 @@ sidebar_label: Refine answer quality
 
 # Refine answer quality
 
-Scaffolding gives you a baseline MDL. This recipe is how you close the loop — bring in the business meaning that lives outside the database, store proven examples, and let the agent compound from every confirmed answer.
+Scaffolding gives you a baseline MDL. This recipe is how you close the loop. Bring in the business meaning that lives outside the database, store proven examples, and let the agent compound from every confirmed answer. It is the hands-on version of the [Know beat](/oss/concepts/knowledge_management): richer knowledge here means more trustworthy BI downstream.
 
 ## What you'll end up with
 
@@ -13,7 +13,7 @@ Scaffolding gives you a baseline MDL. This recipe is how you close the loop — 
 - A `queries.yml` of confirmed natural-language-to-SQL pairs, committable to your repo
 - An agent that gets better at your business each time someone confirms an answer
 
-## Prerequisite — install the `memory` extra
+## Prerequisite: install the `memory` extra
 
 The memory layer is an optional extra. It is **not** included in the base CLI. Install it before running any `wren memory ...` command:
 
@@ -32,7 +32,7 @@ Without the `memory` extra, the memory commands below will not be available.
 
 ## The flow today
 
-The day-to-day refinement loop runs on the `usage` guide plus a few `wren memory` and `instructions.md` edits. When you need to go deeper than incremental edits — backfilling enum meanings, units, default filters, synonyms, or named metrics across a whole project — reach for the [`enrich-context`](#enrich-context) guide described below.
+The day-to-day refinement loop runs on the `usage` guide plus a few `wren memory` and `instructions.md` edits. When you need to go deeper than incremental edits, such as backfilling enum meanings, units, default filters, synonyms, or named metrics across a whole project, reach for the [`enrich-context`](#enrich-context) guide described below.
 
 ### 1. Capture business rules in `instructions.md`
 
@@ -51,7 +51,7 @@ The day-to-day refinement loop runs on the `usage` guide plus a few `wren memory
 - Timestamps are stored in UTC.
 ```
 
-Organize by topic with `##` headings — each heading and its body becomes a retrievable chunk in memory. Edit by hand, or have your agent propose changes when it spots a recurring confusion.
+Organize by topic with `##` headings. Each heading and its body becomes a retrievable chunk in memory. Edit by hand, or have your agent propose changes when it spots a recurring confusion.
 
 ### 2. Let `usage` compound from every confirmed answer
 
@@ -65,7 +65,7 @@ User asks a question
   → wren memory store   (persist the confirmed pair)
 ```
 
-Each stored pair makes future similar questions faster and more accurate. The loop runs on every turn — no separate enrichment phase needed.
+Each stored pair makes future similar questions faster and more accurate. The loop runs on every turn, with no separate enrichment phase needed.
 
 ### 3. Re-index after each change
 
@@ -110,17 +110,17 @@ See the [CLI reference](/oss/reference/cli) for the full memory command surface.
 
 ## `enrich-context`
 
-The `enrich-context` guide goes deeper than incremental `instructions.md` edits. It reads everything you drop into `<project>/raw/` (PDFs, glossaries, handbooks, analyst SQL, data dictionaries), compares it against the current MDL / `instructions.md` / `queries.yml` / memory, and fills the gaps — writing back only to reviewable, version-controlled artifacts. It works from a ten-category gap catalog: enum value meanings, units, NULL semantics, magic sentinels, default filters, synonyms, time conventions, cross-system identifiers, currency rules, and canonical-table preferences. Named aggregation metrics (ARR, churn, DAU) are proposed as cubes.
+The `enrich-context` guide goes deeper than incremental `instructions.md` edits. It reads everything you drop into `<project>/raw/` (PDFs, glossaries, handbooks, analyst SQL, data dictionaries), compares it against the current MDL / `instructions.md` / `queries.yml` / memory, and fills the gaps, writing back only to reviewable, version-controlled artifacts. It works from a ten-category gap catalog: enum value meanings, units, NULL semantics, magic sentinels, default filters, synonyms, time conventions, cross-system identifiers, currency rules, and canonical-table preferences. Named aggregation metrics (ARR, churn, DAU) are proposed as cubes.
 
 Pick one of two modes at session start:
 
-- **Grill mode** — the agent walks each gap one question at a time and asks focused questions ("Which of `customers`, `customers_v3`, `loyalty_v3` is canonical?", "What does `status = 4` mean?"). You answer in plain language; the agent drafts the change and patches MDL, `instructions.md`, `queries.yml`, or memory based on the answer category. With your OK, it can also sample low-cardinality columns from the live DB to discover enum and sentinel values.
-- **Auto-pilot mode** — drop docs, glossaries, SQL history, or a metric handbook into `<project>/raw/` and the agent reads them, applies its best inferences directly, and escalates to grill only on raw-vs-MDL conflicts and high-blast-radius additions (new cubes / views / relationships). It hands you a confidence-tagged audit at the end.
+- **Grill mode**: the agent walks each gap one question at a time and asks focused questions ("Which of `customers`, `customers_v3`, `loyalty_v3` is canonical?", "What does `status = 4` mean?"). You answer in plain language; the agent drafts the change and patches MDL, `instructions.md`, `queries.yml`, or memory based on the answer category. With your OK, it can also sample low-cardinality columns from the live DB to discover enum and sentinel values.
+- **Auto-pilot mode**: drop docs, glossaries, SQL history, or a metric handbook into `<project>/raw/` and the agent reads them, applies its best inferences directly, and escalates to grill only on raw-vs-MDL conflicts and high-blast-radius additions (new cubes / views / relationships). It hands you a confidence-tagged audit at the end.
 
-Both modes only **add** — they never modify an existing field; contradictions are surfaced on a "please fix manually" list. With the `wren` skill installed (`npx skills add Canner/WrenAI`), trigger it by saying "enrich context" or "grill me on this project" — the stub fetches the guide with `wren skills get enrich-context`. See the [skills reference](/oss/reference/skills#enrich-context) for the full breakdown.
+Both modes only **add**. They never modify an existing field; contradictions are surfaced on a "please fix manually" list. With the `wren` skill installed (`npx skills add Canner/WrenAI`), trigger it by saying "enrich context" or "grill me on this project". The stub fetches the guide with `wren skills get enrich-context`. See the [skills reference](/oss/reference/skills#enrich-context) for the full breakdown.
 
 ## See also
 
-- [How does the agent learn from your context?](/oss/concepts/agent_learning) — the design behind the loop
-- [How does memory get smarter over time?](/oss/concepts/memory_system) — what's indexed and how recall works
-- [Model your business](./model.md) — the scaffolding step before you start refining
+- [How does the agent learn from your context?](/oss/concepts/agent_learning): the design behind the loop
+- [How does memory get smarter over time?](/oss/concepts/memory_system): what's indexed and how recall works
+- [Model your business](./model.md): the scaffolding step before you start refining

--- a/docs/core/introduction.mdx
+++ b/docs/core/introduction.mdx
@@ -1,14 +1,24 @@
 # Wren AI
 
-*Turn any AI Agents into world-class data analysts through the open context layer that gives AI agents grounded, governed memory, context, and SQL across 20+ data sources, that helps you build GenBI, dashboards, and agentic analytics.*
+*Open-source GenBI: let your AI agents generate, deploy, and govern dashboards from any database, grounded in a context layer they can actually trust, across 22+ data sources.*
 
-<iframe src="https://ghbtns.com/github-btn.html?user=Canner&repo=WrenAI&type=star&count=true&size=large" frameborder="0" scrolling="0" height="50" title="Wren AI"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=Canner&repo=WrenAI&type=star&count=true&size=large" frameBorder="0" scrolling="0" height="50" title="Wren AI"></iframe>
 
-**Wren AI is the open context layer for AI agents.** It sits between your data sources and any agent or application that needs to query them.
+**Wren AI is the open-source GenBI engine.** It lets any AI agent turn a business question into governed BI, from a single SQL answer to a shareable, deployed dashboard, on top of the data sources you already have.
 
-The goal is simple: **one governed context layer for every data consumer**. Humans and agents should not rebuild business logic from scratch, argue over which number is right, or bypass governance just because the interface changed.
+Generative BI is only as good as the context it stands on. So underneath GenBI, Wren AI is an **open context layer**: it sits between your data sources and any agent or application, and gives them the same machine-readable understanding of your business. That means what the data means, how it should be joined, which definitions are approved, and how queries should be planned against the underlying database.
 
-Wren AI gives them the same machine-readable understanding of your business data: what the data means, how it should be joined, which definitions are approved, and how queries should be planned against the underlying database.
+The goal is simple: **agents that produce trustworthy BI, not plausible guesses**, on one governed context layer that every data consumer, human or agent, can share.
+
+## GenBI in three beats
+
+| Beat | What the agent does | Powered by |
+| --- | --- | --- |
+| **Generate** | Turns a business question into governed SQL and charts | MDL planning, schema retrieval, dry-plan validation |
+| **Deploy** | Ships the answer as a shareable, browser-side dashboard | [`wren-core-wasm`](/oss/sdk/wasm) → Vercel / Cloudflare Pages |
+| **Know** | Captures the business meaning that keeps it all correct | MDL, `instructions.md`, memory (reviewable, Git-friendly) |
+
+The rest of this page explains the layer that makes the *Generate* and *Deploy* beats trustworthy, the **Know** beat, because that is where correctness comes from.
 
 ## Why Wren AI exists
 
@@ -21,15 +31,15 @@ Your agent reads schema, but schema does not tell it:
 
 ![Missing context layer](/img/oss/vision/missing-context-layer.png)
 
-Without that meaning, the agent writes confident, plausible, wrong SQL. The demo looks fine. The pilot looks fine. Production is where it breaks.
+Without that meaning, the agent writes confident, plausible, wrong SQL, and a dashboard built on wrong SQL is worse than no dashboard, because it looks authoritative. The demo looks fine. The pilot looks fine. Production is where it breaks.
 
 Business context cannot be locked inside someone else's product. Your business definitions outlive your tools, and they deserve a format your team can inspect, version, fork, and share.
 
 ## What Wren AI provides
 
-Wren AI turns raw database structure into a reusable context layer. It helps agents move from "I can see tables" to "I know what this business means by revenue, customer, refund, churn, and active account."
+Wren AI turns raw database structure into a reusable context layer, then lets agents generate and deploy BI on top of it. It helps agents move from "I can see tables" to "I know what this business means by revenue, customer, refund, churn, and active account", and from "here is some SQL" to "here is a governed dashboard you can share."
 
-For real business questions on real company data, an agent needs five layers of context (see [What does Wren AI mean by context?](/oss/concepts/what_is_context) for the full breakdown):
+For real business questions on real company data, an agent needs five layers of context (see [What does Wren AI mean by context?](/oss/concepts/what_is_context) for the full breakdown). These five layers are exactly what makes a generated answer, or a deployed dashboard, correct:
 
 | Layer | What it gives the agent | Status |
 | --- | --- | --- |
@@ -76,34 +86,43 @@ Behind the scenes, Wren AI:
 4. Applies any rules from `instructions.md` (default filters, canonical tables, business definitions)
 5. Returns rows
 
+From there, the same context drives the *Deploy* beat: ask your agent to turn an answer into a dashboard and it builds a browser-side GenBI app from the project and ships it to your own hosting. See [Build & deploy a GenBI app](/oss/guides/genbi).
+
 ## What is in the open core
 
 The open core includes:
 
-- **[MDL (Modeling Definition Language)](/oss/concepts/what_is_mdl)** — the semantic contract. MDL defines models, relationships, calculated fields, views, and agent-oriented metadata in files you can read, review, version, and fork.
-- **Rust semantic engine** — powered by Apache DataFusion. It plans and executes modeled SQL across supported data sources such as PostgreSQL, MySQL, BigQuery, Snowflake, DuckDB, ClickHouse, Trino, SQL Server, Databricks, Redshift, Oracle, Athena, Apache Spark, and more.
-- **[`wren` CLI](/oss/reference/cli)** — commands for querying, planning, validating, building context, profiling data, and managing memory.
-- **[Skills](/oss/reference/skills)** — structured workflows such as `generate-mdl` and `onboarding`, served on demand from the `wren` CLI, that let AI coding agents operate Wren AI safely and reproducibly.
-- **Framework SDKs** — [LangChain](/oss/sdk/langchain) and [Pydantic AI](/oss/sdk/pydantic) integrations for attaching a Wren project to agent frameworks.
-- **[wren-core-wasm](/oss/sdk/wasm)** — the semantic engine compiled to WebAssembly, so MDL-aware SQL can run in the browser.
+- **[MDL (Modeling Definition Language)](/oss/concepts/what_is_mdl)**: the semantic contract. MDL defines models, relationships, calculated fields, views, and agent-oriented metadata in files you can read, review, version, and fork.
+- **Rust semantic engine**: powered by Apache DataFusion. It plans and executes modeled SQL across supported data sources such as PostgreSQL, MySQL, BigQuery, Snowflake, DuckDB, ClickHouse, Trino, SQL Server, Databricks, Redshift, Oracle, Athena, Apache Spark, and more.
+- **[`wren` CLI](/oss/reference/cli)**: commands for querying, planning, validating, building context, profiling data, managing memory, and building & deploying GenBI apps.
+- **[GenBI apps](/oss/guides/genbi)**: agent-built, browser-side dashboards powered by [`wren-core-wasm`](/oss/sdk/wasm), deployable to Vercel or Cloudflare Pages.
+- **[Skills](/oss/reference/skills)**: structured workflows such as `generate-mdl`, `onboarding`, `enrich-context`, and `genbi`, served on demand from the `wren` CLI, that let AI coding agents operate Wren AI safely and reproducibly.
+- **Framework SDKs**: [LangChain](/oss/sdk/langchain) and [Pydantic AI](/oss/sdk/pydantic) integrations for attaching a Wren project to agent frameworks.
+- **[wren-core-wasm](/oss/sdk/wasm)**: the semantic engine compiled to WebAssembly, so MDL-aware SQL (and GenBI dashboards) can run in the browser.
 
 ## Roadmap
 
-The active arcs are end-to-end context enrichment, a correctness loop (including small golden evals agents can run), and tighter agent SDK coverage. See [GitHub Discussions](https://github.com/Canner/WrenAI/discussions) for live design threads and the prioritized roadmap.
+The active arcs are end-to-end context enrichment, richer GenBI (more chart types, live-data dashboards), a correctness loop (including small golden evals agents can run), and tighter agent SDK coverage. See [GitHub Discussions](https://github.com/Canner/WrenAI/discussions) for live design threads and the prioritized roadmap.
 
 ## Start here
 
 1. [Install](/oss/get_started/installation)
 2. [Quickstart with `jaffle_shop` sample data](/oss/get_started/quickstart)
 3. [Connect your own database](/oss/guides/connect)
-4. [Concepts](/oss/concepts/what_is_context) — the design ideas
-5. [Model your business](/oss/guides/model) — turn schema into MDL
+4. [Build & deploy a GenBI app](/oss/guides/genbi): the *Generate* + *Deploy* payoff
+5. [Concepts](/oss/concepts/what_is_context): the design ideas behind the *Know* beat
 
-## Looking for the GenBI app docs?
+## A note on the "GenBI" name
 
-The **Wren AI GenBI** app, the Docker-based chat-first BI product, is now **sunset**. Its code lives on the `legacy/v1` branch and no security fixes will be issued. Existing deployments still work; reference docs are kept under [Wren AI GenBI — Sunset](/oss/overview/introduction) in the sidebar.
+"GenBI" here means this open-source generative-BI capability: agents that
+generate governed answers and deploy dashboards on top of Wren's context layer.
 
-For an actively maintained version with the same feature set, see [Wren AI Commercial](https://getwren.ai).
+The earlier **Wren AI GenBI** app, the Docker-based chat-first BI product, is
+now **Wren GenBI Classic** and is **sunset**. Its code lives on the `legacy/v1`
+branch and no security fixes will be issued. Existing deployments still work;
+reference docs are kept under [Wren GenBI Classic · Sunset](/oss/overview/introduction)
+in the sidebar. For an actively maintained, hosted version of that classic
+experience, see [Wren AI Commercial](https://getwren.ai).
 
 ## Dig deeper
 

--- a/docs/core/reference/architecture.md
+++ b/docs/core/reference/architecture.md
@@ -5,7 +5,7 @@ Wren AI is built as an open context layer for agents. Architecturally, that mean
 1. Business meaning is stored in explicit project artifacts: MDL, instructions, profiles, and memory.
 2. Correctness is handled as a system of primitives the agent can orchestrate, not as one hidden feature.
 
-The result is a stack where agents can query through governed business context while Wren AI handles modeling, planning, validation, execution, and recall.
+The result is a stack where agents can generate governed BI, from a SQL answer to a deployed GenBI dashboard, through governed business context, while Wren AI handles modeling, planning, validation, execution, and recall.
 
 ## Correctness is a system
 
@@ -113,7 +113,7 @@ See the [MDL schema reference](/oss/reference/mdl) for the full project structur
 
 ### Wren Python SDK
 
-The `wrenai` Python package exposes the same plan-and-execute pipeline that the CLI drives. The CLI is a thin Typer wrapper over the SDK — both share the orchestration code, both can be embedded in agent frameworks, notebooks, and applications.
+The `wrenai` Python package exposes the same plan-and-execute pipeline that the CLI drives. The CLI is a thin Typer wrapper over the SDK. Both share the orchestration code, and both can be embedded in agent frameworks, notebooks, and applications.
 
 When invoked (via CLI or SDK), the orchestrator:
 
@@ -123,7 +123,7 @@ When invoked (via CLI or SDK), the orchestrator:
 4. Sends planned SQL to the correct connector.
 5. Returns results as a PyArrow table.
 
-For higher-level integrations, see the [LangChain SDK](/oss/sdk/langchain) and [Pydantic AI SDK](/oss/sdk/pydantic) — both wrap this pipeline as agent tools.
+For higher-level integrations, see the [LangChain SDK](/oss/sdk/langchain) and [Pydantic AI SDK](/oss/sdk/pydantic). Both wrap this pipeline as agent tools.
 
 ### SQL planning
 


### PR DESCRIPTION
## What

Rewrites `docs/core/guides/genbi.md` (the **Build & deploy a GenBI app** guide) so it reads as an **agent-workflow guide**, not a command walkthrough.

The page now teaches the *conversation*:
- **Create a dashboard** — a natural-language transcript plus a short "what the agent does behind each turn" list (build → author → verify → preview), each linking to the CLI reference instead of inlining commands.
- **Snapshot vs live data** — the one real choice you make in the conversation (kept as a table).
- **Preview / Deploy it** — framed as "ask your agent to preview / deploy", keeping the token you must supply and the Vercel 401 Deployment Protection gotcha.
- Added an explicit note that deploy currently supports only **Vercel** and **Cloudflare Pages** (Vercel default).

All the per-command mechanics (`build` / `register` / `verify` / `open` / `deploy` flags, the DuckDB export snippet) are removed from the guide and redirected to the [`wren genbi` CLI reference](https://github.com/Canner/WrenAI/blob/main/docs/core/reference/cli.md) for deep dives.

## Why

The guide overlapped heavily with the CLI reference and led with command syntax. Users drive GenBI by talking to an agent, so the guide should teach that and leave the flag-level detail to the reference.

## Notes

- Source of truth only. The published docs site (`docs.getwren.ai`) picks this up automatically via the `sync-docs` workflow on merge — no docs-repo change needed.
- Net: +90 / −118 lines, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMFmA9S81sANeNDee62VMh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Substantially rewrote and reorganized the GenBI build/deploy guide with clearer conversational steps, snapshot-vs-live guidance, local preview instructions, streamlined provider deployment notes (including the Vercel public-link gotcha), and an updated “before you start/create a dashboard/deploy it” flow.
  * Added new concept pages for knowledge management, open source vs commercial, and “why/what it is” positioning; refreshed architecture, correctness, model/learning, memory, context/MDL, and related wording/formatting.
  * Updated README marketing and onboarding, including revised quickstart wording, improved GenBI naming guidance, and refreshed example prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->