### PR TITLE
feat(wren): migrate projects to v5 by building the knowledge/ skeleton

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -439,6 +439,13 @@ _SUPPORTED_SCHEMA_VERSIONS = {1, 2, 3, 4, 5}
 # it adds no engine-facing MDL JSON, so it reuses v4's engine layoutVersion 3.
 _LAYOUT_VERSION_MAP = {1: 1, 2: 1, 3: 2, 4: 3, 5: 3}
 
+# knowledge/ layout (v5). Single source of truth — reused by the v4→v5 upgrade
+# step and by project init. The knowledge axis has its own schema_version in
+# knowledge.yml, decoupled from the MDL schema_version in wren_project.yml.
+_KNOWLEDGE_SUBDIRS = ("rules", "glossary", "metrics", "caveats", "sql")
+_KNOWLEDGE_CONFIG_FILE = "knowledge/knowledge.yml"
+_KNOWLEDGE_SCHEMA_VERSION = 1
+
 # Valid dialect values (matches Rust DataSource enum)
 _VALID_DIALECTS = {
     "athena",
@@ -1163,6 +1170,36 @@ class UpgradeError(Exception):
     """Raised when a project upgrade cannot proceed."""
 
 
+def _knowledge_skeleton_targets() -> list[str]:
+    """Canonical relative paths of a fresh knowledge/ skeleton.
+
+    Empty subdirectories carry a .gitkeep so the layout survives in git.
+    """
+    paths = [f"knowledge/{sub}/.gitkeep" for sub in _KNOWLEDGE_SUBDIRS]
+    paths.append(_KNOWLEDGE_CONFIG_FILE)
+    return paths
+
+
+def create_knowledge_skeleton(project_path: Path) -> list[str]:
+    """Create any missing parts of the knowledge/ skeleton. Idempotent.
+
+    Returns the relative paths actually created (empty if already complete).
+    Existing files are never overwritten.
+    """
+    created: list[str] = []
+    for rel in _knowledge_skeleton_targets():
+        dest = project_path / rel
+        if dest.exists():
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if rel == _KNOWLEDGE_CONFIG_FILE:
+            dest.write_text(f"schema_version: {_KNOWLEDGE_SCHEMA_VERSION}\n")
+        else:
+            dest.write_text("")  # .gitkeep
+        created.append(rel)
+    return created
+
+
 def plan_upgrade(
     project_path: Path,
     target_version: int | None = None,
@@ -1197,6 +1234,10 @@ def plan_upgrade(
     for version in range(current, target):
         if version == 1:
             created, deleted = _plan_v1_to_v2(project_path)
+            files_created.extend(created)
+            files_deleted.extend(deleted)
+        elif version == 4:
+            created, deleted = _plan_v4_to_v5(project_path)
             files_created.extend(created)
             files_deleted.extend(deleted)
         # v2→v3 (dialect) and v3→v4 (composite primary_key): no file layout
@@ -1270,13 +1311,28 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
     return created, deleted
 
 
+def _plan_v4_to_v5(project_path: Path) -> tuple[list[str], list[str]]:
+    """Plan v4→v5: create the knowledge/ skeleton if absent.
+
+    First file-creating step since v1→v2. Idempotent — lists only the
+    skeleton paths that don't already exist.
+    """
+    created = [
+        rel
+        for rel in _knowledge_skeleton_targets()
+        if not (project_path / rel).exists()
+    ]
+    return created, []
+
+
 def apply_upgrade(project_path: Path, result: UpgradeResult) -> None:
-    """Write upgrade changes to disk."""
-    if not result.files_created and not result.files_deleted:
-        # No-op (e.g. v2→v3, only wren_project.yml changes)
-        pass
-    else:
-        _apply_v1_to_v2(project_path)
+    """Write upgrade changes to disk, replaying each version step in order."""
+    for version in range(result.from_version, result.to_version):
+        if version == 1:
+            _apply_v1_to_v2(project_path)
+        elif version == 4:
+            _apply_v4_to_v5(project_path)
+        # v2→v3, v3→v4: only the wren_project.yml stamp changes (handled below)
 
     # Update wren_project.yml
     config = load_project_config(project_path)
@@ -1369,6 +1425,11 @@ def _apply_v1_to_v2(project_path: Path) -> None:
             old_file = project_path / "cubes" / source_file
             if old_file.exists():
                 old_file.unlink()
+
+
+def _apply_v4_to_v5(project_path: Path) -> None:
+    """Execute v4→v5: create the knowledge/ skeleton (idempotent)."""
+    create_knowledge_skeleton(project_path)
 
 
 # ── Semantic validation (view dry-plan + description completeness) ─────────

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1308,6 +1308,73 @@ def test_upgrade_preserves_instructions(tmp_path):
     assert "Rule 1" in content
 
 
+# ── v4 → v5 (knowledge/ skeleton) ─────────────────────────────────────────
+
+_KNOWLEDGE_SKELETON = [
+    "knowledge/rules/.gitkeep",
+    "knowledge/glossary/.gitkeep",
+    "knowledge/metrics/.gitkeep",
+    "knowledge/caveats/.gitkeep",
+    "knowledge/sql/.gitkeep",
+    "knowledge/knowledge.yml",
+]
+
+
+def test_plan_upgrade_v4_to_v5_lists_knowledge(tmp_path):
+    _make_v2_project(tmp_path, schema_version=4)
+    result = plan_upgrade(tmp_path, target_version=5)
+    assert result.from_version == 4
+    assert result.to_version == 5
+    assert set(result.files_created) == set(_KNOWLEDGE_SKELETON)
+    assert "wren_project.yml" in result.files_modified
+    # plan must not touch disk
+    assert not (tmp_path / "knowledge").exists()
+
+
+def test_apply_upgrade_v4_to_v5_creates_knowledge(tmp_path):
+    _make_v2_project(tmp_path, schema_version=4)
+    apply_upgrade(tmp_path, plan_upgrade(tmp_path, target_version=5))
+    assert get_schema_version(tmp_path) == 5
+    for rel in _KNOWLEDGE_SKELETON:
+        assert (tmp_path / rel).exists(), rel
+    # knowledge axis has its own schema_version, decoupled from MDL
+    import yaml as _yaml  # noqa: PLC0415
+
+    kcfg = _yaml.safe_load((tmp_path / "knowledge" / "knowledge.yml").read_text())
+    assert kcfg["schema_version"] == 1
+
+
+def test_upgrade_v4_to_v5_idempotent(tmp_path):
+    _make_v2_project(tmp_path, schema_version=4)
+    apply_upgrade(tmp_path, plan_upgrade(tmp_path, target_version=5))
+    # second pass: already at latest → no-op plan, knowledge untouched
+    again = plan_upgrade(tmp_path, target_version=5)
+    assert again.from_version == again.to_version == 5
+    assert again.files_created == []
+
+
+def test_upgrade_v4_to_v5_preserves_existing_knowledge(tmp_path):
+    """An existing knowledge file is never overwritten by the upgrade."""
+    _make_v2_project(tmp_path, schema_version=4)
+    (tmp_path / "knowledge" / "rules").mkdir(parents=True)
+    (tmp_path / "knowledge" / "rules" / "house.md").write_text("# keep me\n")
+    apply_upgrade(tmp_path, plan_upgrade(tmp_path, target_version=5))
+    assert (tmp_path / "knowledge" / "rules" / "house.md").read_text() == "# keep me\n"
+    assert (tmp_path / "knowledge" / "knowledge.yml").exists()
+
+
+def test_apply_upgrade_v2_to_v5_full_chain(tmp_path):
+    """v2 → v5 restamps through and builds the knowledge skeleton; models still load."""
+    _make_v2_project(tmp_path)
+    d = tmp_path / "models" / "orders"
+    d.mkdir(parents=True)
+    (d / "metadata.yml").write_text("name: orders\ntable_reference:\n  table: orders\n")
+    apply_upgrade(tmp_path, plan_upgrade(tmp_path, target_version=5))
+    assert get_schema_version(tmp_path) == 5
+    assert (tmp_path / "knowledge" / "knowledge.yml").exists()
+    assert load_models(tmp_path)[0]["name"] == "orders"
+
+
 _PROJECT_FILE = "wren_project.yml"
 
 

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -564,6 +564,35 @@ def test_upgrade_cli_explicit_to_version(tmp_path):
     assert config["schema_version"] == 2
 
 
+def test_upgrade_cli_v4_to_v5_builds_knowledge(tmp_path):
+    """Upgrading a v4 project to latest creates the knowledge/ skeleton."""
+    (tmp_path / "wren_project.yml").write_text(
+        "schema_version: 4\nname: test\ndata_source: postgres\n"
+    )
+    result = runner.invoke(app, ["context", "upgrade", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Upgrade complete" in result.output
+    config = yaml.safe_load((tmp_path / "wren_project.yml").read_text())
+    assert config["schema_version"] == 5
+    assert (tmp_path / "knowledge" / "knowledge.yml").exists()
+    assert (tmp_path / "knowledge" / "rules" / ".gitkeep").exists()
+
+
+def test_upgrade_cli_v4_to_v5_dry_run_no_write(tmp_path):
+    """Dry-run lists the knowledge skeleton but writes nothing."""
+    (tmp_path / "wren_project.yml").write_text(
+        "schema_version: 4\nname: test\ndata_source: postgres\n"
+    )
+    result = runner.invoke(
+        app, ["context", "upgrade", "--path", str(tmp_path), "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "knowledge/knowledge.yml" in result.output
+    assert not (tmp_path / "knowledge").exists()
+    config = yaml.safe_load((tmp_path / "wren_project.yml").read_text())
+    assert config["schema_version"] == 4
+
+
 # ── wren context import dbt ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Adds the v4→v5 step to `wren context upgrade`, so existing projects can migrate to the
latest layout. This is the first file-creating migration since v1→v2: it builds the
`knowledge/` skeleton and restamps the project to `schema_version: 5`.

## Changes

- **Canonical knowledge skeleton** — `create_knowledge_skeleton()` plus the
  `_KNOWLEDGE_SUBDIRS` / `_KNOWLEDGE_CONFIG_FILE` / `_KNOWLEDGE_SCHEMA_VERSION` constants
  are the single source of truth for the `knowledge/` layout
  (`rules/`, `glossary/`, `metrics/`, `caveats/`, `sql/` + `knowledge.yml`). The knowledge
  axis carries its own `schema_version`, decoupled from the MDL one.
- **`plan_upgrade`** gains a `version == 4` step (`_plan_v4_to_v5`) that lists the skeleton
  paths that don't yet exist.
- **`apply_upgrade` is now step-aware** — it replays each version transition in order
  (`range(from, to)`) instead of assuming v1→v2. So `v1 → v5` correctly runs both the
  v1→v2 restructure and the v4→v5 knowledge step.
- Idempotent and forward-only: existing knowledge files are never overwritten; `--dry-run`
  previews the skeleton without writing.

The `wren context upgrade` CLI (`--to` / `--dry-run` / default-to-latest) already existed;
this only adds the migration step behind it.

## Tests

- v4→v5: plan lists the skeleton (no disk write), apply creates it + bumps to 5,
  `knowledge.yml` carries `schema_version: 1`.
- Idempotent re-run is a no-op; an existing `knowledge/rules/house.md` survives.
- Full chain v2→v5 restamps through and still loads models.
- CLI: `wren context upgrade` on a v4 project builds the skeleton; `--dry-run` writes nothing.

Full unit suite green (`pytest tests/unit/ --ignore=tests/unit/test_memory.py`):
687 passed, 1 skipped. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Schema v4→v5 upgrade now automatically initializes knowledge directory structure with proper defaults, safely creating required skeleton files through idempotent operations that preserve existing content.

* **Tests**
  * Added comprehensive unit and integration tests for v4→v5 schema upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->