### PR TITLE
fix(redshift): strip trailing semicolon before subquery-wrapping

### DIFF
--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import closing
 
 import pandas as pd
@@ -11,6 +12,21 @@ from wren.model import (
     RedshiftIAMConnectionInfo,
 )
 from wren.model.error import ErrorCode, WrenError
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip any trailing ``;`` characters and surrounding whitespace.
+
+    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _q LIMIT N`` breaks when
+    ``sql`` ends in a semicolon — Redshift rejects ``SELECT 1;`` inside a
+    subquery (``syntax error at or near ";"``). Only the *terminating* run of
+    semicolons/whitespace is stripped, so semicolons inside string literals
+    (e.g. ``SELECT 'a;b' FROM t``) are preserved. Mirrors the postgres/canner/
+    trino/clickhouse connectors, which already strip before subquery-wrapping.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class RedshiftConnector(ConnectorABC):
@@ -45,7 +61,10 @@ class RedshiftConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+            sql = (
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
+                f"AS _q LIMIT {int(limit)}"
+            )
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             cols = [desc[0] for desc in cursor.description]
@@ -55,7 +74,9 @@ class RedshiftConnector(ConnectorABC):
 
     def dry_run(self, sql: str) -> None:
         with closing(self.connection.cursor()) as cursor:
-            cursor.execute(f"SELECT * FROM ({sql}) AS sub LIMIT 0")
+            cursor.execute(
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
+            )
 
     def close(self) -> None:
         try:

--- a/core/wren/tests/unit/test_redshift_semicolon.py
+++ b/core/wren/tests/unit/test_redshift_semicolon.py
@@ -1,0 +1,51 @@
+"""Trailing-semicolon stripping for the Redshift connector (mocked, no live DB).
+
+The Redshift connector wraps user SQL as ``SELECT * FROM (...) AS _q LIMIT N``.
+When the user SQL ends in a semicolon, Redshift rejects ``SELECT 1;`` inside a
+subquery (``syntax error at or near ";"``). These tests use a mocked
+connection and assert on the SQL the connector executes, so no container is
+required. Mirrors the postgres connector's semicolon tests.
+"""
+
+from contextlib import closing  # noqa: F401  (kept for parity / import safety)
+from unittest.mock import MagicMock
+
+from wren.connector.redshift import RedshiftConnector, _strip_trailing_semicolon
+
+
+def _make_mock_connector() -> tuple[RedshiftConnector, MagicMock]:
+    """Build a RedshiftConnector bypassing __init__ (no real connection)."""
+    connector = RedshiftConnector.__new__(RedshiftConnector)
+    cursor = MagicMock()
+    cursor.description = []
+    cursor.fetchall.return_value = []
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_query_strips_trailing_semicolon_before_subquery_wrap() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.query("SELECT 1;", limit=5)
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT 5"
+    assert ";)" not in sent
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;  ")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) AS sub LIMIT 0"
+    assert ";)" not in sent
+
+
+def test_helper_preserves_semicolon_inside_string_literal() -> None:
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_no_trailing_semicolon_unchanged() -> None:
+    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"


### PR DESCRIPTION
## Summary

- The Redshift connector wraps user SQL as `SELECT * FROM (...) AS _q LIMIT N` (in both `query()` and `dry_run()`). When the user SQL ends in a `;`, Redshift rejects it inside the subquery with `syntax error at or near ";"`.
- User-facing impact: any saved query / preview SQL that ends in a semicolon fails on Redshift even though it runs fine standalone.

## Motivation

Mirrors the postgres fix in #2407 (merged). The same subquery-wrap idiom is used across the postgres/canner/trino/clickhouse connectors, all of which already strip a trailing semicolon before wrapping. Redshift was the remaining connector that wrapped without stripping.

The fix adds `_strip_trailing_semicolon()` (identical regex `[;\s]+\Z` to postgres) and applies it in both `query()` and `dry_run()`. Only the *terminating* run of semicolons/whitespace is stripped, so semicolons inside string literals (`SELECT 'a;b'`) are preserved.

## Verification

- `uv run --no-sync pytest tests/unit/test_redshift_semicolon.py -q` — 4 passed.

## Real behavior proof

**Regression test** `core/wren/tests/unit/test_redshift_semicolon.py` asserts the executed SQL and FAILS without the fix.

Without the fix (helper absent):
```
ImportError: cannot import name '_strip_trailing_semicolon' from 'wren.connector.redshift'
1 error in 0.41s
```

With the fix:
```
....                                                                     [100%]
4 passed in 0.34s
```

The query test asserts the executed SQL is exactly `SELECT * FROM (SELECT 1) AS _q LIMIT 5` (no `;)`), proving the semicolon is stripped before wrapping.

## Scope / risk

- Touches only `core/wren/src/wren/connector/redshift.py` (Apache-2.0 path) + a new unit test.
- Does NOT touch type parsing, connection logic, or other connectors.
- String-literal semicolons preserved (covered by a helper test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redshift query handling so SQL with a trailing semicolon now runs correctly when wrapped for limits or dry runs.
  * Preserved semicolons inside quoted text while removing only unnecessary trailing semicolons and whitespace.
* **Tests**
  * Added coverage for trailing-semicolon handling in query execution and dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->