### PR TITLE
fix(oracle): strip trailing semicolon before subquery-wrapping

### DIFF
--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -1,5 +1,6 @@
 """Native oracledb connector — bypasses ibis oracle backend."""
 
+import re
 from decimal import Decimal as PyDecimal
 from urllib.parse import urlparse
 
@@ -8,6 +9,22 @@ import pyarrow as pa
 
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip any trailing ``;`` characters and surrounding whitespace.
+
+    Both ``query`` (with a limit) and ``dry_run`` wrap user SQL as
+    ``SELECT * FROM ({sql}) t WHERE ROWNUM <= N``. Oracle rejects a trailing
+    semicolon inside a subquery (``ORA-00911: invalid character``), so a query
+    that ends in ``;`` fails even though it runs fine standalone. Only the
+    terminating run of semicolons/whitespace is stripped, so semicolons inside
+    string literals (e.g. ``SELECT 'a;b'``) are preserved. Mirrors the
+    postgres/canner/trino/clickhouse connectors.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _ora_number_type(precision, scale) -> pa.DataType:
@@ -131,7 +148,10 @@ class OracleConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) t WHERE ROWNUM <= {limit}"
+            sql = (
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) t "
+                f"WHERE ROWNUM <= {limit}"
+            )
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
@@ -148,7 +168,10 @@ class OracleConnector(ConnectorABC):
         if hasattr(self.connection, "cursor"):
             try:
                 with self.connection.cursor() as cursor:
-                    cursor.execute(f"SELECT * FROM ({sql}) t WHERE ROWNUM <= 0")
+                    cursor.execute(
+                        f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) t "
+                        f"WHERE ROWNUM <= 0"
+                    )
             except oracledb.DatabaseError as e:
                 raise WrenError(
                     ErrorCode.INVALID_SQL,

--- a/core/wren/tests/unit/test_oracle_semicolon.py
+++ b/core/wren/tests/unit/test_oracle_semicolon.py
@@ -1,0 +1,65 @@
+"""Trailing-semicolon stripping for the Oracle connector (mocked, no live DB).
+
+Both ``OracleConnector.query`` (with a limit) and ``dry_run`` wrap user SQL as
+``SELECT * FROM ({sql}) t WHERE ROWNUM <= N``. Oracle rejects a trailing
+semicolon inside a subquery (``ORA-00911``). These tests use a mocked cursor
+and assert on the executed SQL, so no Oracle connection is required.
+"""
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+# The oracle connector imports oracledb at module load; skip cleanly when the
+# oracle extra is not installed (e.g. the base unit-test job).
+pytest.importorskip("oracledb")
+
+from wren.connector import oracle as oracle_mod  # noqa: E402
+from wren.connector.oracle import (  # noqa: E402
+    OracleConnector,
+    _strip_trailing_semicolon,
+)
+
+
+def _make_mock_connector() -> tuple[OracleConnector, MagicMock]:
+    """Build an OracleConnector bypassing __init__ (no real connection)."""
+    connector = OracleConnector.__new__(OracleConnector)
+    cursor = MagicMock()
+
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor_cm
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_query_strips_trailing_semicolon_before_subquery_wrap(monkeypatch) -> None:
+    connector, cursor = _make_mock_connector()
+    monkeypatch.setattr(
+        oracle_mod, "_build_oracle_arrow_table", lambda c: pa.table({})
+    )
+    connector.query("SELECT 1;", limit=5)
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) t WHERE ROWNUM <= 5"
+    assert ";)" not in sent
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;  ")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) t WHERE ROWNUM <= 0"
+    assert ";)" not in sent
+
+
+def test_helper_preserves_semicolon_inside_string_literal() -> None:
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_no_trailing_semicolon_unchanged() -> None:
+    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"


### PR DESCRIPTION
## Summary

- Both `OracleConnector.query` (when a limit is given) and `OracleConnector.dry_run` wrap user SQL as `SELECT * FROM ({sql}) t WHERE ROWNUM <= N`. When the user SQL ends in `;`, the subquery is invalid and Oracle raises `ORA-00911: invalid character`.
- User-facing impact: running (with a row limit) or validating a query that ends in a semicolon fails on Oracle even though the same query executes fine standalone.

## Motivation

The sibling connectors already strip a trailing semicolon before subquery-wrapping: postgres, canner, trino, clickhouse all have a `_strip_trailing_semicolon` helper. Oracle wrapped raw SQL in both code paths.

The fix adds `_strip_trailing_semicolon()` (same `[;\s]+\Z` regex as the postgres connector) and applies it in both `query()` and `dry_run()`. Only the *terminating* run of semicolons/whitespace is stripped, so semicolons inside string literals (`SELECT 'a;b'`) are preserved.

## Verification

- `uv run --no-sync pytest tests/unit/test_oracle_semicolon.py -q` — 4 passed (with the `oracle` extra installed).

## Real behavior proof

**Regression test** `core/wren/tests/unit/test_oracle_semicolon.py` asserts the executed SQL and FAILS without the fix. It `pytest.importorskip("oracledb")` so it skips cleanly when the oracle extra isn't installed.

Without the fix (helper absent):
```
ImportError: cannot import name '_strip_trailing_semicolon' from 'wren.connector.oracle'
1 error
```

With the fix:
```
....                                                                     [100%]
4 passed in 0.21s
```

The query test asserts the executed SQL is exactly `SELECT * FROM (SELECT 1) t WHERE ROWNUM <= 5` (no `;)`); the dry_run test asserts `... WHERE ROWNUM <= 0`.

## Scope / risk

- Touches only `core/wren/src/wren/connector/oracle.py` (Apache-2.0 path) + a new unit test.
- Does NOT touch type parsing or connection logic.
- The no-limit `query()` path (which doesn't wrap) is unchanged; string-literal semicolons preserved (covered by a helper test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle query handling so statements ending with a trailing semicolon no longer fail when used in limited queries or dry runs.
  * Preserved semicolons inside string literals while only trimming unnecessary trailing semicolons and surrounding whitespace.
* **Tests**
  * Added coverage for Oracle SQL wrapping behavior, including trailing-semicolon handling and unchanged behavior when no trailing semicolon is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->