### PR TITLE
feat(wren): make knowledge/sql markdown the source of truth for memory

### DIFF
--- a/core/wren/src/wren/cli.py
+++ b/core/wren/src/wren/cli.py
@@ -607,14 +607,14 @@ app.add_typer(cube_app)
 app.add_typer(utils_app)
 app.add_typer(skills_app)
 
-from importlib.util import find_spec  # noqa: E402
+# The `memory` subcommand group is always registered: `wren memory store`
+# writes knowledge/sql/*.md without the optional `memory` extra, and the
+# lancedb-backed commands degrade with a clear "install wren[memory]" message.
+# Importing memory_app stays light — lancedb / the heavy ML stack are imported
+# lazily inside the commands that need them, never at CLI startup.
+from wren.memory.cli import memory_app  # noqa: E402
 
-# Detect the optional `memory` extra without importing it: a real import would
-# eagerly pull lancedb (and the heavy ML stack it loads) into every CLI startup.
-if find_spec("lancedb") and find_spec("sentence_transformers"):
-    from wren.memory.cli import memory_app  # noqa: PLC0415
-
-    app.add_typer(memory_app)
+app.add_typer(memory_app)
 
 from wren.genbi.cli import genbi_app  # noqa: PLC0415, E402
 from wren.profile_cli import profile_app  # noqa: PLC0415, E402

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -317,10 +317,42 @@ def store(
     tags: Annotated[Optional[str], typer.Option("--tags")] = None,
     path: PathOpt = None,
 ) -> None:
-    """Store a NL→SQL pair for future few-shot retrieval."""
-    mem_store = _get_store(path)
-    mem_store.store_query(nl, sql, datasource=datasource, tags=tags)
-    typer.echo("Query stored.")
+    """Store a NL→SQL pair as knowledge/sql/<slug>.md (source of truth), then index it.
+
+    The markdown file is always written (no extra required). When the ``memory``
+    extra is installed, the pair is also indexed into LanceDB for semantic recall.
+    """
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.markdown import write_query_markdown  # noqa: PLC0415
+
+    try:
+        project_path = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+    md_path = write_query_markdown(
+        project_path, nl, sql, datasource=datasource, tags=tag_list
+    )
+    typer.echo(f"Stored: {md_path}")
+
+    # Best-effort: index into LanceDB when the memory extra is available.
+    try:
+        from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+        resolved = path or str(_default_memory_path())
+        MemoryStore(path=resolved).store_query(
+            nl, sql, datasource=datasource, tags=tags
+        )
+    except ModuleNotFoundError as e:
+        if (e.name or "").split(".")[0] not in {
+            "lancedb",
+            "sentence_transformers",
+            "pyarrow",
+        }:
+            raise
+        # memory extra not installed — markdown-only; run `wren memory index` later.
 
 
 @memory_app.command()

--- a/core/wren/src/wren/memory/markdown.py
+++ b/core/wren/src/wren/memory/markdown.py
@@ -47,18 +47,20 @@ def parse_query_markdown(path: Path) -> dict:
     Returns the frontmatter mapping with an extra ``_body`` key (stripped
     markdown body). Returns {} when the file has no frontmatter.
     """
-    text = path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
         return {}
-    # Split: ---\n<frontmatter>\n---\n<body>
-    parts = text.split("---", 2)
-    if len(parts) < 3:
-        return {}
-    data = yaml.safe_load(parts[1]) or {}
-    if not isinstance(data, dict):
-        return {}
-    data["_body"] = parts[2].strip()
-    return data
+    # The closing delimiter is a line that is exactly "---" at column 0.
+    # Frontmatter values are indented (e.g. block-scalar sql), so a "---" line
+    # inside a value is indented and never matches here.
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\n") == "---":
+            data = yaml.safe_load("".join(lines[1:i])) or {}
+            if not isinstance(data, dict):
+                return {}
+            data["_body"] = "".join(lines[i + 1 :]).strip()
+            return data
+    return {}
 
 
 def _resolve_slug(base: str, nl: str, sql_dir: Path) -> str:
@@ -111,6 +113,7 @@ def write_query_markdown(
     Deterministic: the same NL updates the same file; a different NL that
     slugs to an existing name gets a numeric suffix.
     """
