### PR TITLE
feat(wren): pluggable memory recall backend with dependency-free grep

### DIFF
--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -189,7 +189,8 @@ def index(
             f"grep backend: {n} pair(s) in knowledge/sql/ — no index build needed."
         )
         typer.echo(
-            "Semantic search (`wren memory fetch`/`recall`) needs `wren[memory]`.",
+            "`wren memory recall` works over grep; semantic schema search "
+            "(`wren memory fetch`) needs `wren[memory]`.",
             err=True,
         )
         return

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -167,7 +167,33 @@ def index(
         typer.Option("--no-queries", help="Skip auto-loading project queries.yml."),
     ] = False,
 ) -> None:
-    """Index MDL schema into LanceDB (and optionally seed example queries)."""
+    """Index the project for recall.
+
+    With the ``memory`` extra: builds the LanceDB semantic index (schema + seed
+    + knowledge/sql pairs). Without it: the grep backend reads knowledge/sql/*.md
+    directly, so there is nothing to build.
+    """
+    from wren.memory.index_backend import resolve_backend  # noqa: PLC0415
+
+    if resolve_backend() == "grep":
+        from wren.context import discover_project_path  # noqa: PLC0415
+        from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
+
+        try:
+            project_path = discover_project_path()
+        except SystemExit as e:
+            typer.echo(str(e), err=True)
+            raise typer.Exit(1)
+        n = len(load_query_pairs(project_path))
+        typer.echo(
+            f"grep backend: {n} pair(s) in knowledge/sql/ — no index build needed."
+        )
+        typer.echo(
+            "Semantic search (`wren memory fetch`/`recall`) needs `wren[memory]`.",
+            err=True,
+        )
+        return
+
     manifest = _load_manifest(mdl)
 
     if include_instructions and mdl is None:
@@ -376,9 +402,21 @@ def recall(
     path: PathOpt = None,
     output: OutputOpt = "table",
 ) -> None:
-    """Search past NL→SQL pairs by semantic similarity."""
-    mem_store = _get_store(path)
-    results = mem_store.recall_queries(query, limit=limit, datasource=datasource)
+    """Search past NL→SQL pairs over knowledge/sql/.
+
+    Uses semantic search with the ``memory`` extra, or dependency-free token
+    matching (grep backend) without it.
+    """
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.index_backend import get_index  # noqa: PLC0415
+
+    try:
+        project = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+    idx = get_index(project, path or str(_default_memory_path()))
+    results = idx.search(query, limit=limit, datasource=datasource)
     _annotate_markdown_paths(results)
     _print_results(results, output)
 
@@ -407,10 +445,20 @@ def _annotate_markdown_paths(results: list[dict]) -> None:
 def status(
     path: PathOpt = None,
 ) -> None:
-    """Show memory index statistics."""
-    mem_store = _get_store(path)
-    info = mem_store.status()
-    typer.echo(f"Path: {info['path']}")
+    """Show memory backend and index statistics."""
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.index_backend import get_index  # noqa: PLC0415
+
+    try:
+        project = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+    info = get_index(project, path or str(_default_memory_path())).status()
+    typer.echo(f"Backend: {info['backend']}")
+    if info["backend"] == "grep":
+        typer.echo(f"  knowledge/sql: {info['pairs']} pair(s)")
+        return
     tables = info.get("tables", {})
     if not tables:
         typer.echo("No tables indexed yet.")
