### PR TITLE
feat(wren): update skills and default AGENTS.md to the v5 knowledge/ model

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -43,6 +43,10 @@ When the user wants to add models, change schema, or onboard a new table:
 3. `wren context build` — compile to `target/mdl.json`
 4. `wren memory index` — re-index schema for search
 
+## Capturing business context
+
+Rules the schema can't express — canonical tables, default filters, units, enum meanings — go in `knowledge/rules/*.md` (read by `wren context instructions`). Confirmed NL→SQL examples are saved with `wren memory store` (step 5 above), which writes them to `knowledge/sql/`. Both live in the project and are committed with it.
+
 ## Prerequisites
 
 This project requires the `wren` CLI. Install with your data source extra:
@@ -51,7 +55,7 @@ This project requires the `wren` CLI. Install with your data source extra:
 pip install "wrenai[postgres,memory,ui]"
 ```
 
-Replace `postgres` with your data source (`mysql`, `bigquery`, `snowflake`, `clickhouse`, `trino`, `mssql`, `databricks`, `redshift`, `spark`, `athena`, `oracle`). The `memory` extra enables semantic search; `ui` enables the interactive UI.
+Replace `postgres` with your data source (`mysql`, `bigquery`, `snowflake`, `clickhouse`, `trino`, `mssql`, `databricks`, `redshift`, `spark`, `athena`, `oracle`). The `memory` extra upgrades recall to semantic (embedding) search — without it, `memory store` / `index` / `recall` still work over the `knowledge/` files. `ui` enables the interactive UI.
 
 See https://docs.getwren.ai/oss/engine/get_started/installation for full setup.
 

--- a/core/wren/src/wren/skills_content/dlt-connector/SKILL.md
+++ b/core/wren/src/wren/skills_content/dlt-connector/SKILL.md
@@ -146,7 +146,7 @@ This script:
 - Filters out dlt metadata columns (`_dlt_id`, `_dlt_load_id`, `_dlt_list_idx`) from model definitions
 - Detects parent-child relationships from `_dlt_parent_id` columns and table naming conventions
 - **Normalizes column types using `wren.type_mapping.parse_type()`** (sqlglot-based)
-- Generates a complete v2 YAML project (wren_project.yml, models/, relationships.yml, instructions.md)
+- Generates a complete v5 YAML project (wren_project.yml, models/, relationships.yml, knowledge/rules/)
 
 After running, show the user what was generated:
 

--- a/core/wren/src/wren/skills_content/dlt-connector/scripts/introspect_dlt.py
+++ b/core/wren/src/wren/skills_content/dlt-connector/scripts/introspect_dlt.py
@@ -275,7 +275,7 @@ def generate_project_files(
 
     # -- wren_project.yml --
     project_config = {
-        "schema_version": 2,
+        "schema_version": 5,
         "name": project_name,
         "version": "1.0",
         "catalog": "",
@@ -342,10 +342,10 @@ def generate_project_files(
     else:
         files["relationships.yml"] = "relationships: []\n"
 
-    # -- instructions.md --
+    # -- knowledge/ (v5: business rules live under knowledge/rules/) --
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    instructions = (
-        "# Instructions\n\n"
+    rules = (
+        "# Project rules\n\n"
         f"This Wren project was auto-generated from a dlt DuckDB pipeline.\n\n"
         f"- **Source DuckDB:** `{duckdb_path}`\n"
         f"- **Generated:** {timestamp}\n"
@@ -354,7 +354,9 @@ def generate_project_files(
         "dlt metadata columns (`_dlt_id`, `_dlt_parent_id`, etc.) are hidden from models\n"
         "but still present in the underlying DuckDB tables.\n"
     )
-    files["instructions.md"] = instructions
+    files["knowledge/rules/general.md"] = rules
+    # knowledge axis version marker (decoupled from the MDL schema_version)
+    files["knowledge/knowledge.yml"] = "schema_version: 1\n"
 
     return files
 

--- a/core/wren/src/wren/skills_content/enrich-context/SKILL.md
+++ b/core/wren/src/wren/skills_content/enrich-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: enrich-context
-description: "Augment a Wren project with business context that DB schema cannot carry — enum value meanings, units (USD vs cents, ms vs sec), NULL semantics, magic sentinels (-1 = unknown), soft-delete default filters, business synonyms, time-grain / TZ conventions, cross-system identifiers, currency rules, canonical-table preferences, AND named aggregation metrics (ARR, churn, DAU, WAU, NRR) proposed as cubes. Runs in one of two modes selected at session start: `grill` (one question at a time, user-driven) or `auto-pilot` (agent infers and applies, escalates only on conflicts and high-blast-radius additions like new cubes / views / relationships). Reads everything under <project>/raw/ (PDFs, glossaries, handbooks, code, data dictionaries) and optionally samples low-cardinality columns from the live DB (grill mode), compares against the current MDL / cubes / instructions.md / queries.yml / memory pairs, then fills gaps via the ten-category gap catalog and the cube proposal flow. Confirmed findings are written back to the right sink. Use when: user says 'enrich context', 'augment my project', 'grill me on this project', 'auto-fill my context', 'agent doesn't understand our docs / enum values / units / null meanings', 'business context is missing', 'what does status=A mean', 'is this amount in USD or cents', 'we keep getting wrong aggregations', 'add cubes for ARR / DAU / churn', 'we have a handbook / glossary / data dictionary the agent should know'; or after generating an MDL and noticing the agent lacks business semantics."
+description: "Augment a Wren project with business context that DB schema cannot carry — enum value meanings, units (USD vs cents, ms vs sec), NULL semantics, magic sentinels (-1 = unknown), soft-delete default filters, business synonyms, time-grain / TZ conventions, cross-system identifiers, currency rules, canonical-table preferences, AND named aggregation metrics (ARR, churn, DAU, WAU, NRR) proposed as cubes. Runs in one of two modes selected at session start: `grill` (one question at a time, user-driven) or `auto-pilot` (agent infers and applies, escalates only on conflicts and high-blast-radius additions like new cubes / views / relationships). Reads everything under <project>/raw/ (PDFs, glossaries, handbooks, code, data dictionaries) and optionally samples low-cardinality columns from the live DB (grill mode), compares against the current MDL / cubes / knowledge (rules + NL→SQL pairs), then fills gaps via the ten-category gap catalog and the cube proposal flow. Confirmed findings are written back to the right sink. Use when: user says 'enrich context', 'augment my project', 'grill me on this project', 'auto-fill my context', 'agent doesn't understand our docs / enum values / units / null meanings', 'business context is missing', 'what does status=A mean', 'is this amount in USD or cents', 'we keep getting wrong aggregations', 'add cubes for ARR / DAU / churn', 'we have a handbook / glossary / data dictionary the agent should know'; or after generating an MDL and noticing the agent lacks business semantics."
 license: Apache-2.0
 metadata:
   author: wren-engine
@@ -8,7 +8,7 @@ metadata:
 
 # Wren Enrich Context — Fill the Business-Context Gap
 
-This skill exists because most business context never lives in a DB schema — it lives in handbooks, glossaries, finance reports, support playbooks, code comments, Slack rules-of-thumb. The agent reads those raw artifacts, finds what's missing from the Wren project, and **either grills the user one question at a time (grill mode) or applies its best inferences directly and hands over an audit (auto-pilot mode)** before writing back. The output lands in three (or four) sinks each project already has — no new artifact, no new tooling.
+This skill exists because most business context never lives in a DB schema — it lives in handbooks, glossaries, finance reports, support playbooks, code comments, Slack rules-of-thumb. The agent reads those raw artifacts, finds what's missing from the Wren project, and **either grills the user one question at a time (grill mode) or applies its best inferences directly and hands over an audit (auto-pilot mode)** before writing back. The output lands in the sinks each project already has — MDL, `cubes/`, `knowledge/rules/`, and `knowledge/sql/` — no new artifact, no new tooling.
 
 ## Hard rules — READ FIRST
 
@@ -29,7 +29,7 @@ This skill exists because most business context never lives in a DB schema — i
 7. **Drop into grill for three cases.** Always interrupt auto-pilot and ask the user when:
    - (a) **Lane 2 conflict** — raw and current MDL disagree.
    - (b) **High-blast-radius proposal (any lane)** — new cube, new view, new relationship, or new MDL metric/calculated column. These become public artifacts visible to every future agent session, so blast radius doesn't depend on whether the trigger was raw evidence (Lane 2) or inference (Lane 3).
-   - (c) **Lane 2 routing ambiguity** — you can't confidently pick a sink (MDL / `instructions.md` / `queries.yml` / `cubes/`).
+   - (c) **Lane 2 routing ambiguity** — you can't confidently pick a sink (MDL / `knowledge/rules/` / `knowledge/sql/` / `cubes/`).
 
    Everything else: apply directly and log to the audit list.
 
@@ -88,14 +88,18 @@ If either check fails, stop and tell the user — suggest `wren skills get onboa
 
 From this point on, **every command and file path in this skill is relative to the chosen project root**. Do not switch projects mid-session — if the user wants to work a different project, end this session and re-run.
 
