### PR TITLE
ci(release): auto-sync core/wren lock after wren-core-py publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,19 @@ jobs:
       contents: read
       id-token: write
 
+  # After wren-core-py is published, relock the downstream core/wren SDK against
+  # the new engine binding and open a PR. Runs only if publish-wren-core-py
+  # succeeded, so we never bump to a version that failed to publish.
+  sync-wren-core-py-lock:
+    needs: [release-please, publish-wren-core-py]
+    if: needs.release-please.outputs['wren-core-py--release_created'] == 'true'
+    uses: ./.github/workflows/sync-wren-core-py-lock.yml
+    with:
+      version: ${{ needs.release-please.outputs['wren-core-py--version'] }}
+    permissions:
+      contents: write
+      pull-requests: write
+
   publish-wren:
     needs: release-please
     if: needs.release-please.outputs['wren--release_created'] == 'true'

--- a/.github/workflows/sync-wren-core-py-lock.yml
+++ b/.github/workflows/sync-wren-core-py-lock.yml
@@ -12,6 +12,14 @@ on:
         description: "Released wren-core-py version (e.g. 0.7.1)"
         required: true
         type: string
+  # Manual fallback: re-run the sync if the automatic run after publish failed
+  # or was skipped. Leave version blank to use the release tracked in the repo.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "wren-core-py version to sync to; blank = .release-please-manifest.json"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -21,22 +29,27 @@ jobs:
   sync-lock:
     if: ${{ github.repository == 'Canner/WrenAI' }}
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ inputs.version }}
     steps:
-      - name: Validate version
-        run: |
-          # Guard a malformed version out of the dep edit, branch name, and PR.
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
-            echo "::error::Unsupported version format: ${VERSION}. Expected X.Y.Z or X.Y.ZrcN."
-            exit 1
-          fi
-
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           # publish takes minutes; main may have moved. Base the PR on main tip.
           ref: main
+
+      - name: Resolve and validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          # workflow_call always passes the released version; manual runs may
+          # omit it and fall back to the release tracked in the repo.
+          version="${INPUT_VERSION:-$(jq -r '."core/wren-core-py"' .release-please-manifest.json)}"
+          # Guard a malformed version out of the dep edit, branch name, and PR.
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+            echo "::error::Unsupported version: ${version}. Expected X.Y.Z or X.Y.ZrcN."
+            exit 1
+          fi
+          echo "Syncing core/wren to wren-core-py ${version}"
+          echo "VERSION=${version}" >> "$GITHUB_ENV"
 
       - uses: astral-sh/setup-uv@v4
 

--- a/.github/workflows/sync-wren-core-py-lock.yml
+++ b/.github/workflows/sync-wren-core-py-lock.yml
@@ -25,10 +25,10 @@ permissions:
   contents: write
   pull-requests: write
 
-# Serialize runs for the same version so an automatic run and a manual re-run
-# can't both push chore/sync-wren-core-py-<version>. Don't cancel mid-push.
+# Serialize sync runs so two can't push the same branch at once. Constant key
+# (not per-version) because a blank-dispatch version is only known at run time.
 concurrency:
-  group: sync-wren-core-py-lock-${{ inputs.version }}
+  group: sync-wren-core-py-lock
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/sync-wren-core-py-lock.yml
+++ b/.github/workflows/sync-wren-core-py-lock.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           # publish takes minutes; main may have moved. Base the PR on main tip.
           ref: main
+          # Keep the write token out of .git/config so dependency code uv may
+          # build during resolution can't read it (supply-chain); push re-auths.
+          persist-credentials: false
 
       - name: Resolve and validate version
         env:
@@ -96,7 +99,7 @@ jobs:
         run: |
           BRANCH="chore/sync-wren-core-py-${VERSION}"
           # If a PR is already open for this bump, leave it untouched.
-          if [ "$(gh pr list --state open --head "${BRANCH}" --json number --jq 'length')" != "0" ]; then
+          if [ "$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --head "${BRANCH}" --json number --jq 'length')" != "0" ]; then
             echo "Open PR for ${BRANCH} already exists; leaving it untouched."
             exit 0
           fi
