### PR TITLE
feat(wren): make all project-producing paths emit v5

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -153,11 +153,13 @@ def convert_mdl_to_project(mdl_json: dict) -> list[ProjectFile]:
     files: list[ProjectFile] = []
 
     # ── wren_project.yml ──────────────────────────────────────
-    # Map layoutVersion back to schema_version
+    # Map engine layoutVersion to the schema_version an import should land on.
+    # layoutVersion 3 covers both v4 (composite PK) and v5; a fresh import
+    # targets the current layout (5, knowledge/-native).
     layout_version = mdl_json.get("layoutVersion", 1)
-    _LAYOUT_TO_SCHEMA = {1: 2, 2: 3, 3: 4}
+    _LAYOUT_TO_SCHEMA = {1: 2, 2: 3, 3: 5}
     schema_version = _LAYOUT_TO_SCHEMA.get(
-        layout_version, 4 if layout_version >= 3 else (3 if layout_version >= 2 else 2)
+        layout_version, 5 if layout_version >= 3 else (3 if layout_version >= 2 else 2)
     )
     project_config: dict[str, Any] = {"schema_version": schema_version}
     if "name" in mdl_json:
@@ -264,12 +266,17 @@ def convert_mdl_to_project(mdl_json: dict) -> list[ProjectFile]:
             )
         )
 
