### PR TITLE
fix(trino): treat DECIMAL(p) as scale 0, not a default non-zero scale

### DIFF
--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -101,7 +101,12 @@ def _trino_data_type_to_arrow(node) -> pa.DataType:
         return _TRINO_DATA_TYPE_TO_ARROW[kind]
 
     if kind == T.DECIMAL:
-        precision, scale = 38, 9
+        # Trino DECIMAL semantics: DECIMAL(p) is precision p with scale 0, and
+        # bare DECIMAL is DECIMAL(38, 0). Defaulting the scale to a non-zero
+        # value mistyped precision-only DECIMAL columns and, for small
+        # precisions (e.g. DECIMAL(5)), produced scale > precision, which
+        # PyArrow rejects with an ArrowInvalid.
+        precision, scale = 38, 0
         params = node.expressions
         if len(params) >= 1:
             with contextlib.suppress(AttributeError, ValueError):

--- a/core/wren/tests/connectors/test_trino.py
+++ b/core/wren/tests/connectors/test_trino.py
@@ -64,7 +64,10 @@ _SCHEMA = "default"
         # Decimal
         ("decimal(10,2)", pa.decimal128(10, 2)),
         ("decimal(38,9)", pa.decimal128(38, 9)),
-        ("decimal", pa.decimal128(38, 9)),
+        # DECIMAL(p) is scale 0 and bare DECIMAL is DECIMAL(38, 0) in Trino.
+        ("decimal", pa.decimal128(38, 0)),
+        ("decimal(10)", pa.decimal128(10, 0)),
+        ("decimal(5)", pa.decimal128(5, 0)),
         # Time / timestamp
         ("time", pa.time64("us")),
         ("time(3)", pa.time64("us")),

--- a/core/wren/tests/unit/test_athena_connector.py
+++ b/core/wren/tests/unit/test_athena_connector.py
@@ -74,8 +74,20 @@ def test_parse_athena_type_primitives(type_str, expected):
     assert _parse_athena_type(type_str) == expected
 
 
-def test_parse_athena_type_decimal():
-    assert _parse_athena_type("decimal(12,4)") == pa.decimal128(12, 4)
+@pytest.mark.parametrize(
+    ("type_str", "expected"),
+    [
+        ("decimal(12,4)", pa.decimal128(12, 4)),
+        # bare DECIMAL and precision-only DECIMAL(p) default to scale 0
+        # (kept aligned with the Trino parser).
+        ("decimal", pa.decimal128(38, 0)),
+        ("decimal(10)", pa.decimal128(10, 0)),
+        # small precision must not produce scale > precision (ArrowInvalid).
+        ("decimal(5)", pa.decimal128(5, 0)),
+    ],
+)
+def test_parse_athena_type_decimal(type_str, expected):
+    assert _parse_athena_type(type_str) == expected
 
 
 def test_parse_athena_type_decimal_precision_only_is_scale_zero():
@@ -91,6 +103,21 @@ def test_parse_athena_type_decimal_bare_defaults():
 def test_parse_athena_type_decimal_small_precision_only():
     # Regression: DECIMAL(5) must not yield scale > precision. A non-zero
     # default scale (e.g. 9) produced decimal128(5, 9), which PyArrow rejects.
+    assert _parse_athena_type("decimal(5)") == pa.decimal128(5, 0)
+
+
+def test_parse_athena_type_decimal_bare_defaults_to_scale_0():
+    # Bare DECIMAL is DECIMAL(38, 0) in Athena/Trino semantics.
+    assert _parse_athena_type("decimal") == pa.decimal128(38, 0)
+
+
+def test_parse_athena_type_decimal_precision_only_has_scale_0():
+    # DECIMAL(p) is precision p with scale 0, not a default non-zero scale.
+    assert _parse_athena_type("decimal(10)") == pa.decimal128(10, 0)
+
+
+def test_parse_athena_type_decimal_small_precision_only():
+    # Small precision-only case must not produce scale > precision (ArrowInvalid).
     assert _parse_athena_type("decimal(5)") == pa.decimal128(5, 0)
 
 


