### PR TITLE
feat(wren): add `wren memory export` to migrate LanceDB into knowledge/sql

### DIFF
--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -557,6 +557,61 @@ def check(
         )
 
 
+@memory_app.command()
+def export(
+    path: PathOpt = None,
+    include_seed: Annotated[
+        bool,
+        typer.Option(
+            "--include-seed",
+            help="Also export auto-generated seed pairs (normally regenerated on index).",
+        ),
+    ] = False,
+) -> None:
+    """One-time migration: export the LanceDB query_history into knowledge/sql/*.md.
+
+    Reads the existing index (requires the ``memory`` extra) and writes each
+    NL→SQL pair to the markdown source of truth, preserving source and
+    timestamp. The same NL updates one file (dedup). LanceDB is left intact —
+    run `wren memory index` to rebuild, then `wren memory reset` once verified.
+    """
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.markdown import write_query_markdown  # noqa: PLC0415
+
+    try:
+        project = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    mem_store = _get_store(path)  # requires the memory extra to read LanceDB
+    rows = mem_store.dump_queries()
+    exported, skipped = 0, 0
+    for r in rows:
+        source = _parse_source(r.get("tags", "")) or "user"
+        nl, sql = r.get("nl_query"), r.get("sql_query")
+        if (source == "seed" and not include_seed) or not nl or not sql:
+            skipped += 1
+            continue
+        created = r.get("created_at")
+        created_at = created.isoformat() if hasattr(created, "isoformat") else None
+        write_query_markdown(
+            project,
+            nl,
+            sql,
+            datasource=r.get("datasource") or None,
+            source=source,
+            created_at=created_at,
+        )
+        exported += 1
+
+    typer.echo(f"Exported {exported} pair(s) to knowledge/sql/ ({skipped} skipped).")
+    typer.echo(
+        "Run `wren memory index` to rebuild, then `wren memory reset` once verified.",
+        err=True,
+    )
+
+
 # ── List / Forget / Dump / Load ──────────────────────────────────────────
 
 

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -748,9 +748,9 @@ def forget(
 # ── Dump / Load helpers ──────────────────────────────────────────────────
 
 
-def _parse_source(tags: str) -> str:
-    """Extract source value from tags string."""
-    for part in tags.split():
+def _parse_source(tags: str | None) -> str:
+    """Extract source value from a (possibly null/empty) tags string."""
+    for part in (tags or "").split():
         if part.startswith("source:"):
             return part[len("source:") :]
     return "user"

--- a/core/wren/src/wren/memory/markdown.py
+++ b/core/wren/src/wren/memory/markdown.py
@@ -116,9 +116,12 @@ def render_query_markdown(
     datasource: str | None = None,
     tags: list[str] | None = None,
     source: str = "user",
+    created_at: str | None = None,
 ) -> str:
     """Render the frontmatter document for a NL→SQL pair."""
     front: dict = {"nl": nl.strip(), "sql": sql.strip(), "source": source}
+    if created_at:
+        front["created_at"] = created_at
     if datasource:
         front["datasource"] = datasource
     if tags:
@@ -137,6 +140,7 @@ def write_query_markdown(
     datasource: str | None = None,
     tags: list[str] | None = None,
     source: str = "user",
+    created_at: str | None = None,
 ) -> Path:
     """Write a NL→SQL pair to ``knowledge/sql/<slug>.md``. Returns the path.
 
@@ -149,7 +153,14 @@ def write_query_markdown(
     slug = _resolve_slug(slugify(nl), nl, sql_dir)
     dest = sql_dir / f"{slug}.md"
     dest.write_text(
-        render_query_markdown(nl, sql, datasource=datasource, tags=tags, source=source),
+        render_query_markdown(
+            nl,
+            sql,
+            datasource=datasource,
+            tags=tags,
+            source=source,
+            created_at=created_at,
+        ),
         encoding="utf-8",
     )
     return dest

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -918,3 +918,30 @@ class TestMarkdownSourcedIndex:
         idx.rebuild()
         hits = idx.search("revenue", limit=3)
         assert any("SUM(amount)" in h["sql_query"] for h in hits)
+
+    def test_cli_export_migrates_query_history_to_markdown(self, tmp_path, monkeypatch):
+        """`wren memory export` writes existing LanceDB pairs to knowledge/sql/."""
+        pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
+        pytest.importorskip(
+            "sentence_transformers", reason="wren[memory] extras not installed"
+        )
+        from typer.testing import CliRunner  # noqa: PLC0415
+
+        from wren.cli import app  # noqa: PLC0415
+        from wren.memory.markdown import parse_query_markdown  # noqa: PLC0415
+        from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+        monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+        store = MemoryStore(path=str(tmp_path / ".wren" / "memory"))
+        store.store_query("Top revenue", "SELECT SUM(amount) FROM o", tags="source:user")
+        store.store_query("A seed query", "SELECT 1", tags="source:seed")
+
+        result = CliRunner().invoke(app, ["memory", "export"])
+        assert result.exit_code == 0, result.output
+
+        user_md = tmp_path / "knowledge" / "sql" / "top-revenue.md"
+        assert user_md.exists()
+        assert not (tmp_path / "knowledge" / "sql" / "a-seed-query.md").exists()  # seed skipped
+        fm = parse_query_markdown(user_md)
+        assert fm["source"] == "user"
+        assert "created_at" in fm  # timestamp preserved

--- a/core/wren/tests/unit/test_memory_markdown.py
+++ b/core/wren/tests/unit/test_memory_markdown.py
@@ -88,6 +88,17 @@ def test_slug_collision_gets_suffix(tmp_path):
     assert len(list((tmp_path / "knowledge" / "sql").glob("*.md"))) == 2
 
 
+def test_write_query_markdown_created_at(tmp_path):
+    """created_at is written when provided and ignored by the pair loader."""
+    dest = write_query_markdown(
+        tmp_path, "Q", "SELECT 1", created_at="2026-01-02T03:04:05+00:00"
+    )
+    fm = parse_query_markdown(dest)
+    assert fm["created_at"] == "2026-01-02T03:04:05+00:00"
+    pairs = load_query_pairs(tmp_path)
+    assert pairs[0]["nl"] == "Q" and "created_at" not in pairs[0]
+
+
 def test_load_query_pairs(tmp_path):
     write_query_markdown(
         tmp_path,

--- a/core/wren/tests/unit/test_memory_markdown.py
+++ b/core/wren/tests/unit/test_memory_markdown.py
@@ -88,6 +88,15 @@ def test_slug_collision_gets_suffix(tmp_path):
     assert len(list((tmp_path / "knowledge" / "sql").glob("*.md"))) == 2
 
 
+def test_parse_source_handles_null_tags():
+    """A null/empty tags value must not crash export's source parsing."""
+    from wren.memory.cli import _parse_source  # noqa: PLC0415
+
+    assert _parse_source(None) == "user"
+    assert _parse_source("") == "user"
+    assert _parse_source("source:seed") == "seed"
+
+
 def test_write_query_markdown_created_at(tmp_path):
     """created_at is written when provided and ignored by the pair loader."""
     dest = write_query_markdown(


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

One-time migration for users with an existing `~/.wren/memory` LanceDB: `wren memory export`
writes each `query_history` NL→SQL pair into `knowledge/sql/<slug>.md` (the markdown source
of truth introduced in O4), so pre-markdown history isn't lost when memory moves to the
markdown model.

## Changes

- **`wren memory export`** (new): reads the existing index (requires the `memory` extra to
  read LanceDB) and writes each pair to `knowledge/sql/`. Reuses `dump_queries` +
  `_parse_source` + `write_query_markdown`:
  - **dedup** — the same NL updates one file;
  - **metadata preserved** — `source` and `created_at` (timestamp);
  - **seed pairs skipped** by default (they're regenerated on `index`); `--include-seed`
    to keep them.
  - **LanceDB left intact** — the command points the user at `wren memory index` to rebuild
    and `wren memory reset` once verified (no destructive auto-delete).
- **markdown format** gains an optional `created_at` frontmatter field — backward-compatible
  and ignored by the pair loader (`load_query_pairs`), so readers are unaffected.

## Scope

- Only `query_history` (user NL→SQL pairs). `schema_items` are derived from
  `target/mdl.json` and are rebuilt by `index` — nothing to migrate.

## Tests

- Unit (no extra): `write_query_markdown(created_at=...)` writes the field and the loader
  still parses the pair (ignores `created_at`).
- Integration (`memory` extra, `memory tests` job): `wren memory export` migrates a stored
  user pair into `knowledge/sql/`, skips the seed pair, and preserves `source` + `created_at`.

Verified locally with the extra installed: full memory suite **76 passed**; markdown unit
suite **13 passed**. `uvx ruff` (latest) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wren memory export` CLI command to export stored query history to markdown knowledge files with timestamp preservation and configurable seed query filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->