-    # ── Instructions ──────────────────────────────────────────
+    # ── knowledge/ (v5: business rules under knowledge/rules/) ──
+    files.append(
+        ProjectFile(
+            relative_path="knowledge/knowledge.yml", content="schema_version: 1\n"
+        )
+    )
     instructions = mdl_json.get("_instructions")
     if instructions:
         files.append(
             ProjectFile(
-                relative_path="instructions.md",
+                relative_path="knowledge/rules/general.md",
                 content=instructions.strip() + "\n",
             )
         )

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -255,8 +255,7 @@ def init(
 
     project_file = project_path / PROJECT_FILE
     agents_file = project_path / "AGENTS.md"
-    queries_file = project_path / "queries.yml"
-    conflicts = [f for f in (project_file, agents_file, queries_file) if f.exists()]
+    conflicts = [f for f in (project_file, agents_file) if f.exists()]
     if conflicts and not force:
         names = ", ".join(f"'{c.name}'" for c in conflicts)
         typer.echo(
@@ -359,15 +358,8 @@ def init(
     # ── AGENTS.md ──
     (project_path / "AGENTS.md").write_text(_AGENTS_MD_TEMPLATE)
 
-    # Curated NL-SQL pairs (auto-loaded by `wren memory index`)
-    (project_path / "queries.yml").write_text(
-        "# Curated NL-SQL pairs for this project.\n"
-        "# These are auto-loaded into memory on `wren memory index`.\n"
-        "# Use `wren memory dump` to export pairs from memory to this file.\n"
-        "# Format: same as `wren memory dump` output.\n"
-        "version: 1\n"
-        "pairs: []\n"
-    )
+    # NL→SQL pairs live in knowledge/sql/ (written by `wren memory store`),
+    # so no queries.yml is scaffolded.
 
     typer.echo(f"Wren project initialized: {project_path}")
     typer.echo("  wren_project.yml            — project metadata (edit data_source)")
@@ -383,8 +375,10 @@ def init(
     typer.echo(
         "  knowledge/rules/            — business rules for LLM query generation"
     )
+    typer.echo(
+        "  knowledge/sql/              — confirmed NL-SQL pairs (wren memory store)"
+    )
     typer.echo("  AGENTS.md                   — AI agent workflow guidance")
-    typer.echo("  queries.yml                 — curated NL-SQL pairs for memory")
     typer.echo("")
     typer.echo(
         "Next: Install agent skills via "
@@ -609,7 +603,7 @@ def build(
     """Build into target/mdl.json for the engine.
 
     Default mode: reads wren_project.yml, models/*/metadata.yml (+ref_sql.sql),
-    views/*/metadata.yml (+sql.yml), relationships.yml, and instructions.md.
+    views/*/metadata.yml (+sql.yml), relationships.yml, and knowledge/.
 
     With --from-osi: reads an Open Semantic Interchange YAML file and emits
     MDL JSON directly. The OSI file stays as the single source of truth; no

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -379,6 +379,15 @@ def init(
         "  knowledge/sql/              — confirmed NL-SQL pairs (wren memory store)"
     )
     typer.echo("  AGENTS.md                   — AI agent workflow guidance")
+    # A pre-existing legacy queries.yml is still auto-loaded by `wren memory
+    # index`; surface it so v4 and v5 pair sources don't silently mix.
+    if (project_path / "queries.yml").exists():
+        typer.echo(
+            "Note: a legacy queries.yml is present. It's still loaded on "
+            "`wren memory index`, but is deprecated — migrate its pairs into "
+            "knowledge/sql/ (see the migration reference).",
+            err=True,
+        )
     typer.echo("")
     typer.echo(
         "Next: Install agent skills via "

--- a/core/wren/src/wren/dbt.py
+++ b/core/wren/src/wren/dbt.py
@@ -356,7 +356,7 @@ def convert_dbt_project_to_wren_project(
 
     dbt_binding_dir = _relative_or_absolute_path(target.project_dir, project_root)
     project_config = {
-        "schema_version": 2,
+        "schema_version": 5,
         "name": artifacts.manifest.get("metadata", {}).get(
             "project_name", target.project.get("name", "dbt_project")
         ),
@@ -391,7 +391,7 @@ def convert_dbt_project_to_wren_project(
             ),
         ),
         ProjectFile(
-            relative_path="instructions.md",
+            relative_path="knowledge/rules/general.md",
             content=_build_base_instructions(
                 target,
                 model_count,
@@ -401,17 +401,31 @@ def convert_dbt_project_to_wren_project(
                 artifacts.run_results is not None,
             ),
         ),
-        ProjectFile(relative_path="AGENTS.md", content=_AGENTS_MD_TEMPLATE),
         ProjectFile(
-            relative_path="queries.yml",
-            content=yaml.dump(
-                {"version": 1, "pairs": query_pairs},
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-            ),
+            relative_path="knowledge/knowledge.yml", content="schema_version: 1\n"
         ),
+        ProjectFile(relative_path="AGENTS.md", content=_AGENTS_MD_TEMPLATE),
     ]
+
+    # NL→SQL pairs live one-per-file under knowledge/sql/ (v5 source of truth).
+    from wren.memory.markdown import render_query_markdown, slugify  # noqa: PLC0415
+
+    used_slugs: set[str] = set()
+    for pair in query_pairs:
+        base = slugify(pair["nl"])
+        slug, n = base, 1
+        while slug in used_slugs:
+            n += 1
+            slug = f"{base}-{n}"
+        used_slugs.add(slug)
+        files.append(
+            ProjectFile(
+                relative_path=f"knowledge/sql/{slug}.md",
+                content=render_query_markdown(
+                    pair["nl"], pair["sql"], source=pair.get("source", "dbt")
+                ),
+            )
+        )
 
     files.extend(
         ProjectFile(

--- a/core/wren/src/wren/dbt.py
+++ b/core/wren/src/wren/dbt.py
@@ -422,7 +422,10 @@ def convert_dbt_project_to_wren_project(
             ProjectFile(
                 relative_path=f"knowledge/sql/{slug}.md",
                 content=render_query_markdown(
-                    pair["nl"], pair["sql"], source=pair.get("source", "dbt")
+                    pair["nl"],
+                    pair["sql"],
+                    source=pair.get("source", "dbt"),
+                    datasource=pair.get("datasource"),
                 ),
             )
         )

--- a/core/wren/src/wren/osi.py
+++ b/core/wren/src/wren/osi.py
@@ -588,7 +588,10 @@ def _process_metrics(
     wren_cfg: WrenConfig,
     dataset_names: set[str],
 ) -> tuple[str | None, list[ValidationError]]:
-    """Render OSI top-level metrics as a markdown block for instructions.md.
+    """Render OSI top-level metrics as a markdown block of business rules.
+
+    Surfaced via the manifest's ``_instructions`` carrier, which the importer
+    writes to ``knowledge/rules/`` (or indexes as rules on build).
 
     Wren has no first-class equivalent of OSI's free-floating metrics
     (cubes are bound to a single base_object). For v1 we surface them as

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -328,6 +328,14 @@ def test_init_builds_knowledge_skeleton(tmp_path):
     assert not (tmp_path / "instructions.md").exists()
 
 
+def test_init_warns_on_legacy_queries_yml(tmp_path):
+    """A pre-existing legacy queries.yml is surfaced as deprecated at init."""
+    (tmp_path / "queries.yml").write_text("version: 1\npairs: []\n")
+    result = runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "queries.yml" in result.output and "deprecated" in result.output
+
+
 def test_init_does_not_clobber_existing_rules(tmp_path):
     """Re-running init must not overwrite existing business rules without --force."""
     runner.invoke(app, ["context", "init", "--empty", "--path", str(tmp_path)])
@@ -771,7 +779,9 @@ def test_import_dbt_force_overwrites_managed_files(tmp_path):
     assert forced.exit_code == 0, forced.output
     assert "jaffle_shop" in (output_dir / "wren_project.yml").read_text()
     sql_files = list((output_dir / "knowledge" / "sql").glob("*.md"))
-    assert any("source: dbt" in f.read_text() for f in sql_files)
+    contents = [f.read_text() for f in sql_files]
+    assert any("source: dbt" in c for c in contents)
+    assert any("datasource: duckdb" in c for c in contents)  # metadata preserved
 
 
 def test_write_project_files_force_preserves_queries_without_replacement(tmp_path):

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -307,7 +307,9 @@ def test_init_empty_skips_example_model_and_view(tmp_path):
     assert (tmp_path / "wren_project.yml").exists()
     assert (tmp_path / "relationships.yml").exists()
     assert (tmp_path / "AGENTS.md").exists()
-    assert (tmp_path / "queries.yml").exists()
+    assert (tmp_path / "knowledge" / "knowledge.yml").exists()
+    # v5 no longer scaffolds a legacy queries.yml (pairs live in knowledge/sql/)
+    assert not (tmp_path / "queries.yml").exists()
     # Summary mentions empty rather than the example paths
     assert "empty" in result.output
 
@@ -700,10 +702,13 @@ def test_import_dbt_writes_project_and_builds(tmp_path):
     assert (output_dir / "wren_project.yml").exists()
     assert (output_dir / "models" / "fct_orders" / "metadata.yml").exists()
     assert (output_dir / "relationships.yml").exists()
-    assert (output_dir / "queries.yml").exists()
+    assert (output_dir / "knowledge" / "rules" / "general.md").exists()
+    assert list((output_dir / "knowledge" / "sql").glob("*.md"))  # seeded NL→SQL pairs
+    assert not (output_dir / "queries.yml").exists()
     assert "skipped 1 ephemeral" in result.output
 
     config = yaml.safe_load((output_dir / "wren_project.yml").read_text())
+    assert config["schema_version"] == 5
     assert config["data_source"] == "duckdb"
     assert config["dbt"]["profile"] == "jaffle_shop"
     relationships = yaml.safe_load((output_dir / "relationships.yml").read_text())
@@ -730,7 +735,6 @@ def test_import_dbt_force_overwrites_managed_files(tmp_path):
     output_dir = tmp_path / "wren_project"
     output_dir.mkdir()
     (output_dir / "wren_project.yml").write_text("name: old\n")
-    (output_dir / "queries.yml").write_text("version: 1\npairs: []\n")
 
     result = runner.invoke(
         app,
@@ -766,7 +770,8 @@ def test_import_dbt_force_overwrites_managed_files(tmp_path):
     )
     assert forced.exit_code == 0, forced.output
     assert "jaffle_shop" in (output_dir / "wren_project.yml").read_text()
-    assert "source: dbt" in (output_dir / "queries.yml").read_text()
+    sql_files = list((output_dir / "knowledge" / "sql").glob("*.md"))
+    assert any("source: dbt" in f.read_text() for f in sql_files)
 
 
 def test_write_project_files_force_preserves_queries_without_replacement(tmp_path):

--- a/core/wren/tests/unit/test_convert_mdl.py
+++ b/core/wren/tests/unit/test_convert_mdl.py
@@ -150,7 +150,7 @@ def test_convert_mdl_to_project():
     assert "views/monthly_revenue/metadata.yml" in file_map
     assert "views/monthly_revenue/sql.yml" in file_map
     assert "relationships.yml" in file_map
-    assert "instructions.md" in file_map
+    assert "knowledge/rules/general.md" in file_map
     assert "AGENTS.md" in file_map
     assert file_map["AGENTS.md"] == _AGENTS_MD_TEMPLATE
 
@@ -192,8 +192,8 @@ def test_convert_mdl_to_project():
     assert rels["relationships"][0]["join_type"] == "MANY_TO_ONE"
     assert rels["relationships"][0]["name"] == "orders_customers"
 
-    # Instructions
-    assert "Always use UTC" in file_map["instructions.md"]
+    # Business rules → knowledge/rules/
+    assert "Always use UTC" in file_map["knowledge/rules/general.md"]
 
 
 # ── write_project_files ────────────────────────────────────────────────────
@@ -208,7 +208,7 @@ def test_write_project_files(tmp_path: Path):
     assert (tmp_path / "models" / "revenue_summary" / "ref_sql.sql").exists()
     assert (tmp_path / "views" / "monthly_revenue" / "sql.yml").exists()
     assert (tmp_path / "relationships.yml").exists()
-    assert (tmp_path / "instructions.md").exists()
+    assert (tmp_path / "knowledge" / "rules" / "general.md").exists()
     assert (tmp_path / "AGENTS.md").exists()
     assert (tmp_path / "AGENTS.md").read_text() == _AGENTS_MD_TEMPLATE
 
@@ -256,11 +256,11 @@ def test_convert_then_build_roundtrip(tmp_path: Path):
 
 
 def test_empty_mdl():
-    """Empty models/views/relationships — only wren_project.yml and AGENTS.md are produced."""
+    """Empty models/views/relationships — only the project, AGENTS.md, and the knowledge marker."""
     mdl = {"catalog": "wren", "schema": "public"}
     files = convert_mdl_to_project(mdl)
     paths = {f.relative_path for f in files}
-    assert paths == {"wren_project.yml", "AGENTS.md"}
+    assert paths == {"wren_project.yml", "AGENTS.md", "knowledge/knowledge.yml"}
     assert "instructions.md" not in paths
 
 
@@ -273,10 +273,11 @@ def test_no_data_source():
 
 
 def test_no_instructions():
-    """No _instructions — instructions.md is not produced."""
+    """No _instructions — no business-rules file is produced."""
     mdl = {"catalog": "wren", "schema": "public"}
     files = convert_mdl_to_project(mdl)
     assert not any(f.relative_path == "instructions.md" for f in files)
+    assert not any(f.relative_path == "knowledge/rules/general.md" for f in files)
 
 
 def test_unknown_camel_key_preserved():

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -774,7 +774,7 @@ def test_cli_init_from_osi_scaffolds_project(tmp_path: Path):
     assert (proj / "models" / "orders" / "metadata.yml").exists()
     assert (proj / "models" / "customers" / "metadata.yml").exists()
     assert (proj / "relationships.yml").exists()
-    assert (proj / "instructions.md").exists()
+    assert (proj / "knowledge" / "rules" / "general.md").exists()
     assert (proj / "AGENTS.md").exists()
     # The OSI semantic_model.name flowed into wren_project.yml
     import yaml as _yaml  # noqa: PLC0415


### PR DESCRIPTION
> Targets `feat/v5-project` (the v5 integration branch), not `main`.

## What

Closes the last v5 gap: the project **producers** (init scaffold + importers) still emitted
the pre-v5 layout (`instructions.md` / `queries.yml` / `schema_version` 2–4), so `import dbt`
and `init --from-mdl/--from-osi` handed users a pre-v5 project that then needed
`wren context upgrade`. Now every path that creates a project is v5 / `knowledge/`-native.

## Changes

- **`wren context init`** — no longer scaffolds an empty `queries.yml` (NL→SQL pairs live in
  `knowledge/sql/`, written by `wren memory store`). `instructions.md` was already dropped (O3).
- **`wren context import dbt`** (`dbt.py`) — `schema_version` 2→5; base notes →
  `knowledge/rules/general.md`; the dbt-test-derived NL→SQL pairs are written one-per-file to
  `knowledge/sql/*.md` (via `render_query_markdown`) + `knowledge/knowledge.yml`.
- **`convert_mdl_to_project`** (`init --from-mdl`, and the OSI import path) — `_LAYOUT_TO_SCHEMA`
  tops out at **5**; `_instructions` → `knowledge/rules/general.md`; always emits
  `knowledge/knowledge.yml`.
- **OSI** — the metrics block already flows through the manifest's `_instructions` carrier, so
  it now lands in `knowledge/rules/` via the converter; docstring corrected.
- build/init docstrings updated (`instructions.md` → `knowledge/`).

## Tests

Updated `test_context_cli` (init no queries.yml + dbt import → knowledge/), `test_convert_mdl`
(knowledge/rules + knowledge.yml, schema_version), `test_osi` (init --from-osi →
knowledge/rules). Full unit suite (`--ignore=test_memory`) **721 passed, 1 skipped**;
`uvx ruff` clean. `test_dbt.py` had no stale assertions.

With this, `init` / `import dbt` / `init --from-mdl` / `init --from-osi` all produce v5
projects directly — no follow-up `wren context upgrade` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project imports and scaffolding now organize guidance and SQL examples under a new `knowledge/` structure, including per-query markdown files.
  * `wren context init` now surfaces legacy query data as deprecated and points users to the new location for confirmed pairs.

* **Bug Fixes**
  * Updated conversion behavior so newer layouts map to the correct project schema version.
  * Existing projects are no longer flagged as scaffold conflicts because of legacy query files alone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->