### PR TITLE
fix: finish wren-engine → wrenai rename cleanup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ core/
 ├── wren-core-base/   Shared Rust crate — manifest types (Model, Column, Metric, Relationship, View) + ManifestBuilder
 ├── wren-core-py/     PyO3 bindings exposing wren-core to Python (PyPI: wren-core)
 ├── wren-core-wasm/   WebAssembly build of wren-core for in-browser semantic SQL (npm: wren-core-wasm)
-├── wren/             Python SDK and CLI — `wren` command, profile/context/memory management (PyPI: wren-engine)
+├── wren/             Python SDK and CLI — `wren` command, profile/context/memory management (PyPI: wrenai)
 └── wren-mdl/         MDL JSON schema definition
 
 docs/core/            Module documentation

--- a/core/wren-core-py/README.md
+++ b/core/wren-core-py/README.md
@@ -1,6 +1,6 @@
 # Wren Core Python Binding
 
-Python bindings for [wren-core](../wren-core), the Rust semantic engine behind [Wren Engine](https://github.com/Canner/wren-engine). Built with [PyO3](https://github.com/PyO3/pyo3) and [Maturin](https://github.com/PyO3/maturin).
+Python bindings for [wren-core](../wren-core), the Rust semantic engine behind [Wren Engine](https://github.com/Canner/WrenAI). Built with [PyO3](https://github.com/PyO3/pyo3) and [Maturin](https://github.com/PyO3/maturin).
 
 Wren Engine translates SQL queries through a semantic layer (MDL - Modeling Definition Language) and executes them against 22+ data sources (PostgreSQL, BigQuery, Snowflake, etc.).
 

--- a/core/wren-core/Cargo.toml
+++ b/core/wren-core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 homepage = "https://getwren.ai"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/Canner/wren-engine"
+repository = "https://github.com/Canner/WrenAI"
 rust-version = "1.78"
 version = "0.1.0"
 

--- a/core/wren-core/wren-example/README.md
+++ b/core/wren-core/wren-example/README.md
@@ -6,8 +6,8 @@ The crate includes several examples of how to use Wren Engine APIs and help you 
 To run the examples, use the `cargo run` command, such as:
 
 ```bash
-git clone https://github.com/Canner/wren-engine.git
-cd wren-engine/wren-core
+git clone https://github.com/Canner/WrenAI.git
+cd WrenAI/core/wren-core
 
 # Run the `datafusion_apply` example:
 # ... use the equivalent for other examples

--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -11,23 +11,23 @@ Translate natural SQL queries through an [MDL (Modeling Definition Language)](ht
 ## Installation
 
 ```bash
-pip install wrenai              # Core (DuckDB included)
-pip install wrenai[postgres]    # PostgreSQL
-pip install wrenai[mysql]       # MySQL
-pip install wrenai[bigquery]    # BigQuery
-pip install wrenai[snowflake]   # Snowflake
-pip install wrenai[clickhouse]  # ClickHouse
-pip install wrenai[trino]       # Trino
-pip install wrenai[mssql]       # SQL Server
-pip install wrenai[databricks]  # Databricks
-pip install wrenai[redshift]    # Redshift
-pip install wrenai[spark]       # Spark
-pip install wrenai[athena]      # Athena
-pip install wrenai[oracle]      # Oracle
-pip install 'wrenai[memory]'    # Schema & query memory (LanceDB)
-pip install 'wrenai[ui]'        # Browser-based profile form (starlette + uvicorn)
-pip install 'wrenai[main]'      # memory + interactive prompts + ui
-pip install 'wrenai[all]'       # All connectors + main
+pip install wrenai                 # Core (DuckDB included)
+pip install 'wrenai[postgres]'     # PostgreSQL
+pip install 'wrenai[mysql]'        # MySQL
+pip install 'wrenai[bigquery]'     # BigQuery
+pip install 'wrenai[snowflake]'    # Snowflake
+pip install 'wrenai[clickhouse]'   # ClickHouse
+pip install 'wrenai[trino]'        # Trino
+pip install 'wrenai[mssql]'        # SQL Server
+pip install 'wrenai[databricks]'   # Databricks
+pip install 'wrenai[redshift]'     # Redshift
+pip install 'wrenai[spark]'        # Spark
+pip install 'wrenai[athena]'       # Athena
+pip install 'wrenai[oracle]'       # Oracle
+pip install 'wrenai[memory]'       # Schema & query memory (LanceDB)
+pip install 'wrenai[ui]'           # Browser-based profile form (starlette + uvicorn)
+pip install 'wrenai[main]'         # memory + interactive prompts + ui
+pip install 'wrenai[all]'          # All connectors + main
 ```
 
 Requires Python 3.11+.

--- a/core/wren/src/wren/connector/factory.py
+++ b/core/wren/src/wren/connector/factory.py
@@ -58,7 +58,7 @@ def get_connector(data_source: DataSource, connection_info):
         raise WrenError(
             ErrorCode.NOT_IMPLEMENTED,
             f"Connector '{data_source.value}' requires additional dependencies: {e}. "
-            f"Install with: pip install wren[{extra}]",
+            f"Install with: pip install 'wrenai[{extra}]'",
         ) from e
 
     if data_source in _NEEDS_DATA_SOURCE:

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -339,7 +339,7 @@ def _parse_trino_url(url: str, extra_kwargs: dict | None) -> dict:
 
 _TRINO_IMPORT_HINT = (
     "The 'trino' package is required for the Trino connector. "
-    "Install it with: pip install wren-engine[trino]"
+    "Install it with: pip install 'wrenai[trino]'"
 )
 
 

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -663,7 +663,7 @@ def _interactive_forget(mem_store, source: str | None, limit: int) -> None:
     except ImportError:
         typer.echo(
             "Interactive mode requires InquirerPy.\n"
-            "Install with: pip install wrenai[interactive]\n"
+            "Install with: pip install 'wrenai[interactive]'\n"
             "Or use: wren memory forget --id <ID> [--id <ID> ...]",
             err=True,
         )

--- a/core/wren/src/wren/skills_content/enrich-context/SKILL.md
+++ b/core/wren/src/wren/skills_content/enrich-context/SKILL.md
@@ -3,7 +3,7 @@ name: enrich-context
 description: "Augment a Wren project with business context that DB schema cannot carry — enum value meanings, units (USD vs cents, ms vs sec), NULL semantics, magic sentinels (-1 = unknown), soft-delete default filters, business synonyms, time-grain / TZ conventions, cross-system identifiers, currency rules, canonical-table preferences, AND named aggregation metrics (ARR, churn, DAU, WAU, NRR) proposed as cubes. Runs in one of two modes selected at session start: `grill` (one question at a time, user-driven) or `auto-pilot` (agent infers and applies, escalates only on conflicts and high-blast-radius additions like new cubes / views / relationships). Reads everything under <project>/raw/ (PDFs, glossaries, handbooks, code, data dictionaries) and optionally samples low-cardinality columns from the live DB (grill mode), compares against the current MDL / cubes / knowledge (rules + NL→SQL pairs), then fills gaps via the ten-category gap catalog and the cube proposal flow. Confirmed findings are written back to the right sink. Use when: user says 'enrich context', 'augment my project', 'grill me on this project', 'auto-fill my context', 'agent doesn't understand our docs / enum values / units / null meanings', 'business context is missing', 'what does status=A mean', 'is this amount in USD or cents', 'we keep getting wrong aggregations', 'add cubes for ARR / DAU / churn', 'we have a handbook / glossary / data dictionary the agent should know'; or after generating an MDL and noticing the agent lacks business semantics."
 license: Apache-2.0
 metadata:
-  author: wren-engine
+  author: wrenai
 ---
 
 # Wren Enrich Context — Fill the Business-Context Gap

--- a/core/wren/src/wren/skills_content/genbi/SKILL.md
+++ b/core/wren/src/wren/skills_content/genbi/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 # Wren GenBI App — Agent Workflow Guide
 
 > This guide is served by the `wren` CLI (`wren skills get genbi`), so it
-> always matches your installed wren-engine version.
+> always matches your installed wrenai version.
 
 Turn a Wren context layer into a shareable GenBI app — from a natural-language
 request to a public URL in one conversation.

--- a/core/wren/src/wren/skills_content/usage/SKILL.md
+++ b/core/wren/src/wren/skills_content/usage/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Wren Engine CLI — Agent Workflow Guide
 
-> This guide is served by the `wren` CLI (`wren skills get usage`), so it always matches your installed wren-engine version. Pull the deeper reference docs with `wren skills get usage --full`.
+> This guide is served by the `wren` CLI (`wren skills get usage`), so it always matches your installed wrenai version. Pull the deeper reference docs with `wren skills get usage --full`.
 
 ## Preflight — Verify environment and installation
 

--- a/core/wren/tests/connectors/test_trino.py
+++ b/core/wren/tests/connectors/test_trino.py
@@ -191,7 +191,7 @@ def test_parse_trino_url_rejects_bad_scheme() -> None:
 
 def test_trino_connector_import_error_has_install_hint(monkeypatch) -> None:
     """If ``import trino`` fails, the connector should raise a WrenError with
-    a clear ``pip install wren-engine[trino]`` hint rather than a raw
+    a clear ``pip install 'wrenai[trino]'`` hint rather than a raw
     ImportError.
     """
     import builtins  # noqa: PLC0415
@@ -214,7 +214,7 @@ def test_trino_connector_import_error_has_install_hint(monkeypatch) -> None:
         trino_module._import_trino()
     assert exc.value.error_code == ErrorCode.INVALID_CONNECTION_INFO
     msg = str(exc.value)
-    assert "wren-engine[trino]" in msg
+    assert "pip install 'wrenai[trino]'" in msg
 
 
 def test_native_connector_does_not_import_ibis() -> None:

--- a/core/wren/tests/unit/test_connector_factory.py
+++ b/core/wren/tests/unit/test_connector_factory.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from wren.connector import factory
+from wren.model.data_source import DataSource
+from wren.model.error import ErrorCode, WrenError
+
+pytestmark = pytest.mark.unit
+
+
+def test_connector_import_error_has_quoted_wrenai_extra_hint(monkeypatch) -> None:
+    def _fake_import_module(name: str):
+        if name == "wren.connector.mysql":
+            raise ImportError("No module named 'mysqlclient'")
+        raise AssertionError(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(factory.importlib, "import_module", _fake_import_module)
+
+    with pytest.raises(WrenError) as exc:
+        factory.get_connector(DataSource.doris, {})
+
+    assert exc.value.error_code == ErrorCode.NOT_IMPLEMENTED
+    assert "pip install 'wrenai[mysql]'" in str(exc.value)

--- a/core/wren/tests/unit/test_served_content_guard.py
+++ b/core/wren/tests/unit/test_served_content_guard.py
@@ -52,7 +52,7 @@ def _walk(cmd, prefix: str = "") -> dict[str, set[str]]:
 
 COMMANDS: dict[str, set[str]] = _walk(typer.main.get_command(app))
 
-# ``wren memory`` is conditionally registered (needs `wren-engine[memory]`
+# ``wren memory`` is conditionally registered (needs `wrenai[memory]`
 # extras). It's a real public surface; bundled content correctly references
 # it. Allow-list its subcommands so this guard doesn't flag false positives
 # when the test env lacks memory extras.

--- a/docs/core/sdk/langchain.md
+++ b/docs/core/sdk/langchain.md
@@ -196,7 +196,7 @@ Cross-project joins must happen in Python, not in SQL — each project has its o
 
 | `wren-langchain` | `wrenai` | `langchain` | `langgraph` |
 |---|---|---|---|
-| 0.2.x | >= 0.5.0 | >= 1.0 | >= 1.0 |
+| 0.2.x | >= 0.7.0 | >= 1.0 | >= 1.0 |
 
 ---
 

--- a/docs/core/sdk/pydantic.md
+++ b/docs/core/sdk/pydantic.md
@@ -217,7 +217,7 @@ Cross-project joins must happen in Python, not in SQL — each project has its o
 
 | `wren-pydantic` | `wrenai` | `pydantic-ai` |
 |---|---|---|
-| 0.1.x | >= 0.5.0 | >= 1.0, < 2.0 |
+| 0.1.x | >= 0.7.0 | >= 1.0, < 2.0 |
 
 ---
 

--- a/sdk/wren-langchain/README.md
+++ b/sdk/wren-langchain/README.md
@@ -37,16 +37,16 @@ wren memory index   # optional but recommended
 wren profile add ...
 ```
 
-If you haven't installed the CLI yet, install `wren-engine` first:
+If you haven't installed the CLI yet, install `wrenai` first:
 
 ```bash
-pip install "wren-engine[memory,postgres]"
+pip install "wrenai[memory,postgres]"
 ```
 
 ## Installation
 
 `wren-langchain` exposes datasource and memory extras that pass through to
-the matching `wren-engine` extras, so you only have to install once:
+the matching `wrenai` extras, so you only have to install once:
 
 ```bash
 # Match the datasource your wren_project.yml uses (DuckDB needs no extra):
@@ -65,8 +65,8 @@ pip install "wren-langchain[bigquery,memory]"
 pip install "wren-langchain[all,memory]"
 ```
 
-If you prefer to install `wren-engine` separately (e.g. you already use the
-CLI), the bare package is enough and your existing `wren-engine` extras carry
+If you prefer to install `wrenai` separately (e.g. you already use the
+CLI), the bare package is enough and your existing `wrenai` extras carry
 over:
 
 ```bash
@@ -225,9 +225,9 @@ elsewhere on the same machine.
 
 ## Compatibility matrix
 
-| `wren-langchain` | `wren-engine` | `langchain` | `langgraph` |
+| `wren-langchain` | `wrenai` | `langchain` | `langgraph` |
 |---|---|---|---|
-| 0.1.0 | >= 0.5.0 | >= 1.0 | >= 1.0 |
+| 0.1.0 | >= 0.7.0 | >= 1.0 | >= 1.0 |
 
 ## Known limitations (v0.1)
 

--- a/sdk/wren-langchain/pyproject.toml
+++ b/sdk/wren-langchain/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   # Core: provides WrenEngine, MemoryStore, profile resolution, MDL handling.
-  "wren-engine>=0.5.0",
+  "wrenai>=0.7.0",
   # langchain >=1.0 ships the recommended `langchain.agents.create_agent`
   # entrypoint. Older `langgraph.prebuilt.create_react_agent` still works
   # but emits deprecation warnings and is scheduled for removal in
@@ -43,39 +43,39 @@ dependencies = [
 [project.optional-dependencies]
 # ── Datasource pass-through extras ────────────────────────────────────────
 # Pick the one matching your project's `data_source` (in wren_project.yml).
-# These chain through to the matching `wren-engine[<datasource>]` extra so
+# These chain through to the matching `wrenai[<datasource>]` extra so
 # you don't have to install the connector dependency twice.
 #
 #   pip install "wren-langchain[mysql]"
 #   pip install "wren-langchain[mysql,memory]"
 #
-# DuckDB is built into wren-engine — no extra needed.
-postgres   = ["wren-engine[postgres]>=0.5.0"]
-mysql      = ["wren-engine[mysql]>=0.5.0"]
-bigquery   = ["wren-engine[bigquery]>=0.5.0"]
-snowflake  = ["wren-engine[snowflake]>=0.5.0"]
-clickhouse = ["wren-engine[clickhouse]>=0.5.0"]
-trino      = ["wren-engine[trino]>=0.5.0"]
-mssql      = ["wren-engine[mssql]>=0.5.0"]
-databricks = ["wren-engine[databricks]>=0.5.0"]
-redshift   = ["wren-engine[redshift]>=0.5.0"]
-spark      = ["wren-engine[spark]>=0.5.0"]
-athena     = ["wren-engine[athena]>=0.5.0"]
-oracle     = ["wren-engine[oracle]>=0.5.0"]
+# DuckDB is built into wrenai — no extra needed.
+postgres   = ["wrenai[postgres]>=0.7.0"]
+mysql      = ["wrenai[mysql]>=0.7.0"]
+bigquery   = ["wrenai[bigquery]>=0.7.0"]
+snowflake  = ["wrenai[snowflake]>=0.7.0"]
+clickhouse = ["wrenai[clickhouse]>=0.7.0"]
+trino      = ["wrenai[trino]>=0.7.0"]
+mssql      = ["wrenai[mssql]>=0.7.0"]
+databricks = ["wrenai[databricks]>=0.7.0"]
+redshift   = ["wrenai[redshift]>=0.7.0"]
+spark      = ["wrenai[spark]>=0.7.0"]
+athena     = ["wrenai[athena]>=0.7.0"]
+oracle     = ["wrenai[oracle]>=0.7.0"]
 
 # ── Memory extra ──────────────────────────────────────────────────────────
 # Required to use the three memory tools (wren_fetch_context,
 # wren_recall_queries, wren_store_query). Pulls in LanceDB and the
-# sentence-transformer model deps via wren-engine.
+# sentence-transformer model deps via wrenai.
 #
 # Without this, the toolkit auto-detects no memory and exposes only the
 # three runtime tools.
-memory = ["wren-engine[memory]>=0.5.0"]
+memory = ["wrenai[memory]>=0.7.0"]
 
 # ── Convenience aggregate ─────────────────────────────────────────────────
 # Installs every datasource + memory at once. Useful for CI / examples,
 # heavyweight for production where you usually want only one datasource.
-all = ["wren-engine[all]>=0.5.0"]
+all = ["wrenai[all]>=0.7.0"]
 
 # ── Dev / test deps ───────────────────────────────────────────────────────
 dev = [
@@ -83,7 +83,7 @@ dev = [
   "pytest-mock>=3",
   "ruff>=0.4",
   # Tests run real DuckDB + LanceDB integrations, so memory deps are required.
-  "wren-engine[memory]>=0.5.0",
+  "wrenai[memory]>=0.7.0",
 ]
 
 [project.urls]

--- a/sdk/wren-pydantic/README.md
+++ b/sdk/wren-pydantic/README.md
@@ -42,16 +42,16 @@ wren context build                                # produces target/mdl.json
 wren memory index                                 # optional but recommended
 ```
 
-If you haven't installed the CLI yet, install `wren-engine` first:
+If you haven't installed the CLI yet, install `wrenai` first:
 
 ```bash
-pip install "wren-engine[memory,postgres]"
+pip install "wrenai[memory,postgres]"
 ```
 
 ## Installation
 
 `wren-pydantic` exposes datasource and memory extras that pass through to the
-matching `wren-engine` extras, so you only have to install once:
+matching `wrenai` extras, so you only have to install once:
 
 ```bash
 # Match the datasource your wren_project.yml uses (DuckDB needs no extra):
@@ -70,7 +70,7 @@ pip install "wren-pydantic[bigquery,memory]"
 pip install "wren-pydantic[all,memory]"
 ```
 
-If `wren-engine` is already installed (e.g. you use the CLI), the bare
+If `wrenai` is already installed (e.g. you use the CLI), the bare
 `pip install wren-pydantic` is enough — your existing extras carry over.
 
 ## What you get
@@ -140,9 +140,9 @@ already captures its own state.
 
 ## Compatibility matrix
 
-| `wren-pydantic` | `wren-engine` | `pydantic-ai` |
+| `wren-pydantic` | `wrenai` | `pydantic-ai` |
 |---|---|---|
-| 0.1.x | >= 0.5.0 | >= 1.0, < 2.0 |
+| 0.1.x | >= 0.7.0 | >= 1.0, < 2.0 |
 
 ## Known limitations (v0.1)
 

--- a/sdk/wren-pydantic/pyproject.toml
+++ b/sdk/wren-pydantic/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   # Core: provides WrenEngine, MemoryStore, profile resolution, MDL handling.
-  "wren-engine>=0.5.0",
+  "wrenai>=0.7.0",
   # Pydantic AI v1 is GA. Pin major so breaking changes are an explicit
   # opt-in via CHANGELOG.
   "pydantic-ai>=1.0,<2.0",
@@ -39,39 +39,39 @@ dependencies = [
 [project.optional-dependencies]
 # ── Datasource pass-through extras ────────────────────────────────────────
 # Pick the one matching your project's `data_source` (in wren_project.yml).
-# These chain through to the matching `wren-engine[<datasource>]` extra so
+# These chain through to the matching `wrenai[<datasource>]` extra so
 # you don't have to install the connector dependency twice.
 #
 #   pip install "wren-pydantic[mysql]"
 #   pip install "wren-pydantic[mysql,memory]"
 #
-# DuckDB is built into wren-engine — no extra needed.
-postgres   = ["wren-engine[postgres]>=0.5.0"]
-mysql      = ["wren-engine[mysql]>=0.5.0"]
-bigquery   = ["wren-engine[bigquery]>=0.5.0"]
-snowflake  = ["wren-engine[snowflake]>=0.5.0"]
-clickhouse = ["wren-engine[clickhouse]>=0.5.0"]
-trino      = ["wren-engine[trino]>=0.5.0"]
-mssql      = ["wren-engine[mssql]>=0.5.0"]
-databricks = ["wren-engine[databricks]>=0.5.0"]
-redshift   = ["wren-engine[redshift]>=0.5.0"]
-spark      = ["wren-engine[spark]>=0.5.0"]
-athena     = ["wren-engine[athena]>=0.5.0"]
-oracle     = ["wren-engine[oracle]>=0.5.0"]
+# DuckDB is built into wrenai — no extra needed.
+postgres   = ["wrenai[postgres]>=0.7.0"]
+mysql      = ["wrenai[mysql]>=0.7.0"]
+bigquery   = ["wrenai[bigquery]>=0.7.0"]
+snowflake  = ["wrenai[snowflake]>=0.7.0"]
+clickhouse = ["wrenai[clickhouse]>=0.7.0"]
+trino      = ["wrenai[trino]>=0.7.0"]
+mssql      = ["wrenai[mssql]>=0.7.0"]
+databricks = ["wrenai[databricks]>=0.7.0"]
+redshift   = ["wrenai[redshift]>=0.7.0"]
+spark      = ["wrenai[spark]>=0.7.0"]
+athena     = ["wrenai[athena]>=0.7.0"]
+oracle     = ["wrenai[oracle]>=0.7.0"]
 
 # ── Memory extra ──────────────────────────────────────────────────────────
 # Required to use the three memory tools (wren_fetch_context,
 # wren_recall_queries, wren_store_query). Pulls in LanceDB and the
-# sentence-transformer model deps via wren-engine.
+# sentence-transformer model deps via wrenai.
 #
 # Without this, the toolkit auto-detects no memory and exposes only the
 # three runtime tools.
-memory = ["wren-engine[memory]>=0.5.0"]
+memory = ["wrenai[memory]>=0.7.0"]
 
 # ── Convenience aggregate ─────────────────────────────────────────────────
 # Installs every datasource + memory at once. Useful for CI / examples,
 # heavyweight for production where you usually want only one datasource.
-all = ["wren-engine[all]>=0.5.0"]
+all = ["wrenai[all]>=0.7.0"]
 
 # ── Dev / test deps ───────────────────────────────────────────────────────
 dev = [
@@ -79,7 +79,7 @@ dev = [
   "pytest-mock>=3",
   "ruff>=0.4",
   # Tests run real DuckDB + LanceDB integrations, so memory deps are required.
-  "wren-engine[memory]>=0.5.0",
+  "wrenai[memory]>=0.7.0",
 ]
 
 [project.urls]

--- a/skills/AUTHORING.md
+++ b/skills/AUTHORING.md
@@ -43,7 +43,7 @@ metadata:
 ---
 ```
 
-**Drop the `version:` field.** Content version = the installed wren-engine
+**Drop the `version:` field.** Content version = the installed wrenai
 version, since the SKILL.md ships inside the wheel.
 
 ---

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,7 +4,7 @@ The actual skill content (workflow guides, reference docs, prompt helpers)
 **lives inside the `wren` CLI**. This directory ships a single discovery stub
 that an AI client installs once; the stub then tells the agent to fetch
 everything else from the CLI at runtime (so content always matches the
-installed wren-engine version).
+installed wrenai version).
 
 See [`SKILLS.md`](SKILLS.md) for the full design and command surface.
 

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -1,7 +1,7 @@
 # Wren Engine — Agent Skills
 
 The actual workflow guides, reference docs, and prompt helpers live **inside
-the `wren` CLI itself**, so they always match the installed wren-engine
+the `wren` CLI itself**, so they always match the installed wrenai
 version (no skill cache, no version drift).
 
 This directory ships a single discovery stub ([`wren/SKILL.md`](wren/SKILL.md))

--- a/skills/wren/SKILL.md
+++ b/skills/wren/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(wren:*)
 
 This is a discovery stub. The actual workflow guides and prompt helpers
 live inside the `wren` CLI itself, so they always match the installed
-wren-engine version (no skill cache, no version drift).
+wrenai version (no skill cache, no version drift).
 
 Install: `pip install wrenai`.
 


### PR DESCRIPTION
## Summary
- Quote `pip install 'wrenai[extra]'` hints so they don't break under zsh glob expansion
- Fix install hints/deps that still pointed at the wrong or pre-rename package name (`wren[extra]`, `wren-engine[trino]`, `wren-engine>=0.5.0` in wren-pydantic/wren-langchain)
- Bump `wrenai` version floor to `>=0.7.0` (0.5.0/0.6.0 were published as `wren-engine`, before the rename)
- Fix stale `wren-engine` metadata/links (Cargo.toml repo URL, CLAUDE.md, skill docs)

## Test plan
- [x] `pytest` in `core/wren` (871 passed, Docker-dependent tests excluded)
- [x] Both SDK `pyproject.toml` files validated as parseable TOML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and compatibility guidance to use the new `wrenai` naming and version requirements.
  * Clarified CLI, SDK, and skill instructions to match the current package and command names.

* **Bug Fixes**
  * Improved missing-dependency error messages to show the correct install commands with quoted extras.
  * Adjusted connector guidance so users see the right package names for optional components.

* **Tests**
  * Updated and added tests to verify the new install hints and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->