### PR TITLE
fix(clickhouse): default port-less clickhouse+https URLs to 8443, not 8123

### DIFF
--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -261,9 +261,15 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
         # urlparse leaves percent-encoded characters in userinfo, so decode
         # them before clickhouse-connect sees the credentials. Matches the
         # mssql / postgres URL handling elsewhere in this package.
+        secure = parsed.scheme == "clickhouse+https"
+        # Pick the port-less default from the scheme: ClickHouse listens for
+        # HTTPS on 8443 and plaintext HTTP on 8123. Defaulting an https URL to
+        # 8123 silently dialed the plaintext port with ``secure=True``, so the
+        # TLS handshake hit a non-TLS listener and the connection failed.
+        default_port = 8443 if secure else 8123
         out: dict = {
             "host": parsed.hostname,
-            "port": int(parsed.port) if parsed.port else 8123,
+            "port": int(parsed.port) if parsed.port else default_port,
             "username": (
                 unquote_plus(parsed.username) if parsed.username else "default"
             ),
@@ -272,7 +278,7 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
         }
         if parsed.path and parsed.path != "/":
             out["database"] = parsed.path.lstrip("/")
-        if parsed.scheme == "clickhouse+https":
+        if secure:
             out["secure"] = True
         # ``settings`` already popped above, so ``out["settings"]`` survives.
         out.update(kwargs)

--- a/core/wren/tests/connectors/test_clickhouse.py
+++ b/core/wren/tests/connectors/test_clickhouse.py
@@ -289,3 +289,45 @@ class TestClickHouseClientKwargs:
         info = _FakeChInfo(kwargs={"statement_timeout": 10})
         out = _build_clickhouse_client_kwargs(info)
         assert out["settings"] == {"max_execution_time": 10}
+
+
+class _FakeChUrl:
+    """Stand-in exposing a ``connection_url`` for the URL kwargs path."""
+
+    def __init__(self, url: str) -> None:
+        from pydantic import SecretStr
+
+        self.connection_url = SecretStr(url)
+        self.kwargs = None
+
+
+@pytest.mark.clickhouse
+class TestClickHouseUrlKwargs:
+    """Pure-Python tests for the ``connection_url`` branch of the kwargs builder."""
+
+    def test_https_url_without_port_uses_secure_default_port(self) -> None:
+        """A port-less clickhouse+https URL must dial 8443 (TLS), not 8123.
+
+        ClickHouse serves HTTPS on 8443 and plaintext HTTP on 8123. Defaulting
+        an https URL to 8123 while also setting ``secure=True`` made the TLS
+        client connect to the plaintext listener — the handshake fails.
+        """
+        out = _build_clickhouse_client_kwargs(
+            _FakeChUrl("clickhouse+https://user:pw@host/db")
+        )
+        assert out["secure"] is True
+        assert out["port"] == 8443
+
+    def test_http_url_without_port_uses_plaintext_default_port(self) -> None:
+        out = _build_clickhouse_client_kwargs(
+            _FakeChUrl("clickhouse+http://user:pw@host/db")
+        )
+        assert "secure" not in out
+        assert out["port"] == 8123
+
+    def test_explicit_port_is_respected_for_https(self) -> None:
+        out = _build_clickhouse_client_kwargs(
+            _FakeChUrl("clickhouse+https://user:pw@host:9440/db")
+        )
+        assert out["secure"] is True
+        assert out["port"] == 9440


### PR DESCRIPTION
## What

A `clickhouse+https://` connection URL **without an explicit port** is parsed into client kwargs with `secure=True` but `port=8123` — the plaintext HTTP port. ClickHouse serves HTTPS on **8443** and plaintext HTTP on 8123, so the TLS client dials the non-TLS listener and the handshake fails.

This fixes `_build_clickhouse_client_kwargs` in the URL branch to derive the port-less default from the scheme: `8443` for HTTPS, `8123` for plaintext HTTP. An explicit port in the URL is still respected.

## Why it's a bug

The scheme says "use TLS" but the default port says "plaintext" — they contradict each other, so a perfectly valid `clickhouse+https://user:pw@host/db` URL (no port) is unconnectable.

## Evidence

**Before (unpatched)** — new test fails:
```
>       assert out["port"] == 8443
E       assert 8123 == 8443
tests/connectors/test_clickhouse.py:319: AssertionError
1 failed, 2 passed
```

**After (patched)** — all pass:
```
$ pytest tests/connectors/test_clickhouse.py -k "Kwargs or Url"
6 passed, 46 deselected
```

## Scope

- `core/wren/src/wren/connector/clickhouse.py` — derive default port from scheme (1 change)
- `core/wren/tests/connectors/test_clickhouse.py` — `TestClickHouseUrlKwargs` covering https→8443, http→8123, and explicit-port-respected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse URL handling so secure connections are detected correctly from the URL scheme.
  * Default ports now match the connection type: secure URLs use 8443, non-secure URLs use 8123.
  * Explicit ports provided in the URL are preserved while still applying the correct secure setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->