@@ -106,8 +109,12 @@ jobs:
           git add core/wren/pyproject.toml core/wren/uv.lock
           git commit -m "chore(wren): bump wren-core-py to ${VERSION}"
           # No open PR: --force only overwrites a leftover branch from a closed PR.
-          git push --force origin "${BRANCH}"
+          # Auth the push explicitly since credentials aren't persisted (masked in logs).
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@${GITHUB_SERVER_URL#https://}/${GITHUB_REPOSITORY}.git" \
+            "${BRANCH}"
           gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
             --base main \
             --head "${BRANCH}" \
             --title "chore(wren): bump wren-core-py to ${VERSION}" \

--- a/.github/workflows/sync-wren-core-py-lock.yml
+++ b/.github/workflows/sync-wren-core-py-lock.yml
@@ -1,0 +1,100 @@
+name: Sync core/wren lock after wren-core-py release
+
+# After wren-core-py publishes to PyPI, core/wren still pins the old engine in
+# its pyproject floor and uv.lock (release-please extra-files only touch a
+# component's own dir). Relock core/wren against the release and open a PR.
+# Called after publish-wren-core-py succeeds, so a failed publish is never bumped.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Released wren-core-py version (e.g. 0.7.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-lock:
+    if: ${{ github.repository == 'Canner/WrenAI' }}
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Validate version
+        run: |
+          # Guard a malformed version out of the dep edit, branch name, and PR.
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+            echo "::error::Unsupported version format: ${VERSION}. Expected X.Y.Z or X.Y.ZrcN."
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          # publish takes minutes; main may have moved. Base the PR on main tip.
+          ref: main
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Bump floor and relock core/wren against published wren-core-py
+        working-directory: core/wren
+        run: |
+          # uv add rewrites the pyproject floor in place and relocks in one step;
+          # --no-sync skips the heavy env. Retry for PyPI index lag after publish.
+          for attempt in 1 2 3 4 5; do
+            if uv add --no-sync "wren-core-py>=${VERSION}"; then
+              exit 0
+            fi
+            echo "uv add attempt ${attempt} failed; retrying after PyPI propagation delay"
+            sleep 20
+          done
+          echo "::error::uv add did not succeed after retries"
+          exit 1
+
+      - name: Verify lock resolved to the released version
+        run: |
+          locked=$(awk -F'"' '/^name = "wren-core-py"$/{getline; print $2}' core/wren/uv.lock)
+          if [[ "${locked}" != "${VERSION}" ]]; then
+            echo "::error::core/wren/uv.lock resolved wren-core-py ${locked:-<none>}, expected ${VERSION}"
+            exit 1
+          fi
+          echo "core/wren/uv.lock resolved wren-core-py ${locked}"
+
+      - name: Validate lockfile is consistent
+        working-directory: core/wren
+        run: uv lock --check
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- core/wren/pyproject.toml core/wren/uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open sync PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="chore/sync-wren-core-py-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add core/wren/pyproject.toml core/wren/uv.lock
+          git commit -m "chore(wren): bump wren-core-py to ${VERSION}"
+          git push --force origin "${BRANCH}"
+          if gh pr view "${BRANCH}" --json number >/dev/null 2>&1; then
+            echo "PR for ${BRANCH} already exists; branch updated."
+          else
+            gh pr create \
+              --base main \
+              --head "${BRANCH}" \
+              --title "chore(wren): bump wren-core-py to ${VERSION}" \
+              --body "Automated follow-up after \`wren-core-py\` ${VERSION} was published to PyPI. Relocks \`core/wren\` against the new engine binding. Please review and merge."
+          fi

--- a/.github/workflows/sync-wren-core-py-lock.yml
+++ b/.github/workflows/sync-wren-core-py-lock.yml
@@ -25,6 +25,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize runs for the same version so an automatic run and a manual re-run
+# can't both push chore/sync-wren-core-py-<version>. Don't cancel mid-push.
+concurrency:
+  group: sync-wren-core-py-lock-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   sync-lock:
     if: ${{ github.repository == 'Canner/WrenAI' }}
@@ -62,20 +68,13 @@ jobs:
             if uv add --no-sync "wren-core-py>=${VERSION}"; then
               exit 0
             fi
-            echo "uv add attempt ${attempt} failed; retrying after PyPI propagation delay"
-            sleep 20
+            if [ "${attempt}" -lt 5 ]; then
+              echo "uv add attempt ${attempt} failed; retrying after PyPI propagation delay"
+              sleep 20
+            fi
           done
           echo "::error::uv add did not succeed after retries"
           exit 1
-
-      - name: Verify lock resolved to the released version
-        run: |
-          locked=$(awk -F'"' '/^name = "wren-core-py"$/{getline; print $2}' core/wren/uv.lock)
-          if [[ "${locked}" != "${VERSION}" ]]; then
-            echo "::error::core/wren/uv.lock resolved wren-core-py ${locked:-<none>}, expected ${VERSION}"
-            exit 1
-          fi
-          echo "core/wren/uv.lock resolved wren-core-py ${locked}"
 
       - name: Validate lockfile is consistent
         working-directory: core/wren
@@ -96,18 +95,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH="chore/sync-wren-core-py-${VERSION}"
+          # If a PR is already open for this bump, leave it untouched.
+          if [ "$(gh pr list --state open --head "${BRANCH}" --json number --jq 'length')" != "0" ]; then
+            echo "Open PR for ${BRANCH} already exists; leaving it untouched."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "${BRANCH}"
           git add core/wren/pyproject.toml core/wren/uv.lock
           git commit -m "chore(wren): bump wren-core-py to ${VERSION}"
+          # No open PR: --force only overwrites a leftover branch from a closed PR.
           git push --force origin "${BRANCH}"
-          if gh pr view "${BRANCH}" --json number >/dev/null 2>&1; then
-            echo "PR for ${BRANCH} already exists; branch updated."
-          else
-            gh pr create \
-              --base main \
-              --head "${BRANCH}" \
-              --title "chore(wren): bump wren-core-py to ${VERSION}" \
-              --body "Automated follow-up after \`wren-core-py\` ${VERSION} was published to PyPI. Relocks \`core/wren\` against the new engine binding. Please review and merge."
-          fi
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(wren): bump wren-core-py to ${VERSION}" \
+            --body "Automated follow-up after \`wren-core-py\` ${VERSION} was published to PyPI. Relocks \`core/wren\` against the new engine binding. Please review and merge."


### PR DESCRIPTION
## What

When `wren-core-py` is published to PyPI, `core/wren` still pins the previous engine in its `pyproject.toml` floor and `uv.lock`. This automates the downstream bump that was done by hand before (e.g. #2385).

A reusable workflow `sync-wren-core-py-lock.yml` is called from `release-please.yml` after `publish-wren-core-py` succeeds (so a failed publish is never bumped). It raises the `wren-core-py` floor, relocks `core/wren`, verifies the resolved version, and opens a PR.

## Notes

- **The PR won't auto-run CI.** It's opened with `GH_TOKEN: ${{ github.token }}`,  and GitHub does not trigger `on: pull_request` runs for PRs created by   `GITHUB_TOKEN` (loop-prevention). The in-workflow `uv lock --check` +  resolved-version check give pre-merge confidence, and a maintainer can nudge  CI on the PR. Can move to a PAT / App token later if auto-CI is preferred.
- **Actions pinned to `@v4`** intentionally, to match the existing workflows;  the `github-actions` Dependabot config owns version bumps repo-wide.
- **vs Dependabot:** the weekly uv group relocks `uv.lock` eventually; this adds  the floor bump (which Dependabot can't do) and release-time immediacy in an  isolated PR.

## Follows existing patterns

- Reusable workflow invoked from `release-please.yml`, same as the `publish-*` jobs.
- Bot commit + `gh pr create`, same as `sync-docs.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically syncs the Python core dependency lockfile after a new Python core release is published.
  * Creates/updates a dedicated sync branch and opens a pull request when lock files change.
* **Bug Fixes**
  * Validates the released version format before syncing to prevent incorrect updates.
  * Retries lock updates to reduce failures caused by delays in newly published package availability.
* **Maintenance**
  * Adds a controlled post-release workflow that only runs when a release is newly created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->