### PR TITLE
chore(wren-core-py): sync wren-core-py uv.lock on release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,12 @@
       "release-type": "python",
       "bump-minor-pre-major": true,
       "extra-files": [
-        "Cargo.toml"
+        "Cargo.toml",
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-core-py')].version"
+        }
       ]
     },
     "core/wren": {


### PR DESCRIPTION
## Why

The `wren-core-py` release PR (#2376) fails CI on **every** job at the install step:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
Process completed with exit code 1.
```

release-please bumps `core/wren-core-py/pyproject.toml` (`0.7.0` → `0.7.1`) but never updates `core/wren-core-py/uv.lock`, which keeps `wren-core-py` pinned at the old version. Since `uv.lock` records the project's own version (`source = { editable = "." }`), it goes stale the moment the version bumps, and `uv sync --locked` refuses to run — blocking Core Python CI and all Wren SDK CI jobs (which build the wren-core-py wheel first).

## Fix

Add a `uv.lock` `extra-files` entry for `core/wren-core-py`, mirroring the existing `core/wren` config so the lockfile version is updated via jsonpath alongside the `pyproject.toml`/`Cargo.toml` bump.

Once merged, release-please will regenerate the open release PR (#2376) with the lockfile change included, turning CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to improve package version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->