### PR TITLE
fix(clickhouse): use unquote (not unquote_plus) for URL credentials; decode database

### DIFF
--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -273,9 +273,7 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
         out: dict = {
             "host": parsed.hostname,
             "port": int(parsed.port) if parsed.port else default_port,
-            "username": (
-                unquote(parsed.username) if parsed.username else "default"
-            ),
+            "username": (unquote(parsed.username) if parsed.username else "default"),
             "password": unquote(parsed.password) if parsed.password else "",
             "settings": settings,
         }

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -13,7 +13,7 @@ import json
 import re
 from decimal import Decimal as PyDecimal
 from typing import Any
-from urllib.parse import parse_qsl, unquote_plus, urlparse
+from urllib.parse import parse_qsl, unquote, urlparse
 
 import pyarrow as pa
 import sqlglot
@@ -258,9 +258,12 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
         if statement_timeout is not None:
             settings["max_execution_time"] = int(statement_timeout)
 
-        # urlparse leaves percent-encoded characters in userinfo, so decode
-        # them before clickhouse-connect sees the credentials. Matches the
-        # mssql / postgres URL handling elsewhere in this package.
+        # urlparse leaves percent-encoded characters in userinfo/path, so
+        # decode them before clickhouse-connect sees the credentials. Use
+        # ``unquote`` (not ``unquote_plus``): in a URL, ``+`` is only a space
+        # inside a query string, NOT in userinfo or the path — so a literal
+        # ``+`` in a password (e.g. ``pw+1``) must be preserved. This matches
+        # the mssql / mysql / oracle / trino URL handling in this package.
         secure = parsed.scheme == "clickhouse+https"
         # Pick the port-less default from the scheme: ClickHouse listens for
         # HTTPS on 8443 and plaintext HTTP on 8123. Defaulting an https URL to
@@ -271,13 +274,13 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
             "host": parsed.hostname,
             "port": int(parsed.port) if parsed.port else default_port,
             "username": (
-                unquote_plus(parsed.username) if parsed.username else "default"
+                unquote(parsed.username) if parsed.username else "default"
             ),
-            "password": unquote_plus(parsed.password) if parsed.password else "",
+            "password": unquote(parsed.password) if parsed.password else "",
             "settings": settings,
         }
         if parsed.path and parsed.path != "/":
-            out["database"] = parsed.path.lstrip("/")
+            out["database"] = unquote(parsed.path.lstrip("/"))
         if secure:
             out["secure"] = True
         # ``settings`` already popped above, so ``out["settings"]`` survives.

--- a/core/wren/tests/unit/test_clickhouse_helpers.py
+++ b/core/wren/tests/unit/test_clickhouse_helpers.py
@@ -42,7 +42,7 @@ class _FakeConnInfoFromUrl:
 
 
 def test_clickhouse_url_decodes_username_and_password() -> None:
-    """user / password from the URL must be unquote_plus'd.
+    """user / password / database from the URL must be percent-decoded.
 
     urlparse leaves ``%40`` (``@``) and ``%20`` (space) literal in the
     userinfo, which would otherwise reach ClickHouse verbatim and fail auth.
@@ -58,6 +58,35 @@ def test_clickhouse_url_decodes_username_and_password() -> None:
     assert out["host"] == "clickhouse-host"
     assert out["port"] == 9000
     assert out["database"] == "analytics"
+
+
+def test_clickhouse_url_preserves_literal_plus_in_credentials() -> None:
+    """A literal ``+`` in userinfo is a plus, not a space.
+
+    Regression: the parser used ``unquote_plus``, which turned a literal
+    ``+`` in a password into a space and corrupted the credential. In a URL,
+    ``+`` only means space inside a query string — never in userinfo/path.
+    """
+    info = _FakeConnInfoFromUrl(
+        "clickhouse://svc+etl:pw+1@clickhouse-host:9000/an+db"
+    )
+
+    out = _build_clickhouse_client_kwargs(info)
+
+    assert out["username"] == "svc+etl"
+    assert out["password"] == "pw+1"
+    assert out["database"] == "an+db"
+
+
+def test_clickhouse_url_decodes_percent_encoded_database() -> None:
+    """A percent-encoded database name in the path must be decoded too."""
+    info = _FakeConnInfoFromUrl(
+        "clickhouse://clickhouse-host:9000/my%20analytics"
+    )
+
+    out = _build_clickhouse_client_kwargs(info)
+
+    assert out["database"] == "my analytics"
 
 
 def test_clickhouse_url_defaults_username_when_omitted() -> None:


### PR DESCRIPTION
## Summary

- The ClickHouse `connection_url` path now decodes userinfo with `unquote` instead of `unquote_plus`, and also `unquote`s the database name parsed from the path.
- Fixes silent credential corruption when a password contains a literal `+`, and a missing-decode bug for percent-encoded database names.

## Motivation

In `_build_clickhouse_client_kwargs` (`core/wren/src/wren/connector/clickhouse.py`), the URL username/password were decoded with `unquote_plus`. But `+` only means "space" inside a URL **query string** — never in the userinfo or path (RFC 3986). So a password like `pw+1` (written literally in the URL) was silently turned into `pw 1`, and authentication failed with no clear cause.

Every other connector in this package (mssql, mysql, oracle, trino) uses plain `unquote` for exactly this reason. This brings ClickHouse in line.

Separately, the `database` name parsed from the URL path was passed through **raw** (never decoded), so a percent-encoded database name (e.g. `my%20analytics`) reached ClickHouse verbatim.

`unquote` still decodes `%20`→space, `%40`→`@`, etc., so the existing decode test continues to pass unchanged.

## Verification

Real output on current `upstream/main` (fix reverted, tests present):

```
E         - my analytics
E         + my%20analytics
FAILED tests/unit/test_clickhouse_helpers.py::test_clickhouse_url_preserves_literal_plus_in_credentials
FAILED tests/unit/test_clickhouse_helpers.py::test_clickhouse_url_decodes_percent_encoded_database
2 failed, 2 passed
```

With the fix applied:

```
python3 -m pytest tests/unit/test_clickhouse_helpers.py -q
25 passed in 0.77s
```

- Two new regression tests (literal `+` preserved; database path decoded); the pre-existing `%40`/`%20` decode test still passes.
- Path is Apache-2.0 (`core/**`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse connection URL parsing so username, password, and database values are decoded correctly.
  * Preserved literal `+` characters in credential userinfo instead of converting them to spaces.
  * Properly decoded percent-encoded database names from the URL path.
* **Tests**
  * Added regression coverage to verify correct `+` handling in credentials and percent-decoding of database names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->