### PR TITLE
fix(memory): guard seed-query generation against null relationship models/condition

### DIFF
--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -133,8 +133,12 @@ def _model_seeds(
 
 
 def _relationship_seed(rel: dict, model_layers: dict[str, str]) -> dict | None:
-    models = rel.get("models", [])
-    condition = rel.get("condition", "").strip()
+    # Use `or` fallbacks so an explicit JSON null ("models": null /
+    # "condition": null in the manifest) does not slip a None past `.get()`'s
+    # default and crash `len(None)` / `None.strip()`. Mirrors the defensive
+    # `rel.get("condition") or ""` in `_relationship_key_columns`.
+    models = rel.get("models") or []
+    condition = (rel.get("condition") or "").strip()
 
     if len(models) < 2 or not condition:
         return None

--- a/core/wren/tests/unit/test_seed_queries.py
+++ b/core/wren/tests/unit/test_seed_queries.py
@@ -285,6 +285,32 @@ class TestGenerateSeedQueries:
         pairs = generate_seed_queries(manifest)
         assert not any("with" in p["nl"] for p in pairs)
 
+    def test_relationship_null_condition_skipped(self):
+        # An explicit JSON null for "condition" must be treated like a missing
+        # condition, not crash `None.strip()`.
+        manifest = {
+            "models": [
+                _model("a", "aid", [_col("aid", "varchar")]),
+                _model("b", "bid", [_col("bid", "varchar")]),
+            ],
+            "relationships": [
+                {"name": "a_b", "models": ["a", "b"], "condition": None}
+            ],
+        }
+        pairs = generate_seed_queries(manifest)
+        assert not any("with" in p["nl"] for p in pairs)
+
+    def test_relationship_null_models_skipped(self):
+        # An explicit JSON null for "models" must not crash `len(None)`.
+        manifest = {
+            "models": [_model("a", "aid", [_col("aid", "varchar")])],
+            "relationships": [
+                {"name": "a_b", "models": None, "condition": "a.id = b.id"}
+            ],
+        }
+        pairs = generate_seed_queries(manifest)
+        assert not any("with" in p["nl"] for p in pairs)
+
     def test_relationship_fewer_than_two_models_skipped(self):
         manifest = {
             "models": [_model("a", "aid", [_col("aid", "varchar")])],


### PR DESCRIPTION
## Summary
- Guard `_relationship_seed` (in `wren.memory.seed_queries`) against an explicit JSON `null` for a relationship's `models` or `condition`.
- User-facing impact: a manifest with a null relationship field no longer aborts **all** seed-query generation with an unhandled `TypeError`.

## Motivation
`_relationship_seed` read:

```python
models = rel.get("models", [])
condition = rel.get("condition", "").strip()
```

`dict.get(key, default)` only substitutes the default when the key is **absent**, not when its value is `None`. A manifest relationship with `"models": null` or `"condition": null` therefore passes `None` straight through, crashing `len(None)` / `None.strip()` and aborting seed-query generation for the entire manifest.

The sibling helper `_relationship_key_columns` in the same module already uses the defensive `rel.get("condition") or ""`; this brings `_relationship_seed` in line.

## Fix
Use `or` fallbacks: `rel.get("models") or []` and `(rel.get("condition") or "").strip()`.

## Verification
- `python -m pytest tests/unit/test_seed_queries.py` — **38 passed** (Apache-2.0 path: `core/**`).
- Two new regression tests (`test_relationship_null_condition_skipped`, `test_relationship_null_models_skipped`) FAIL without the change:
  - Without fix: `TypeError: object of type 'NoneType' has no len()` — `2 failed`.
  - With fix: `2 passed` (relationships with null fields are skipped, like the existing empty/whitespace cases).

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of relationship metadata so missing values no longer cause seed generation to fail.
  * Seed generation now safely skips relationships with empty or invalid relationship details instead of crashing.
  * Added coverage to confirm these cases are ignored and do not produce relationship-based seed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->