-### Step 2 — Detect memory availability
+### Step 2 — Detect semantic-memory availability
 
 ```bash
-wren memory --help >/dev/null 2>&1
+wren memory fetch -q probe >/dev/null 2>&1
 ```
 
-- Exit 0 → set `MEMORY_AVAILABLE = true`. The fourth sink (direct `wren memory store`) is open.
-- Exit non-zero → set `MEMORY_AVAILABLE = false`. Skip the memory-only paths below.
+Writing NL→SQL pairs (`wren memory store` → `knowledge/sql/*.md`) works **regardless** — that
+sink is always open. This probe only tells you whether the optional `memory` extra is
+installed, which gates the *embedding* features used while reading:
+
+- Exit 0 → set `MEMORY_AVAILABLE = true`. Semantic recall and `wren memory fetch` are usable, and `wren memory index` will build an embedding index in Step 8.
+- Exit non-zero → set `MEMORY_AVAILABLE = false`. Skip the semantic read/index paths below; pair writeback still happens via `wren memory store`.
 
 ### Step 3 — Ensure raw/ folder exists
 
@@ -128,10 +132,10 @@ Read every file under `raw/`. Use whatever capability your agent has natively (t
 | Source | Command |
 |---|---|
 | MDL (full) | `wren context show --output json` |
-| Project instructions | `wren context instructions` |
+| Business rules | `wren context instructions` (reads `knowledge/rules/` + any legacy `instructions.md`) |
 | Existing cubes (names) | `wren cube list` |
 | Existing cubes (measures + dimensions) | `wren cube describe <cube>` for each name above |
-| Curated NL-SQL pairs | read `queries.yml` directly |
+| NL→SQL pairs | read `knowledge/sql/*.md` directly |
 | (Memory) stored pairs | `wren memory list -n 200 --output json` |
 | (Memory) schema as text | `wren memory describe` |
 
@@ -190,16 +194,16 @@ Scan the current MDL and check:
 - Every column has a description (at least for non-PK, non-FK ones)?
 - Every model has a `primary_key`?
 - Every model has at least one relationship (orphan models are suspicious)?
-- `instructions.md` is more than the scaffold default?
-- `queries.yml` has at least a few canonical pairs?
+- `knowledge/rules/` has real content beyond the scaffold default?
+- `knowledge/sql/` has at least a few canonical NL→SQL pairs?
 
 Plus, walk every column / model against `gap_catalog` triggers:
 
 - For each column matching catalog #1 / #2 / #3 / #5 / #7 triggers → is the corresponding `[tag]` line present in `properties.description`?
-- For each model with a soft-delete column (`deleted_at`, `is_active`, `archived_at`, etc.) → is there a `## Default filters` rule in `instructions.md` covering it (catalog #4)?
+- For each model with a soft-delete column (`deleted_at`, `is_active`, `archived_at`, etc.) → is there a `## Default filters` rule in `knowledge/rules/` covering it (catalog #4)?
 - For each lookalike table pair (e.g. `users` / `users_v3`) → is there a `## Canonical tables` rule (catalog #10)?
 - For each `*_currency` / `fx_rate` / external-system ID column → is the matching `## Currency` (#9) or `## External identifiers` (#8) section present?
-- Business terms in `instructions.md` or raw that don't map verbatim to model / column names → catalog #6 `## Naming conventions` rule missing.
+- Business terms in `knowledge/rules/` or raw that don't map verbatim to model / column names → catalog #6 `## Naming conventions` rule missing.
 
 Each unsatisfied check is a candidate. Combine with Step 4.5 probe results (if available) before moving to Lane 2.
 
@@ -222,7 +226,7 @@ After reading raw and the current MDL, propose additions the user did **not** li
 - "Your support handbook keeps mentioning `core users` without defining it. Is this `users WHERE tier = 'premium'`? Want me to make a view?"
 - "The data dictionary says `events.payload` is JSON but the column has no description — let me draft one."
 
-For any aggregation-shaped proposal (`SUM`, `COUNT`, `AVG`, "by month / by status / per customer" patterns), **default to a cube**. Run `wren cube list` + `wren cube describe` first to confirm no existing cube already covers the measure expression; if one does, skip the proposal and add a `queries.yml` example pointing at the existing cube instead. The full decision tree, naming rules, and validation flow live in `cube_proposals`.
+For any aggregation-shaped proposal (`SUM`, `COUNT`, `AVG`, "by month / by status / per customer" patterns), **default to a cube**. Run `wren cube list` + `wren cube describe` first to confirm no existing cube already covers the measure expression; if one does, skip the proposal and add a `knowledge/sql/` example pointing at the existing cube instead. The full decision tree, naming rules, and validation flow live in `cube_proposals`.
 
 **In grill mode, open every Lane 3 question with "I'm guessing — ".** In auto-pilot, tag the audit entry with `agent inference` so the user sees you extrapolated.
 
@@ -244,7 +248,7 @@ For every grill turn:
 
 1. State the gap and where it came from (Lane 1 / 2 / 3, and for Lane 2 quote the raw file + a short excerpt).
 2. Propose the concrete answer — draft the description, the rule, the SQL pair, the relationship.
-3. **Propose the sink** ("I'll add this to `instructions.md` as a rule" / "I'll add this to the `users` model description in MDL").
+3. **Propose the sink** ("I'll add this to `knowledge/rules/` as a rule" / "I'll add this to the `users` model description in MDL").
 4. Let the user accept / edit / skip.
 5. On accept: write back (Step 7).
 6. On edit: apply their wording, then write back.
@@ -278,11 +282,10 @@ Decide the sink as part of the proposal (Step 6.3 in grill mode; Step 6.2 in aut
 |---|---|---|
 | Schema structure / relationship / view / model or column description | **MDL YAML** under `models/`, `views/`, `relationships.yml` | Edit the YAML file directly. For catalog #1 / #2 / #3 / #5 / #7 / PII, append a `[tag]` line to `properties.description` (prose first, then one tag per category). See `gap_catalog` for the exact tag format and triggers. |
 | Aggregation metric / named measure (with measures + dimensions) | **`cubes/<name>/metadata.yml`** | New file per cube. Default sink for any `SUM` / `COUNT` / `AVG` / ratio metric raw defines or Lane 3 infers. See `cube_proposals` for the YAML template, naming policy, duplication guard, and validation flow. Run `wren context validate` + `wren cube query --cube <name> --sql-only` after writing; revert on either failure. **Always escalates to grill in auto-pilot** (Universal Rule 7b). |
-| Default filter / implicit rule / business convention / naming convention / external mapping / currency / canonical table | **`instructions.md`** | Append under the catalog-specified `##` section heading (#4 → `## Default filters`, #6 → `## Naming conventions`, #8 → `## External identifiers`, #9 → `## Currency`, #10 → `## Canonical tables`). Create the heading if absent; never modify existing text. |
-| Canonical NL→SQL example the team should share | **`queries.yml`** | Append a new entry under `pairs:` |
-| Ad-hoc NL→SQL pair (user-local, not for the repo) — **only if `MEMORY_AVAILABLE = true`** | **`wren memory store`** | `wren memory store --nl "..." --sql "..." --tags "source:enrich"` |
+| Default filter / implicit rule / business convention / naming convention / external mapping / currency / canonical table | **`knowledge/rules/`** | Append under the catalog-specified `##` section heading (#4 → `## Default filters`, #6 → `## Naming conventions`, #8 → `## External identifiers`, #9 → `## Currency`, #10 → `## Canonical tables`) inside a topic file under `knowledge/rules/` (e.g. `knowledge/rules/conventions.md`). Create the file/heading if absent; never modify existing text. |
+| NL→SQL example (canonical or ad-hoc) | **`knowledge/sql/`** | `wren memory store --nl "..." --sql "..." --tags "source:enrich"` — writes `knowledge/sql/<slug>.md` (committable) and indexes it when the extra is present. Works whether or not `MEMORY_AVAILABLE`. |
 
-Catalog-driven routing means every column-local proposal goes to the column's `properties.description` with a `[tag]` line; every cross-model rule goes to `instructions.md` under a fixed heading. This keeps re-enrichment deterministic (greppable) and avoids inventing new sink locations.
+Catalog-driven routing means every column-local proposal goes to the column's `properties.description` with a `[tag]` line; every cross-model rule goes to `knowledge/rules/` under a fixed heading. This keeps re-enrichment deterministic (greppable) and avoids inventing new sink locations.
 
 ### After every MDL edit
 
@@ -298,9 +301,9 @@ If it fails:
 
 ### Format reminders
 
-- `queries.yml` schema follows `wren memory dump` output: `version: 1`, `pairs:` list of `{nl, sql, source}` (use `source: enrich`).
+- NL→SQL pairs are written by `wren memory store`; each becomes a `knowledge/sql/<slug>.md` with YAML frontmatter (`nl`, `sql`, `source`, optional `datasource`/`tags`). Don't hand-write the files — use `wren memory store --tags "source:enrich"`.
 - MDL YAML uses snake_case keys (e.g. `primary_key`, `is_calculated`, `not_null`). `wren context build` converts to camelCase for `target/mdl.json`.
-- `instructions.md` is free-form markdown. Group rules by topic with headings.
+- `knowledge/rules/` holds free-form markdown, one file per topic. Group rules by topic with `##` headings.
 
 ## Step 8 — Session finalize
 
@@ -318,7 +321,7 @@ If `MEMORY_AVAILABLE = true`:
 wren memory index
 ```
 
-This re-embeds the new schema items, the updated `instructions.md`, and the new `queries.yml` entries.
+This re-embeds the new schema items, the updated `knowledge/rules/`, and the new `knowledge/sql/` pairs.
 
 ## Step 9 — Summary
 
@@ -333,10 +336,9 @@ Added:
   MDL              : N model descriptions, N column descriptions, N relationships, N views
                      by tag: [enum]=N [unit]=N [null]=N [magic]=N [time]=N [pii]=N
   cubes            : N new (names: <list>)                                    via cubes/<name>/metadata.yml
-  instructions.md  : N new rules across sections
+  knowledge/rules/ : N new rules across sections
                      by section: Default filters=N | Naming conventions=N | External identifiers=N | Currency=N | Canonical tables=N
-  queries.yml      : N new NL→SQL pairs
-  memory store     : N ad-hoc pairs                                          (only if MEMORY_AVAILABLE)
+  knowledge/sql/   : N new NL→SQL pairs                                       via wren memory store
   Probe            : N columns sampled, M failed                             (grill mode only)
 
 Please fix manually (we don't edit existing fields):
@@ -359,10 +361,10 @@ Append a detailed audit so the user can sanity-check inferences:
 
 ```text
 Inferred items (please review):
-  high   | MDL model:orders.description           | from raw/glossary.pdf p.2 — "Order = ..."
-  high   | instructions.md rule                    | from raw/handbook.md §4 — "default tier ..."
-  med    | MDL column:users.signup_source.desc    | agent inference from raw/onboarding.md
-  low    | queries.yml: "weekly active customers"  | agent inference, no direct raw evidence
+  high   | MDL model:orders.description            | from raw/glossary.pdf p.2 — "Order = ..."
+  high   | knowledge/rules/ rule                   | from raw/handbook.md §4 — "default tier ..."
+  med    | MDL column:users.signup_source.desc     | agent inference from raw/onboarding.md
+  low    | knowledge/sql/: "weekly active customers" | agent inference, no direct raw evidence
 
 Validation:
   K successful applies, M reverted after wren context validate failed:
@@ -377,20 +379,20 @@ The user should be encouraged to skim the audit and either accept it as-is, manu
 ## Things to avoid
 
 - Do not write a `gaps.yml`, `state.yml`, or any other tracking artifact. The session lives entirely in conversation.
-- Do not modify any existing MDL field, instructions rule, or queries.yml entry — only append / add. Surface mismatches on the manual-fix list.
+- Do not modify any existing MDL field, `knowledge/rules/` rule, or `knowledge/sql/` pair — only append / add. Surface mismatches on the manual-fix list.
 - Do not install new Python packages (`pypdf`, `docling`, …) to read raw. Use what your agent already has; ask the user to convert files you can't open.
 - Do not auto-resolve a conflict between raw and current MDL — always grill the user, in **both** modes.
 - Do not present Lane 3 inferences as if they were quoted from raw. Open with "I'm guessing — " (grill) or tag `agent inference` (auto-pilot).
-- Do not call `wren memory store` when `MEMORY_AVAILABLE = false` — write to `queries.yml` instead so the pair survives a future `wren memory index`.
+- `wren memory store` works whether or not `MEMORY_AVAILABLE` — it always writes the `knowledge/sql/*.md` pair (and indexes it only when the extra is present). No need to fall back to another sink.
 - Do not commit anything to git. The user owns the commit decision.
 - Do not nag about skipped questions. Skip is skip for this session (grill mode only — auto-pilot has no skip concept).
 - Do not run `wren context build` after every single MDL edit — once at the end is enough. Do run `wren context validate` after every edit.
 - Do not assume `raw/` was created by `wren context init` — it isn't. This skill creates it.
 - Do not switch modes mid-session. The user re-runs to change mode.
 - Do not append a `[tag]` line if the same category tag already exists for that column — Universal Rule 1. Surface contradictions on the manual-fix list instead.
-- Do not invent new `instructions.md` section headings. Stick to the five catalog-defined headings (`## Default filters`, `## Naming conventions`, `## External identifiers`, `## Currency`, `## Canonical tables`). Anything that doesn't fit goes on the manual-fix list.
+- Do not invent new `knowledge/rules/` section headings. Stick to the five catalog-defined headings (`## Default filters`, `## Naming conventions`, `## External identifiers`, `## Currency`, `## Canonical tables`). Anything that doesn't fit goes on the manual-fix list.
 - Do not probe the live DB in auto-pilot mode. Step 4.5 is grill-only by default.
-- Do not propose a cube whose measure expression already exists in another cube on the same `base_object` — write a `queries.yml` example pointing at the existing cube instead. See `cube_proposals` duplication guard.
+- Do not propose a cube whose measure expression already exists in another cube on the same `base_object` — write a `knowledge/sql/` example pointing at the existing cube instead. See `cube_proposals` duplication guard.
 - Do not modify an existing cube YAML even when raw contradicts it — Universal Rule 1. Surface on the manual-fix list.
 - Do not write a new cube alongside an old MDL `metrics:` entry that already covers the same logic. Surface as "consider migrating to cube" on the manual-fix list.
 - Do not skip `wren cube query --cube <name> --sql-only` after creating a cube. Structural `wren context validate` doesn't catch unresolvable measure / dimension expressions.

--- a/core/wren/src/wren/skills_content/enrich-context/references/cube_proposals.md
+++ b/core/wren/src/wren/skills_content/enrich-context/references/cube_proposals.md
@@ -31,7 +31,7 @@ wren cube describe <cube_name>       # measures + expressions per cube
 
 For each measure you're about to propose:
 
-- **Same expression already exists in another cube** (e.g. `SUM(amount)` for the same `base_object`) → do **not** propose a new cube. Add a `queries.yml` example pointing at the existing cube instead, so the agent learns to reach for it.
+- **Same expression already exists in another cube** (e.g. `SUM(amount)` for the same `base_object`) → do **not** propose a new cube. Store a `knowledge/sql/` example (via `wren memory store`) pointing at the existing cube instead, so the agent learns to reach for it.
 - **Same name in `wren cube list`** but different `base_object` → name collision. Either fall back to `<name>_v2` (auto-pilot) or grill the user for a better name (grill mode).
 - **Old MDL `metrics:` already defines this** (visible in `wren context show --output json` under each model's `metrics:` array) → do not propose. Surface on the Step 9 "please fix manually" list with the note "old metrics: entry — consider migrating to a cube".
 
@@ -155,22 +155,18 @@ properties:
 
 Note no `time_dimensions` because raw didn't ask for time-bucketing. Add one when raw also says "monthly ARR trend" or similar.
 
-### Example 2 — raw mentions a measure already covered (skip, write queries.yml)
+### Example 2 — raw mentions a measure already covered (skip, store an NL→SQL pair)
 
 Raw `support_handbook.md`: *"DAU = distinct active users per day."*
 
 Existing cube `daily_engagement` already has measure `dau` with expression `COUNT(DISTINCT user_id)`.
 
-Action: skip the cube proposal. Add to `queries.yml`:
+Action: skip the cube proposal. Store a pair pointing at the existing cube (lands in `knowledge/sql/`):
 
-```yaml
-- nl: "daily active users for last week"
-  sql: |
-    -- via cube
-    SELECT day, dau FROM (
-      <result of: wren cube query --cube daily_engagement --measures dau --time-dimension "day:day:2024-01-01,2024-01-08">
-    )
-  source: enrich
+```bash
+wren memory store --tags "source:enrich" \
+  --nl "daily active users for last week" \
+  --sql "SELECT day, dau FROM (<result of: wren cube query --cube daily_engagement --measures dau --time-dimension 'day:day:2024-01-01,2024-01-08'>)"
 ```
 
 (Or simpler — log it in the Step 9 audit and let the agent reach for `wren cube query` directly at usage time.)

--- a/core/wren/src/wren/skills_content/enrich-context/references/gap_catalog.md
+++ b/core/wren/src/wren/skills_content/enrich-context/references/gap_catalog.md
@@ -10,7 +10,7 @@ Ten business-semantic categories that the schema alone cannot carry. The main `S
 | **Lane 2** (claim-diff) | For each atomic claim extracted from raw, classify it under one of the 10 categories before deciding the sink. |
 | **Lane 3** (inference) | If raw is silent but a trigger from this catalog fires AND the slot is empty, propose an inference (open with "I'm guessing — " in grill mode, tag `agent inference` in auto-pilot). |
 
-Categories 1, 2, 3, 5, 7 write to **column `properties.description`** (prose + `[tag]` line). Categories 4, 6, 8, 9, 10 write to **`instructions.md`** (new `##` section appended). All sinks are append-only — never modify what's there.
+Categories 1, 2, 3, 5, 7 write to **column `properties.description`** (prose + `[tag]` line). Categories 4, 6, 8, 9, 10 write to **`knowledge/rules/`** (new `##` section appended in a topic file). All sinks are append-only — never modify what's there.
 
 ## Description write format (column-local categories)
 
@@ -59,7 +59,7 @@ Use lowercase tag names exactly as listed below — Lane 1 greps these for re-en
 ### 4. Soft-delete / active filters
 
 - **Trigger:** model has any of `deleted_at`, `is_deleted`, `archived_at`, `is_active`, `is_internal`, `tombstone_at` column OR raw mentions "soft delete", "tombstone", "active rows only", "exclude internal".
-- **Sink:** `instructions.md` under heading `## Default filters` (create if absent, append rule if present).
+- **Sink:** `knowledge/rules/` under heading `## Default filters` (create if absent, append rule if present).
 - **Write format:**
   ```markdown
   ## Default filters
@@ -80,7 +80,7 @@ Use lowercase tag names exactly as listed below — Lane 1 greps these for re-en
 
 - **Trigger:** raw uses a business term that maps to a model / column / metric, but the term doesn't appear verbatim in MDL names or descriptions.
   - Examples: "customer" → `customers` (vs `accounts`, `customers_v3`); "ARR" → `mrr * 12`; "DAU" → distinct active users per day.
-- **Sink:** `instructions.md` under heading `## Naming conventions`.
+- **Sink:** `knowledge/rules/` under heading `## Naming conventions`.
 - **Write format:**
   ```markdown
   ## Naming conventions
@@ -102,7 +102,7 @@ Use lowercase tag names exactly as listed below — Lane 1 greps these for re-en
 ### 8. Cross-system identifiers
 
 - **Trigger:** column name contains an external-system tag (`stripe_*`, `salesforce_*`, `intercom_*`, `hubspot_*`, `*_external_id`, `*_external_ref`) OR raw maps an internal ID to an external system.
-- **Sink:** `instructions.md` under heading `## External identifiers`.
+- **Sink:** `knowledge/rules/` under heading `## External identifiers`.
 - **Write format:**
   ```markdown
   ## External identifiers
@@ -114,7 +114,7 @@ Use lowercase tag names exactly as listed below — Lane 1 greps these for re-en
 ### 9. Currency / locale
 
 - **Trigger:** any model has `currency`, `locale`, `country`, `region`, `fx_rate`, `original_amount` column OR raw mentions FX rates, multi-currency, or non-USD reporting.
-- **Sink:** `instructions.md` under heading `## Currency`.
+- **Sink:** `knowledge/rules/` under heading `## Currency`.
 - **Write format:**
   ```markdown
   ## Currency
@@ -126,7 +126,7 @@ Use lowercase tag names exactly as listed below — Lane 1 greps these for re-en
 ### 10. Canonical table preferences
 
 - **Trigger:** schema has lookalike tables (`users` / `users_v3`, `orders` / `orders_archive` / `orders_summary`) OR raw says "use X not Y" / "deprecated" / "raw mirror".
-- **Sink:** `instructions.md` under heading `## Canonical tables`.
+- **Sink:** `knowledge/rules/` under heading `## Canonical tables`.
 - **Write format:**
   ```markdown
   ## Canonical tables
@@ -143,8 +143,8 @@ To check what a previous enrich run already covered before adding more:
 # Column-local tags
 grep -rE '\[(enum|unit|null|magic|time|pii)\]' models/
 
-# instructions.md section headings written by enrich
-grep -E '^## (Default filters|Naming conventions|External identifiers|Currency|Canonical tables)' instructions.md
+# knowledge/rules/ section headings written by enrich
+grep -rE '^## (Default filters|Naming conventions|External identifiers|Currency|Canonical tables)' knowledge/rules/
 ```
 
 Any existing `[tag]` line or `##` section means that category has been touched on that target — **do not rewrite by Universal Rule 1**. Surface contradictions on the manual-fix list instead.

--- a/core/wren/src/wren/skills_content/generate-mdl/SKILL.md
+++ b/core/wren/src/wren/skills_content/generate-mdl/SKILL.md
@@ -31,7 +31,7 @@ Check whether `wren_project.yml` exists in the current working directory
 1. Tell the user that an existing wren project was detected and show its path.
 2. Ask:
    - **Reset** — wipe the existing project (`models/`, `views/`,
-     `relationships.yml`, `instructions.md`, and rebuild `wren_project.yml`)
+     `relationships.yml`, `knowledge/`, and rebuild `wren_project.yml`)
      and regenerate from scratch in the same directory.
    - **New path** — keep the existing project untouched and choose a
      different directory for the new project. Ask the user for the new path,
@@ -160,7 +160,7 @@ project/
 ├── views/               # named SQL statements
 ├── cubes/               # pre-aggregation cubes (measures + dimensions)
 ├── relationships.yml
-└── instructions.md
+└── knowledge/           # business rules (rules/) + NL→SQL pairs (sql/)
 ```
 
 > **When to define cubes:** If the user asks aggregation questions like

--- a/core/wren/src/wren/skills_content/onboarding/SKILL.md
+++ b/core/wren/src/wren/skills_content/onboarding/SKILL.md
@@ -113,7 +113,7 @@ Validation runs automatically. The CLI overwrites profiles silently — there is
 wren context init --empty
 ```
 
-Refuses to overwrite an existing `wren_project.yml`. Creates the project directory layout (`models/`, `views/`, `relationships.yml`, `instructions.md`, `AGENTS.md`, `queries.yml`).
+Refuses to overwrite an existing `wren_project.yml`. Creates the project directory layout (`models/`, `views/`, `relationships.yml`, `knowledge/` (rules + sql), `AGENTS.md`).
 
 ## Step 3.6 — Bind the profile to the project
 


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Updates the bundled agent skills to write business context to `knowledge/` (v5) instead of
`instructions.md` / `queries.yml`, and makes the dlt generator emit a v5 project.

## Changes

- **`enrich-context`** (SKILL.md + `gap_catalog.md` + `cube_proposals.md`) — the skill that
  writes context. Its sinks are now MDL, `cubes/`, **`knowledge/rules/`**, and
  **`knowledge/sql/`**:
  - Routing table, Lane-1 structural checks, grill/auto-pilot sink proposals, format
    reminders, Step 9 summary, and "things to avoid" all retargeted.
  - The NL→SQL sink is `wren memory store` (writes `knowledge/sql/<slug>.md`), now
    **always available** — Step 2 reframed: the `memory` extra only gates embedding
    recall / `fetch` / `index`, not the ability to store pairs.
- **`dlt-connector/scripts/introspect_dlt.py`** — generates a **v5** project:
  `schema_version: 5` + `knowledge/rules/general.md` + `knowledge/knowledge.yml` instead of
  `schema_version: 2` + `instructions.md`.
- **`generate-mdl` / `onboarding` / `dlt-connector` SKILL docs** — layout descriptions show
  `knowledge/` (they scaffold via `wren context init`, which is already v5).

`usage/memory.md` is unchanged — the `store`/`recall` command interface is the same; only
the storage underneath moved (covered by earlier PRs).

## Verification

`uvx ruff` clean (incl. the generator script); skill tests (`test_skill_stubs`,
`test_skills_cli`) pass — 26. `introspect_dlt.py` compiles; its `write_project` already
`mkdir -p`s nested paths, so `knowledge/rules/` is created. No tests pin the old generator
output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill documentation to reflect modernized project structure with `knowledge/rules/` for business rules and `knowledge/sql/` for NL→SQL pairs, replacing previous `instructions.md` and `queries.yml` files.
  * Wren projects now support schema version 5 format.
  * Updated context detection and enrichment workflows to align with new artifact locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->