### PR TITLE
fix(athena): treat DECIMAL(p) as scale 0, not a default non-zero scale

### DIFF
--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -91,7 +91,13 @@ def _trino_data_type_to_arrow(node) -> pa.DataType:
         return _TRINO_DATA_TYPE_TO_ARROW[kind]
 
     if kind == T.DECIMAL:
-        precision, scale = 38, 9
+        # Trino/Athena DECIMAL semantics: DECIMAL(p) means scale 0 (an integer
+        # of p digits), NOT an unspecified scale. Bare DECIMAL defaults to
+        # (38, 0). Only DECIMAL(p, s) carries a non-zero scale. Defaulting the
+        # scale to a non-zero value here both mistyped DECIMAL(p) columns and,
+        # for small precisions (e.g. DECIMAL(5)), produced scale > precision,
+        # which PyArrow rejects with an ArrowInvalid.
+        precision, scale = 38, 0
         params = node.expressions
         if len(params) >= 1:
             with contextlib.suppress(AttributeError, ValueError, TypeError):

--- a/core/wren/tests/unit/test_athena_connector.py
+++ b/core/wren/tests/unit/test_athena_connector.py
@@ -78,6 +78,22 @@ def test_parse_athena_type_decimal():
     assert _parse_athena_type("decimal(12,4)") == pa.decimal128(12, 4)
 
 
+def test_parse_athena_type_decimal_precision_only_is_scale_zero():
+    # Trino/Athena: DECIMAL(p) means scale 0, not an unspecified/default scale.
+    assert _parse_athena_type("decimal(10)") == pa.decimal128(10, 0)
+
+
+def test_parse_athena_type_decimal_bare_defaults():
+    # Bare DECIMAL is DECIMAL(38, 0) per the SQL standard / Trino.
+    assert _parse_athena_type("decimal") == pa.decimal128(38, 0)
+
+
+def test_parse_athena_type_decimal_small_precision_only():
+    # Regression: DECIMAL(5) must not yield scale > precision. A non-zero
+    # default scale (e.g. 9) produced decimal128(5, 9), which PyArrow rejects.
+    assert _parse_athena_type("decimal(5)") == pa.decimal128(5, 0)
+
+
 def test_parse_athena_type_array():
     assert _parse_athena_type("array(varchar)") == pa.list_(pa.string())
 


### PR DESCRIPTION
## Summary

- The Athena/Trino cursor type parser maps `DECIMAL(p)` (precision only) to a PyArrow decimal with a **default scale of 9** instead of scale `0`.
- This mistypes every precision-only `DECIMAL` column, and for small precisions (e.g. `DECIMAL(5)`) produces `scale > precision`, which PyArrow rejects outright.

## Root Cause

**Symptom** — Columns declared as `DECIMAL(p)` in Athena/Trino come back from `wren` with a fractional scale (e.g. `DECIMAL(10)` → `decimal128(10, 9)`). For small precisions like `DECIMAL(5)`, materialising the result table raises `pyarrow.lib.ArrowInvalid` because the requested scale (9) exceeds the precision (5).

**Root cause** — In `_trino_data_type_to_arrow` (`core/wren/src/wren/connector/athena.py`), the `T.DECIMAL` branch initialises `precision, scale = 38, 9`. The scale is only overwritten when an *explicit* second parameter is present. But in Trino/Athena (and the SQL standard) `DECIMAL(p)` means precision `p` with **scale 0**, and bare `DECIMAL` is `DECIMAL(38, 0)`. The non-zero default scale is simply wrong.

**Evidence** — Before the fix, on current `main`:

```
decimal(10)   -> decimal128(10, 9)   # should be (10, 0)
decimal       -> decimal128(38, 9)   # should be (38, 0)
decimal(5)    -> decimal128(5, 9)    # scale > precision; ArrowInvalid when building the array
decimal(10,2) -> decimal128(10, 2)   # explicit scale unaffected (correct)
```

**Fix + why this level** — Change the default to `precision, scale = 38, 0`. This is the correct layer: the cursor-type → Arrow mapping is the single place Athena DECIMAL types are interpreted, so fixing the default here corrects schema typing, value coercion, and avoids the downstream ArrowInvalid without touching any caller. The explicit `DECIMAL(p, s)` path is unchanged.

**Scope / risk** — Touches only the `T.DECIMAL` branch in the Athena connector. `DECIMAL(p, s)` (explicit scale) behaviour is identical; bare `DECIMAL` and `DECIMAL(p)` now follow Trino/Athena semantics. No other connector or type is affected.

## Verification

- `just test-unit` / `uv run --no-sync pytest tests/unit/ -q` — **779 passed, 42 skipped** (was 776 passed; +3 new tests).
- `ruff format --check src/` + `ruff check src/` — clean.

## Real behavior proof

Captured from a real run on this branch (`uv run python3`):

```
decimal(10)   -> decimal128(10, 0)
decimal       -> decimal128(38, 0)
decimal(5)    -> decimal128(5, 0)
decimal(10,2) -> decimal128(10, 2)
```

**Regression tests** (in `tests/unit/test_athena_connector.py`) assert the new shape and FAIL on current `main`:

```
FAILED test_parse_athena_type_decimal_precision_only_is_scale_zero
        assert decimal128(10, 9) == decimal128(10, 0)
FAILED test_parse_athena_type_decimal_bare_defaults
        assert decimal128(38, 9) == decimal128(38, 0)
FAILED test_parse_athena_type_decimal_small_precision_only
        assert decimal128(5, 9) == decimal128(5, 0)
```

All three pass with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Athena/Trino decimal parsing so bare `DECIMAL(p)` values now default to scale `0` instead of `9`.
  * Improved handling of bare `DECIMAL` values to use a valid default decimal type.
  * Prevented invalid decimal precision/scale combinations that could fail type conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->