### PR TITLE
fix(databricks): strip trailing semicolon before subquery-wrapping in dry_run

### DIFF
--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import closing
 
 import pyarrow as pa
@@ -9,6 +10,20 @@ from wren.model import (
     DatabricksServicePrincipalConnectionInfo,
     DatabricksTokenConnectionInfo,
 )
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip any trailing ``;`` characters and surrounding whitespace.
+
+    ``dry_run`` wraps user SQL as ``SELECT * FROM ({sql}) AS sub LIMIT 0``; a
+    trailing semicolon (``SELECT 1;``) becomes a syntax error inside the
+    subquery. Only the terminating run of semicolons/whitespace is stripped,
+    so semicolons inside string literals (e.g. ``SELECT 'a;b'``) are preserved.
+    Mirrors the postgres/canner/trino/clickhouse connectors.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _connection_kwargs(connection_info: DatabricksConnectionUnion) -> dict[str, str]:
@@ -58,7 +73,9 @@ class DatabricksConnector(ConnectorABC):
 
     def dry_run(self, sql: str) -> None:
         with closing(self.connection.cursor()) as cursor:
-            cursor.execute(f"SELECT * FROM ({sql}) AS sub LIMIT 0")
+            cursor.execute(
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
+            )
 
     def close(self) -> None:
         try:

--- a/core/wren/tests/unit/test_databricks_semicolon.py
+++ b/core/wren/tests/unit/test_databricks_semicolon.py
@@ -1,0 +1,45 @@
+"""Trailing-semicolon stripping for the Databricks connector (mocked, no live DB).
+
+``DatabricksConnector.dry_run`` wraps user SQL as
+``SELECT * FROM ({sql}) AS sub LIMIT 0``. A trailing semicolon (``SELECT 1;``)
+becomes a syntax error inside the subquery. These tests use a mocked cursor
+and assert on the executed SQL, so no Databricks connection is required.
+"""
+
+from unittest.mock import MagicMock
+
+from wren.connector.databricks import DatabricksConnector, _strip_trailing_semicolon
+
+
+def _make_mock_connector() -> tuple[DatabricksConnector, MagicMock]:
+    """Build a DatabricksConnector bypassing __init__ (no real connection)."""
+    connector = DatabricksConnector.__new__(DatabricksConnector)
+    cursor = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_dry_run_strips_trailing_semicolon_before_subquery_wrap() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) AS sub LIMIT 0"
+    assert ";)" not in sent
+
+
+def test_dry_run_strips_semicolon_and_whitespace() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;  \n")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) AS sub LIMIT 0"
+
+
+def test_helper_preserves_semicolon_inside_string_literal() -> None:
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_no_trailing_semicolon_unchanged() -> None:
+    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"


### PR DESCRIPTION
## Summary

- `DatabricksConnector.dry_run` wraps user SQL as `SELECT * FROM ({sql}) AS sub LIMIT 0`. When the user SQL ends in `;`, the subquery is invalid (`SELECT * FROM (SELECT 1;) AS sub LIMIT 0` → syntax error).
- User-facing impact: dry-running / validating a query that ends in a semicolon fails on Databricks even though the same query executes fine standalone.

## Motivation

The sibling connectors already strip a trailing semicolon before subquery-wrapping: postgres, canner, trino, clickhouse all have a `_strip_trailing_semicolon` helper. Databricks's `dry_run` was wrapping raw SQL. (`query()` uses `fetchmany_arrow(limit)` and never wraps, so it's unaffected.)

The fix adds `_strip_trailing_semicolon()` (same `[;\s]+\Z` regex as the postgres connector) and applies it in `dry_run`. Only the *terminating* run of semicolons/whitespace is stripped, so semicolons inside string literals (`SELECT 'a;b'`) are preserved.

## Verification

- `uv run --no-sync pytest tests/unit/test_databricks_semicolon.py -q` — 4 passed.

## Real behavior proof

**Regression test** `core/wren/tests/unit/test_databricks_semicolon.py` asserts the executed SQL and FAILS without the fix.

Without the fix (helper absent):
```
ImportError: cannot import name '_strip_trailing_semicolon' from 'wren.connector.databricks'
1 error in 0.24s
```

With the fix:
```
....                                                                     [100%]
4 passed in 0.66s
```

The dry_run test asserts the executed SQL is exactly `SELECT * FROM (SELECT 1) AS sub LIMIT 0` (no `;)`).

## Scope / risk

- Touches only `core/wren/src/wren/connector/databricks.py` (Apache-2.0 path) + a new unit test.
- Does NOT touch `query()`, type handling, or connection logic.
- String-literal semicolons preserved (covered by a helper test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL handling for Databricks dry runs so queries with trailing semicolons or extra whitespace now run correctly.
  * Preserved semicolons inside string values, avoiding unintended changes to valid SQL.
* **Tests**
  * Added coverage for dry-run SQL wrapping with trailing semicolons, whitespace, and unchanged queries without a trailing semicolon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->