### PR TITLE
feat(policy): govern data-reading TVFs in all positions + structure source-func allowlist

### DIFF
--- a/core/wren/src/wren/config.py
+++ b/core/wren/src/wren/config.py
@@ -21,10 +21,17 @@ class WrenConfig:
     denied_functions:
         Set of function names (lowercase) that are forbidden in SQL queries.
         Matching is case-insensitive.
+    allowed_source_functions:
+        Set of synthetic-generator function names (lowercase) the operator
+        explicitly opts in as query sources under strict mode (e.g.
+        ``generate_series``). Empty by default — generators are blocked unless
+        listed here. Data/file readers (``read_csv``, ``dblink``, ...) can
+        NEVER be allowed via this list; they are always blocked in strict mode.
     """
 
     strict_mode: bool = False
     denied_functions: frozenset[str] = field(default_factory=frozenset)
+    allowed_source_functions: frozenset[str] = field(default_factory=frozenset)
 
 
 def load_config(wren_home: Path) -> WrenConfig:
@@ -71,4 +78,21 @@ def load_config(wren_home: Path) -> WrenConfig:
         )
     denied_functions = frozenset(f.lower() for f in denied_raw)
 
-    return WrenConfig(strict_mode=strict_mode_raw, denied_functions=denied_functions)
+    allowed_src_raw = raw.get("allowed_source_functions", [])
+    if not isinstance(allowed_src_raw, list):
+        raise WrenError(
+            ErrorCode.GENERIC_USER_ERROR,
+            f"{config_path}: 'allowed_source_functions' must be a JSON array.",
+        )
+    if any(not isinstance(f, str) for f in allowed_src_raw):
+        raise WrenError(
+            ErrorCode.GENERIC_USER_ERROR,
+            f"{config_path}: 'allowed_source_functions' must contain only strings.",
+        )
+    allowed_source_functions = frozenset(f.lower() for f in allowed_src_raw)
+
+    return WrenConfig(
+        strict_mode=strict_mode_raw,
+        denied_functions=denied_functions,
+        allowed_source_functions=allowed_source_functions,
+    )

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -23,12 +23,76 @@ from wren.model.error import ErrorCode, ErrorPhase, WrenError
 # ``exp.Unnest`` (trino/postgres/duckdb), Snowflake ``FLATTEN`` -> ``exp.Explode``,
 # so no per-dialect name matching is needed.
 #
-# Note: ``UNNEST(read_csv(...))`` is therefore also allowed, but that is an
-# instance of the broader pre-existing gap (data-reading TVFs in non-source
-# positions — already reachable today via projection/WHERE subqueries, since
-# strict mode only governs the top-level source position) and is tracked
-# separately. It is not a regression introduced here.
+# Note: ``UNNEST(read_csv(...))`` used to be allowed because the data-reader
+# guard only governed the top-level source position. As of the all-positions
+# data-reader check below (issue #2409 section C), the inner ``read_csv`` is now
+# blocked regardless of being wrapped by UNNEST — the reader scan walks every
+# AST position, so it sees the nested reader before the row-expansion allow-list
+# is ever consulted.
 _ROW_EXPANSION_FUNCS: tuple[type[exp.Func], ...] = (exp.Unnest, exp.Explode)
+
+# ── Category C: data/file readers (issue #2409) ─────────────────────────────
+#
+# Data-reading table-valued functions read bytes from *outside* the MDL
+# manifest: local files (``read_csv('/etc/passwd')`` → path traversal), object
+# storage / URLs (``read_parquet('s3://...')`` → SSRF / exfiltration), or other
+# databases (``dblink`` / ``postgres_scan`` → lateral movement). Allowing any of
+# them defeats strict-mode governance (RLAC/CLAC), so they are ALWAYS blocked
+# under strict mode, in EVERY AST position — not just the FROM/JOIN source slot
+# (which is all PR #2405 covered). Reader detection is fail-closed: this list is
+# the source of truth for *known* reader names, matched by both the raw
+# function name (for ``exp.Anonymous`` parses like ``glob`` / ``dblink``) and by
+# the canonical sqlglot class key (e.g. ``read_csv`` → ``exp.ReadCSV`` →
+# ``"readcsv"``), via the same dialect-probe used for the denylist.
+_DATA_READER_NAMES: frozenset[str] = frozenset(
+    {
+        # duckdb file readers
+        "read_csv",
+        "read_csv_auto",
+        "read_parquet",
+        "read_json",
+        "read_json_auto",
+        "read_ndjson",
+        "read_ndjson_auto",
+        "read_json_objects",
+        "read_text",
+        "read_blob",
+        "read_xlsx",
+        "parquet_scan",
+        "glob",
+        # duckdb extension scanners (lakehouse / external db)
+        "iceberg_scan",
+        "delta_scan",
+        "postgres_scan",
+        "postgres_query",
+        "mysql_scan",
+        "mysql_query",
+        "sqlite_scan",
+        "sqlite_query",
+        # postgres file / remote readers
+        "pg_read_file",
+        "pg_read_binary_file",
+        "pg_ls_dir",
+        "lo_import",
+        "lo_get",
+        "dblink",
+        "dblink_exec",
+        # generic external fetch
+        "url",
+    }
+)
+
+# ── Category B: synthetic generators (issue #2409) ──────────────────────────
+#
+# Generators (``generate_series`` / ``sequence`` / ``range``) read nothing
+# outside the manifest, so they are not an exfiltration risk — but an unbounded
+# range is a denial-of-service vector (``generate_series(1, 1e12)`` materialises
+# a trillion rows). They are therefore blocked by default in source position and
+# only allowed when the operator explicitly opts a name in via
+# ``allowed_source_functions``. Matching goes through the shared canonicalizer
+# so an opt-in of ``generate_series`` matches whether sqlglot lands it on
+# ``exp.GenerateSeries`` / ``exp.ExplodingGenerateSeries`` or ``exp.Anonymous``.
+_GENERATOR_NAMES: frozenset[str] = frozenset({"generate_series", "sequence", "range"})
 
 # Dialects we probe when canonicalising the user's denylist. sqlglot can map
 # the same function name (e.g. ``version()``) onto different concrete AST
@@ -94,7 +158,12 @@ def validate_sql_policy(
         Wren configuration with strict_mode and denied_functions settings.
     """
     if config.strict_mode:
