### PR TITLE
fix(genbi): normalise null apps/schema_version in app index

### DIFF
--- a/core/wren/src/wren/genbi/index.py
+++ b/core/wren/src/wren/genbi/index.py
@@ -50,8 +50,19 @@ def load_index(project_path: Path) -> dict:
             f"{path} is malformed — expected a mapping at the top level, "
             f"got {type(data).__name__}."
         )
-    data.setdefault("schema_version", INDEX_SCHEMA_VERSION)
-    data.setdefault("apps", {})
+    # Use ``or`` rather than ``setdefault`` so an explicit null value
+    # (``apps:`` / ``schema_version:`` with no value, e.g. from a hand-edit or
+    # a truncated write) is normalised too. ``setdefault`` is a no-op when the
+    # key already exists, which left ``apps: None`` in place and made every
+    # accessor crash with an opaque ``AttributeError`` deep in a command.
+    data["schema_version"] = data.get("schema_version") or INDEX_SCHEMA_VERSION
+    apps = data.get("apps") or {}
+    if not isinstance(apps, dict):
+        raise MalformedIndexError(
+            f"{path} is malformed — 'apps' must be a mapping, "
+            f"got {type(apps).__name__}."
+        )
+    data["apps"] = apps
     return data
 
 

--- a/core/wren/src/wren/genbi/index.py
+++ b/core/wren/src/wren/genbi/index.py
@@ -50,13 +50,18 @@ def load_index(project_path: Path) -> dict:
             f"{path} is malformed — expected a mapping at the top level, "
             f"got {type(data).__name__}."
         )
