### PR TITLE
fix(datafusion): strip trailing semicolon before subquery-wrapping in query

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import re
 from pathlib import Path
 
 import pyarrow as pa
@@ -10,6 +11,22 @@ from loguru import logger
 from wren.connector.base import ConnectorABC
 from wren.model import DataFusionConnectionInfo
 from wren.model.error import ErrorCode, WrenError
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip the terminating run of ``;`` characters and surrounding whitespace.
+
+    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _q LIMIT N`` breaks when
+    ``sql`` ends in a semicolon — DataFusion rejects ``SELECT 1;`` inside a
+    subquery (``sql parser error: Expected: an expression, found: ;``). Only
+    the *terminating* run of semicolons/whitespace is stripped, so semicolons
+    inside string literals (e.g. ``SELECT 'a;b' FROM t``) are preserved.
+    Mirrors the postgres/redshift/duckdb connectors, which already strip
+    before subquery-wrapping.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class DataFusionConnector(ConnectorABC):
@@ -30,7 +47,10 @@ class DataFusionConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+            sql = (
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
+                f"AS _q LIMIT {int(limit)}"
+            )
         ipc_bytes = self.ctx.query(sql)
         reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))
         return reader.read_all()

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -1,0 +1,61 @@
+"""Trailing-semicolon stripping for the DataFusion connector (mocked ctx).
+
+The DataFusion connector wraps user SQL as ``SELECT * FROM (...) AS _q LIMIT N``
+when a limit is supplied. If the user SQL ends in a semicolon, DataFusion
+rejects ``SELECT 1;`` inside a subquery
+(``sql parser error: Expected: an expression, found: ;``). These tests use a
+mocked ``ctx`` and assert on the SQL string the connector builds, so no native
+runtime file registration is required. Mirrors the postgres/redshift/duckdb
+connector semicolon tests.
+"""
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+
+from wren.connector.datafusion import (
+    DataFusionConnector,
+    _strip_trailing_semicolon,
+)
+
+
+def _make_mock_connector() -> tuple[DataFusionConnector, MagicMock]:
+    """Build a DataFusionConnector bypassing __init__ (no real runtime)."""
+    connector = DataFusionConnector.__new__(DataFusionConnector)
+    ctx = MagicMock()
+
+    # ctx.query must return IPC-stream bytes that read back into a table.
+    empty = pa.table({"x": pa.array([], type=pa.int64())})
+    sink = pa.BufferOutputStream()
+    with ipc.new_stream(sink, empty.schema) as writer:
+        writer.write_table(empty)
+    ctx.query.return_value = sink.getvalue().to_pybytes()
+
+    connector.ctx = ctx
+    return connector, ctx
+
+
+def test_query_strips_trailing_semicolon_before_subquery_wrap() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.query("SELECT 1;", limit=5)
+    (sent,), _ = ctx.query.call_args
+    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT 5"
+    assert ";)" not in sent
+
+
+def test_query_without_limit_is_unwrapped() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.query("SELECT 1;")
+    (sent,), _ = ctx.query.call_args
+    # No limit -> no subquery wrapping; passed through verbatim.
+    assert sent == "SELECT 1;"
+
+
+def test_helper_preserves_semicolon_inside_string_literal() -> None:
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_no_trailing_semicolon_unchanged() -> None:
+    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"


### PR DESCRIPTION
## Summary

- The DataFusion connector's `query()` wraps user SQL as `SELECT * FROM ({sql}) AS _q LIMIT N` when a limit is supplied.
- A trailing semicolon in the user SQL produced `SELECT * FROM (SELECT 1;) AS _q LIMIT 5`, which DataFusion's parser rejects.
- Strip the terminating run of semicolons/whitespace before wrapping, matching the postgres/redshift/duckdb connectors.

## Motivation

This is the same subquery-wrapping semicolon bug already fixed for postgres (#2407) and hardened for duckdb (#2411), now present in the DataFusion connector. When a user's SQL ends in `;` and a `limit` is passed, wrapping it in a subquery yields `... (SELECT 1;) AS _q ...`; DataFusion raises `sql parser error: Expected: an expression, found: ;`.

The fix reuses the established pattern: a `_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")` helper that strips only the *terminating* run of semicolons/whitespace, so semicolons inside string literals (`SELECT 'a;b'`) are preserved. Only `query()` is affected — `dry_run()` delegates to `ctx.dry_run(sql)` and is unchanged.

## Verification

- `python -m pytest tests/unit/test_datafusion_semicolon.py -v` — 4 passed.
- Real behavior proof of the wrapped SQL (before vs. after the strip):

```
BEFORE fix: SELECT * FROM (SELECT 1;) AS _q LIMIT 5   <- contains ";)": True
AFTER  fix: SELECT * FROM (SELECT 1) AS _q LIMIT 5    <- contains ";)": False
```

- Did NOT change: the no-limit path (SQL passed through verbatim) or `dry_run`.

Apache-2.0 path (`core/**`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL handling for queries with trailing semicolons when a row limit is applied.
  * Prevented subquery parsing errors by removing only the final trailing semicolon/whitespace before wrapping the query.
  * Preserved semicolons inside string literals and kept unchanged queries without limits behaving as before.

* **Tests**
  * Added coverage for trailing-semicolon behavior with and without limits, including string-literal edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->