### PR TITLE
docs(core): add Open source vs Commercial comparison page

### DIFF
--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -1,0 +1,39 @@
+---
+sidebar_label: Open source vs Commercial
+---
+
+# Open source vs Commercial
+
+Wren AI open source is the full engine: free, self-hosted, and driven by one engineer or agent through the CLI and SDK.
+
+Wren AI Commercial is the same engine built for a team. It runs as a hosted cloud service or as a self-hosted enterprise deployment, and it adds a web UI, accounts, managed access control, integrations, and support. Full overview: [Wren AI Commercial](/cp/overview).
+
+## Feature comparison
+
+| Capability | Open source | Commercial |
+| --- | :---: | :---: |
+| Free and fully self-hosted | ✅ | ✅ |
+| Fully managed cloud | ❌ | ✅ |
+| CLI and SDK for your own agents | ✅ | ✅ |
+| MCP server and hosted REST API | ❌ | ✅ |
+| Access control defined in MDL (RLAC/CLAC) | ✅ | ✅ |
+| GenBI dashboards | ✅ | ✅ |
+| Web UI for non-technical users | ❌ | ✅ |
+| Slack and Microsoft Teams | ❌ | ✅ |
+| Built-in agentic sandbox mode | ❌ | ✅ |
+| Accounts, roles, multi-user | ❌ | ✅ |
+| SSO, LDAP, SCIM provisioning | ❌ | ✅ |
+| RLS/CLS per user, session properties, audit log | ❌ | ✅ |
+| Evaluation, AI Advisor, feedback tracing | ❌ | ✅ |
+| Vendor support | ❌ | ✅ |
+
+## Consider Commercial when
+
+- A team needs accounts, roles, and SSO, or LDAP/SCIM from your identity provider.
+- Non-technical users want to ask in a browser, Slack, or Teams.
+- You need RLS/CLS enforced per real user, or multi-tenant isolation for your own customers.
+- You want a managed cloud, scheduled dashboards, or vendor support.
+
+## Talk to us
+
+See [Wren AI Commercial](/cp/overview) for details and to reach the team. Open source stays first-class either way.


### PR DESCRIPTION
## What

Adds `docs/core/concepts/oss_vs_commercial.md`: a short, scannable **checkbox comparison** of open source vs Commercial, plus a brief "Consider Commercial when" list. It lives as a new tab directly under the OSS **Overview** in the sidebar.

Goal: help an OSS user see at a glance what the commercial product adds, and when to reach out. OSS stays first-class. CTA points to `/cp/overview`.

## Feature accuracy

Commercial capabilities were verified against the `WrenAI-saas` repo (main + on-prem), not guessed: Slack/Microsoft Teams, agentic sandbox mode, SSO/LDAP/SCIM (enterprise), RLS/CLS bound to users + audit log, hosted REST API + MCP server, hosted dashboards, evaluation/AI Advisor. Excel/Sheets was intentionally excluded. OSS has no MCP server, so MCP sits with the hosted API on the commercial side.

## Notes for reviewers

- **Stacked on the GenBI reposition.** Base is `feat/reposition` (PR #2381) so this diff shows only the new page. Retarget to `main` once #2381 merges.
- **Source of truth only.** The sidebar entry lives in the docs repo and ships in a separate sidebars-only PR there.
- 1 file, +39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMFmA9S81sANeNDee62VMh