### PR TITLE
fix(oracle): URL-decode credentials from connection_url

### DIFF
--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -62,11 +62,8 @@ jobs:
           uv sync --locked --no-install-project
           uv run --no-sync maturin build
       - name: Install dependencies
-        # Install the `oracle` extra so tests/unit/test_oracle_url_decode.py
-        # (guarded by pytest.importorskip("oracledb")) actually runs here
-        # instead of silently skipping.
         run: |
-          uv sync --locked --extra oracle
+          uv sync --locked --no-install-project
           uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run unit tests
         # Run the whole tests/unit/ tree rather than filtering on `-m unit`:

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -63,7 +63,7 @@ jobs:
           uv run --no-sync maturin build
       - name: Install dependencies
         run: |
-          uv sync --locked --no-install-project
+          uv sync --locked
           uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run unit tests
         # Run the whole tests/unit/ tree rather than filtering on `-m unit`:

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -62,8 +62,11 @@ jobs:
           uv sync --locked --no-install-project
           uv run --no-sync maturin build
       - name: Install dependencies
+        # Install the `oracle` extra so tests/unit/test_oracle_url_decode.py
+        # (guarded by pytest.importorskip("oracledb")) actually runs here
+        # instead of silently skipping.
         run: |
-          uv sync --locked
+          uv sync --locked --extra oracle
           uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Run unit tests
         # Run the whole tests/unit/ tree rather than filtering on `-m unit`:

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -3,8 +3,16 @@
 from decimal import Decimal as PyDecimal
 from urllib.parse import unquote, urlparse
 
-import oracledb
 import pyarrow as pa
+
+# Lazy driver import: keep the module importable without the ``oracle`` extra so
+# URL-decode/helper tests run under plain unit deps (mirrors the mysql/mssql/
+# clickhouse connectors). ``oracledb`` is only touched when a connection is
+# actually made.
+try:
+    import oracledb
+except ImportError:  # pragma: no cover
+    oracledb = None
 
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -101,7 +101,8 @@ def _make_oracle_connection(connection_info):
         # decoding, oracledb receives the literal ``%40`` and auth fails. Use
         # ``unquote`` (not ``unquote_plus``) so a literal ``+`` in a credential
         # is preserved — ``+`` only means space in query strings, not userinfo.