+    nl = nl.strip()  # canonical form — stored, slugged, and matched consistently
     sql_dir = knowledge_sql_dir(project_path)
     sql_dir.mkdir(parents=True, exist_ok=True)
     slug = _resolve_slug(slugify(nl), nl, sql_dir)

--- a/core/wren/src/wren/memory/markdown.py
+++ b/core/wren/src/wren/memory/markdown.py
@@ -1,0 +1,122 @@
+"""Markdown source-of-truth for NL→SQL memory pairs (``knowledge/sql/<slug>.md``).
+
+Dependency-free: no LanceDB / pyarrow / sentence-transformers. The markdown file
+is the source of truth; the LanceDB index (when the ``memory`` extra is
+installed) is a derived artifact built from it — mirroring how ``wren context
+build`` compiles YAML into ``target/mdl.json``.
+
+File format — YAML frontmatter, optional markdown body for notes::
+
+    ---
+    nl: What is the total revenue across all orders?
+    sql: |
+      SELECT SUM(amount) AS total_revenue FROM orders
+    datasource: postgres
+    tags:
+      - revenue
+    source: user
+    ---
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_KNOWLEDGE_SQL_SUBDIR = ("knowledge", "sql")
+_MAX_SLUG_LEN = 60
+
+
+def slugify(text: str) -> str:
+    """Normalize NL text into a filesystem-safe, deterministic slug."""
+    text = re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+    if len(text) > _MAX_SLUG_LEN:
+        text = text[:_MAX_SLUG_LEN].rstrip("-")
+    return text or "query"
+
+
+def knowledge_sql_dir(project_path: Path) -> Path:
+    return project_path.joinpath(*_KNOWLEDGE_SQL_SUBDIR)
+
+
+def parse_query_markdown(path: Path) -> dict:
+    """Parse a knowledge/sql/*.md file into its frontmatter dict.
+
+    Returns the frontmatter mapping with an extra ``_body`` key (stripped
+    markdown body). Returns {} when the file has no frontmatter.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    # Split: ---\n<frontmatter>\n---\n<body>
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    data = yaml.safe_load(parts[1]) or {}
+    if not isinstance(data, dict):
+        return {}
+    data["_body"] = parts[2].strip()
+    return data
+
+
+def _resolve_slug(base: str, nl: str, sql_dir: Path) -> str:
+    """Deterministic slug; reuse the file for the same NL, suffix on collision."""
+    candidate = base
+    n = 1
+    while True:
+        dest = sql_dir / f"{candidate}.md"
+        if not dest.exists():
+            return candidate
+        # Same NL → same logical pair → reuse (update in place).
+        existing = parse_query_markdown(dest).get("nl")
+        if existing == nl:
+            return candidate
+        n += 1
+        candidate = f"{base}-{n}"
+
+
+def render_query_markdown(
+    nl: str,
+    sql: str,
+    *,
+    datasource: str | None = None,
+    tags: list[str] | None = None,
+    source: str = "user",
+) -> str:
+    """Render the frontmatter document for a NL→SQL pair."""
+    front: dict = {"nl": nl.strip(), "sql": sql.strip(), "source": source}
+    if datasource:
+        front["datasource"] = datasource
+    if tags:
+        front["tags"] = tags
+    body = yaml.safe_dump(
+        front, sort_keys=False, allow_unicode=True, default_flow_style=False
+    )
+    return f"---\n{body}---\n"
+
+
+def write_query_markdown(
+    project_path: Path,
+    nl: str,
+    sql: str,
+    *,
+    datasource: str | None = None,
+    tags: list[str] | None = None,
+    source: str = "user",
+) -> Path:
+    """Write a NL→SQL pair to ``knowledge/sql/<slug>.md``. Returns the path.
+
+    Deterministic: the same NL updates the same file; a different NL that
+    slugs to an existing name gets a numeric suffix.
+    """
+    sql_dir = knowledge_sql_dir(project_path)
+    sql_dir.mkdir(parents=True, exist_ok=True)
+    slug = _resolve_slug(slugify(nl), nl, sql_dir)
+    dest = sql_dir / f"{slug}.md"
+    dest.write_text(
+        render_query_markdown(nl, sql, datasource=datasource, tags=tags, source=source),
+        encoding="utf-8",
+    )
+    return dest

--- a/core/wren/tests/test_cli_memory_detection.py
+++ b/core/wren/tests/test_cli_memory_detection.py
@@ -44,9 +44,9 @@ def test_memory_subcommand_registered_when_extra_present():
     assert "memory" in names, "memory subcommand not registered despite extra installed"
 
 
-@pytest.mark.skipif(MEMORY_INSTALLED, reason="memory extra IS installed")
-def test_memory_subcommand_absent_when_extra_missing():
-    """The `memory` subcommand group is not registered when the extra is missing."""
+def test_memory_subcommand_always_registered():
+    """`memory` is always registered — `wren memory store` writes knowledge/sql/*.md
+    without the extra; lancedb-backed commands degrade with a clear message."""
     cli = importlib.import_module("wren.cli")
     names = {g.typer_instance.info.name for g in cli.app.registered_groups}
-    assert "memory" not in names, "memory subcommand registered without the extra"
+    assert "memory" in names, "memory subcommand should always be registered"

--- a/core/wren/tests/unit/test_memory_markdown.py
+++ b/core/wren/tests/unit/test_memory_markdown.py
@@ -1,0 +1,96 @@
+"""O4 — knowledge/sql/*.md is the source of truth for NL→SQL memory.
+
+These run in the unit job (no `memory` extra): markdown writing is
+dependency-free and `wren memory store` must work without LanceDB.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from wren.cli import app
+from wren.memory.markdown import (
+    parse_query_markdown,
+    slugify,
+    write_query_markdown,
+)
+
+runner = CliRunner()
+
+
+def test_slugify_normalizes_and_truncates():
+    assert slugify("What is the total revenue?") == "what-is-the-total-revenue"
+    assert slugify("  Trim/These  ") == "trim-these"
+    assert slugify("!!!") == "query"
+    assert len(slugify("word " * 40)) <= 60
+
+
+def test_write_query_markdown_frontmatter(tmp_path):
+    dest = write_query_markdown(
+        tmp_path,
+        "Total revenue?",
+        "SELECT SUM(amount) FROM orders",
+        datasource="postgres",
+        tags=["revenue", "kpi"],
+    )
+    assert dest == tmp_path / "knowledge" / "sql" / "total-revenue.md"
+    fm = parse_query_markdown(dest)
+    assert fm["nl"] == "Total revenue?"
+    assert "SUM(amount)" in fm["sql"]
+    assert fm["datasource"] == "postgres"
+    assert fm["tags"] == ["revenue", "kpi"]
+    assert fm["source"] == "user"
+
+
+def test_write_query_markdown_minimal(tmp_path):
+    dest = write_query_markdown(tmp_path, "Count orders", "SELECT COUNT(*) FROM orders")
+    fm = parse_query_markdown(dest)
+    assert fm["nl"] == "Count orders"
+    assert "datasource" not in fm
+    assert "tags" not in fm
+
+
+def test_same_nl_updates_same_file(tmp_path):
+    a = write_query_markdown(tmp_path, "Total revenue?", "SELECT 1")
+    b = write_query_markdown(
+        tmp_path, "Total revenue?", "SELECT SUM(amount) FROM orders"
+    )
+    assert a == b  # same slug, updated in place
+    files = list((tmp_path / "knowledge" / "sql").glob("*.md"))
+    assert len(files) == 1
+    assert "SUM(amount)" in parse_query_markdown(b)["sql"]
+
+
+def test_slug_collision_gets_suffix(tmp_path):
+    a = write_query_markdown(tmp_path, "Revenue?!", "SELECT 1")
+    b = write_query_markdown(tmp_path, "Revenue???", "SELECT 2")  # same slug base
+    assert a != b
+    assert b.name == "revenue-2.md"
+    assert len(list((tmp_path / "knowledge" / "sql").glob("*.md"))) == 2
+
+
+def test_cli_store_writes_markdown_without_extra(tmp_path, monkeypatch):
+    """`wren memory store` works without the memory extra — markdown only."""
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "memory",
+            "store",
+            "--nl",
+            "Top customers by revenue",
+            "--sql",
+            "SELECT customer_id, SUM(amount) FROM orders GROUP BY 1",
+            "--tags",
+            "revenue,customers",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Stored:" in result.output
+    md = tmp_path / "knowledge" / "sql" / "top-customers-by-revenue.md"
+    assert md.exists()
+    fm = yaml.safe_load(md.read_text().split("---")[1])
+    assert fm["tags"] == ["revenue", "customers"]

--- a/core/wren/tests/unit/test_memory_markdown.py
+++ b/core/wren/tests/unit/test_memory_markdown.py
@@ -64,6 +64,23 @@ def test_same_nl_updates_same_file(tmp_path):
     assert "SUM(amount)" in parse_query_markdown(b)["sql"]
 
 
+def test_same_nl_with_whitespace_reuses_file(tmp_path):
+    """NLs differing only by surrounding whitespace map to the same file."""
+    a = write_query_markdown(tmp_path, "Total revenue?", "SELECT 1")
+    b = write_query_markdown(tmp_path, "  Total revenue?  ", "SELECT 2")
+    assert a == b
+    assert len(list((tmp_path / "knowledge" / "sql").glob("*.md"))) == 1
+
+
+def test_sql_containing_dashes_roundtrips(tmp_path):
+    """SQL whose body contains a '---' line must not break frontmatter parsing."""
+    sql = "SELECT 1\n---\nUNION ALL\nSELECT 2"
+    dest = write_query_markdown(tmp_path, "Dashy query", sql)
+    fm = parse_query_markdown(dest)
+    assert fm["nl"] == "Dashy query"
+    assert fm["sql"] == sql
+
+
 def test_slug_collision_gets_suffix(tmp_path):
     a = write_query_markdown(tmp_path, "Revenue?!", "SELECT 1")
     b = write_query_markdown(tmp_path, "Revenue???", "SELECT 2")  # same slug base

--- a/examples/v5-jaffle/knowledge/sql/total-revenue.md
+++ b/examples/v5-jaffle/knowledge/sql/total-revenue.md
@@ -1,7 +1,8 @@
-# Total revenue
-
-**NL:** What is the total revenue across all orders?
-
-```sql
-SELECT SUM(amount) AS total_revenue FROM orders
-```
+---
+nl: What is the total revenue across all orders?
+sql: |
+  SELECT SUM(amount) AS total_revenue FROM orders
+source: user
+tags:
+  - revenue
+---


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Makes `knowledge/sql/<slug>.md` the source of truth for NL→SQL memory. `wren memory store`
now writes a markdown file first (always), then best-effort indexes it into LanceDB when
the `memory` extra is installed — mirroring how YAML compiles to `target/mdl.json`.

## Changes

- **New `wren.memory.markdown`** — dependency-free (no lancedb/pyarrow/sentence-transformers):
  `slugify`, `write_query_markdown`, `parse_query_markdown`. Format is YAML frontmatter
  (`nl`, `sql`, `datasource`, `tags`, `source`) with an optional markdown body.
  Deterministic slug: the same NL updates the same file; a colliding slug gets a numeric
  suffix.
- **`wren memory store`** writes the markdown (source of truth) unconditionally, then
  best-effort indexes into LanceDB — when the extra is absent it silently stays
  markdown-only.
- **`memory` subcommand group is now always registered** so `store` works without the
  extra. The lancedb-backed commands (`index`/`recall`/`status`/`reset`) still degrade with
  the existing "install wren[memory]" message. CLI startup stays light — lancedb and the ML
  stack are imported lazily inside the commands that need them, never at import time
  (guarded by the existing heavy-import test).
- Aligned the `v5-jaffle` golden `knowledge/sql` example with the frontmatter format.

## Scope / boundaries

- `recall`/`index`/`reset` still read from LanceDB — re-sourcing them from markdown is **O5**;
  a pluggable index backend + grep recall without the extra is **O6**; migrating existing
  LanceDB history into markdown is **O7**.
- `WrenMemory.store_query` (the Python API) is unchanged here; the CLI is the documented
  store entry point.

## Tests

New `tests/unit/test_memory_markdown.py` (runs in the unit job, **no extra**): slug
normalization/truncation, frontmatter round-trip, same-NL update vs collision suffix, and
`wren memory store` writing markdown with no `memory` extra installed.
`test_cli_memory_detection.py` updated: `memory` is always registered, and the
heavy-import guard (no torch/lancedb at startup) still holds.

Full unit suite green (`pytest tests/unit/ --ignore=tests/unit/test_memory.py`):
704 passed, 1 skipped. `ruff` clean. The with-extra indexing path is covered by the
`memory tests` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory commands are now always accessible in the CLI
  * Queries are automatically saved to project knowledge files with metadata support (tags, data source)

* **Improvements**
  * Enhanced graceful handling when optional semantic indexing dependencies are unavailable—queries still save successfully with clear messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->