-    # Use ``or`` rather than ``setdefault`` so an explicit null value
-    # (``apps:`` / ``schema_version:`` with no value, e.g. from a hand-edit or
-    # a truncated write) is normalised too. ``setdefault`` is a no-op when the
-    # key already exists, which left ``apps: None`` in place and made every
-    # accessor crash with an opaque ``AttributeError`` deep in a command.
-    data["schema_version"] = data.get("schema_version") or INDEX_SCHEMA_VERSION
-    apps = data.get("apps") or {}
+    # Normalise explicit null values (``apps:`` / ``schema_version:`` with no
+    # value, e.g. from a hand-edit or a truncated write). ``setdefault`` is a
+    # no-op when the key already exists, which left ``apps: None`` in place and
+    # made every accessor crash with an opaque ``AttributeError`` deep in a
+    # command. We check ``is None`` specifically rather than truthiness so a
+    # valid falsy value is preserved and surfaced for validation instead of
+    # being silently coerced to a default.
+    if data.get("schema_version") is None:
+        data["schema_version"] = INDEX_SCHEMA_VERSION
+    apps = data.get("apps")
+    if apps is None:
+        apps = {}
     if not isinstance(apps, dict):
         raise MalformedIndexError(
             f"{path} is malformed — 'apps' must be a mapping, "

--- a/core/wren/tests/unit/test_genbi_index.py
+++ b/core/wren/tests/unit/test_genbi_index.py
@@ -145,3 +145,39 @@ def test_register_rejects_path_traversal_name(tmp_path: Path) -> None:
     result = runner.invoke(app, ["genbi", "register", "../evil", "-p", str(project)])
     assert result.exit_code != 0
     assert "invalid app name" in result.output
+
+
+def test_load_index_normalises_null_apps(tmp_path: Path) -> None:
+    # Regression: an explicit ``apps:`` with no value (hand-edit / truncated
+    # write) is valid YAML and parses to None. setdefault() was a no-op since
+    # the key existed, leaving ``apps: None`` so every accessor crashed with an
+    # opaque AttributeError. load_index must normalise it to an empty dict.
+    path = index_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("schema_version: 1\napps:\n")
+
+    data = load_index(tmp_path)
+    assert data["apps"] == {}
+    assert data["schema_version"] == 1
+    # And the normal accessor must not crash on it.
+    from wren.genbi.index import get_app
+
+    assert get_app(tmp_path, "missing") is None
+
+
+def test_load_index_normalises_null_schema_version(tmp_path: Path) -> None:
+    path = index_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("schema_version:\napps: {}\n")
+
+    data = load_index(tmp_path)
+    assert data["schema_version"] == 1
+
+
+def test_load_index_raises_on_non_mapping_apps(tmp_path: Path) -> None:
+    path = index_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("apps:\n  - one\n  - two\n")  # apps is a list, not a mapping
+
+    with pytest.raises(MalformedIndexError):
+        load_index(tmp_path)

--- a/core/wren/tests/unit/test_genbi_index.py
+++ b/core/wren/tests/unit/test_genbi_index.py
@@ -181,3 +181,14 @@ def test_load_index_raises_on_non_mapping_apps(tmp_path: Path) -> None:
 
     with pytest.raises(MalformedIndexError):
         load_index(tmp_path)
+
+
+def test_load_index_preserves_falsy_schema_version(tmp_path: Path) -> None:
+    # A literal 0 is a real value, not a missing one — it must be preserved
+    # rather than coerced to the default, so only explicit null normalises.
+    path = index_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("schema_version: 0\napps: {}\n")
+
+    data = load_index(tmp_path)
+    assert data["schema_version"] == 0


### PR DESCRIPTION
## Summary

- `load_index` normalised a missing `apps` key with `data.setdefault("apps", {})`, but `setdefault` is a no-op when the key already exists.
- An `apps.yml` with an explicit-but-empty `apps:` (a hand-edit or a truncated write) is valid YAML that parses to `{"apps": None}` — the key is present, so `setdefault` leaves `None` in place. Every accessor (`get_app`, `register_app`, `remove_app`, `update_app`) then crashes with an opaque `AttributeError: 'NoneType' object has no attribute 'get'`.

This defeats the whole point of `MalformedIndexError`, which exists precisely so a bad index file fails clearly instead of crashing deep in a command.

## Reproduction

```python
# .wren/apps.yml:
#   schema_version: 1
#   apps:
load_index(project)["apps"]   # -> None
get_app(project, "foo")       # -> AttributeError: 'NoneType' object has no attribute 'get'
```

## Fix

Normalise null values with `or` instead of `setdefault`, so an explicit null `apps:` / `schema_version:` is coerced to its default. Also raise `MalformedIndexError` (not a later opaque crash) when `apps` is present but is a non-mapping (e.g. a list).

## Real behavior proof

**Real environment:** Python 3.12, `core/wren` via `uv run --no-sync`, repo `main`.

**Commands:**
```
uv run --no-sync pytest tests/unit/test_genbi_index.py -q
uv run --no-sync pytest tests/unit -q
```

**AFTER fix:**
```
13 passed                      # test_genbi_index.py
779 passed, 42 skipped         # full unit suite
```

**BEFORE fix (new tests stashed onto unpatched index.py):**
```
3 failed, 10 passed
FAILED test_load_index_normalises_null_apps
FAILED test_load_index_normalises_null_schema_version
FAILED test_load_index_raises_on_non_mapping_apps
```

## Tests

`tests/unit/test_genbi_index.py` gains coverage for null `apps`, null `schema_version`, and a non-mapping `apps` (raises `MalformedIndexError`). The null-apps test fails without the fix.

## Scope / risk

Apache-2.0 path (`core/wren`). Only changes index normalisation; well-formed index files behave identically (covered by the existing 10 index tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of incomplete index data, safely handling explicit null top-level fields.
  * Added clearer error reporting when the `apps` field isn’t a mapping, preventing downstream crashes.
  * Ensured schema version defaults apply for null/absent values while preserving explicit `0`.
* **Tests**
  * Added unit tests covering null/empty `apps`, null `schema_version`, invalid (non-mapping) `apps`, and preservation of `schema_version: 0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->