-        # Mirrors the mssql/mysql/clickhouse connectors.
+        # Mirrors the mssql/mysql connectors' ``unquote`` handling.
+        # (clickhouse uses ``unquote_plus``, which differs on literal ``+``.)
         return oracledb.connect(
             user=unquote(parsed.username) if parsed.username else None,
             password=unquote(parsed.password) if parsed.password else None,

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -1,7 +1,7 @@
 """Native oracledb connector — bypasses ibis oracle backend."""
 
 from decimal import Decimal as PyDecimal
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import oracledb
 import pyarrow as pa
@@ -95,12 +95,19 @@ def _make_oracle_connection(connection_info):
     if hasattr(connection_info, "connection_url") and connection_info.connection_url:
         url = connection_info.connection_url.get_secret_value()
         parsed = urlparse(url)
+        # urlparse leaves percent-encoded characters in the userinfo/path, so
+        # decode them here. Credentials routinely contain reserved characters
+        # (``@ / : ?``) that MUST be percent-encoded in the URL; without
+        # decoding, oracledb receives the literal ``%40`` and auth fails. Use
+        # ``unquote`` (not ``unquote_plus``) so a literal ``+`` in a credential
+        # is preserved — ``+`` only means space in query strings, not userinfo.
+        # Mirrors the mssql/mysql/clickhouse connectors.
         return oracledb.connect(
-            user=parsed.username,
-            password=parsed.password,
+            user=unquote(parsed.username) if parsed.username else None,
+            password=unquote(parsed.password) if parsed.password else None,
             host=parsed.hostname,
             port=parsed.port or 1521,
-            service_name=parsed.path.lstrip("/"),
+            service_name=unquote(parsed.path.lstrip("/")),
         )
     if hasattr(connection_info, "dsn") and connection_info.dsn:
         return oracledb.connect(

--- a/core/wren/tests/unit/test_oracle_url_decode.py
+++ b/core/wren/tests/unit/test_oracle_url_decode.py
@@ -6,19 +6,17 @@ escapes in place, so the connector must ``unquote`` them before handing them to
 ``oracledb.connect`` — otherwise auth fails with the literal ``%40`` etc.
 
 These tests patch ``oracledb.connect`` and assert on the decoded kwargs, so no
-live Oracle instance is required.
+live Oracle instance — and no ``oracle`` extra — is required. The connector
+lazy-imports ``oracledb``, so we inject a stand-in module attribute when the
+real driver isn't installed.
 """
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
-
-pytest.importorskip("oracledb")
-
-from wren.connector import oracle as oracle_mod  # noqa: E402
-from wren.connector.oracle import _make_oracle_connection  # noqa: E402
+from wren.connector import oracle as oracle_mod
+from wren.connector.oracle import _make_oracle_connection
 
 
 class _Secret:
@@ -36,7 +34,11 @@ def _capture_connect(monkeypatch) -> dict:
         captured.update(kwargs)
         return object()
 
-    monkeypatch.setattr(oracle_mod.oracledb, "connect", _fake_connect)
+    # The driver is lazy-imported and may be ``None`` when the ``oracle`` extra
+    # isn't installed; provide a stand-in namespace exposing ``connect``.
+    stub = oracle_mod.oracledb or SimpleNamespace()
+    monkeypatch.setattr(oracle_mod, "oracledb", stub)
+    monkeypatch.setattr(stub, "connect", _fake_connect, raising=False)
     return captured
 
 

--- a/core/wren/tests/unit/test_oracle_url_decode.py
+++ b/core/wren/tests/unit/test_oracle_url_decode.py
@@ -1,0 +1,69 @@
+"""Percent-decoding of credentials in the Oracle ``connection_url`` path.
+
+Credentials routinely contain reserved characters (``@ / : ?``) which MUST be
+percent-encoded inside a connection URL. ``urllib.parse.urlparse`` leaves those
+escapes in place, so the connector must ``unquote`` them before handing them to
+``oracledb.connect`` — otherwise auth fails with the literal ``%40`` etc.
+
+These tests patch ``oracledb.connect`` and assert on the decoded kwargs, so no
+live Oracle instance is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("oracledb")
+
+from wren.connector import oracle as oracle_mod  # noqa: E402
+from wren.connector.oracle import _make_oracle_connection  # noqa: E402
+
+
+class _Secret:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get_secret_value(self) -> str:
+        return self._value
+
+
+def _capture_connect(monkeypatch) -> dict:
+    captured: dict = {}
+
+    def _fake_connect(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(oracle_mod.oracledb, "connect", _fake_connect)
+    return captured
+
+
+def test_connection_url_decodes_percent_encoded_credentials(monkeypatch):
+    captured = _capture_connect(monkeypatch)
+    # password is ``p@ss/word`` — the ``@`` and ``/`` are percent-encoded so
+    # the URL parses at all.
+    info = SimpleNamespace(
+        connection_url=_Secret("oracle://us%40er:p%40ss%2Fword@host:1521/svc")
+    )
+    _make_oracle_connection(info)
+
+    assert captured["user"] == "us@er"
+    assert captured["password"] == "p@ss/word"
+    assert captured["host"] == "host"
+    assert captured["port"] == 1521
+    assert captured["service_name"] == "svc"
+
+
+def test_connection_url_preserves_literal_plus_in_credentials(monkeypatch):
+    # ``+`` in userinfo is a literal plus, not a space — unquote (not
+    # unquote_plus) must leave it intact.
+    captured = _capture_connect(monkeypatch)
+    info = SimpleNamespace(
+        connection_url=_Secret("oracle://svc+etl:pw+1@host:1521/svc")
+    )
+    _make_oracle_connection(info)
+
+    assert captured["user"] == "svc+etl"
+    assert captured["password"] == "pw+1"


### PR DESCRIPTION
## Summary

- The Oracle connector's `connection_url` path now `unquote()`s the username, password, and service name parsed out of the URL.
- Fixes auth failures when a credential contains a reserved character that must be percent-encoded in the URL.

## Motivation

`_make_oracle_connection` (in `core/wren/src/wren/connector/oracle.py`) parsed a `oracle://user:pass@host:port/svc` URL and passed `parsed.username` / `parsed.password` / `parsed.path` straight to `oracledb.connect()`.

`urllib.parse.urlparse` leaves percent-encoded characters in the userinfo and path. Credentials routinely contain reserved characters (`@`, `/`, `:`, `?`) that **must** be percent-encoded for the URL to parse at all — so a password like `p@ss/word` arrives as `oracle://user:p%40ss%2Fword@...`, and `oracledb` receives the literal `p%40ss%2Fword`, causing an authentication failure.

The mssql and mysql connectors already `unquote()` these components; this brings Oracle in line with them. (clickhouse uses `unquote_plus`, which differs on a literal `+`.) `unquote` (not `unquote_plus`) is used here so a literal `+` in a credential is preserved — `+` only means space in query strings, not userinfo.

## Verification

Real output on current `upstream/main` (fix reverted, tests present):

```
E         - us@er
E         + us%40er
FAILED tests/unit/test_oracle_url_decode.py::test_connection_url_decodes_percent_encoded_credentials
1 failed, 1 passed
```

With the fix applied:

```
python3 -m pytest tests/unit/test_oracle_url_decode.py -q
2 passed in 0.19s
```

- Two regression tests (mocked `oracledb.connect`, no live DB): one asserts percent-decoding, one asserts a literal `+` is preserved.
- Path is Apache-2.0 (`core/**`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle connection URL handling by percent-decoding usernames, passwords, and service names before connecting.
  * Preserved literal `+` characters in Oracle credentials to avoid unintended character conversion.
* **Tests**
  * Added unit tests covering percent-decoded credential parsing and ensuring `+` remains literal.
  * Added coverage that the Oracle connection logic can be exercised without requiring a live Oracle installation.
* **Chores**
  * Updated CI dependency installation to use `uv sync --locked --no-install-project` for the unit test job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->