### PR TITLE
feat(wren): source memory index/recall/reset from knowledge/sql markdown

### DIFF
--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -200,12 +200,25 @@ def index(
         + "."
     )
 
-    # ── Auto-load project queries.yml ──
+    # ── Rebuild query history from knowledge/sql/*.md (source of truth) ──
+    # Legacy queries.yml is still loaded when present, for the transition.
     if not no_queries:
         try:
             from wren.context import discover_project_path  # noqa: PLC0415
+            from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
 
             project_path = discover_project_path(explicit=None)
+
+            md_pairs = load_query_pairs(project_path)
+            if md_pairs:
+                # upsert → re-running index converges on the markdown content.
+                res = mem_store.load_queries(md_pairs, upsert=True)
+                typer.echo(
+                    f"Indexed {res['loaded'] + res['updated']} pair(s) from "
+                    f"knowledge/sql/.",
+                    err=True,
+                )
+
             queries_file = project_path / "queries.yml"
             if queries_file.exists():
                 raw = queries_file.read_text(encoding="utf-8")
@@ -216,7 +229,7 @@ def index(
                     skipped = load_result["skipped"]
                     if loaded:
                         typer.echo(
-                            f"Loaded {loaded} pair(s) from queries.yml"
+                            f"Loaded {loaded} pair(s) from queries.yml (legacy)"
                             f" ({skipped} skipped).",
                             err=True,
                         )
@@ -366,7 +379,27 @@ def recall(
     """Search past NL→SQL pairs by semantic similarity."""
     mem_store = _get_store(path)
     results = mem_store.recall_queries(query, limit=limit, datasource=datasource)
+    _annotate_markdown_paths(results)
     _print_results(results, output)
+
+
+def _annotate_markdown_paths(results: list[dict]) -> None:
+    """Best-effort: point each recall result at its knowledge/sql/*.md source."""
+    try:
+        from wren.context import discover_project_path  # noqa: PLC0415
+        from wren.memory.markdown import knowledge_sql_dir, slugify  # noqa: PLC0415
+
+        project = discover_project_path()
+    except (SystemExit, Exception):  # noqa: BLE001 — annotation is optional
+        return
+    sql_dir = knowledge_sql_dir(project)
+    for r in results:
+        nl = r.get("nl_query") or r.get("nl")
+        if not nl:
+            continue
+        candidate = sql_dir / f"{slugify(nl)}.md"
+        if candidate.exists():
+            r["path"] = str(candidate.relative_to(project))
 
 
 @memory_app.command()
@@ -392,14 +425,61 @@ def reset(
         bool, typer.Option("--force", "-f", help="Skip confirmation")
     ] = False,
 ) -> None:
-    """Drop all memory tables and start fresh."""
+    """Drop the derived memory index. knowledge/sql/*.md is preserved.
+
+    The LanceDB index is a derived artifact — after reset, run `wren memory
+    index` to rebuild it from the markdown source of truth.
+    """
     if not force:
-        confirm = typer.confirm("This will delete all indexed memory. Continue?")
+        confirm = typer.confirm(
+            "This drops the derived memory index. Your knowledge/sql/*.md "
+            "source files are kept. Continue?"
+        )
         if not confirm:
             raise typer.Abort()
     mem_store = _get_store(path)
     mem_store.reset()
-    typer.echo("Memory reset.")
+    typer.echo(
+        "Memory index reset. Run `wren memory index` to rebuild from knowledge/sql/."
+    )
+
+
+@memory_app.command()
+def check(
+    path: PathOpt = None,
+) -> None:
+    """Report drift between knowledge/sql/*.md (source) and the LanceDB index."""
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
+
+    try:
+        project = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    md_nls = {p["nl"] for p in load_query_pairs(project)}
+    mem_store = _get_store(path)
+    indexed, _ = mem_store.list_queries(limit=1_000_000)
+    indexed_nls = {r.get("nl_query") for r in indexed}
+    # Only user-sourced pairs come from markdown; seeds/views are derived from
+    # the manifest and are not expected to have a knowledge/sql/ file.
+    indexed_user = {r.get("nl_query") for r in indexed if r.get("tags") == "source:user"}
+
+    missing = md_nls - indexed_nls  # in markdown but not indexed
+    stale = indexed_user - md_nls  # user-indexed but no longer in markdown
+
+    typer.echo(f"knowledge/sql: {len(md_nls)} pair(s); index: {len(indexed_nls)} pair(s)")
+    if not missing and not stale:
+        typer.echo("In sync.")
+        return
+    if missing:
+        typer.echo(f"  {len(missing)} not indexed — run `wren memory index`.")
+    if stale:
+        typer.echo(
+            f"  {len(stale)} user pair(s) indexed without markdown — "
+            "stale index, run `wren memory index`."
+        )
 
 
 # ── List / Forget / Dump / Load ──────────────────────────────────────────

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -384,22 +384,23 @@ def recall(
 
 
 def _annotate_markdown_paths(results: list[dict]) -> None:
-    """Best-effort: point each recall result at its knowledge/sql/*.md source."""
+    """Best-effort: point each recall result at its knowledge/sql/*.md source.
+
+    Matches on the exact NL (not a derived slug), so collision-suffixed files
+    are attributed correctly.
+    """
     try:
         from wren.context import discover_project_path  # noqa: PLC0415
-        from wren.memory.markdown import knowledge_sql_dir, slugify  # noqa: PLC0415
+        from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
 
         project = discover_project_path()
     except (SystemExit, Exception):  # noqa: BLE001 — annotation is optional
         return
-    sql_dir = knowledge_sql_dir(project)
+    nl_to_path = {p["nl"]: p["path"] for p in load_query_pairs(project)}
     for r in results:
         nl = r.get("nl_query") or r.get("nl")
-        if not nl:
-            continue
-        candidate = sql_dir / f"{slugify(nl)}.md"
-        if candidate.exists():
-            r["path"] = str(candidate.relative_to(project))
+        if nl and nl in nl_to_path:
+            r["path"] = nl_to_path[nl]
 
 
 @memory_app.command()
@@ -468,7 +469,8 @@ def check(
         r.get("nl_query") for r in indexed if r.get("tags") == "source:user"
     }
 
-    missing = md_nls - indexed_nls  # in markdown but not indexed
+    # Compare user pairs only — seed/view rows aren't markdown-backed.
+    missing = md_nls - indexed_user  # in markdown but not indexed as a user pair
     stale = indexed_user - md_nls  # user-indexed but no longer in markdown
 
     typer.echo(

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -464,12 +464,16 @@ def check(
     indexed_nls = {r.get("nl_query") for r in indexed}
     # Only user-sourced pairs come from markdown; seeds/views are derived from
     # the manifest and are not expected to have a knowledge/sql/ file.
-    indexed_user = {r.get("nl_query") for r in indexed if r.get("tags") == "source:user"}
+    indexed_user = {
+        r.get("nl_query") for r in indexed if r.get("tags") == "source:user"
+    }
 
     missing = md_nls - indexed_nls  # in markdown but not indexed
     stale = indexed_user - md_nls  # user-indexed but no longer in markdown
 
-    typer.echo(f"knowledge/sql: {len(md_nls)} pair(s); index: {len(indexed_nls)} pair(s)")
+    typer.echo(
+        f"knowledge/sql: {len(md_nls)} pair(s); index: {len(indexed_nls)} pair(s)"
+    )
     if not missing and not stale:
         typer.echo("In sync.")
         return

--- a/core/wren/src/wren/memory/markdown.py
+++ b/core/wren/src/wren/memory/markdown.py
@@ -55,7 +55,10 @@ def parse_query_markdown(path: Path) -> dict:
     # inside a value is indented and never matches here.
     for i in range(1, len(lines)):
         if lines[i].rstrip("\n") == "---":
-            data = yaml.safe_load("".join(lines[1:i])) or {}
+            try:
+                data = yaml.safe_load("".join(lines[1:i])) or {}
+            except yaml.YAMLError:
+                return {}  # malformed frontmatter — treat as no pair, don't crash callers
             if not isinstance(data, dict):
                 return {}
             data["_body"] = "".join(lines[i + 1 :]).strip()

--- a/core/wren/src/wren/memory/markdown.py
+++ b/core/wren/src/wren/memory/markdown.py
@@ -63,6 +63,33 @@ def parse_query_markdown(path: Path) -> dict:
     return {}
 
 
+def load_query_pairs(project_path: Path) -> list[dict]:
+    """Load every NL→SQL pair from ``knowledge/sql/*.md`` (the source of truth).
+
+    Returns dicts shaped for ``MemoryStore.load_queries``: ``nl``, ``sql``,
+    plus ``datasource`` / ``tags`` / ``source`` when present and ``path`` (the
+    source file, relative to the project). Files without a parseable ``nl``+``sql``
+    frontmatter are skipped.
+    """
+    sql_dir = knowledge_sql_dir(project_path)
+    if not sql_dir.is_dir():
+        return []
+    pairs: list[dict] = []
+    for md in sorted(sql_dir.glob("*.md")):
+        fm = parse_query_markdown(md)
+        nl, sql = fm.get("nl"), fm.get("sql")
+        if not nl or not sql:
+            continue
+        pair: dict = {"nl": nl, "sql": sql, "source": fm.get("source", "user")}
+        if fm.get("datasource"):
+            pair["datasource"] = fm["datasource"]
+        if fm.get("tags"):
+            pair["tags"] = fm["tags"]
+        pair["path"] = str(md.relative_to(project_path))
+        pairs.append(pair)
+    return pairs
+
+
 def _resolve_slug(base: str, nl: str, sql_dir: Path) -> str:
     """Deterministic slug; reuse the file for the same NL, suffix on collision."""
     candidate = base

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -857,3 +857,47 @@ class TestYamlRoundTrip:
         # All should be skipped as duplicates
         assert result["skipped"] == 2
         assert result["loaded"] == 0
+
+
+# ── O5: knowledge/sql markdown is the source of truth for the index ────────
+
+
+@pytest.mark.unit
+class TestMarkdownSourcedIndex:
+    """index/recall/reset treat LanceDB as a derived index over knowledge/sql/."""
+
+    def test_load_query_pairs_index_is_convergent(self, memory_store, tmp_path):
+        from wren.memory.markdown import (  # noqa: PLC0415
+            load_query_pairs,
+            write_query_markdown,
+        )
+
+        write_query_markdown(tmp_path, "Total revenue", "SELECT SUM(amount) FROM o")
+        write_query_markdown(tmp_path, "Count orders", "SELECT COUNT(*) FROM o")
+        pairs = load_query_pairs(tmp_path)
+
+        memory_store.load_queries(pairs, upsert=True)
+        first, _ = memory_store.list_queries(limit=100)
+        # re-running index converges (no duplication)
+        memory_store.load_queries(load_query_pairs(tmp_path), upsert=True)
+        second, _ = memory_store.list_queries(limit=100)
+        assert len(first) == len(second) == 2
+
+    def test_reset_then_reindex_restores_from_markdown(self, memory_store, tmp_path):
+        from wren.memory.markdown import (  # noqa: PLC0415
+            load_query_pairs,
+            write_query_markdown,
+        )
+
+        write_query_markdown(tmp_path, "Total revenue", "SELECT SUM(amount) FROM o")
+        memory_store.load_queries(load_query_pairs(tmp_path), upsert=True)
+
+        memory_store.reset()  # derived index dropped
+        assert memory_store.status()["tables"] == {}
+        # markdown source survives the reset
+        assert (tmp_path / "knowledge" / "sql" / "total-revenue.md").exists()
+
+        # rebuild from markdown → recall works again
+        memory_store.load_queries(load_query_pairs(tmp_path), upsert=True)
+        hits = memory_store.recall_queries("revenue", limit=3)
+        assert any("SUM(amount)" in h["sql_query"] for h in hits)

--- a/core/wren/tests/unit/test_memory_markdown.py
+++ b/core/wren/tests/unit/test_memory_markdown.py
@@ -6,13 +6,12 @@ dependency-free and `wren memory store` must work without LanceDB.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import yaml
 from typer.testing import CliRunner
 
 from wren.cli import app
 from wren.memory.markdown import (
+    load_query_pairs,
     parse_query_markdown,
     slugify,
     write_query_markdown,
@@ -87,6 +86,37 @@ def test_slug_collision_gets_suffix(tmp_path):
     assert a != b
     assert b.name == "revenue-2.md"
     assert len(list((tmp_path / "knowledge" / "sql").glob("*.md"))) == 2
+
+
+def test_load_query_pairs(tmp_path):
+    write_query_markdown(
+        tmp_path,
+        "Total revenue",
+        "SELECT SUM(amount) FROM orders",
+        datasource="postgres",
+        tags=["revenue"],
+    )
+    write_query_markdown(tmp_path, "Count orders", "SELECT COUNT(*) FROM orders")
+    pairs = load_query_pairs(tmp_path)
+    assert len(pairs) == 2
+    by_nl = {p["nl"]: p for p in pairs}
+    assert by_nl["Total revenue"]["sql"].startswith("SELECT SUM")
+    assert by_nl["Total revenue"]["datasource"] == "postgres"
+    assert by_nl["Total revenue"]["tags"] == ["revenue"]
+    assert by_nl["Total revenue"]["source"] == "user"
+    assert by_nl["Count orders"]["path"] == "knowledge/sql/count-orders.md"
+
+
+def test_load_query_pairs_empty(tmp_path):
+    assert load_query_pairs(tmp_path) == []
+
+
+def test_load_query_pairs_skips_unparseable(tmp_path):
+    sql_dir = tmp_path / "knowledge" / "sql"
+    sql_dir.mkdir(parents=True)
+    (sql_dir / "notes.md").write_text("# just a note, no frontmatter\n")
+    (sql_dir / "partial.md").write_text("---\nnl: only nl, no sql\n---\n")
+    assert load_query_pairs(tmp_path) == []
 
 
 def test_cli_store_writes_markdown_without_extra(tmp_path, monkeypatch):

--- a/core/wren/tests/unit/test_memory_markdown.py
+++ b/core/wren/tests/unit/test_memory_markdown.py
@@ -116,7 +116,23 @@ def test_load_query_pairs_skips_unparseable(tmp_path):
     sql_dir.mkdir(parents=True)
     (sql_dir / "notes.md").write_text("# just a note, no frontmatter\n")
     (sql_dir / "partial.md").write_text("---\nnl: only nl, no sql\n---\n")
-    assert load_query_pairs(tmp_path) == []
+    # malformed YAML frontmatter must be skipped, not crash the whole load
+    (sql_dir / "broken.md").write_text("---\nnl: [unterminated\nsql: x\n---\n")
+    write_query_markdown(tmp_path, "Good one", "SELECT 1")
+    pairs = load_query_pairs(tmp_path)
+    assert [p["nl"] for p in pairs] == ["Good one"]
+
+
+def test_recall_path_annotation_handles_collisions(tmp_path, monkeypatch):
+    """recall path annotation matches on exact NL, not a derived slug."""
+    from wren.memory.cli import _annotate_markdown_paths  # noqa: PLC0415
+
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    write_query_markdown(tmp_path, "Revenue?!", "SELECT 1")  # -> revenue.md
+    write_query_markdown(tmp_path, "Revenue???", "SELECT 2")  # -> revenue-2.md
+    results = [{"nl_query": "Revenue???", "sql_query": "SELECT 2"}]
+    _annotate_markdown_paths(results)
+    assert results[0]["path"] == "knowledge/sql/revenue-2.md"
 
 
 def test_cli_store_writes_markdown_without_extra(tmp_path, monkeypatch):


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Makes the LanceDB index a **derived artifact** over `knowledge/sql/*.md` (the source of
truth, from O4) — mirroring how YAML compiles to `target/mdl.json`. `index` rebuilds from
markdown, `reset` no longer loses data, and `recall` traces back to the source file.

## Changes

- **`wren memory index`** now rebuilds query history from `knowledge/sql/*.md` (`upsert` →
  re-running converges on the markdown). The legacy `queries.yml` is still loaded when
  present, for the transition.
- **`wren memory recall`** annotates each hit with its `knowledge/sql/*.md` path.
- **`wren memory reset`** drops only the derived index; the markdown source is preserved,
  and the message points at `wren memory index` to rebuild. (Data is no longer lost on
  reset.)
- **`wren memory check`** (new) reports drift between `knowledge/sql/` and the index.
  Seed/view pairs are excluded — only user pairs originate from markdown.
- **`load_query_pairs()`** (new, dependency-free) reads `knowledge/sql/*.md` into
  `load_queries`-shaped dicts.

`store.py` is unchanged — the markdown↔index wiring lives in the CLI, which already has the
project context; the store stays project-agnostic.

## Scope

- Still assumes the `memory` extra for `index`/`recall`/`check` (they're semantic search).
  Decoupling the index backend + grep recall without the extra is **O6**; migrating an
  existing LanceDB `query_history` into markdown is **O7**.

## Tests

- Unit (no extra): `load_query_pairs` parsing — fields, `path`, skips unparseable files.
- Integration (`memory` extra, `memory tests` job): index is convergent under re-run
  (`upsert`), and `reset` → re-`index` restores recall from the untouched markdown.

Verified locally with the `memory` extra installed: full memory suite **88 passed**, and
the end-to-end CLI flow (`index` → `check` "in sync" → `recall` shows path → `reset` →
`check` "not indexed"). Full unit suite **783 passed, 1 skipped**; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `check` command to detect synchronization issues between markdown source files and indexed memory
  * `recall` command now displays markdown file paths for results

* **Improvements**
  * Enhanced query loading from markdown sources with improved error handling
  * Clarified `reset` command messaging: source files are preserved; rerun `index` to rebuild memory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->