### PR TITLE
feat(wren): make knowledge/ a first-class part of the project

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -445,6 +445,7 @@ _LAYOUT_VERSION_MAP = {1: 1, 2: 1, 3: 2, 4: 3, 5: 3}
 _KNOWLEDGE_SUBDIRS = ("rules", "glossary", "metrics", "caveats", "sql")
 _KNOWLEDGE_CONFIG_FILE = "knowledge/knowledge.yml"
 _KNOWLEDGE_SCHEMA_VERSION = 1
+_SUPPORTED_KNOWLEDGE_VERSIONS = {1}
 
 # Valid dialect values (matches Rust DataSource enum)
 _VALID_DIALECTS = {
@@ -677,11 +678,71 @@ def load_relationships(project_path: Path) -> list[dict]:
 
 
 def load_instructions(project_path: Path) -> str | None:
-    """Load instructions.md as a string."""
+    """Load the legacy instructions.md as a string.
+
+    Deprecated in favour of knowledge/rules/ — see load_rules().
+    """
     inst_file = project_path / "instructions.md"
     if not inst_file.exists():
         return None
     return inst_file.read_text(encoding="utf-8").strip() or None
+
+
+def load_knowledge_rules(project_path: Path) -> str | None:
+    """Concatenate knowledge/rules/*.md (sorted). None if there are none."""
+    rules_dir = project_path / "knowledge" / "rules"
+    if not rules_dir.is_dir():
+        return None
+    parts = [
+        text
+        for f in sorted(rules_dir.glob("*.md"))
+        if (text := f.read_text(encoding="utf-8").strip())
+    ]
+    return "\n\n".join(parts) if parts else None
+
+
+def load_rules(project_path: Path) -> tuple[str | None, bool]:
+    """Load business rules from knowledge/rules/ and the legacy instructions.md.
+
+    Returns ``(content, used_legacy)`` where ``used_legacy`` is True when the
+    deprecated instructions.md contributed content, so callers can warn.
+    """
+    parts: list[str] = []
+    rules = load_knowledge_rules(project_path)
+    if rules:
+        parts.append(rules)
+    legacy = load_instructions(project_path)
+    if legacy:
+        parts.append(legacy)
+    content = "\n\n".join(parts) if parts else None
+    return content, legacy is not None
+
+
+def load_knowledge_config(project_path: Path) -> dict:
+    """Load knowledge/knowledge.yml (knowledge version axis). Empty dict if absent."""
+    kfile = project_path / _KNOWLEDGE_CONFIG_FILE
+    if not kfile.exists():
+        return {}
+    data = yaml.safe_load(kfile.read_text(encoding="utf-8")) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def get_knowledge_schema_version(project_path: Path) -> int:
+    """Return the knowledge-axis schema_version (default 1). Decoupled from MDL.
+
+    Returns 0 when there is no knowledge/ at all.
+    """
+    if not (project_path / "knowledge").is_dir():
+        return 0
+    cfg = load_knowledge_config(project_path)
+    raw = cfg.get("schema_version", _KNOWLEDGE_SCHEMA_VERSION)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        raise SystemExit(
+            f"Error: invalid schema_version {raw!r} in {_KNOWLEDGE_CONFIG_FILE}. "
+            "Expected an integer."
+        )
 
 
 # ── Build ─────────────────────────────────────────────────────────────────
@@ -813,6 +874,30 @@ def validate_project(project_path: Path) -> list[ValidationError]:
 
     if any(e.path == PROJECT_FILE and "schema_version" in e.message for e in errors):
         return errors
+
+    # knowledge/ version axis — independent of the MDL schema_version above.
+    if (project_path / "knowledge").is_dir():
+        kcfg = load_knowledge_config(project_path)
+        raw_kv = kcfg.get("schema_version", _KNOWLEDGE_SCHEMA_VERSION)
+        try:
+            kv = int(raw_kv)
+        except (TypeError, ValueError):
+            errors.append(
+                ValidationError(
+                    "error",
+                    _KNOWLEDGE_CONFIG_FILE,
+                    f"schema_version must be an integer, got {raw_kv!r}",
+                )
+            )
+        else:
+            if kv not in _SUPPORTED_KNOWLEDGE_VERSIONS:
+                errors.append(
+                    ValidationError(
+                        "error",
+                        _KNOWLEDGE_CONFIG_FILE,
+                        f"unsupported knowledge schema_version {kv} — please upgrade wren CLI",
+                    )
+                )
 
     # Load data (snake_case)
     models = load_models(project_path)

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -715,7 +715,10 @@ def load_rules(project_path: Path) -> tuple[str | None, bool]:
     if legacy:
         parts.append(legacy)
     content = "\n\n".join(parts) if parts else None
-    return content, legacy is not None
+    # Presence-based: an existing (even empty) instructions.md is the deprecated
+    # pattern worth flagging, regardless of whether it currently has content.
+    used_legacy = (project_path / "instructions.md").exists()
+    return content, used_legacy
 
 
 def load_knowledge_config(project_path: Path) -> dict:

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -349,10 +349,12 @@ def init(
     )
 
     create_knowledge_skeleton(project_path)
-    (project_path / "knowledge" / "rules" / "general.md").write_text(
-        "# Business rules\n\n"
-        "Add custom rules or guidelines for LLM-based query generation here.\n"
-    )
+    general_rules = project_path / "knowledge" / "rules" / "general.md"
+    if force or not general_rules.exists():
+        general_rules.write_text(
+            "# Business rules\n\n"
+            "Add custom rules or guidelines for LLM-based query generation here.\n"
+        )
 
     # ── AGENTS.md ──
     (project_path / "AGENTS.md").write_text(_AGENTS_MD_TEMPLATE)

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -342,15 +342,19 @@ def init(
             "statement: >\n  SELECT * FROM example LIMIT 100\n"
         )
 
-    # Instructions placeholder
-    (project_path / "instructions.md").write_text(
-        "# User Instructions\n\n"
+    # ── knowledge/ skeleton (first-class business context) ──
+    from wren.context import (  # noqa: PLC0415
+        _AGENTS_MD_TEMPLATE,
+        create_knowledge_skeleton,
+    )
+
+    create_knowledge_skeleton(project_path)
+    (project_path / "knowledge" / "rules" / "general.md").write_text(
+        "# Business rules\n\n"
         "Add custom rules or guidelines for LLM-based query generation here.\n"
     )
 
     # ── AGENTS.md ──
-    from wren.context import _AGENTS_MD_TEMPLATE  # noqa: PLC0415
-
     (project_path / "AGENTS.md").write_text(_AGENTS_MD_TEMPLATE)
 
     # Curated NL-SQL pairs (auto-loaded by `wren memory index`)
@@ -374,7 +378,9 @@ def init(
         typer.echo("  models/                     — (empty; add your own models)")
         typer.echo("  views/                      — (empty; add your own views)")
     typer.echo("  relationships.yml           — define joins between models")
-    typer.echo("  instructions.md             — LLM instructions")
+    typer.echo(
+        "  knowledge/rules/            — business rules for LLM query generation"
+    )
     typer.echo("  AGENTS.md                   — AI agent workflow guidance")
     typer.echo("  queries.yml                 — curated NL-SQL pairs for memory")
     typer.echo("")
@@ -693,8 +699,8 @@ def show(
         build_json,
         build_manifest,
         discover_project_path,
-        load_instructions,
         load_project_config,
+        load_rules,
     )
 
     try:
@@ -722,7 +728,7 @@ def show(
         models = manifest.get("models", [])
         views = manifest.get("views", [])
         rels = manifest.get("relationships", [])
-        instr_content = load_instructions(project_path)
+        instr_content, used_legacy_instructions = load_rules(project_path)
 
         typer.echo(
             f"Project: {config.get('name', '?')} (v{config.get('version', '?')})"
@@ -752,7 +758,11 @@ def show(
 
         if instr_content:
             lines = instr_content.strip().split("\n")
-            typer.echo(f"\nInstructions: {len(lines)} lines")
+            typer.echo(f"\nBusiness rules: {len(lines)} lines")
+        if used_legacy_instructions:
+            typer.echo(
+                "  (instructions.md is deprecated — move it into knowledge/rules/*.md)"
+            )
 
         if not models and not views:
             typer.echo("Empty project. Run `wren context init` to get started.")
@@ -762,8 +772,8 @@ def show(
 def instructions(
     path: ProjectPathOpt = None,
 ) -> None:
-    """Print user instructions for LLM consumption."""
-    from wren.context import discover_project_path, load_instructions  # noqa: PLC0415
+    """Print business rules (knowledge/rules/ + legacy instructions.md) for LLM consumption."""
+    from wren.context import discover_project_path, load_rules  # noqa: PLC0415
 
     try:
         project_path = discover_project_path(path)
@@ -771,7 +781,13 @@ def instructions(
         typer.echo(str(e), err=True)
         raise typer.Exit(1)
 
-    content = load_instructions(project_path)
+    content, used_legacy = load_rules(project_path)
+    if used_legacy:
+        typer.echo(
+            "Warning: instructions.md is deprecated — move its content into "
+            "knowledge/rules/*.md.",
+            err=True,
+        )
     if content:
         typer.echo(content)
 

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -174,11 +174,11 @@ def index(
         try:
             from wren.context import (  # noqa: I001, PLC0415
                 discover_project_path,
-                load_instructions,
+                load_rules,
             )
 
             project_path = discover_project_path()
-            instr = load_instructions(project_path)
+            instr, _ = load_rules(project_path)
             if instr:
                 manifest["_instructions"] = instr
         except (

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -280,6 +280,72 @@ def test_load_instructions_missing(tmp_path):
     assert load_instructions(tmp_path) is None
 
 
+# ── knowledge/ rules + version axis (O3) ──────────────────────────────────
+
+
+def test_load_knowledge_rules_concatenates_sorted(tmp_path):
+    from wren.context import load_knowledge_rules  # noqa: PLC0415
+
+    _make_v2_project(tmp_path)
+    rdir = tmp_path / "knowledge" / "rules"
+    rdir.mkdir(parents=True)
+    (rdir / "b_units.md").write_text("Amounts are USD.\n")
+    (rdir / "a_filters.md").write_text("Exclude soft-deleted rows.\n")
+    result = load_knowledge_rules(tmp_path)
+    # sorted by filename: a_filters before b_units
+    assert result == "Exclude soft-deleted rows.\n\nAmounts are USD."
+
+
+def test_load_knowledge_rules_missing(tmp_path):
+    from wren.context import load_knowledge_rules  # noqa: PLC0415
+
+    _make_v2_project(tmp_path)
+    assert load_knowledge_rules(tmp_path) is None
+
+
+def test_load_rules_combines_knowledge_and_legacy(tmp_path):
+    from wren.context import load_rules  # noqa: PLC0415
+
+    _make_v2_project(tmp_path)
+    (tmp_path / "knowledge" / "rules").mkdir(parents=True)
+    (tmp_path / "knowledge" / "rules" / "general.md").write_text("From knowledge.\n")
+    (tmp_path / "instructions.md").write_text("From legacy.\n")
+    content, used_legacy = load_rules(tmp_path)
+    assert content == "From knowledge.\n\nFrom legacy."
+    assert used_legacy is True
+
+
+def test_load_rules_knowledge_only_no_legacy_flag(tmp_path):
+    from wren.context import load_rules  # noqa: PLC0415
+
+    _make_v2_project(tmp_path)
+    (tmp_path / "knowledge" / "rules").mkdir(parents=True)
+    (tmp_path / "knowledge" / "rules" / "general.md").write_text("Only knowledge.\n")
+    content, used_legacy = load_rules(tmp_path)
+    assert content == "Only knowledge."
+    assert used_legacy is False
+
+
+def test_get_knowledge_schema_version(tmp_path):
+    from wren.context import create_knowledge_skeleton, get_knowledge_schema_version  # noqa: PLC0415
+
+    _make_v2_project(tmp_path)
+    assert get_knowledge_schema_version(tmp_path) == 0  # no knowledge/ yet
+    create_knowledge_skeleton(tmp_path)
+    assert get_knowledge_schema_version(tmp_path) == 1
+
+
+def test_validate_rejects_unsupported_knowledge_version(tmp_path):
+    _make_v2_project(tmp_path, schema_version=5)
+    (tmp_path / "knowledge").mkdir()
+    (tmp_path / "knowledge" / "knowledge.yml").write_text("schema_version: 99\n")
+    errors = validate_project(tmp_path)
+    assert any(
+        "knowledge" in e.path and "unsupported knowledge schema_version" in e.message
+        for e in errors
+    )
+
+
 # ── build_manifest / build_json ───────────────────────────────────────────
 
 

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -326,6 +326,17 @@ def test_load_rules_knowledge_only_no_legacy_flag(tmp_path):
     assert used_legacy is False
 
 
+def test_load_rules_flags_empty_legacy_file(tmp_path):
+    """An existing-but-empty instructions.md still flags the deprecated pattern."""
+    from wren.context import load_rules  # noqa: PLC0415
+
+    _make_v2_project(tmp_path)
+    (tmp_path / "instructions.md").write_text("")
+    content, used_legacy = load_rules(tmp_path)
+    assert content is None  # empty file contributes no content
+    assert used_legacy is True
+
+
 def test_get_knowledge_schema_version(tmp_path):
     from wren.context import create_knowledge_skeleton, get_knowledge_schema_version  # noqa: PLC0415
 

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -223,7 +223,10 @@ def test_init_creates_scaffold(tmp_path):
     assert (tmp_path / "views" / "example_view" / "metadata.yml").exists()
     assert (tmp_path / "views" / "example_view" / "sql.yml").exists()
     assert (tmp_path / "relationships.yml").exists()
-    assert (tmp_path / "instructions.md").exists()
+    # knowledge/ is first-class: rules live here, not in the legacy instructions.md
+    assert (tmp_path / "knowledge" / "knowledge.yml").exists()
+    assert (tmp_path / "knowledge" / "rules" / "general.md").exists()
+    assert not (tmp_path / "instructions.md").exists()
 
     # Verify wren_project.yml contains namespace clarification comments and defaults
     project_yml = (tmp_path / "wren_project.yml").read_text()
@@ -307,6 +310,37 @@ def test_init_empty_skips_example_model_and_view(tmp_path):
     assert (tmp_path / "queries.yml").exists()
     # Summary mentions empty rather than the example paths
     assert "empty" in result.output
+
+
+# ── knowledge/ as first-class (O3) ────────────────────────────────────────
+
+
+def test_init_builds_knowledge_skeleton(tmp_path):
+    result = runner.invoke(app, ["context", "init", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    for sub in ("rules", "glossary", "metrics", "caveats", "sql"):
+        assert (tmp_path / "knowledge" / sub).is_dir()
+    assert (tmp_path / "knowledge" / "knowledge.yml").exists()
+    assert (tmp_path / "knowledge" / "rules" / "general.md").exists()
+    # legacy single-file instructions.md is no longer scaffolded
+    assert not (tmp_path / "instructions.md").exists()
+
+
+def test_instructions_cmd_reads_knowledge_rules(tmp_path):
+    runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
+    (tmp_path / "knowledge" / "rules" / "units.md").write_text("Amounts are USD.\n")
+    result = runner.invoke(app, ["context", "instructions", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Amounts are USD." in result.output
+
+
+def test_instructions_cmd_warns_on_legacy(tmp_path):
+    runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
+    (tmp_path / "instructions.md").write_text("Legacy rule.\n")
+    result = runner.invoke(app, ["context", "instructions", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Legacy rule." in result.output
+    assert "deprecated" in result.output
 
 
 # ── v5 is the default init layout (O1) ───────────────────────────────────

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -326,6 +326,26 @@ def test_init_builds_knowledge_skeleton(tmp_path):
     assert not (tmp_path / "instructions.md").exists()
 
 
+def test_init_does_not_clobber_existing_rules(tmp_path):
+    """Re-running init must not overwrite existing business rules without --force."""
+    runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
+    general = tmp_path / "knowledge" / "rules" / "general.md"
+    general.write_text("My real rules.\n")
+    # init again with --force (clears the project-file conflict guard)
+    result = runner.invoke(
+        app, ["context", "init", "--empty", "--force", "--path", str(tmp_path)]
+    )
+    assert result.exit_code == 0, result.output
+    # --force intentionally re-seeds the starter content
+    assert "Add custom rules" in general.read_text()
+
+    # but without --force, an existing general.md is preserved
+    general.write_text("My real rules.\n")
+    (tmp_path / "wren_project.yml").unlink()  # avoid the conflict-guard early exit
+    runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
+    assert general.read_text() == "My real rules.\n"
+
+
 def test_instructions_cmd_reads_knowledge_rules(tmp_path):
     runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
     (tmp_path / "knowledge" / "rules" / "units.md").write_text("Amounts are USD.\n")


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Makes `knowledge/` a first-class part of a Wren project: `wren context init` seeds the
knowledge base, and business rules are read from `knowledge/rules/` with the single-file
`instructions.md` kept as a deprecated fallback.

## Changes

- **`init`** seeds the `knowledge/` skeleton via the shared `create_knowledge_skeleton`
  helper and writes the starter business rules to `knowledge/rules/general.md` — it no
  longer scaffolds `instructions.md`, so new projects are knowledge-native.
- **`load_rules()`** returns business rules from `knowledge/rules/*.md` combined with the
  legacy `instructions.md`, plus a flag for whether the legacy file contributed.
  `wren context instructions`, `wren context build`, and `wren memory index` all use it.
- **Deprecation notice** — when `instructions.md` is still present, those commands point
  the user to `knowledge/rules/`.
- **`knowledge.yml`** carries its own `schema_version`, independent of the MDL
  `schema_version`; `validate_project` checks it (`get_knowledge_schema_version`).

`dbt`/`osi` import still produce `instructions.md`; migrating those producers is left to a
follow-up — the dual-read + deprecation notice covers them in the meantime.

## Tests

- Loaders: `knowledge/rules/` concatenation (sorted), `load_rules` combine + legacy flag,
  `get_knowledge_schema_version` (0 when absent, 1 with skeleton), validation rejects an
  unsupported knowledge version.
- CLI: `init` builds the skeleton + `general.md` and writes no `instructions.md`;
  `wren context instructions` reads `knowledge/rules/` and warns on a legacy file.

Full unit suite green (`pytest tests/unit/ --ignore=tests/unit/test_memory.py`):
696 passed, 1 skipped. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated `knowledge/rules/` directory structure for managing business rules, replacing the legacy `instructions.md` approach.
  * Added schema versioning support for knowledge content.

* **Documentation**
  * Deprecation notice now displayed when legacy `instructions.md` is detected; users are encouraged to migrate content to the new `knowledge/rules/` directory.
  * Updated initialization scaffolding to create the new knowledge directory structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->