### PR TITLE
fix(wren): run full unit suite in CI and fix upgrade tests for schema_version 5

### DIFF
--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -66,7 +66,11 @@ jobs:
           uv sync --locked
           uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run unit tests
-        run: uv run --no-sync pytest tests/unit/ -v -m unit
+        # Run the whole tests/unit/ tree rather than filtering on `-m unit`:
+        # the marker is opt-in, so any unmarked file (e.g. test_context_cli.py)
+        # was silently skipped. Exclude test_memory.py — it needs the `memory`
+        # extra and runs in the dedicated `memory tests` job below.
+        run: uv run --no-sync pytest tests/unit/ -v --ignore=tests/unit/test_memory.py
 
   test-connector:
     name: ${{ matrix.datasource }} tests

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -467,12 +467,14 @@ def _make_v1_project(tmp_path: Path) -> Path:
 
 
 def test_upgrade_cli_default_to_latest(tmp_path):
+    from wren.context import _LATEST_SCHEMA_VERSION  # noqa: PLC0415
+
     _make_valid_project(tmp_path)
     result = runner.invoke(app, ["context", "upgrade", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     assert "Upgrade complete" in result.output
     config = yaml.safe_load((tmp_path / "wren_project.yml").read_text())
-    assert config["schema_version"] == 4
+    assert config["schema_version"] == _LATEST_SCHEMA_VERSION == 5
 
 
 def test_upgrade_cli_dry_run(tmp_path):
@@ -491,7 +493,7 @@ def test_upgrade_cli_dry_run(tmp_path):
 
 def test_upgrade_cli_already_current(tmp_path):
     (tmp_path / "wren_project.yml").write_text(
-        "schema_version: 4\nname: test\ndata_source: postgres\n"
+        "schema_version: 5\nname: test\ndata_source: postgres\n"
     )
     result = runner.invoke(app, ["context", "upgrade", "--path", str(tmp_path)])
     assert result.exit_code == 0


### PR DESCRIPTION
## Why

The `unit tests` CI job ran `pytest tests/unit/ -m unit`. The `unit` marker is
opt-in, so any test file without it was silently deselected and **never run in CI** —
296 of 753 unit tests, including the entire `test_context_cli.py`. As a result, two
upgrade tests that asserted the previous latest `schema_version` (4) went red on `main`
without CI noticing.

## Changes

**CI — run the whole unit tree (`.github/workflows/wren-ci.yml`)**

Replace `pytest tests/unit/ -m unit` with `pytest tests/unit/ --ignore=tests/unit/test_memory.py`.
The directory is the unit-test boundary by convention; the marker filter was a fragile,
opt-in gate. `test_memory.py` is excluded because it needs the `memory` extra and already
runs in the dedicated `memory tests` job.

**Tests — fix the two upgrade tests for latest = 5 (`test_context_cli.py`)**

- `test_upgrade_cli_already_current`: use a project already at the latest version.
- `test_upgrade_cli_default_to_latest`: bind to `_LATEST_SCHEMA_VERSION` so it tracks
  future bumps instead of hard-coding the number.

Test/CI only; no production code changes.

## Verification

`pytest tests/unit/ --ignore=tests/unit/test_memory.py` → 677 passed, 1 skipped — and this
now includes `test_context_cli.py`, which the old marker filter skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
