### PR TITLE
fix(osi): skip empty expressions when picking a dialect expression

### DIFF
--- a/core/wren/src/wren/osi.py
+++ b/core/wren/src/wren/osi.py
@@ -288,14 +288,20 @@ def _pick_expression(expr_field: Any, dialect_preference: str) -> str:
             val = d.get("expression", "")
             if isinstance(key, str):
                 by_dialect[key] = val if isinstance(val, str) else ""
-    if dialect_preference in by_dialect:
+    # Resolve in priority order, but skip empty expressions so a present-but-
+    # blank preferred (or ANSI_SQL) entry does not shadow a real expression
+    # further down the list. An empty string carries no SQL, so treating it as
+    # "found" would emit an empty/identity column for a genuinely calculated
+    # field.
+    if by_dialect.get(dialect_preference):
         return by_dialect[dialect_preference]
-    if "ANSI_SQL" in by_dialect:
+    if by_dialect.get("ANSI_SQL"):
         return by_dialect["ANSI_SQL"]
-    first = dialects[0]
-    if isinstance(first, dict):
-        val = first.get("expression", "")
-        return val if isinstance(val, str) else ""
+    for d in dialects:
+        if isinstance(d, dict):
+            val = d.get("expression", "")
+            if isinstance(val, str) and val:
+                return val
     return ""
 
 

--- a/core/wren/tests/unit/test_osi.py
+++ b/core/wren/tests/unit/test_osi.py
@@ -241,6 +241,30 @@ def test_pick_expression_falls_back_to_first():
     assert _pick_expression(expr, "SNOWFLAKE") == "[x]"
 
 
+def test_pick_expression_skips_empty_preferred_and_uses_ansi():
+    # An empty preferred-dialect expression must not shadow a real ANSI_SQL one.
+    expr = {
+        "dialects": [
+            {"dialect": "SNOWFLAKE", "expression": ""},
+            {"dialect": "ANSI_SQL", "expression": "SUM(x)"},
+        ]
+    }
+    assert _pick_expression(expr, "SNOWFLAKE") == "SUM(x)"
+
+
+def test_pick_expression_skips_empty_ansi_and_uses_first_nonempty():
+    # Empty preferred AND empty ANSI_SQL must fall through to the next
+    # non-empty expression rather than returning "".
+    expr = {
+        "dialects": [
+            {"dialect": "SNOWFLAKE", "expression": ""},
+            {"dialect": "ANSI_SQL", "expression": ""},
+            {"dialect": "MDX", "expression": "[x]"},
+        ]
+    }
+    assert _pick_expression(expr, "SNOWFLAKE") == "[x]"
+
+
 def test_pick_expression_shorthand_string():
     assert _pick_expression("x", "ANSI_SQL") == "x"
 


### PR DESCRIPTION
## What

`_pick_expression` (OSI → MDL importer) resolves a SQL expression for a field/metric in priority order: preferred dialect → `ANSI_SQL` → first available. The membership checks used `in by_dialect`, so a **present-but-empty** expression for the preferred dialect (or for `ANSI_SQL`) counted as "found" and was returned verbatim — shadowing a real expression sitting in another dialect entry.

This skips blank expressions at every resolution tier and falls through to the first non-empty expression.

## Why it's a bug

An empty string carries no SQL. When the preferred dialect entry is blank, the field is genuinely calculated elsewhere in the `dialects` list, but the importer would emit it as an empty/identity column — silently dropping the calculation.

## Evidence

**Before (unpatched)** — new tests fail:
```
test_pick_expression_skips_empty_preferred_and_uses_ansi      FAILED
test_pick_expression_skips_empty_ansi_and_uses_first_nonempty FAILED
  assert "" == "SUM(x)"   /   assert "" == "[x]"
```

**After (patched)** — whole OSI suite green:
```
$ pytest tests/unit/test_osi.py
74 passed
```

## Scope

- `core/wren/src/wren/osi.py` — `_pick_expression` skips empty entries per tier (1 change)
- `core/wren/tests/unit/test_osi.py` — 2 new cases (empty-preferred→ANSI, empty-preferred+empty-ANSI→first non-empty)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression selection so blank dialect-specific values are skipped instead of being treated as valid results.
  * Prevented empty calculated fields from being emitted when the preferred or fallback dialect entry has no expression.
* **Tests**
  * Added coverage for empty-expression handling and fallback behavior across dialects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->