### PR TITLE
fix(athena): strip trailing semicolon before EXPLAIN in dry_run

### DIFF
--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -35,6 +35,7 @@ def _strip_trailing_semicolon(sql: str) -> str:
     """
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
+
 # Athena's DB-API cursor returns Trino-style type names. We delegate the
 # lexing to sqlglot so we get nested type support (array<row<a int, b varchar>>,
 # decimal(p, s), map<K, V>, etc.) for free.

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import datetime as dtlib
 import json
+import re
 from decimal import Decimal as PyDecimal
 from typing import Any
 
@@ -18,6 +19,21 @@ import pyarrow as pa
 
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip any trailing ``;`` characters and surrounding whitespace.
+
+    ``dry_run`` runs ``EXPLAIN {sql}``; Athena (Trino-flavoured) rejects a
+    trailing semicolon there (``EXPLAIN SELECT 1;`` → syntax error). Only the
+    terminating run of semicolons/whitespace is stripped, so semicolons inside
+    string literals (e.g. ``SELECT 'a;b'``) are preserved. Mirrors the
+    trino/postgres/mysql connectors, which already strip before EXPLAIN or
+    subquery-wrapping.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 # Athena's DB-API cursor returns Trino-style type names. We delegate the
 # lexing to sqlglot so we get nested type support (array<row<a int, b varchar>>,
@@ -318,7 +334,7 @@ class AthenaConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
-                cursor.execute(f"EXPLAIN {sql}")
+                cursor.execute(f"EXPLAIN {_strip_trailing_semicolon(sql)}")
         except (WrenError, TimeoutError):
             raise
         except Exception as e:

--- a/core/wren/tests/unit/test_athena_semicolon.py
+++ b/core/wren/tests/unit/test_athena_semicolon.py
@@ -1,0 +1,45 @@
+"""Trailing-semicolon stripping for the Athena connector (mocked, no live DB).
+
+``AthenaConnector.dry_run`` runs ``EXPLAIN {sql}``. Athena's engine is
+Trino-flavoured and rejects a trailing semicolon there
+(``EXPLAIN SELECT 1;`` -> syntax error). These tests use a mocked cursor and
+assert on the executed SQL, so no AWS connection is required.
+"""
+
+from unittest.mock import MagicMock
+
+from wren.connector.athena import AthenaConnector, _strip_trailing_semicolon
+
+
+def _make_mock_connector() -> tuple[AthenaConnector, MagicMock]:
+    """Build an AthenaConnector bypassing __init__ (no real connection)."""
+    connector = AthenaConnector.__new__(AthenaConnector)
+    cursor = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_dry_run_strips_trailing_semicolon_before_explain() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "EXPLAIN SELECT 1"
+    assert not sent.endswith(";")
+
+
+def test_dry_run_strips_trailing_semicolon_and_whitespace() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;  \n")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "EXPLAIN SELECT 1"
+
+
+def test_helper_preserves_semicolon_inside_string_literal() -> None:
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_no_trailing_semicolon_unchanged() -> None:
+    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"


### PR DESCRIPTION
## Summary

- `AthenaConnector.dry_run` runs `EXPLAIN {sql}` with the user SQL spliced in verbatim. Athena's Trino-flavoured engine rejects a trailing semicolon there (`EXPLAIN SELECT 1;` → syntax error).
- User-facing impact: dry-running / validating a query that ends in `;` fails on Athena even though the same query executes fine standalone.

## Motivation

The sibling connectors already strip a trailing semicolon before EXPLAIN / subquery-wrapping: `trino` and `postgres` (`_strip_trailing_semicolon`), `mysql` (`EXPLAIN {sql.rstrip().rstrip(';')...}`). Athena's `dry_run` was the remaining EXPLAIN path that interpolated raw SQL.

The fix adds `_strip_trailing_semicolon()` (same `[;\s]+\Z` regex as the postgres connector) and applies it in `dry_run`. Only the *terminating* run of semicolons/whitespace is stripped, so semicolons inside string literals (`SELECT 'a;b'`) are preserved. `query()` already slices a fetched PyArrow table for its limit (no subquery wrap), so it is unaffected.

## Verification

- `uv run --no-sync pytest tests/unit/test_athena_semicolon.py -q` — 4 passed.

## Real behavior proof

**Regression test** `core/wren/tests/unit/test_athena_semicolon.py` asserts the executed SQL and FAILS without the fix.

Without the fix (helper absent):
```
ImportError: cannot import name '_strip_trailing_semicolon' from 'wren.connector.athena'
1 error in 0.21s
```

With the fix:
```
....                                                                     [100%]
4 passed in 0.16s
```

The dry_run test asserts the executed statement is exactly `EXPLAIN SELECT 1` (no trailing `;`).

## Scope / risk

- Touches only `core/wren/src/wren/connector/athena.py` (Apache-2.0 path) + a new unit test.
- Does NOT touch type parsing, `query()`, or connection logic.
- String-literal semicolons preserved (covered by a helper test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Athena dry-run behavior to ignore trailing semicolons and surrounding whitespace when building the `EXPLAIN` statement.
  * Ensured semicolons inside string literals are left unchanged.
* **Tests**
  * Added unit tests covering trailing semicolon trimming, whitespace/newline handling, and string-literal edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->