### PR DESCRIPTION
## Summary

- The Trino cursor type parser maps `DECIMAL(p)` (precision only) and bare `DECIMAL` to a PyArrow decimal with a **default scale of 9** instead of scale `0`.
- This mistypes every precision-only `DECIMAL` column, and for small precisions (e.g. `DECIMAL(5)`) produces `scale > precision`, which PyArrow rejects outright.

## Root Cause

**Symptom** — Columns declared as `DECIMAL(p)` (or bare `DECIMAL`) in Trino come back from `wren` with a fractional scale (e.g. `DECIMAL(10)` → `decimal128(10, 9)`). For small precisions like `DECIMAL(5)`, materialising the result table raises `pyarrow.lib.ArrowInvalid` because the requested scale (9) exceeds the precision (5).

**Root cause** — In `_trino_data_type_to_arrow` (`core/wren/src/wren/connector/trino.py`), the `T.DECIMAL` branch initialises `precision, scale = 38, 9`. The scale is only overwritten when an *explicit* second parameter is present. But in Trino `DECIMAL(p)` means precision `p` with **scale 0**, and bare `DECIMAL` is `DECIMAL(38, 0)`. The non-zero default scale is wrong.

**Evidence** — Before the fix, on current `main`:

```
decimal(10)   -> decimal128(10, 9)   # should be (10, 0)
decimal       -> decimal128(38, 9)   # should be (38, 0)
decimal(5)    -> decimal128(5, 9)    # scale > precision; ArrowInvalid when building the array
decimal(10,2) -> decimal128(10, 2)   # explicit scale unaffected (correct)
```

The existing test even codified the wrong default (`("decimal", pa.decimal128(38, 9))`); it is corrected here to `(38, 0)`.

**Fix + why this level** — Change the default to `precision, scale = 38, 0`. This is the correct layer: the cursor-type → Arrow mapping is the single place Trino DECIMAL types are interpreted, so fixing the default here corrects schema typing, value coercion, and avoids the downstream ArrowInvalid without touching any caller. The explicit `DECIMAL(p, s)` path is unchanged.

**Scope / risk** — Touches only the `T.DECIMAL` branch in the Trino connector (and the corresponding test expectations). `DECIMAL(p, s)` behaviour is identical. This mirrors the same fix in the Athena connector (#2403); the two connectors share the Trino-flavoured type grammar.

## Verification

- `uv run --no-sync pytest tests/connectors/test_trino.py -k data_type` — **40 passed** (was 37; +3 new cases).
- `ruff format --check src/` + `ruff check src/` — clean.

## Real behavior proof

Captured from a real run on this branch (`uv run python3`):

```
decimal(10)   -> decimal128(10, 0)
decimal       -> decimal128(38, 0)
decimal(5)    -> decimal128(5, 0)
decimal(10,2) -> decimal128(10, 2)
```

**Regression cases** (added to the parametrized `test_parse_trino_data_type`) assert the new shape and FAIL on current `main`:

```
FAILED test_parse_trino_data_type[decimal-expected18]      assert decimal128(38, 9) == decimal128(38, 0)
FAILED test_parse_trino_data_type[decimal(10)-expected19]  assert decimal128(10, 9) == decimal128(10, 0)
FAILED test_parse_trino_data_type[decimal(5)-expected20]   assert decimal128(5, 9)  == decimal128(5, 0)
```

All three pass with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parsing of Trino and Athena `DECIMAL` types so bare `DECIMAL` and precision-only `DECIMAL(p)` now default to scale `0`.
  * Improved handling of small-precision decimals (e.g., `DECIMAL(5)`) to prevent invalid decimal definitions during conversion.
  * Updated and expanded unit-test expectations to match the revised `DECIMAL` parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->