### PR TITLE
ci(workflows): restrict release workflows to upstream repo

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   create-rc:
+    if: ${{ github.repository == 'Canner/WrenAI' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.repository == 'Canner/WrenAI' }}
     runs-on: ubuntu-latest
     outputs:
       wren-core-py--release_created: ${{ steps.release.outputs['core/wren-core-py--release_created'] }}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   sync-docs:
+    if: ${{ github.repository == 'Canner/WrenAI' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout WrenAI


### PR DESCRIPTION
## Summary
- Clicking **Sync fork** on a fork of `Canner/WrenAI` to pull in upstream `main` updates fires a `push` event on the fork's `main`, which triggers **Release Please** and **Sync Docs to Website** — both fail because neither workflow checks `github.repository` before running.
- Failing run evidence (from my fork):
  - [Release Please run](https://github.com/ttw225/WrenAI/actions/runs/28638165221) → `GitHub Actions is not permitted to create or approve pull requests`
  - [Sync Docs to Website run](https://github.com/ttw225/WrenAI/actions/runs/28638165111) → `Input required and not supplied: token`.
- Fix: add `if: ${{ github.repository == 'Canner/WrenAI' }}` to the entry job of `release-please.yml`, `sync-docs.yml`, and `rc-release.yml`.
- The six `publish-*.yml` workflows are `workflow_call`-only and already cascade-skip via `needs: release-please` / `needs: create-rc`, so they don't need a separate guard.
- Test CI (`wren-ci`, `core-py-ci`, `rust`, `wasm-ci`, `sdk-*-ci`) is untouched — it should keep running on forks for contributor PR validation.
- Same guard pattern as [commitizen-tools/commitizen#1889](https://github.com/commitizen-tools/commitizen/pull/1889), which I did for the same fork/CI issue there.

## Test plan
- [x] `actionlint` on the three changed files — no new findings
- [x] Confirmed against the fork's actual run history — see links above
- [ ] After merge: confirm `release-please` still runs normally on `Canner/WrenAI`
- [ ] After merge: confirm a fork push to `main` shows `release-please`/`sync-docs` as Skipped, not Failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted release and documentation automation to run only in the primary repository, reducing unintended runs in other copies or forks.
  * Release-related jobs now execute more selectively, which helps prevent accidental publishing or sync actions outside the intended project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->