### PR TITLE
fix(context): preserve leading underscores in _snake_to_camel key conversion

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -76,9 +76,20 @@ See https://docs.getwren.ai/oss/engine/get_started/installation for full setup.
 
 
 def _snake_to_camel(name: str) -> str:
-    """Convert snake_case to camelCase."""
-    parts = name.split("_")
-    return parts[0] + "".join(w.capitalize() for w in parts[1:])
+    """Convert snake_case to camelCase, preserving any leading underscores.
+
+    Keys like ``_instructions`` are sentinel carriers consumed downstream
+    under that exact name. The naive ``"_instructions".split("_")`` yields
+    ``["", "instructions"]`` → ``"Instructions"`` — the leading underscore is
+    lost and the first real word is capitalized, mangling the key. Strip and
+    re-attach the leading underscore run so it round-trips.
+    """
+    stripped = name.lstrip("_")
+    prefix = name[: len(name) - len(stripped)]
+    parts = stripped.split("_")
+    if not stripped:
+        return name
+    return prefix + parts[0] + "".join(w.capitalize() for w in parts[1:])
 
 
 def _convert_keys(obj: Any) -> Any:

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -43,6 +43,24 @@ def test_snake_to_camel():
     assert _snake_to_camel("name") == "name"
 
 
+def test_snake_to_camel_preserves_leading_underscore():
+    # Sentinel keys like `_instructions` must keep their leading underscore
+    # and not capitalize the first real word (the naive split mangled this
+    # into "Instructions").
+    assert _snake_to_camel("_instructions") == "_instructions"
+    assert _snake_to_camel("_dbt_tests") == "_dbtTests"
+    assert _snake_to_camel("__double") == "__double"
+
+
+def test_convert_keys_does_not_mangle_nested_instructions():
+    # A nested `_instructions` carrier must survive the camelCase pass intact;
+    # the top-level pop workarounds elsewhere don't protect nested ones.
+    obj = {"models": [{"name": "m", "_instructions": "do x"}]}
+    result = _convert_keys(obj)
+    assert result["models"][0]["_instructions"] == "do x"
+    assert "Instructions" not in result["models"][0]
+
+
 def test_convert_keys_nested():
     obj = {
         "table_reference": {"catalog": "c", "schema_name": "s"},


### PR DESCRIPTION
## What

`_snake_to_camel` (snake_case → camelCase key conversion used by `_convert_keys` across the MDL/OSI export path) mangles keys with a leading underscore:

```python
"_instructions".split("_")  # → ["", "instructions"]
# parts[0]="" + "Instructions"  → "Instructions"
```

The leading underscore is dropped **and** the first real word is capitalized, so `_instructions` becomes `Instructions`. This fix strips the leading-underscore run, camelizes the remainder, and re-attaches the prefix.

## Why it's a bug

`_instructions` is a sentinel carrier consumed downstream under that exact name (`context.convert_mdl_to_project`, `memory.schema_indexer`, OSI metrics rules). Two call sites (`osi.build_json_from_osi`, `context_cli`) already `pop("_instructions")` before `_convert_keys` and re-attach it afterward — a manual workaround that betrays the root defect and only protects the **top-level** key. A nested `_instructions` (e.g. per-model) still gets silently renamed to `Instructions` and lost.

## Evidence

**Before (unpatched)** — new tests fail:
```
test_snake_to_camel_preserves_leading_underscore       FAILED  ("_instructions" → "Instructions")
test_convert_keys_does_not_mangle_nested_instructions  FAILED  KeyError: '_instructions'
```

**After (patched)** — full context/MDL/OSI suites green:
```
$ pytest tests/unit/test_context.py tests/unit/test_convert_mdl.py tests/unit/test_osi.py
217 passed
```

Round-trips verified: `_instructions`→`_instructions`, `_dbt_tests`→`_dbtTests`, `__double`→`__double`, and all existing mappings (`table_reference`→`tableReference`, etc.) unchanged.

## Scope

- `core/wren/src/wren/context.py` — `_snake_to_camel` preserves leading underscores (1 change)
- `core/wren/tests/unit/test_context.py` — 2 new cases (leading-underscore preservation + nested-`_instructions` survival)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved leading underscores in key names during conversion, so special fields like `_instructions` keep their expected form instead of being altered.
  * Improved handling of nested keys so underscore-prefixed values are passed through correctly in model-related data.

* **Tests**
  * Added coverage for underscore-preserving key conversion and nested key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->