### PR TITLE
feat(wren): default new projects to v5 layout

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -494,11 +494,12 @@ def load_models(project_path: Path) -> list[dict]:
     """Load models — dispatches on schema_version.
 
     v1 (legacy): models/*.yml (flat files)
-    v2: models/<name>/metadata.yml + optional ref_sql.sql
+    v2-v5: models/<name>/metadata.yml + optional ref_sql.sql (directory-per-model)
     """
     sv = get_schema_version(project_path)
     if sv == 1:
         return _load_models_v1(project_path)
+    # sv in {2, 3, 4, 5}: directory-per-model layout
     return _load_models_v2(project_path)
 
 
@@ -553,11 +554,12 @@ def load_views(project_path: Path) -> list[dict]:
     """Load views — dispatches on schema_version.
 
     v1 (legacy): views.yml (single file with `views:` list)
-    v2: views/<name>/metadata.yml + optional sql.yml
+    v2-v5: views/<name>/metadata.yml + optional sql.yml (directory-per-view)
     """
     sv = get_schema_version(project_path)
     if sv == 1:
         return _load_views_v1(project_path)
+    # sv in {2, 3, 4, 5}: directory-per-view layout
     return _load_views_v2(project_path)
 
 
@@ -607,11 +609,12 @@ def load_cubes(project_path: Path) -> list[dict]:
     """Load cubes — dispatches on schema_version.
 
     v1 (legacy): cubes/*.yml
-    v2: cubes/<name>/metadata.yml
+    v2-v5: cubes/<name>/metadata.yml (directory-per-cube)
     """
     sv = get_schema_version(project_path)
     if sv == 1:
         return _load_cubes_v1(project_path)
+    # sv in {2, 3, 4, 5}: directory-per-cube layout
     return _load_cubes_v2(project_path)
 
 

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -272,7 +272,7 @@ def init(
 
     # wren_project.yml
     project_yml = (
-        "schema_version: 3\n"
+        "schema_version: 5\n"
         "name: my_project\n"
         'version: "1.0"\n'
         "\n"

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -309,6 +309,59 @@ def test_init_empty_skips_example_model_and_view(tmp_path):
     assert "empty" in result.output
 
 
+# ── v5 is the default init layout (O1) ───────────────────────────────────
+
+
+def test_init_writes_v5(tmp_path):
+    """`wren context init` stamps the latest layout, schema_version 5."""
+    result = runner.invoke(app, ["context", "init", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    config = yaml.safe_load((tmp_path / "wren_project.yml").read_text())
+    assert config["schema_version"] == 5
+    # per-model / per-view directory layout (unchanged since v2)
+    assert (tmp_path / "models" / "example" / "metadata.yml").exists()
+    assert (tmp_path / "views" / "example_view" / "metadata.yml").exists()
+
+
+def test_v5_build_roundtrip(tmp_path):
+    """init → build produces a valid mdl.json stamped layoutVersion 3."""
+    assert (
+        runner.invoke(app, ["context", "init", "--path", str(tmp_path)]).exit_code == 0
+    )
+    result = runner.invoke(app, ["context", "build", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    mdl = json.loads((tmp_path / "target" / "mdl.json").read_text())
+    assert mdl["layoutVersion"] == 3
+    assert any(m["name"] == "example" for m in mdl["models"])
+
+
+def test_v5_uses_v2_reader(tmp_path):
+    """A v5 project reads models/views identically to the same project at v3."""
+    from wren.context import load_models, load_views  # noqa: PLC0415
+
+    def _populate(root: Path, sv: int) -> Path:
+        root.mkdir(parents=True)
+        (root / "wren_project.yml").write_text(
+            f"schema_version: {sv}\nname: t\ndata_source: postgres\n"
+            "catalog: wren\nschema: public\n"
+        )
+        md = root / "models" / "orders"
+        md.mkdir(parents=True)
+        (md / "metadata.yml").write_text(
+            "name: orders\ntable_reference:\n  table: orders\n"
+            "columns:\n  - name: id\n    type: INTEGER\n"
+        )
+        vd = root / "views" / "summary"
+        vd.mkdir(parents=True)
+        (vd / "metadata.yml").write_text("name: summary\nstatement: SELECT 1\n")
+        return root
+
+    v3 = _populate(tmp_path / "v3", 3)
+    v5 = _populate(tmp_path / "v5", 5)
+    assert load_models(v5) == load_models(v3)
+    assert load_views(v5) == load_views(v3)
+
+
 # ── wren context validate ─────────────────────────────────────────────────
 
 
@@ -852,7 +905,7 @@ def test_set_profile_preserves_other_fields(tmp_path, monkeypatch):
     assert config["name"] == "my_project"
     assert config["catalog"] == "wren"
     assert config["schema"] == "public"
-    assert config["schema_version"] == 3
+    assert config["schema_version"] == 5
 
 
 def test_set_profile_preserves_custom_fields(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Makes `schema_version: 5` the default layout that `wren context init` produces, so new
projects are created at the latest version. v5 reuses the directory-per-model/view/cube
layout introduced in v2, so this is a small change — no new reader behavior.

## Changes

- **`context_cli.py`** — `wren context init` now stamps `schema_version: 5` (was 3).
- **`context.py`** — `load_models` / `load_views` / `load_cubes` dispatch now spells out
  that v2–v5 share the same directory-per-folder reader (docstring + comment; behavior
  unchanged, the legacy v1 flat-file path is still separate).
- **`test_context_cli.py`** — new tests, plus the `set_profile` field-preservation test
  updated for the new init default.

## Tests

- `test_init_writes_v5` — `init` produces `schema_version: 5` with the per-folder layout.
- `test_v5_build_roundtrip` — `init` → `build` yields a valid `mdl.json` stamped
  `layoutVersion 3`.
- `test_v5_uses_v2_reader` — a v5 project reads models/views identically to the same
  project at v3 (locks the reader equivalence).

Full unit suite green (`pytest tests/unit/ --ignore=tests/unit/test_memory.py`):
680 passed, 1 skipped. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Wren projects now initialize with schema version 5 by default (previously version 3).

* **Documentation**
  * Enhanced documentation for schema version layouts and configuration structures.

* **Tests**
  * Added compatibility tests for the new default schema version to ensure backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->