@@ -431,6 +479,18 @@ def reset(
     The LanceDB index is a derived artifact — after reset, run `wren memory
     index` to rebuild it from the markdown source of truth.
     """
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.index_backend import get_index  # noqa: PLC0415
+
+    try:
+        project = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+    idx = get_index(project, path or str(_default_memory_path()))
+    if idx.name == "grep":
+        typer.echo("grep backend has no derived index — knowledge/sql/ is the source.")
+        return
     if not force:
         confirm = typer.confirm(
             "This drops the derived memory index. Your knowledge/sql/*.md "
@@ -438,8 +498,7 @@ def reset(
         )
         if not confirm:
             raise typer.Abort()
-    mem_store = _get_store(path)
-    mem_store.reset()
+    idx.reset()
     typer.echo(
         "Memory index reset. Run `wren memory index` to rebuild from knowledge/sql/."
     )
@@ -449,8 +508,9 @@ def reset(
 def check(
     path: PathOpt = None,
 ) -> None:
-    """Report drift between knowledge/sql/*.md (source) and the LanceDB index."""
+    """Report drift between knowledge/sql/*.md (source) and the derived index."""
     from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.index_backend import get_index  # noqa: PLC0415
     from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
 
     try:
@@ -459,8 +519,16 @@ def check(
         typer.echo(str(e), err=True)
         raise typer.Exit(1)
 
+    idx = get_index(project, path or str(_default_memory_path()))
+    if idx.name == "grep":
+        n = len(load_query_pairs(project))
+        typer.echo(
+            f"grep backend: knowledge/sql/ is the index ({n} pair(s)) — always in sync."
+        )
+        return
+
     md_nls = {p["nl"] for p in load_query_pairs(project)}
-    mem_store = _get_store(path)
+    mem_store = idx.store
     indexed, _ = mem_store.list_queries(limit=1_000_000)
     indexed_nls = {r.get("nl_query") for r in indexed}
     # Only user-sourced pairs come from markdown; seeds/views are derived from

--- a/core/wren/src/wren/memory/index_backend.py
+++ b/core/wren/src/wren/memory/index_backend.py
@@ -145,14 +145,21 @@ def _extra_available() -> bool:
 
 
 def resolve_backend(env: str | None = None) -> str:
-    """Return the backend name: explicit env override, else auto-detect."""
+    """Return the backend that will actually be used.
+
+    Honors an explicit ``WREN_MEMORY_BACKEND=grep|lancedb`` (or *env*) override,
+    else auto-detects. ``lancedb`` is downgraded to ``grep`` whenever its extra
+    is unavailable — so the result always reflects what ``get_index`` will build.
+    """
     choice = (
         (env if env is not None else os.environ.get("WREN_MEMORY_BACKEND", ""))
         .strip()
         .lower()
     )
-    if choice in {"grep", "lancedb"}:
-        return choice
+    if choice == "grep":
+        return "grep"
+    # explicit "lancedb", an unrecognized value, or empty → prefer lancedb when
+    # its extra is importable, otherwise grep.
     return "lancedb" if _extra_available() else "grep"
 
 
@@ -161,9 +168,13 @@ def get_index(
 ) -> MemoryIndex:
     """Construct the resolved MemoryIndex for *project_path*.
 
-    Falls back to GrepIndex if LanceDB is requested but its extra is missing.
+    An explicit *backend* is normalized (``" LanceDB "`` → ``lancedb``); an
+    unrecognized value falls back to auto-detection. LanceDB downgrades to
+    GrepIndex when its extra is missing.
     """
-    name = backend or resolve_backend()
+    name = (backend or "").strip().lower()
+    if name not in {"grep", "lancedb"}:
+        name = resolve_backend()
     if name == "lancedb" and _extra_available():
         return LanceDBIndex(project_path, path)
     return GrepIndex(project_path)

--- a/core/wren/src/wren/memory/index_backend.py
+++ b/core/wren/src/wren/memory/index_backend.py
@@ -1,0 +1,169 @@
+"""Pluggable NL→SQL recall backends over ``knowledge/sql/*.md``.
+
+The markdown files are the source of truth. A backend is just a query interface
+over them:
+
+- ``GrepIndex`` — dependency-free token/substring search. The default when the
+  ``memory`` extra is absent; ``knowledge/sql/`` *is* the index (nothing to build).
+- ``LanceDBIndex`` — semantic search via the ``memory`` extra (lancedb +
+  sentence-transformers), with LanceDB as a derived index.
+
+Backend selection: ``WREN_MEMORY_BACKEND=grep|lancedb`` forces a choice;
+otherwise LanceDB is used when its extra is importable, else Grep.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from abc import ABC, abstractmethod
+from importlib.util import find_spec
+from pathlib import Path
+
+from wren.memory.markdown import load_query_pairs
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(text: str) -> set[str]:
+    return {t for t in _TOKEN_RE.findall((text or "").lower()) if len(t) >= 2}
+
+
+def _pair_to_result(pair: dict, *, score: int | None = None) -> dict:
+    """Shape a knowledge/sql pair like a recall row (parity with LanceDB)."""
+    tags = pair.get("tags")
+    row = {
+        "nl_query": pair["nl"],
+        "sql_query": pair["sql"],
+        "datasource": pair.get("datasource", ""),
+        "tags": ",".join(tags) if isinstance(tags, list) else (tags or ""),
+        "path": pair.get("path"),
+    }
+    if score is not None:
+        row["score"] = score
+    return row
+
+
+class MemoryIndex(ABC):
+    """Recall interface over knowledge/sql/. Implementations never persist the
+    markdown — they only build/search a (possibly derived) index over it."""
+
+    name: str
+
+    @abstractmethod
+    def rebuild(self) -> dict:
+        """(Re)build the index from knowledge/sql/. Returns a small summary."""
+
+    @abstractmethod
+    def search(
+        self, query: str, *, limit: int = 3, datasource: str | None = None
+    ) -> list[dict]:
+        """Return up to *limit* NL→SQL pairs relevant to *query*."""
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Drop any derived index. The markdown source is never touched."""
+
+    @abstractmethod
+    def status(self) -> dict:
+        """Return backend + size info."""
+
+
+class GrepIndex(MemoryIndex):
+    """Dependency-free recall: token-overlap + substring over knowledge/sql/."""
+
+    name = "grep"
+
+    def __init__(self, project_path: Path):
+        self._project = project_path
+
+    def rebuild(self) -> dict:
+        # The markdown is the index — nothing to build.
+        return {"backend": self.name, "pairs": len(load_query_pairs(self._project))}
+
+    def reset(self) -> None:
+        return  # no derived index to drop
+
+    def status(self) -> dict:
+        return {"backend": self.name, "pairs": len(load_query_pairs(self._project))}
+
+    def search(
+        self, query: str, *, limit: int = 3, datasource: str | None = None
+    ) -> list[dict]:
+        q_tokens = _tokens(query)
+        q_lower = query.strip().lower()
+        scored: list[tuple[int, dict]] = []
+        for pair in load_query_pairs(self._project):
+            if datasource and pair.get("datasource") != datasource:
+                continue
+            score = len(q_tokens & (_tokens(pair["nl"]) | _tokens(pair["sql"])))
+            if q_lower and q_lower in pair["nl"].lower():
+                score += 5  # whole-query substring match in the NL ranks highest
+            if score > 0:
+                scored.append((score, pair))
+        # Highest score first; stable tie-break by NL for determinism.
+        scored.sort(key=lambda s: (-s[0], s[1]["nl"]))
+        return [_pair_to_result(p, score=score) for score, p in scored[:limit]]
+
+
+class LanceDBIndex(MemoryIndex):
+    """Semantic recall via the ``memory`` extra; LanceDB is a derived index."""
+
+    name = "lancedb"
+
+    def __init__(self, project_path: Path, path: str):
+        from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+        self._project = project_path
+        self._store = MemoryStore(path=path)
+
+    @property
+    def store(self):
+        return self._store
+
+    def rebuild(self) -> dict:
+        pairs = load_query_pairs(self._project)
+        if not pairs:
+            return {"backend": self.name, "loaded": 0, "updated": 0}
+        res = self._store.load_queries(pairs, upsert=True)
+        return {"backend": self.name, **res}
+
+    def reset(self) -> None:
+        self._store.reset()
+
+    def status(self) -> dict:
+        return {"backend": self.name, **self._store.status()}
+
+    def search(
+        self, query: str, *, limit: int = 3, datasource: str | None = None
+    ) -> list[dict]:
+        return self._store.recall_queries(query, limit=limit, datasource=datasource)
+
+
+def _extra_available() -> bool:
+    return bool(find_spec("lancedb")) and bool(find_spec("sentence_transformers"))
+
+
+def resolve_backend(env: str | None = None) -> str:
+    """Return the backend name: explicit env override, else auto-detect."""
+    choice = (
+        (env if env is not None else os.environ.get("WREN_MEMORY_BACKEND", ""))
+        .strip()
+        .lower()
+    )
+    if choice in {"grep", "lancedb"}:
+        return choice
+    return "lancedb" if _extra_available() else "grep"
+
+
+def get_index(
+    project_path: Path, path: str, *, backend: str | None = None
+) -> MemoryIndex:
+    """Construct the resolved MemoryIndex for *project_path*.
+
+    Falls back to GrepIndex if LanceDB is requested but its extra is missing.
+    """
+    name = backend or resolve_backend()
+    if name == "lancedb" and _extra_available():
+        return LanceDBIndex(project_path, path)
+    return GrepIndex(project_path)

--- a/core/wren/tests/unit/test_index_backend.py
+++ b/core/wren/tests/unit/test_index_backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typer.testing import CliRunner
 
 from wren.cli import app
-from wren.memory.index_backend import GrepIndex, resolve_backend
+from wren.memory.index_backend import GrepIndex, get_index, resolve_backend
 from wren.memory.markdown import write_query_markdown
 
 runner = CliRunner()
@@ -58,8 +58,18 @@ def test_grep_rebuild_and_status_and_reset(tmp_path):
 
 
 def test_resolve_backend_env_override():
+    from wren.memory.index_backend import _extra_available  # noqa: PLC0415
+
     assert resolve_backend("grep") == "grep"
-    assert resolve_backend("lancedb") == "lancedb"
+    # explicit lancedb is honored only when its extra is importable, else grep
+    assert resolve_backend("lancedb") == ("lancedb" if _extra_available() else "grep")
+    # unrecognized values fall back to auto-detection
+    assert resolve_backend("bogus") in {"grep", "lancedb"}
+
+
+def test_get_index_normalizes_explicit_backend(tmp_path):
+    # explicit backend is stripped/lowercased before selection
+    assert isinstance(get_index(tmp_path, "x", backend=" GREP "), GrepIndex)
 
 
 # ── CLI commands over the grep backend (no extra needed) ───────────────────

--- a/core/wren/tests/unit/test_index_backend.py
+++ b/core/wren/tests/unit/test_index_backend.py
@@ -1,0 +1,105 @@
+"""O6 — pluggable recall backend; grep works without the `memory` extra.
+
+Runs in the unit job. The grep backend is dependency-free; CLI tests force
+WREN_MEMORY_BACKEND=grep so they exercise the no-extra path even when the
+extra happens to be installed locally.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from wren.cli import app
+from wren.memory.index_backend import GrepIndex, resolve_backend
+from wren.memory.markdown import write_query_markdown
+
+runner = CliRunner()
+
+
+# ── GrepIndex (dependency-free) ────────────────────────────────────────────
+
+
+def _seed(tmp_path):
+    write_query_markdown(
+        tmp_path, "Total revenue by month", "SELECT month, SUM(amount) FROM orders"
+    )
+    write_query_markdown(
+        tmp_path, "Number of customers", "SELECT COUNT(*) FROM customers"
+    )
+
+
+def test_grep_search_token_overlap(tmp_path):
+    _seed(tmp_path)
+    hits = GrepIndex(tmp_path).search("monthly revenue", limit=3)
+    assert hits
+    assert hits[0]["nl_query"] == "Total revenue by month"
+    assert hits[0]["path"] == "knowledge/sql/total-revenue-by-month.md"
+
+
+def test_grep_search_no_match(tmp_path):
+    _seed(tmp_path)
+    assert GrepIndex(tmp_path).search("xyzzy unrelated", limit=3) == []
+
+
+def test_grep_search_datasource_filter(tmp_path):
+    write_query_markdown(tmp_path, "Revenue pg", "SELECT 1", datasource="postgres")
+    write_query_markdown(tmp_path, "Revenue bq", "SELECT 2", datasource="bigquery")
+    hits = GrepIndex(tmp_path).search("revenue", limit=5, datasource="postgres")
+    assert [h["nl_query"] for h in hits] == ["Revenue pg"]
+
+
+def test_grep_rebuild_and_status_and_reset(tmp_path):
+    _seed(tmp_path)
+    idx = GrepIndex(tmp_path)
+    assert idx.rebuild()["pairs"] == 2
+    assert idx.status() == {"backend": "grep", "pairs": 2}
+    idx.reset()  # no-op, must not raise
+    assert idx.status()["pairs"] == 2
+
+
+def test_resolve_backend_env_override():
+    assert resolve_backend("grep") == "grep"
+    assert resolve_backend("lancedb") == "lancedb"
+
+
+# ── CLI commands over the grep backend (no extra needed) ───────────────────
+
+
+def test_cli_recall_grep_without_semantic(tmp_path, monkeypatch):
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    monkeypatch.setenv("WREN_MEMORY_BACKEND", "grep")
+    _seed(tmp_path)
+    result = runner.invoke(
+        app, ["memory", "recall", "-q", "revenue by month", "-o", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Total revenue by month" in result.output
+    assert "knowledge/sql/total-revenue-by-month.md" in result.output
+
+
+def test_cli_index_grep_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    monkeypatch.setenv("WREN_MEMORY_BACKEND", "grep")
+    _seed(tmp_path)
+    result = runner.invoke(app, ["memory", "index"])
+    assert result.exit_code == 0, result.output
+    assert "grep backend" in result.output
+    assert "2 pair(s)" in result.output
+
+
+def test_cli_status_and_reset_and_check_grep(tmp_path, monkeypatch):
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    monkeypatch.setenv("WREN_MEMORY_BACKEND", "grep")
+    _seed(tmp_path)
+
+    status = runner.invoke(app, ["memory", "status"])
+    assert status.exit_code == 0, status.output
+    assert "Backend: grep" in status.output
+
+    reset = runner.invoke(app, ["memory", "reset", "--force"])
+    assert reset.exit_code == 0, reset.output
+    assert "no derived index" in reset.output
+
+    check = runner.invoke(app, ["memory", "check"])
+    assert check.exit_code == 0, check.output
+    assert "always in sync" in check.output

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -904,6 +904,10 @@ class TestMarkdownSourcedIndex:
 
     def test_lancedb_backend_via_get_index(self, tmp_path, monkeypatch):
         """With the extra, get_index resolves to LanceDBIndex and recalls semantically."""
+        pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
+        pytest.importorskip(
+            "sentence_transformers", reason="wren[memory] extras not installed"
+        )
         monkeypatch.setenv("WREN_MEMORY_BACKEND", "lancedb")
         from wren.memory.index_backend import get_index  # noqa: PLC0415
         from wren.memory.markdown import write_query_markdown  # noqa: PLC0415

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -901,3 +901,16 @@ class TestMarkdownSourcedIndex:
         memory_store.load_queries(load_query_pairs(tmp_path), upsert=True)
         hits = memory_store.recall_queries("revenue", limit=3)
         assert any("SUM(amount)" in h["sql_query"] for h in hits)
+
+    def test_lancedb_backend_via_get_index(self, tmp_path, monkeypatch):
+        """With the extra, get_index resolves to LanceDBIndex and recalls semantically."""
+        monkeypatch.setenv("WREN_MEMORY_BACKEND", "lancedb")
+        from wren.memory.index_backend import get_index  # noqa: PLC0415
+        from wren.memory.markdown import write_query_markdown  # noqa: PLC0415
+
+        write_query_markdown(tmp_path, "Total revenue", "SELECT SUM(amount) FROM o")
+        idx = get_index(tmp_path, str(tmp_path / ".wren" / "memory"))
+        assert idx.name == "lancedb"
+        idx.rebuild()
+        hits = idx.search("revenue", limit=3)
+        assert any("SUM(amount)" in h["sql_query"] for h in hits)


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Makes memory recall a **pluggable query interface** over `knowledge/sql/*.md`, so
`wren memory store` / `index` / `recall` work **without** the `memory` extra. Plain
`pip install wren-engine` now gets you store + recall; the extra is only needed for
*semantic* search.

## Changes

- **New `memory/index_backend.py`** — `MemoryIndex` interface with two backends:
  - **`GrepIndex`** (dependency-free): token-overlap + substring search over
    `knowledge/sql/*.md`. The markdown *is* the index — nothing to build.
  - **`LanceDBIndex`** (the `memory` extra): semantic search, LanceDB as a derived index.
  - Backend resolves from `WREN_MEMORY_BACKEND=grep|lancedb`, else auto: LanceDB when its
    extra is importable, otherwise grep.
- **`recall` / `index` / `status` / `reset` / `check`** use the resolved backend. Without
  the extra: `recall` returns token-matched pairs (each with its source path), `index` is a
  no-op (`knowledge/sql/` is the index), and `status`/`reset`/`check` report the grep
  backend. Semantic schema search (`wren memory fetch`) still requires the extra.
- A new backend only implements `MemoryIndex`; `store.py` is untouched.

(`memory_app` was already registered unconditionally as of O4 — O6 makes the recall path
actually work there.)

## Scope

- No pgvector / SQLite-FTS backends (interface leaves room; add on demand).
- Migrating an existing LanceDB `query_history` into markdown is **O7**.

## Tests

- Unit (no extra; CLI tests force `WREN_MEMORY_BACKEND=grep`): `GrepIndex` ranking,
  datasource filter, rebuild/status/reset; backend resolution; and `wren memory
  recall/index/status/reset/check` over grep — all exit 0 with no missing-dependency error.
- Integration (`memory` extra, `memory tests` job): `get_index` resolves to `LanceDBIndex`
  and recalls semantically.

Verified locally with the extra installed: grep suite 8 passed, LanceDB-backend suite
3 passed, unit suite 721 passed / 1 skipped. `uvx ruff` (latest) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced pluggable memory index backends—users can now choose between grep (simple token-overlap search) and LanceDB (semantic search) via the `WREN_MEMORY_BACKEND` environment variable
  * Enhanced `wren memory` CLI commands with automatic backend detection and graceful fallback to grep when semantic search features are unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->