-        _check_tables(ast, model_names)
+        # Data-reading TVFs (read_csv / dblink / postgres_scan / ...) are
+        # blocked in EVERY position first (issue #2409 section C) so a reader
+        # smuggled into a projection or subquery can't slip past the
+        # source-only table scan below.
+        _check_data_readers(ast)
+        _check_tables(ast, model_names, config.allowed_source_functions)
     if config.denied_functions:
         _check_functions(ast, config.denied_functions)
 
@@ -123,12 +192,22 @@ def _visible_cte_names(node: exp.Expression) -> set[str]:
 def _check_tables(
     ast: exp.Expression,
     model_names: set[str],
+    allowed_source_functions: frozenset[str] = frozenset(),
 ) -> None:
     for table in ast.find_all(exp.Table):
         name = table.name
         if not name:
             # Table nodes with no name are table-valued functions
-            # (e.g. read_csv(), generate_series()). Block them in strict mode.
+            # (e.g. read_csv(), generate_series()). A TVF written WITH an alias
+            # (``generate_series(1,10) AS t(x)``) parses as an exp.Table whose
+            # ``this`` is the inner func, so the category checks must look at
+            # the wrapped func here too. Data readers are already blocked
+            # globally by _check_data_readers; a generator may be opted in.
+            inner = table.this
+            if isinstance(inner, exp.Func) and _is_allowed_generator(
+                inner, allowed_source_functions
+            ):
+                continue
             sql_text = table.sql()
             if sql_text:
                 raise WrenError(
@@ -171,10 +250,17 @@ def _check_tables(
             if isinstance(source, exp.Alias):
                 source = source.this
         if isinstance(source, _ROW_EXPANSION_FUNCS):
-            # Row-expansion over an in-scope expression (e.g. a governed model
-            # column) reads nothing outside the manifest — allow it.
+            # Category A — row-expansion over an in-scope expression (e.g. a
+            # governed model column) reads nothing outside the manifest: allow.
             continue
         if isinstance(source, exp.Func):
+            # Category C readers are already blocked everywhere by
+            # _check_data_readers; reaching here means the source func is a
+            # generator (category B) or some other non-model source func.
+            # Category B — synthetic generators are blocked by default (DoS via
+            # unbounded ranges) but may be opted in by the operator per name.
+            if _is_allowed_generator(source, allowed_source_functions):
+                continue
             raise WrenError(
                 ErrorCode.MODEL_NOT_FOUND,
                 f"Table-valued function '{source.sql()}' is not allowed. "
@@ -184,32 +270,111 @@ def _check_tables(
 
 
 @lru_cache(maxsize=128)
-def _canonical_denied(denied: frozenset[str]) -> frozenset[str]:
-    """Expand the user's denylist to also cover sqlglot's canonical keys.
+def _canonical_names(names: frozenset[str]) -> frozenset[str]:
+    """Expand a set of function names to also cover sqlglot's canonical keys.
 
     sqlglot >=29 maps several common functions onto concrete subclasses —
     e.g. ``version()`` becomes ``exp.CurrentVersion`` in
     postgres/mysql/duckdb/trino/clickhouse (with ``type(node).key ==
     "currentversion"``), while in tsql/oracle/bigquery/snowflake it stays
-    as ``exp.Anonymous(name="version")``. A user denylist entry of
-    ``"version"`` would only match the anonymous case without this
-    expansion. Probing each known dialect collects every class key the
-    name might land on at parse time and adds them all to the result.
+    as ``exp.Anonymous(name="version")``. A plain name entry of ``"version"``
+    would only match the anonymous case without this expansion. Probing each
+    known dialect collects every class key the name might land on at parse
+    time and adds them all to the result.
+
+    Used for the denylist, the data-reader blocklist, and the generator
+    opt-in allowlist so all three match a function whether sqlglot keeps it
+    anonymous or reclassifies it to a concrete subclass.
     """
-    expanded: set[str] = {d.lower() for d in denied}
+    expanded: set[str] = {d.lower() for d in names}
     for name in list(expanded):
         for dialect in _CANONICALISE_DIALECTS:
-            try:
-                ast = parse_one(f"SELECT {name}()", dialect=dialect)
-            except SqlglotError:
-                # A malformed denylist entry can fail tokenizing or parsing on
-                # some dialects; skip it for this dialect rather than crashing
-                # validation (SqlglotError covers ParseError and TokenError).
-                continue
-            first_func = next(ast.find_all(exp.Func), None)
-            if first_func is not None and not isinstance(first_func, exp.Anonymous):
-                expanded.add(type(first_func).key.lower())
+            # Probe both arity-0 and arity-1 forms: some functions only parse to
+            # their concrete subclass when given an argument (e.g. duckdb
+            # ``read_csv('x')`` -> exp.ReadCSV, while ``read_csv()`` fails to
+            # parse), so an args-less probe alone would miss the class key.
+            for probe in (
+                f"SELECT {name}()",
+                f"SELECT {name}('x')",
+                f"SELECT {name}(1, 2)",
+            ):
+                try:
+                    ast = parse_one(probe, dialect=dialect)
+                except SqlglotError:
+                    # A malformed entry can fail tokenizing or parsing on some
+                    # dialects; skip it rather than crashing validation
+                    # (SqlglotError covers ParseError and TokenError).
+                    continue
+                first_func = next(ast.find_all(exp.Func), None)
+                if first_func is not None and not isinstance(first_func, exp.Anonymous):
+                    expanded.add(type(first_func).key.lower())
     return frozenset(expanded)
+
+
+# Backwards-compatible alias: the denylist canonicalizer is the generic one.
+_canonical_denied = _canonical_names
+
+
+def _func_match_keys(func: exp.Func) -> tuple[str, str]:
+    """Return the (raw-name, class-key) pair used to match *func* against a set.
+
+    Anonymous funcs carry the user-written name (e.g. ``glob``, ``dblink``);
+    concrete subclasses carry a stable class key (e.g. ``read_csv`` ->
+    ``"readcsv"``). Checking both against a canonicalized name set means a
+    single source-of-truth name list matches regardless of how sqlglot parsed
+    the call on a given dialect.
+    """
+    return (func.name or "").lower(), type(func).key.lower()
+
+
+def _is_data_reader(func: exp.Func) -> bool:
+    """True if *func* is a known data/file/remote reader (issue #2409 cat. C)."""
+    raw, key = _func_match_keys(func)
+    canonical = _canonical_names(_DATA_READER_NAMES)
+    return raw in canonical or key in canonical
+
+
+def _is_allowed_generator(
+    func: exp.Func, allowed_source_functions: frozenset[str]
+) -> bool:
+    """True if *func* is a generator the operator explicitly opted in.
+
+    Generators are only relevant in the source position; the opt-in is matched
+    through the shared canonicalizer so ``generate_series`` matches whether it
+    parsed to ``exp.GenerateSeries`` / ``exp.ExplodingGenerateSeries`` or
+    ``exp.Anonymous``. Only names that are *both* known generators and present
+    in the operator allowlist are permitted — never readers.
+    """
+    if not allowed_source_functions:
+        return False
+    raw, key = _func_match_keys(func)
+    generators = _canonical_names(_GENERATOR_NAMES)
+    if raw not in generators and key not in generators:
+        return False
+    allowed = _canonical_names(allowed_source_functions)
+    return raw in allowed or key in allowed
+
+
+def _check_data_readers(ast: exp.Expression) -> None:
+    """Block data-reading TVFs in EVERY AST position under strict mode.
+
+    PR #2405 only governed readers in the top-level FROM/JOIN source slot, so a
+    reader smuggled into a projection (``SELECT read_csv('/etc/passwd')``), a
+    WHERE/IN subquery, or a nested function argument
+    (``UNNEST(read_csv(...))``) bypassed MDL governance entirely — a real
+    path-traversal / SSRF / exfiltration hole. This walks the whole tree and
+    fails closed on the first known reader, wherever it appears.
+    """
+    for func in ast.find_all(exp.Func):
+        if _is_data_reader(func):
+            raise WrenError(
+                ErrorCode.MODEL_NOT_FOUND,
+                f"Data-reading function '{func.sql()}' is not allowed. "
+                "In strict mode, reading data outside the MDL manifest "
+                "(files, URLs, or external databases) is forbidden in all "
+                "query positions.",
+                phase=ErrorPhase.SQL_POLICY_CHECK,
+            )
 
 
 def _check_functions(

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -39,11 +39,21 @@ _ROW_EXPANSION_FUNCS: tuple[type[exp.Func], ...] = (exp.Unnest, exp.Explode)
 # databases (``dblink`` / ``postgres_scan`` → lateral movement). Allowing any of
 # them defeats strict-mode governance (RLAC/CLAC), so they are ALWAYS blocked
 # under strict mode, in EVERY AST position — not just the FROM/JOIN source slot
-# (which is all PR #2405 covered). Reader detection is fail-closed: this list is
-# the source of truth for *known* reader names, matched by both the raw
-# function name (for ``exp.Anonymous`` parses like ``glob`` / ``dblink``) and by
-# the canonical sqlglot class key (e.g. ``read_csv`` → ``exp.ReadCSV`` →
-# ``"readcsv"``), via the same dialect-probe used for the denylist.
+# (which is all PR #2405 covered).
+#
+# IMPORTANT — for non-source positions this is a *blocklist*, not a fail-closed
+# allowlist. The source position (FROM/JOIN) is genuinely fail-closed:
+# ``_check_tables`` rejects ANY unknown TVF there. But you cannot allowlist
+# every scalar function that may appear in a projection or WHERE clause, so for
+# non-source positions this named list is the security boundary: a reader that
+# is not enumerated here will pass in a projection / subquery / nested-arg
+# position. The list must therefore be MAINTAINED PER-CONNECTOR as new
+# file/remote readers land upstream, and operators who need to guard a reader
+# not covered here should add it to ``denied_functions`` as a defense-in-depth
+# backstop. Matching is by both the raw function name (for ``exp.Anonymous``
+# parses like ``glob`` / ``dblink``) and by the canonical sqlglot class key
+# (e.g. ``read_csv`` → ``exp.ReadCSV`` → ``"readcsv"``), via the same
+# dialect-probe used for the denylist.
 _DATA_READER_NAMES: frozenset[str] = frozenset(
     {
         # duckdb file readers
@@ -73,10 +83,29 @@ _DATA_READER_NAMES: frozenset[str] = frozenset(
         "pg_read_file",
         "pg_read_binary_file",
         "pg_ls_dir",
+        "pg_ls_logdir",
+        "pg_ls_waldir",
+        "pg_ls_tmpdir",
+        "pg_ls_archive_statusdir",
+        "pg_stat_file",
         "lo_import",
         "lo_get",
         "dblink",
         "dblink_exec",
+        # mysql file reader (same arbitrary-file-read primitive as read_csv,
+        # just via a first-class connector)
+        "load_file",
+        # duckdb spatial / sniffing / metadata scanners over arbitrary paths
+        "sniff_csv",
+        "st_read",
+        "st_readosm",
+        "st_read_meta",
+        "parquet_metadata",
+        "parquet_file_metadata",
+        "parquet_kv_metadata",
+        "parquet_schema",
+        "iceberg_metadata",
+        "iceberg_snapshots",
         # generic external fetch
         "url",
     }
@@ -367,9 +396,21 @@ def _check_data_readers(ast: exp.Expression) -> None:
     """
     for func in ast.find_all(exp.Func):
         if _is_data_reader(func):
+            # Report only the function name, never ``func.sql()`` — the full
+            # expression would echo the argument (file paths, URLs, DSNs /
+            # connection strings) back into the error message and logs, which
+            # is a needless info-leak of exactly the sensitive target this
+            # guard exists to block.
+            # For exp.Anonymous the user-written name is authoritative; for
+            # concrete subclasses ``func.name`` can return the *argument*
+            # (e.g. exp.ReadCSV.name -> the file path), so use the stable class
+            # key there to avoid leaking the target.
+            reader_name = (
+                func.name if isinstance(func, exp.Anonymous) else type(func).key
+            )
             raise WrenError(
                 ErrorCode.MODEL_NOT_FOUND,
-                f"Data-reading function '{func.sql()}' is not allowed. "
+                f"Data-reading function '{reader_name}' is not allowed. "
                 "In strict mode, reading data outside the MDL manifest "
                 "(files, URLs, or external databases) is forbidden in all "
                 "query positions.",

--- a/core/wren/tests/unit/test_config.py
+++ b/core/wren/tests/unit/test_config.py
@@ -102,3 +102,32 @@ def test_load_config_denied_functions_mixed_types_rejected(tmp_path):
     (tmp_path / "config.json").write_text(json.dumps(data))
     with pytest.raises(WrenError):
         load_config(tmp_path)
+
+
+def test_load_config_allowed_source_functions(tmp_path):
+    data = {
+        "strict_mode": True,
+        "allowed_source_functions": ["Generate_Series", "RANGE"],
+    }
+    (tmp_path / "config.json").write_text(json.dumps(data))
+    config = load_config(tmp_path)
+    assert config.allowed_source_functions == frozenset(["generate_series", "range"])
+
+
+def test_load_config_allowed_source_functions_default_empty(tmp_path):
+    config = load_config(tmp_path)
+    assert config.allowed_source_functions == frozenset()
+
+
+def test_load_config_allowed_source_functions_not_array(tmp_path):
+    data = {"allowed_source_functions": "generate_series"}
+    (tmp_path / "config.json").write_text(json.dumps(data))
+    with pytest.raises(WrenError):
+        load_config(tmp_path)
+
+
+def test_load_config_allowed_source_functions_mixed_types_rejected(tmp_path):
+    data = {"allowed_source_functions": ["generate_series", 3]}
+    (tmp_path / "config.json").write_text(json.dumps(data))
+    with pytest.raises(WrenError):
+        load_config(tmp_path)

--- a/core/wren/tests/unit/test_policy.py
+++ b/core/wren/tests/unit/test_policy.py
@@ -155,13 +155,26 @@ def test_empty_denied_list_allows_everything():
 
 
 def test_strict_mode_and_denied_functions_together():
+    # ``pg_read_file`` is BOTH a known data reader (always blocked in strict
+    # mode, in all positions — issue #2409) and on the user denylist. The
+    # strict-mode reader guard runs first, so MODEL_NOT_FOUND fires; either
+    # security control rejecting the query is the correct, fail-closed result.
     sql = 'SELECT pg_read_file(o_orderkey) FROM "orders"'
     ast = parse_one(sql, dialect="postgres")
     config = WrenConfig(strict_mode=True, denied_functions=frozenset(["pg_read_file"]))
     with pytest.raises(WrenError) as exc_info:
         validate_sql_policy(ast, _MODELS, config)
-    # Either error is acceptable — table check runs first, but orders is valid
-    # so function check should fire
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_denied_reader_function_without_strict_mode_uses_denylist():
+    # Without strict mode the data-reader guard does not run, so a reader is
+    # only rejected via the explicit denylist (BLOCKED_FUNCTION).
+    sql = "SELECT pg_read_file('/etc/passwd')"
+    ast = parse_one(sql, dialect="postgres")
+    config = WrenConfig(strict_mode=False, denied_functions=frozenset(["pg_read_file"]))
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, config)
     assert exc_info.value.error_code == ErrorCode.BLOCKED_FUNCTION
 
 
@@ -242,25 +255,20 @@ def test_unnest_model_column_allowed():
     validate_sql_policy(ast, _MODELS, config)
 
 
-def test_unnest_over_reader_tvf_allowed_known_gap():
-    # Regression anchor for CodeRabbit's nested-reader question.
+def test_unnest_over_reader_tvf_now_blocked():
+    # Closes the gap previously pinned as "known" (issue #2409 section C).
     #
-    # ``UNNEST(read_csv(...))`` is currently ALLOWED, and intentionally so for
-    # this PR. The row-expansion allow-list keys on the wrapper class
-    # (exp.Unnest/exp.Explode), and the inner reader contributes no exp.Table
-    # node, so the data-source guard never sees ``read_csv``. This is NOT a
-    # regression introduced here: strict mode only governs the *top-level*
-    # source position, so readers in non-source positions (projection, WHERE
-    # subqueries, and now a row-expansion argument) were already reachable on
-    # main. The collaborator (goldmedal) confirmed this and filed the broader
-    # non-source-reader gap as a separate issue rather than blocking it here.
-    #
-    # This test pins the agreed behavior so the gap is explicit and any future
-    # tightening is a deliberate, reviewed change rather than a silent flip.
+    # ``UNNEST(read_csv(...))`` USED to be allowed because the data-source guard
+    # only governed the top-level FROM/JOIN slot and the inner reader
+    # contributed no exp.Table node. As of the all-positions data-reader scan,
+    # the nested ``read_csv`` is seen and blocked regardless of the UNNEST
+    # wrapper — closing the path-traversal / SSRF / exfiltration hole.
     sql = "SELECT * FROM orders CROSS JOIN UNNEST(read_csv('s3://b/f.csv')) AS t(c)"
     ast = parse_one(sql, dialect="duckdb")
     config = WrenConfig(strict_mode=True)
-    validate_sql_policy(ast, _MODELS, config)
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, config)
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
 
 
 def test_tvf_generate_series_in_join_blocked():
@@ -303,3 +311,185 @@ def test_join_between_two_mdl_models_allowed():
     ast = parse_one(sql, dialect="trino")
     config = WrenConfig(strict_mode=True)
     validate_sql_policy(ast, _MODELS, config)
+
+
+# ── Data-reading TVFs governed in ALL positions (issue #2409, section C) ───
+#
+# Strict mode previously blocked data-reading table-valued functions (read_csv,
+# read_parquet, dblink, postgres_scan, ...) ONLY in the top-level FROM/JOIN
+# source slot. A reader smuggled into a projection, a WHERE/IN subquery, or a
+# nested function argument bypassed MDL governance entirely — a real
+# path-traversal / SSRF / exfiltration hole. These tests assert the reader is
+# now fail-closed in every AST position, while legitimate queries still pass.
+
+
+def test_reader_in_source_position_blocked():
+    ast = parse_one("SELECT * FROM read_csv('/etc/passwd')", dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_reader_in_projection_blocked():
+    # BYPASS before fix: a reader in the SELECT list is not a FROM/JOIN source,
+    # so the source-only scan never saw it.
+    ast = parse_one("SELECT read_csv('/etc/passwd')", dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_reader_in_where_subquery_blocked():
+    # BYPASS before fix: reader hidden in a WHERE ... IN (subquery).
+    sql = "SELECT * FROM orders WHERE id IN (SELECT read_csv('/etc/passwd'))"
+    ast = parse_one(sql, dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_reader_nested_in_unnest_arg_blocked():
+    # BYPASS before fix: reader as a nested arg of a row-expansion op.
+    sql = "SELECT * FROM orders CROSS JOIN UNNEST(read_csv('s3://b/f.csv')) AS t(c)"
+    ast = parse_one(sql, dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_reader_nested_in_function_arg_blocked():
+    # BYPASS before fix: reader buried inside another scalar function call.
+    sql = "SELECT length(read_text('/etc/passwd')) FROM orders"
+    ast = parse_one(sql, dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_anonymous_reader_glob_in_projection_blocked():
+    # ``glob`` parses to exp.Anonymous on every dialect — matched by raw name.
+    ast = parse_one("SELECT glob('/etc/*') FROM orders", dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_dblink_remote_reader_blocked():
+    # External-database reader (lateral movement / SSRF) in source position.
+    sql = "SELECT * FROM dblink('host=evil', 'SELECT 1') AS t(x int)"
+    ast = parse_one(sql, dialect="postgres")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_postgres_scan_external_db_blocked():
+    sql = "SELECT * FROM postgres_scan('host=evil', 'public', 'secrets')"
+    ast = parse_one(sql, dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_reader_case_insensitive_blocked():
+    ast = parse_one("SELECT READ_CSV('/etc/passwd')", dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_reader_not_blocked_when_strict_off():
+    # The reader guard is a strict-mode control; without strict mode (and no
+    # denylist) the query is allowed, preserving non-governed behaviour.
+    ast = parse_one("SELECT read_csv('/etc/passwd')", dialect="duckdb")
+    validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=False))
+
+
+def test_reader_can_never_be_opted_in_as_source_func():
+    # allowed_source_functions must NEVER unblock a data reader — only
+    # generators are opt-in-able. A reader on the allowlist is still blocked.
+    sql = "SELECT * FROM read_csv('/etc/passwd') AS t(c)"
+    ast = parse_one(sql, dialect="duckdb")
+    config = WrenConfig(
+        strict_mode=True, allowed_source_functions=frozenset(["read_csv"])
+    )
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, config)
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+# ── No false positives: legitimate queries still pass ─────────────────────
+
+
+def test_legit_query_with_column_named_like_reader_passes():
+    # A model column / identifier is not a function call — must not be blocked.
+    ast = parse_one('SELECT o_orderkey FROM "orders"', dialect="duckdb")
+    validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+
+
+def test_legit_aggregate_and_scalar_funcs_pass():
+    sql = 'SELECT COUNT(*), UPPER(o_status), SUM(o_total) FROM "orders"'
+    ast = parse_one(sql, dialect="duckdb")
+    validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+
+
+def test_legit_join_and_cte_pass_with_strict():
+    sql = (
+        'WITH t AS (SELECT * FROM "orders") '
+        'SELECT * FROM t JOIN "customers" c ON t.customer_id = c.id'
+    )
+    ast = parse_one(sql, dialect="duckdb")
+    validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+
+
+# ── Category B: synthetic generators (issue #2409) ────────────────────────
+
+
+def test_generator_blocked_by_default():
+    sql = "SELECT * FROM generate_series(1, 10) AS t(x)"
+    ast = parse_one(sql, dialect="postgres")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_generator_allowed_when_opted_in():
+    sql = "SELECT * FROM generate_series(1, 10) AS t(x)"
+    config = WrenConfig(
+        strict_mode=True, allowed_source_functions=frozenset(["generate_series"])
+    )
+    for dialect in ("postgres", "duckdb"):
+        ast = parse_one(sql, dialect=dialect)
+        validate_sql_policy(ast, _MODELS, config)
+
+
+def test_generator_in_join_allowed_when_opted_in():
+    sql = "SELECT * FROM orders JOIN generate_series(1, 10) AS g(x) ON true"
+    ast = parse_one(sql, dialect="postgres")
+    config = WrenConfig(
+        strict_mode=True, allowed_source_functions=frozenset(["generate_series"])
+    )
+    validate_sql_policy(ast, _MODELS, config)
+
+
+def test_optin_generator_does_not_unblock_distinct_generator():
+    # Opting in `generate_series` must not silently allow a generator that
+    # parses to a DISTINCT class/name. On postgres `sequence` stays
+    # exp.Anonymous(name="sequence"), distinct from generate_series's
+    # ExplodingGenerateSeries, so it remains blocked.
+    #
+    # Caveat (documented, not a bug): on some dialects sqlglot collapses
+    # `sequence`/`range`/`generate_series` onto the SAME class (e.g. trino
+    # `sequence` -> exp.GenerateSeries). Where the AST cannot distinguish them,
+    # opting one in opts in the class. That is acceptable for category B:
+    # generators carry no exfiltration risk (only DoS), and an operator opting
+    # in any generator has accepted bounded-range responsibility. Readers
+    # (category C) are never affected — they can never be opted in.
+    sql = "SELECT * FROM sequence(1, 10) AS t(x)"
+    ast = parse_one(sql, dialect="postgres")
+    config = WrenConfig(
+        strict_mode=True, allowed_source_functions=frozenset(["generate_series"])
+    )
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, config)
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND

--- a/core/wren/tests/unit/test_policy.py
+++ b/core/wren/tests/unit/test_policy.py
@@ -398,6 +398,51 @@ def test_reader_case_insensitive_blocked():
     assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
 
 
+def test_mysql_load_file_reader_in_projection_blocked():
+    # ``load_file`` is the same arbitrary-file-read primitive as read_csv, via
+    # a first-class connector (MySQL). It must be blocked in a projection just
+    # like the duckdb reader family (goldmedal review on PR #2419).
+    ast = parse_one("SELECT load_file('/etc/passwd')", dialect="mysql")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND
+
+
+def test_postgres_filesystem_enumeration_readers_blocked():
+    # Postgres filesystem enumeration / stat readers in a projection.
+    for sql in (
+        "SELECT pg_stat_file('/etc/passwd')",
+        "SELECT pg_ls_waldir()",
+        "SELECT pg_ls_logdir()",
+        "SELECT pg_ls_tmpdir()",
+    ):
+        ast = parse_one(sql, dialect="postgres")
+        with pytest.raises(WrenError) as exc_info:
+            validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+        assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND, sql
+
+
+def test_duckdb_spatial_and_sniff_readers_blocked():
+    # duckdb sniff / spatial readers over arbitrary paths, in a projection.
+    for sql in (
+        "SELECT sniff_csv('/etc/passwd') FROM orders",
+        "SELECT st_read('/x.shp') FROM orders",
+    ):
+        ast = parse_one(sql, dialect="duckdb")
+        with pytest.raises(WrenError) as exc_info:
+            validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+        assert exc_info.value.error_code == ErrorCode.MODEL_NOT_FOUND, sql
+
+
+def test_reader_error_message_does_not_leak_argument():
+    # The error must report only the function name, never the full expression
+    # (which would echo the path / URL / DSN back into messages and logs).
+    ast = parse_one("SELECT read_csv('/etc/passwd')", dialect="duckdb")
+    with pytest.raises(WrenError) as exc_info:
+        validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    assert "/etc/passwd" not in str(exc_info.value)
+
+
 def test_reader_not_blocked_when_strict_off():
     # The reader guard is a strict-mode control; without strict mode (and no
     # denylist) the query is allowed, preserving non-governed behaviour.
@@ -422,9 +467,13 @@ def test_reader_can_never_be_opted_in_as_source_func():
 
 
 def test_legit_query_with_column_named_like_reader_passes():
-    # A model column / identifier is not a function call — must not be blocked.
-    ast = parse_one('SELECT o_orderkey FROM "orders"', dialect="duckdb")
+    # An identifier that collides with a reader name (quoted column / alias) is
+    # not a function call — _check_data_readers must only reject exp.Func nodes,
+    # never plain identifiers.
+    ast = parse_one('SELECT "read_csv" FROM "orders"', dialect="duckdb")
     validate_sql_policy(ast, _MODELS, WrenConfig(strict_mode=True))
+    ast2 = parse_one('SELECT o_orderkey AS "read_csv" FROM "orders"', dialect="duckdb")
+    validate_sql_policy(ast2, _MODELS, WrenConfig(strict_mode=True))
 
 
 def test_legit_aggregate_and_scalar_funcs_pass():


### PR DESCRIPTION
Closes #2409.

## Threat addressed

`core/wren/src/wren/policy.py` strict mode enforces "every source must be an MDL model." PR #2405 widened the table-valued-function (TVF) source scan from `FROM` to `FROM`+`JOIN`+`LATERAL` — but only in the **top-level source position**. Data-reading TVFs in any *other* AST position bypassed MDL governance entirely:

| SQL (strict_mode=True, manifest={orders}) | Before | After |
|---|---|---|
| `SELECT * FROM read_csv('/etc/passwd')` | BLOCKED ✅ | BLOCKED ✅ |
| `SELECT read_csv('/etc/passwd')` (projection) | **ALLOWED ⚠️** | BLOCKED ✅ |
| `SELECT * FROM orders WHERE id IN (SELECT read_csv('/etc/passwd'))` | **ALLOWED ⚠️** | BLOCKED ✅ |
| `SELECT * FROM orders CROSS JOIN UNNEST(read_csv('s3://b/f.csv')) t(i)` | **ALLOWED ⚠️** | BLOCKED ✅ |
| `SELECT length(read_text('/etc/passwd')) FROM orders` | **ALLOWED ⚠️** | BLOCKED ✅ |

**Risk:** a data-reading TVF in a non-source position reads data outside the manifest (defeats RLAC/CLAC), enables **path traversal** (`read_csv('/etc/passwd')`, `~/.aws/credentials`), **SSRF / external reads** (`read_parquet('s3://...')`, `url(...)`), and **external-DB lateral movement** (`dblink`, `postgres_scan`).

## Approach (matches the issue's acceptance criteria)

**Section C — govern readers in ALL positions.** New `_check_data_readers` runs first under strict mode and walks the *entire* AST (`ast.find_all(exp.Func)`), failing closed on the first known data/file/remote reader regardless of position. Reader detection is matched both by raw function name (anonymous parses like `glob` / `dblink` / `pg_read_file`) and by canonical sqlglot class key (`read_csv` → `exp.ReadCSV` → `"readcsv"`).

**Section #2 — structure the source-func allowlist by category** (replaces the implicit flat handling):

| Cat | Examples | Risk | Handling |
|---|---|---|---|
| **A** row-expansion | `UNNEST`/`FLATTEN`/`EXPLODE` | none | class allowlist (`exp.Unnest`, `exp.Explode`) — unchanged |
| **B** generators | `generate_series`/`sequence`/`range` | DoS (unbounded range) | **blocked by default**; opt-in per name via new `allowed_source_functions` config |
| **C** readers | `read_csv`/`dblink`/`postgres_scan`/… | governance bypass, traversal, SSRF | **always blocked, all positions** |

Reader/generator name matching reuses the existing cross-dialect canonicalization — `_canonical_denied` was generalized to `_canonical_names` and now probes arity 0/1/2 so subclass-only-with-args readers (`read_csv('x')` → `exp.ReadCSV`, which fails to parse with zero args) are captured. **Readers can never be opted in** via `allowed_source_functions` — only generators.

### Why this layer
This is the single MDL-governance choke point for SQL sources. Fixing it here closes the bypass for *all* connectors at once without touching any connector, and keeps the policy fail-closed (allowlist for readers/generators, never denylist).

## New config (opt-in, backwards compatible)
```json
{ "strict_mode": true, "allowed_source_functions": ["generate_series"] }
```
Defaults to empty — existing configs are unaffected; generators stay blocked unless explicitly listed.

## Test evidence

New tests assert the enforcement (each fails without the fix) AND that legitimate queries still pass (no false positives). Reader-bypass tests verified failing on pre-fix code:

```
$ git stash push src/wren/policy.py src/wren/config.py   # revert the fix
$ pytest tests/unit/test_policy.py -k "projection or where_subquery or nested_in or unnest_over_reader or dblink or postgres_scan or anonymous_reader or can_never"
FAILED test_unnest_over_reader_tvf_now_blocked
FAILED test_reader_in_projection_blocked
FAILED test_reader_in_where_subquery_blocked
FAILED test_reader_nested_in_unnest_arg_blocked
FAILED test_reader_nested_in_function_arg_blocked
FAILED test_anonymous_reader_glob_in_projection_blocked
FAILED test_reader_can_never_be_opted_in_as_source_func
7 failed, 3 passed
```

With the fix (full policy + config unit suites):
```
$ pytest tests/unit/test_policy.py tests/unit/test_config.py -q
64 passed in 0.33s

$ pytest tests/unit -q
833 passed, 42 skipped in 8.92s

$ ruff check ...  -> All checks passed!
$ ruff format --check ... -> all formatted
```

Tests live in `tests/unit/test_policy.py` / `tests/unit/test_config.py` (the `pytest.mark.unit` suite that runs in the core CI job) — not behind any `importorskip`; they use sqlglot parsing only, no DB required.

## Files changed
- `core/wren/src/wren/policy.py` — all-position reader guard, A/B/C category handling, generalized canonicalizer
- `core/wren/src/wren/config.py` — new `allowed_source_functions` field + validation
- `core/wren/tests/unit/test_policy.py` — reader-in-all-positions, generator opt-in, no-false-positive tests
- `core/wren/tests/unit/test_config.py` — config parsing/validation tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in configuration for specific generator-style functions to be used as query sources in strict mode.
* **Bug Fixes**
  * Stricter enforcement now blocks data/file reader functions across more SQL locations (including nested expressions and joins), while continuing to honor the denylist when strict mode is off.
  * UNNEST over reader TVFs is now blocked in strict mode.
  * Improved function-name matching for consistent policy decisions.
* **Tests**
  * Expanded strict-mode and opt-in coverage, including configuration validation and deterministic error expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->