### PR TITLE
feat(memory): add 'wren memory watch' to auto-reindex on source changes

### DIFF
--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -140,6 +140,7 @@ wren memory index                              # index MDL schema
 wren memory fetch -q "customer order price"    # fetch relevant schema context
 wren memory store --nl "top customers" --sql "SELECT ..."  # store NL→SQL pair
 wren memory recall -q "best customers"         # retrieve similar past queries
+wren memory watch                              # auto-reindex on schema/query changes
 ```
 
 **7. (Optional) Build a shareable GenBI app** — turn the context layer into a

--- a/core/wren/docs/cli.md
+++ b/core/wren/docs/cli.md
@@ -111,6 +111,31 @@ wren memory index                          # uses ~/.wren/mdl.json
 wren memory index --mdl /path/to/mdl.json  # explicit MDL file
 ```
 
+### `wren memory watch`
+
+Watch project sources and auto-reindex on change so semantic recall never serves a stale
+schema while you are actively modelling. Polls `target/mdl.json` and `knowledge/sql/*.md`
+on an interval; when their content fingerprint changes it runs the equivalent of
+`wren memory index`. A failed reindex leaves the change pending and is retried on the next
+poll — an update is never silently dropped. Runs until `Ctrl+C`.
+
+Requires the `memory` extra. With the grep backend there is no derived index to keep
+fresh, so this command exits with a message.
+
+| Flag | Description |
+|------|-------------|
+| `--interval`, `-i` | Seconds between polls (min 1). Default: `5`. |
+| `--reindex-on-start` / `--no-reindex-on-start` | Reindex once on startup before watching. Default: off. |
+| `--max-polls` | Stop after N polls (mainly for scripting/testing). Default: run until Ctrl+C. |
+| `--mdl` | Explicit MDL file (must live under the watched project root). |
+| `--path` | Project root to watch. Defaults to the discovered project. |
+
+```bash
+wren memory watch                    # poll every 5s, reindex on change
+wren memory watch -i 2                # poll every 2s
+wren memory watch --reindex-on-start  # ensure the index is fresh before the first interval
+```
+
 ### `wren memory describe`
 
 Print the full schema as structured plain text. No embedding or LanceDB required — this is a pure transformation of the MDL manifest into a human/LLM-readable format.

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -560,6 +560,112 @@ def check(
 
 
 @memory_app.command()
+def watch(
+    mdl: MdlOpt = None,
+    path: PathOpt = None,
+    interval: Annotated[
+        float,
+        typer.Option(
+            "--interval",
+            "-i",
+            help="Seconds between polls (min 1).",
+        ),
+    ] = 5.0,
+    reindex_on_start: Annotated[
+        bool,
+        typer.Option(
+            "--reindex-on-start/--no-reindex-on-start",
+            help="Reindex once on startup before watching.",
+        ),
+    ] = False,
+    max_polls: Annotated[
+        Optional[int],
+        typer.Option(
+            "--max-polls",
+            help="Stop after N polls (mainly for scripting/testing). "
+            "Default: run until Ctrl+C.",
+        ),
+    ] = None,
+) -> None:
+    """Watch project sources and auto-reindex memory on change.
+
+    Polls ``target/mdl.json`` and ``knowledge/sql/*.md`` on an interval; when
+    their content fingerprint changes, runs the equivalent of
+    ``wren memory index`` so semantic recall never serves a stale schema while
+    you are actively modelling. A reindex that fails leaves the change pending
+    and is retried on the next poll — an update is never silently dropped.
+
+    Requires the ``memory`` extra (the index it maintains is LanceDB-backed).
+    With the grep backend there is no derived index to keep fresh.
+    """
+    from wren.context import discover_project_path  # noqa: PLC0415
+    from wren.memory.index_backend import resolve_backend  # noqa: PLC0415
+    from wren.memory.watch import watch_loop  # noqa: PLC0415
+
+    if resolve_backend() == "grep":
+        typer.echo(
+            "grep backend: knowledge/sql/ IS the index — nothing to watch. "
+            "Install `wrenai[memory]` for a derived index to keep fresh.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    try:
+        project_path = discover_project_path()
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    def _reindex() -> None:
+        manifest = _load_manifest(mdl)
+        mem_store = _get_store(path)
+        result = mem_store.index_schema(manifest, seed_queries=True)
+        from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
+
+        md_pairs = load_query_pairs(project_path)
+        loaded = 0
+        if md_pairs:
+            res = mem_store.load_queries(md_pairs, upsert=True)
+            loaded = res["loaded"] + res["updated"]
+        typer.echo(
+            f"Reindexed {result['schema_items']} schema item(s)"
+            + (f", {loaded} pair(s)" if loaded else "")
+            + "."
+        )
+
+    def _on_event(event: str) -> None:
+        if event == "change-detected":
+            typer.echo("Change detected — reindexing...", err=True)
+        elif event == "reindex-error":
+            typer.echo(
+                "Reindex failed; change kept pending, will retry next poll.",
+                err=True,
+            )
+        elif event == "stopped":
+            typer.echo("Stopped watching.", err=True)
+
+    typer.echo(
+        f"Watching {project_path} every {max(interval, 1.0):g}s "
+        "(target/mdl.json + knowledge/sql/). Ctrl+C to stop.",
+        err=True,
+    )
+    state = watch_loop(
+        project_path,
+        _reindex,
+        interval=interval,
+        max_polls=max_polls,
+        reindex_on_start=reindex_on_start,
+        on_event=_on_event,
+    )
+    if max_polls is not None:
+        typer.echo(
+            f"Polled {state.polls} time(s), {state.reindexes} reindex(es), "
+            f"{state.errors} error(s).",
+            err=True,
+        )
+
+
+@memory_app.command()
 def export(
     path: PathOpt = None,
     include_seed: Annotated[

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -616,6 +616,26 @@ def watch(
         typer.echo(str(e), err=True)
         raise typer.Exit(1)
 
+    # The watcher polls <project_path>/target/mdl.json + <project_path>/knowledge/sql,
+    # but the reindex reads --mdl and load_query_pairs(project_path). If an explicit
+    # --mdl points outside the watched project root we'd watch one tree and index a
+    # mixed one — fail fast instead of silently building a cross-project index.
+    if mdl:
+        mdl_path = Path(mdl).expanduser().resolve()
+        root = project_path.resolve()
+        if root != mdl_path and root not in mdl_path.parents:
+            typer.echo(
+                f"Error: --mdl ({mdl_path}) is outside the watched project "
+                f"root ({root}).\n"
+                "  `watch` monitors target/mdl.json + knowledge/sql/ under the "
+                "project root and reindexes from that same tree, so an --mdl "
+                "from another project would watch and index mismatched files.\n"
+                "  Run from the project that owns this MDL, or point --mdl at a "
+                "file under this root.",
+                err=True,
+            )
+            raise typer.Exit(1)
+
     def _reindex() -> None:
         manifest = _load_manifest(mdl)
         mem_store = _get_store(path)

--- a/core/wren/src/wren/memory/watch.py
+++ b/core/wren/src/wren/memory/watch.py
@@ -169,7 +169,18 @@ def watch_loop(
 
     try:
         while max_polls is None or state.polls < max_polls:
-            poll_once(project_path, state, reindex, on_event=on_event)
+            try:
+                poll_once(project_path, state, reindex, on_event=on_event)
+            except Exception:
+                # A transient reindex/poll failure must not kill the watcher.
+                # poll_once keeps the old fingerprint on reindex failure, so
+                # the same change is retried on the next interval.
+                if on_event is not None:
+                    on_event("error")
+                if max_polls is not None and state.polls >= max_polls:
+                    break
+                sleep(interval)
+                continue
             if max_polls is not None and state.polls >= max_polls:
                 break
             sleep(interval)

--- a/core/wren/src/wren/memory/watch.py
+++ b/core/wren/src/wren/memory/watch.py
@@ -1,0 +1,179 @@
+"""Polling watch loop that auto-reindexes memory when project sources change.
+
+The semantic memory index (``wren memory index``) is a derived artifact built
+from a project's source of truth:
+
+* the compiled MDL manifest (``target/mdl.json``), and
+* the NL→SQL pairs under ``knowledge/sql/*.md``.
+
+During active modelling these sources change often, and a stale index silently
+returns wrong schema context to the LLM. ``wren memory watch`` closes that loop:
+it polls the watched sources on an interval, and whenever their content
+fingerprint changes it triggers a reindex.
+
+The change-detection logic lives here, decoupled from the CLI and from the
+optional ``memory`` extra, so it is fully unit-testable with only the standard
+library. The CLI (:mod:`wren.memory.cli`) supplies the reindex callback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Default sources to watch, relative to the project root. The MDL manifest is
+# the compiled schema; knowledge/sql holds the NL→SQL pairs. Both feed the
+# index, so a change to either should trigger a rebuild.
+_DEFAULT_MDL_REL = ("target", "mdl.json")
+_KNOWLEDGE_SQL_REL = ("knowledge", "sql")
+
+# Guard against pathological tight loops while still allowing snappy local use.
+MIN_INTERVAL_SECONDS = 1.0
+
+
+def _iter_watched_files(project_path: Path) -> list[Path]:
+    """Return the sorted list of files whose content is fingerprinted.
+
+    Covers the compiled MDL manifest plus every ``knowledge/sql/*.md`` pair.
+    Missing paths are simply absent from the list — a watcher started before
+    ``target/mdl.json`` exists will pick it up on the poll after it appears.
+    """
+    files: list[Path] = []
+    mdl = project_path.joinpath(*_DEFAULT_MDL_REL)
+    if mdl.is_file():
+        files.append(mdl)
+    sql_dir = project_path.joinpath(*_KNOWLEDGE_SQL_REL)
+    if sql_dir.is_dir():
+        files.extend(sorted(p for p in sql_dir.glob("*.md") if p.is_file()))
+    return files
+
+
+def compute_fingerprint(
+    project_path: Path,
+    files: Iterable[Path] | None = None,
+) -> str:
+    """Compute a content fingerprint over the watched sources.
+
+    The digest folds in each file's project-relative path, size and mtime
+    (nanosecond resolution). Path + size + mtime is enough to detect adds,
+    deletes, and edits without reading file bodies, which keeps each poll cheap
+    even for large projects. The result is a stable hex string; an empty
+    project (no watched files) yields the digest of the empty input.
+    """
+    if files is None:
+        files = _iter_watched_files(project_path)
+    hasher = hashlib.sha256()
+    for path in sorted(files):
+        try:
+            stat = path.stat()
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            # Raced away between listing and stat — treat as absent. The next
+            # poll re-lists and converges.
+            continue
+        try:
+            rel = path.relative_to(project_path)
+        except ValueError:
+            rel = path
+        hasher.update(str(rel).encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(str(stat.st_size).encode("ascii"))
+        hasher.update(b"\0")
+        hasher.update(str(stat.st_mtime_ns).encode("ascii"))
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+@dataclass
+class WatchState:
+    """Mutable bookkeeping for a running (or simulated) watch loop."""
+
+    fingerprint: str
+    polls: int = 0
+    reindexes: int = 0
+    errors: int = 0
+    last_change_poll: int = 0
+    history: list[str] = field(default_factory=list)
+
+
+def poll_once(
+    project_path: Path,
+    state: WatchState,
+    reindex: Callable[[], object],
+    *,
+    on_event: Callable[[str], None] | None = None,
+) -> bool:
+    """Run a single poll cycle. Returns True iff a reindex was triggered.
+
+    The fingerprint is recomputed and compared to ``state.fingerprint``. On a
+    change the ``reindex`` callback is invoked and the state is advanced. A
+    callback that raises does NOT advance the fingerprint, so the change stays
+    pending and is retried on the next poll — a transient reindex failure can
+    never silently drop an update. ``on_event`` receives short status strings
+    for logging.
+    """
+    state.polls += 1
+    current = compute_fingerprint(project_path)
+    if current == state.fingerprint:
+        return False
+
+    if on_event is not None:
+        on_event("change-detected")
+    try:
+        reindex()
+    except Exception:  # noqa: BLE001 — surface count, keep change pending for retry
+        state.errors += 1
+        if on_event is not None:
+            on_event("reindex-error")
+        raise
+    # Only advance the baseline after a clean reindex.
+    state.fingerprint = current
+    state.reindexes += 1
+    state.last_change_poll = state.polls
+    state.history.append(current)
+    if on_event is not None:
+        on_event("reindexed")
+    return True
+
+
+def watch_loop(
+    project_path: Path,
+    reindex: Callable[[], object],
+    *,
+    interval: float = 5.0,
+    max_polls: int | None = None,
+    reindex_on_start: bool = False,
+    on_event: Callable[[str], None] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> WatchState:
+    """Poll ``project_path`` and reindex on change until interrupted.
+
+    Parameters
+    ----------
+    interval:
+        Seconds between polls. Clamped to :data:`MIN_INTERVAL_SECONDS`.
+    max_polls:
+        Stop after this many polls (used by tests and ``--once``-style runs).
+        ``None`` runs until ``KeyboardInterrupt``.
+    reindex_on_start:
+        Reindex immediately on startup regardless of change, so the index is
+        known-fresh before the first poll interval elapses.
+    sleep:
+        Injectable sleep, so tests can drive the loop without real delays.
+    """
+    interval = max(float(interval), MIN_INTERVAL_SECONDS)
+    baseline = "" if reindex_on_start else compute_fingerprint(project_path)
+    state = WatchState(fingerprint=baseline)
+
+    try:
+        while max_polls is None or state.polls < max_polls:
+            poll_once(project_path, state, reindex, on_event=on_event)
+            if max_polls is not None and state.polls >= max_polls:
+                break
+            sleep(interval)
+    except KeyboardInterrupt:
+        if on_event is not None:
+            on_event("stopped")
+    return state

--- a/core/wren/src/wren/skills_content/usage/references/memory.md
+++ b/core/wren/src/wren/skills_content/usage/references/memory.md
@@ -58,6 +58,15 @@ dimensions, time dimensions, and hierarchies in markdown.
 wren memory index
 ```
 
+**Automate it while modelling:** instead of re-running `index` by hand every time
+sources change, run `wren memory watch` — it polls `target/mdl.json` and
+`knowledge/sql/*.md` and reindexes automatically on change, so `fetch` never serves a
+stale schema.
+
+```bash
+wren memory watch   # poll + auto-reindex until Ctrl+C
+```
+
 ---
 
 ## Storing queries: `wren memory store`

--- a/core/wren/tests/unit/test_memory_watch.py
+++ b/core/wren/tests/unit/test_memory_watch.py
@@ -67,6 +67,18 @@ def test_fingerprint_empty_project_is_deterministic(tmp_path):
     assert compute_fingerprint(tmp_path) == compute_fingerprint(tmp_path)
 
 
+def test_fingerprint_changes_on_delete(tmp_path):
+    # Deleting a watched knowledge/sql file must change the digest so the
+    # watcher reindexes on disappearance, not just add/edit.
+    _touch_mdl(tmp_path)
+    write_query_markdown(tmp_path, "Customer count", "SELECT COUNT(*) FROM customers")
+    before = compute_fingerprint(tmp_path)
+    for path in (tmp_path / "knowledge" / "sql").glob("*.md"):
+        path.unlink()
+    after = compute_fingerprint(tmp_path)
+    assert before != after
+
+
 # ── poll_once ───────────────────────────────────────────────────────────────
 
 
@@ -154,6 +166,38 @@ def test_watch_loop_demonstrates_autoreindex(tmp_path):
     assert "reindexed" in events
     # After reindexing, later polls see no further change.
     assert state.last_change_poll < state.polls
+
+
+def test_watch_loop_survives_transient_reindex_failure(tmp_path):
+    """A raising reindex must not terminate the loop; the change is retried."""
+    _touch_mdl(tmp_path, '{"v": 1}')
+    events: list[str] = []
+    attempts: list[int] = []
+
+    def flaky_reindex():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("transient indexing failure")
+
+    # reindex_on_start=True gives an empty baseline, so poll 1 always detects a
+    # change and calls reindex — which raises the first time. The loop must keep
+    # going and retry on the next poll (change stays pending) instead of dying.
+    state = watch_loop(
+        tmp_path,
+        flaky_reindex,
+        interval=5.0,
+        max_polls=3,
+        reindex_on_start=True,
+        on_event=events.append,
+        sleep=lambda _s: None,
+    )
+
+    # Loop did not die on the first failure; it retried and eventually succeeded.
+    assert state.polls == 3
+    assert len(attempts) >= 2
+    assert state.reindexes == 1
+    assert state.errors == 1
+    assert "error" in events
 
 
 def test_watch_loop_reindex_on_start(tmp_path):

--- a/core/wren/tests/unit/test_memory_watch.py
+++ b/core/wren/tests/unit/test_memory_watch.py
@@ -1,0 +1,198 @@
+"""Unit tests for the dependency-free memory watch loop (`wren memory watch`).
+
+These run in the unit CI job: they exercise the change-detection + reindex
+loop logic in :mod:`wren.memory.watch` using only the standard library, plus
+the CLI's grep-backend guard. No `memory` extra (LanceDB) is required, so the
+feature's core behaviour is guarded in every CI run, not skipped.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from typer.testing import CliRunner
+
+from wren.cli import app
+from wren.memory.markdown import write_query_markdown
+from wren.memory.watch import (
+    MIN_INTERVAL_SECONDS,
+    WatchState,
+    compute_fingerprint,
+    poll_once,
+    watch_loop,
+)
+
+runner = CliRunner()
+
+
+def _touch_mdl(project, content="{}"):
+    target = project / "target"
+    target.mkdir(exist_ok=True)
+    (target / "mdl.json").write_text(content, encoding="utf-8")
+
+
+# ── compute_fingerprint ────────────────────────────────────────────────────
+
+
+def test_fingerprint_stable_when_unchanged(tmp_path):
+    _touch_mdl(tmp_path)
+    write_query_markdown(tmp_path, "Total revenue", "SELECT SUM(amount) FROM orders")
+    fp1 = compute_fingerprint(tmp_path)
+    fp2 = compute_fingerprint(tmp_path)
+    assert fp1 == fp2
+    assert isinstance(fp1, str) and len(fp1) == 64  # sha256 hex
+
+
+def test_fingerprint_changes_on_new_pair(tmp_path):
+    _touch_mdl(tmp_path)
+    before = compute_fingerprint(tmp_path)
+    write_query_markdown(tmp_path, "Customer count", "SELECT COUNT(*) FROM customers")
+    after = compute_fingerprint(tmp_path)
+    assert before != after
+
+
+def test_fingerprint_changes_on_mdl_edit(tmp_path):
+    _touch_mdl(tmp_path, '{"models": []}')
+    before = compute_fingerprint(tmp_path)
+    # Force a distinct mtime even on coarse-resolution filesystems.
+    time.sleep(0.01)
+    _touch_mdl(tmp_path, '{"models": [{"name": "orders"}]}')
+    after = compute_fingerprint(tmp_path)
+    assert before != after
+
+
+def test_fingerprint_empty_project_is_deterministic(tmp_path):
+    # No mdl, no knowledge/sql — must not raise and must be stable.
+    assert compute_fingerprint(tmp_path) == compute_fingerprint(tmp_path)
+
+
+# ── poll_once ───────────────────────────────────────────────────────────────
+
+
+def test_poll_once_no_change_does_not_reindex(tmp_path):
+    _touch_mdl(tmp_path)
+    state = WatchState(fingerprint=compute_fingerprint(tmp_path))
+    calls = []
+    triggered = poll_once(tmp_path, state, lambda: calls.append(1))
+    assert triggered is False
+    assert calls == []
+    assert state.polls == 1
+    assert state.reindexes == 0
+
+
+def test_poll_once_reindexes_on_change(tmp_path):
+    _touch_mdl(tmp_path)
+    state = WatchState(fingerprint=compute_fingerprint(tmp_path))
+    write_query_markdown(tmp_path, "New q", "SELECT 1")
+    calls = []
+    triggered = poll_once(tmp_path, state, lambda: calls.append(1))
+    assert triggered is True
+    assert calls == [1]
+    assert state.reindexes == 1
+    assert state.fingerprint == compute_fingerprint(tmp_path)
+
+
+def test_failed_reindex_keeps_change_pending(tmp_path):
+    """A raising reindex must NOT advance the baseline (no silent drop)."""
+    _touch_mdl(tmp_path)
+    baseline = compute_fingerprint(tmp_path)
+    state = WatchState(fingerprint=baseline)
+    write_query_markdown(tmp_path, "Boom", "SELECT 1")
+
+    def boom():
+        raise RuntimeError("reindex failed")
+
+    with pytest.raises(RuntimeError):
+        poll_once(tmp_path, state, boom)
+    # Fingerprint unchanged → next poll will retry the same pending change.
+    assert state.fingerprint == baseline
+    assert state.errors == 1
+    assert state.reindexes == 0
+
+    # Subsequent successful poll picks up the still-pending change.
+    calls = []
+    triggered = poll_once(tmp_path, state, lambda: calls.append(1))
+    assert triggered is True
+    assert calls == [1]
+
+
+# ── watch_loop (driven, no real sleeping) ────────────────────────────────────
+
+
+def test_watch_loop_demonstrates_autoreindex(tmp_path):
+    """End-to-end: edits mid-loop are picked up and trigger reindex.
+
+    Drives the loop with an injected `sleep` that mutates the project on the
+    first interval, proving the watcher detects a change that lands *after*
+    startup and reindexes exactly once for it.
+    """
+    _touch_mdl(tmp_path, '{"v": 1}')
+    events: list[str] = []
+    reindex_calls: list[int] = []
+
+    def fake_sleep(_seconds):
+        # On the first inter-poll sleep, mutate a watched source.
+        if len(reindex_calls) == 0 and not getattr(fake_sleep, "done", False):
+            time.sleep(0.01)  # ensure distinct mtime
+            write_query_markdown(tmp_path, "Mid-loop edit", "SELECT 42")
+            fake_sleep.done = True
+
+    state = watch_loop(
+        tmp_path,
+        lambda: reindex_calls.append(1),
+        interval=5.0,
+        max_polls=3,
+        on_event=events.append,
+        sleep=fake_sleep,
+    )
+
+    assert state.polls == 3
+    assert state.reindexes == 1  # exactly one reindex for the single edit
+    assert reindex_calls == [1]
+    assert "change-detected" in events
+    assert "reindexed" in events
+    # After reindexing, later polls see no further change.
+    assert state.last_change_poll < state.polls
+
+
+def test_watch_loop_reindex_on_start(tmp_path):
+    _touch_mdl(tmp_path)
+    calls = []
+    state = watch_loop(
+        tmp_path,
+        lambda: calls.append(1),
+        interval=5.0,
+        max_polls=1,
+        reindex_on_start=True,
+        sleep=lambda _s: None,
+    )
+    # Baseline starts empty, so the first poll always reindexes once.
+    assert state.reindexes == 1
+    assert calls == [1]
+
+
+def test_watch_loop_clamps_interval(tmp_path, monkeypatch):
+    _touch_mdl(tmp_path)
+    seen = []
+    state = watch_loop(
+        tmp_path,
+        lambda: None,
+        interval=0.0,  # below the floor
+        max_polls=2,
+        sleep=lambda s: seen.append(s),
+    )
+    assert state.polls == 2
+    assert all(s >= MIN_INTERVAL_SECONDS for s in seen)
+
+
+# ── CLI guard (grep backend has no derived index to watch) ────────────────────
+
+
+def test_cli_watch_grep_backend_exits(tmp_path, monkeypatch):
+    monkeypatch.setenv("WREN_MEMORY_BACKEND", "grep")
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    (tmp_path / "wren_project.yml").write_text("name: t\n", encoding="utf-8")
+    result = runner.invoke(app, ["memory", "watch", "--max-polls", "1"])
+    assert result.exit_code == 1
+    assert "grep backend" in result.output

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -180,6 +180,31 @@ wren memory index                          # uses ~/.wren/mdl.json
 wren memory index --mdl /path/to/mdl.json  # explicit MDL file
 ```
 
+### `wren memory watch`
+
+Watch project sources and auto-reindex on change, so semantic recall never serves a
+stale schema while you are actively modelling. Polls `target/mdl.json` and
+`knowledge/sql/*.md` on an interval; when their content fingerprint changes it runs the
+equivalent of `wren memory index`. A reindex that fails leaves the change pending and is
+retried on the next poll — an update is never silently dropped. Runs until `Ctrl+C`.
+
+Requires the `memory` extra (the index it maintains is LanceDB-backed). With the grep
+backend there is no derived index to keep fresh, so this command exits with a message.
+
+| Flag | Description |
+|------|-------------|
+| `--interval`, `-i` | Seconds between polls (min 1). Default: `5`. |
+| `--reindex-on-start` / `--no-reindex-on-start` | Reindex once on startup before watching. Default: off. |
+| `--max-polls` | Stop after N polls (mainly for scripting/testing). Default: run until Ctrl+C. |
+| `--mdl` | Explicit MDL file (must live under the watched project root). |
+| `--path` | Project root to watch. Defaults to the discovered project. |
+
+```bash
+wren memory watch                       # poll every 5s, reindex on change
+wren memory watch -i 2                   # poll every 2s
+wren memory watch --reindex-on-start     # ensure the index is fresh before the first interval
+```
+
 ### `wren memory describe`
 
 Print the full schema as structured plain text. No embedding or LanceDB required — this is a pure transformation of the MDL manifest into a human/LLM-readable format.


### PR DESCRIPTION
## Problem

The semantic memory index (`wren memory index`) is a **derived artifact** built from a project's sources of truth — the compiled MDL manifest (`target/mdl.json`) and the NL→SQL pairs under `knowledge/sql/*.md`. During active modelling these sources change frequently (you edit YAML, run `wren context build`, `wren memory store` a new pair, etc.). Today the index only refreshes when you *remember* to re-run `wren memory index`. In between, semantic recall (`wren memory fetch` / `recall`) silently serves **stale schema context to the LLM** — the most expensive kind of bug, because it's invisible: the command succeeds, it just returns the wrong thing.

## Approach

Add `wren memory watch`: a polling loop that fingerprints the watched sources on an interval and reindexes whenever the content changes — closing the modelling→index loop automatically.

**Why this layer.** The change-detection logic lives in a new stdlib-only module `wren.memory.watch`, fully decoupled from both the CLI and the optional `memory` extra. That keeps the loop logic:
- **testable in the unit CI job** (no LanceDB/`memory` extra needed — tests are *guarded*, not `importorskip`-skipped), and
- **injectable** — `watch_loop` takes an injected `sleep` and a `reindex` callback, so the CLI wires in the real LanceDB reindex while tests drive the loop deterministically with zero real delays.

**Reliability detail (no silent drops).** `poll_once` only advances the fingerprint baseline *after* a clean reindex. If the reindex callback raises, the error is counted and surfaced, but the change stays **pending** and is retried on the next poll — a transient reindex failure can never silently swallow an update. This mirrors the repo's "escalate, don't fail silently" instinct.

Fingerprint = sha256 over each watched file's project-relative path + size + mtime_ns. That detects adds/edits/deletes without reading file bodies, so each poll stays cheap even on large projects.

The CLI guards the grep backend (no derived index → nothing to watch) and exits with a clear message pointing at `wrenai[memory]`.

## Files changed

| File | Change |
|------|--------|
| `core/wren/src/wren/memory/watch.py` | **New.** Stdlib-only loop: `compute_fingerprint`, `poll_once`, `watch_loop`, `WatchState`. |
| `core/wren/src/wren/memory/cli.py` | New `wren memory watch` command (`--interval`, `--reindex-on-start`, `--max-polls`, `--mdl`, `--path`). |
| `core/wren/tests/unit/test_memory_watch.py` | **New.** 11 unit tests — placed in `tests/unit/` so they run in the `unit tests` CI job. |
| `core/wren/README.md` | Document the command in the memory section. |

## Test evidence

Tests live in `tests/unit/` (the unit job runs the whole tree, no extra needed) — **not** behind `importorskip`, so the feature is guarded in CI.

```
$ pytest tests/unit/test_memory_watch.py -v
tests/unit/test_memory_watch.py::test_fingerprint_stable_when_unchanged PASSED
tests/unit/test_memory_watch.py::test_fingerprint_changes_on_new_pair PASSED
tests/unit/test_memory_watch.py::test_fingerprint_changes_on_mdl_edit PASSED
tests/unit/test_memory_watch.py::test_fingerprint_empty_project_is_deterministic PASSED
tests/unit/test_memory_watch.py::test_poll_once_no_change_does_not_reindex PASSED
tests/unit/test_memory_watch.py::test_poll_once_reindexes_on_change PASSED
tests/unit/test_memory_watch.py::test_failed_reindex_keeps_change_pending PASSED
tests/unit/test_memory_watch.py::test_watch_loop_demonstrates_autoreindex PASSED
tests/unit/test_memory_watch.py::test_watch_loop_reindex_on_start PASSED
tests/unit/test_memory_watch.py::test_watch_loop_clamps_interval PASSED
tests/unit/test_memory_watch.py::test_cli_watch_grep_backend_exits PASSED
============================== 11 passed in 0.29s ==============================
```

`test_watch_loop_demonstrates_autoreindex` is the **feature-working demonstration**: it drives the loop with an injected sleep that edits a watched source mid-loop, then asserts the watcher detects the change and reindexes exactly once.

Full unit suite stays green (`786 passed, 1 skipped`), and `ruff format --check` + `ruff check` pass on all touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wren memory watch` to monitor project semantic-search inputs (`target/mdl.json` and `knowledge/sql/*.md`) and automatically refresh the memory index when they change.
  * Supports `--reindex-on-start/--no-reindex-on-start` and `--max-polls`.
* **Documentation**
  * Updated CLI docs/reference and Quick Start to describe watch-mode behavior (including `grep` backend limitations).
* **Bug Fixes**
  * If reindexing fails, the change is kept pending and retried on the next poll (no silent drop).
* **Tests**
  * Added unit tests covering fingerprint stability, reindex triggering, failure retry, interval clamping, and the `grep` backend exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->