### PR TITLE
feat(wren): serve project capabilities over MCP

### DIFF
--- a/core/wren/.claude/CLAUDE.md
+++ b/core/wren/.claude/CLAUDE.md
@@ -32,6 +32,7 @@ Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend.
 - `wren docs connection-info` — Generate connection field docs
 - `wren utils parse-type` — SQL type normalization
 - `wren memory index|fetch|store|recall` — Semantic memory (when `wren[memory]` installed)
+- `wren serve mcp` — Serve query/schema/knowledge tools as an MCP server (in-process engine, when `wren[mcp]` installed)
 
 ## Key Design Points
 

--- a/core/wren/.claude/CLAUDE.md
+++ b/core/wren/.claude/CLAUDE.md
@@ -32,7 +32,7 @@ Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend.
 - `wren docs connection-info` — Generate connection field docs
 - `wren utils parse-type` — SQL type normalization
 - `wren memory index|fetch|store|recall` — Semantic memory (when `wren[memory]` installed)
-- `wren serve mcp` — Serve query/schema/knowledge tools as an MCP server (in-process engine, when `wren[mcp]` installed)
+- `wren serve mcp` — Serve query/schema/knowledge tools as an MCP server (in-process engine, when `wrenai[mcp]` installed)
 
 ## Key Design Points
 

--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -162,6 +162,21 @@ never CLI flags; Cloudflare needs `wrangler` installed. See the
 [GenBI guide](../../docs/core/guides/genbi.md) and the
 [CLI reference](../../docs/core/reference/cli.md#wren-genbi--build--deploy-genbi-apps).
 
+**8. (Optional) Serve an MCP server** — expose the project's query, schema, and
+knowledge tools to Claude Desktop/Code, Cursor, or any MCP client. Runs
+in-process against the compiled MDL — no ibis-server, no separate service:
+
+```bash
+wren serve mcp                                # stdio (default) — client spawns this as a child process
+wren serve mcp --transport http --port 8080   # local Streamable HTTP for other clients
+```
+
+Requires `wren context build` to have already run and the `mcp` extra:
+`pip install 'wrenai[mcp]'`. See the
+[MCP guide](../../docs/core/guides/mcp.md) and the
+[CLI reference](../../docs/core/reference/cli.md#wren-serve--mcp-server) for
+the full tool/resource list and client wiring.
+
 ---
 
 ## Connection profiles

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -61,9 +61,10 @@ oracle = ["oracledb>=2"]
 memory = ["lancedb>=0.6", "sentence-transformers>=2.2"]
 interactive = ["InquirerPy>=0.3.4"]
 ui = ["starlette>=0.37", "uvicorn>=0.29", "jinja2>=3.1", "python-multipart>=0.0.9"]
+mcp = ["mcp[cli]>=1.19"]
 main = ["wrenai[interactive,ui]"]
 all = [
-  "wrenai[postgres,mysql,bigquery,snowflake,clickhouse,trino,mssql,databricks,redshift,athena,oracle,spark,main,memory]",
+  "wrenai[postgres,mysql,bigquery,snowflake,clickhouse,trino,mssql,databricks,redshift,athena,oracle,spark,main,memory,mcp]",
 ]
 
 [project.scripts]

--- a/core/wren/src/wren/cli.py
+++ b/core/wren/src/wren/cli.py
@@ -622,6 +622,10 @@ from wren.profile_cli import profile_app  # noqa: PLC0415, E402
 app.add_typer(genbi_app)
 app.add_typer(profile_app)
 
+from wren.serve_cli import serve_app  # noqa: PLC0415, E402
+
+app.add_typer(serve_app)
+
 
 if __name__ == "__main__":
     app()

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -9,7 +9,10 @@ has already verified the ``mcp`` extra is installed (see ``serve_cli.py``).
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
+from datetime import date, datetime, time
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -31,24 +34,51 @@ class ServeContext:
     no_connect: bool
 
 
-def _table_to_result(table, limit_requested: int | None) -> dict:
+def _normalize_value(value: Any) -> Any:
+    """Recursively coerce a value into a JSON-native type."""
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode(errors="replace")
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return value
+    if hasattr(value, "item"):
+        return _normalize_value(value.item())
+    if isinstance(value, dict):
+        return {k: _normalize_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(v) for v in value]
+    return value
+
+
+def _table_to_result(table, *, truncated: bool) -> dict:
     """Serialize a pyarrow.Table into the MCP result shape."""
-    try:
-        rows = table.to_pandas().to_dict(orient="records")
-    except Exception:
-        pydict = table.to_pydict()
-        columns = list(pydict.keys())
-        row_count = len(next(iter(pydict.values()), []))
-        rows = [{col: pydict[col][i] for col in columns} for i in range(row_count)]
     columns = [f.name for f in table.schema]
-    row_count = len(rows)
-    truncated = limit_requested is not None and row_count >= limit_requested
+    rows = [
+        {col: _normalize_value(val) for col, val in row.items()}
+        for row in table.to_pylist()
+    ]
     return {
         "columns": columns,
         "rows": rows,
-        "row_count": row_count,
+        "row_count": len(rows),
         "truncated": truncated,
     }
+
+
+def _query_with_limit_probe(ctx: ServeContext, sql: str, limit: int | None) -> dict:
+    """Run ``sql`` capped at ``MAX_ROW_LIMIT``, probing one extra row to detect truncation."""
+    effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
+    effective_limit = min(effective_limit, MAX_ROW_LIMIT)
+    table = ctx.engine.query(sql, effective_limit + 1)
+    truncated = table.num_rows > effective_limit
+    if truncated:
+        table = table.slice(0, effective_limit)
+    return _table_to_result(table, truncated=truncated)
 
 
 def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
@@ -57,17 +87,14 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(title="Run SQL", readOnlyHint=True),
         )
-        def run_sql(sql: str, limit: int | None = None, format: str = "json") -> dict:
+        def run_sql(sql: str, limit: int | None = None) -> dict:
             """Execute a SQL query through the Wren semantic layer and return rows.
 
             SQL is written against MDL model names, not raw database tables.
             Applies a default cap of 1000 rows when ``limit`` is not given, and
             a hard maximum of 10000 rows regardless of the requested limit.
             """
-            effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
-            effective_limit = min(effective_limit, MAX_ROW_LIMIT)
-            table = ctx.engine.query(sql, effective_limit)
-            return _table_to_result(table, effective_limit)
+            return _query_with_limit_probe(ctx, sql, limit)
 
         @mcp.tool(
             annotations=ToolAnnotations(title="Dry Run SQL", readOnlyHint=True),
@@ -124,10 +151,7 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
             if sql_only:
                 return {"sql": sql}
 
-            effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
-            effective_limit = min(effective_limit, MAX_ROW_LIMIT)
-            table = ctx.engine.query(sql, effective_limit)
-            return _table_to_result(table, effective_limit)
+            return _query_with_limit_probe(ctx, sql, limit)
 
     @mcp.tool(
         annotations=ToolAnnotations(title="Dry Plan SQL", readOnlyHint=True),
@@ -345,13 +369,8 @@ def _register_write_tools(mcp: FastMCP, ctx: ServeContext) -> None:
             MemoryStore(path=str(_default_memory_path())).store_query(
                 nl_query, sql_query, datasource=datasource, tags=tags
             )
-        except ModuleNotFoundError as e:
-            if (e.name or "").split(".")[0] not in {
-                "lancedb",
-                "sentence_transformers",
-                "pyarrow",
-            }:
-                raise
+        except Exception as e:
+            logger.warning(f"LanceDB indexing failed for stored query (non-fatal): {e}")
 
         return {"path": str(md_path)}
 

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -339,6 +339,134 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         idx = get_index(ctx.project, mem_path)
         return {"matches": idx.search(question, limit=limit)}
 
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Get Context", readOnlyHint=True),
+    )
+    def get_context(
+        question: str,
+        limit: int = 5,
+        item_type: str | None = None,
+        model_name: str | None = None,
+    ) -> dict:
+        """Semantic retrieval of the schema fragments relevant to a question.
+
+        The schema-axis twin of ``recall_queries``: instead of NL->SQL
+        exemplars, this returns models/columns/cubes ranked by relevance.
+        Uses embedding search when the ``memory`` extra is installed and the
+        schema has been indexed (``wren memory index``); otherwise falls back
+        to the full plain-text schema description (same content as
+        ``describe_schema``).
+        """
+        from wren.context import build_json  # noqa: PLC0415
+        from wren.memory import schema_indexer  # noqa: PLC0415
+
+        manifest = build_json(ctx.project)
+        try:
+            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
+            from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+            store = MemoryStore(path=str(_default_memory_path()))
+            return store.get_context(
+                manifest,
+                question,
+                limit=limit,
+                item_type=item_type,
+                model_name=model_name,
+            )
+        except ImportError:
+            # Only the missing `memory` extra falls back to full-text; real
+            # index/embedding errors from an installed store surface as-is.
+            return {
+                "strategy": "full",
+                "schema": schema_indexer.describe_schema(manifest),
+                "note": (
+                    "Install wrenai[memory] and run `wren memory index` for "
+                    "embedding-based schema search on large schemas."
+                ),
+            }
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Describe Schema", readOnlyHint=True),
+    )
+    def describe_schema() -> dict:
+        """Return the full MDL schema as a structured plain-text description.
+
+        The human-readable counterpart to ``get_mdl`` (JSON) — suitable for
+        pasting directly into an LLM prompt. No optional dependencies
+        required.
+        """
+        from wren.context import build_json  # noqa: PLC0415
+        from wren.memory import schema_indexer  # noqa: PLC0415
+
+        return {"schema": schema_indexer.describe_schema(build_json(ctx.project))}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Stored Queries", readOnlyHint=True),
+    )
+    def list_stored_queries(
+        source: str | None = None, limit: int | None = None
+    ) -> dict:
+        """Enumerate stored NL->SQL pairs from knowledge/sql/.
+
+        Unlike ``recall_queries`` (semantic top-k for a question), this lists
+        every stored pair, optionally filtered by ``source`` tag (e.g.
+        "user", "seed"). Returns ``{"queries": [...]}``.
+        """
+        try:
+            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
+            from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+            store = MemoryStore(path=str(_default_memory_path()))
+            rows, _total = store.list_queries(
+                source=source,
+                limit=limit if limit is not None else MAX_ROW_LIMIT,
+            )
+            return {"queries": [_normalize_value(row) for row in rows]}
+        except Exception:
+            from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
+
+            pairs = load_query_pairs(ctx.project)
+            if source:
+                pairs = [p for p in pairs if p.get("source", "user") == source]
+            if limit is not None:
+                pairs = pairs[:limit]
+            queries = [
+                {
+                    "nl_query": p["nl"],
+                    "sql_query": p["sql"],
+                    "datasource": p.get("datasource", ""),
+                    "tags": p.get("tags", ""),
+                    "source": p.get("source", "user"),
+                    "path": p.get("path"),
+                }
+                for p in pairs
+            ]
+            return {"queries": queries}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Knowledge", readOnlyHint=True),
+    )
+    def list_knowledge() -> dict:
+        """List knowledge files readable via the wren://knowledge/{path} resource.
+
+        Walks knowledge/ recursively (knowledge.yml, rules/*.md, sql/*.md) and
+        reports whether AGENTS.md exists at the project root.
+        """
+        knowledge_dir = ctx.project / "knowledge"
+        files: list[str] = []
+        if knowledge_dir.is_dir():
+            # Only list what the wren://knowledge/{name} and
+            # wren://knowledge/{subdir}/{name} templates can serve: top-level
+            # files and one directory level down. Deeper files aren't readable.
+            candidates = [*knowledge_dir.glob("*"), *knowledge_dir.glob("*/*")]
+            files = sorted(
+                str(p.relative_to(knowledge_dir)) for p in candidates if p.is_file()
+            )
+        return {
+            "files": files,
+            "agents": (ctx.project / "AGENTS.md").exists(),
+        }
+
 
 def _register_write_tools(mcp: FastMCP, ctx: ServeContext) -> None:
     @mcp.tool(
@@ -395,6 +523,7 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
     def project_resource() -> str:
         """Summary of wren_project.yml (name, catalog, schema, data source)."""
         from wren.context import (  # noqa: PLC0415
+            get_knowledge_schema_version,
             get_schema_version,
             load_project_config,
         )
@@ -407,8 +536,57 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
                 "schema": config.get("schema"),
                 "data_source": config.get("data_source"),
                 "schema_version": get_schema_version(ctx.project),
+                "knowledge_schema_version": get_knowledge_schema_version(ctx.project),
             }
         )
+
+    @mcp.resource("wren://agents", mime_type="text/markdown")
+    def agents_resource() -> str:
+        """The project's AGENTS.md, if present."""
+        agents_path = ctx.project / "AGENTS.md"
+        if not agents_path.exists():
+            return ""
+        try:
+            return agents_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError("AGENTS.md is not valid UTF-8 text.") from e
+
+    def _read_knowledge_file(rel_path: str) -> str:
+        """Read ``<project>/knowledge/<rel_path>``, rejecting escapes.
+
+        Shared by both knowledge resource templates below.
+        """
+        knowledge_dir = (ctx.project / "knowledge").resolve()
+        target = (ctx.project / "knowledge" / rel_path).resolve()
+        if not target.is_relative_to(knowledge_dir) or not target.is_file():
+            raise ValueError(f"Invalid knowledge path: '{rel_path}'.")
+        try:
+            return target.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Knowledge file is not valid UTF-8 text: '{rel_path}'."
+            ) from e
+
+    # The installed MCP SDK matches each `{param}` against a single path
+    # segment (`[^/]+`), so one `{path}` placeholder cannot span a slash
+    # (e.g. "rules/general.md"). knowledge/ is only ever one level deep in
+    # practice (knowledge.yml at the root; rules/*.md, sql/*.md, ... one
+    # directory down), so two templates cover the real layout.
+    @mcp.resource("wren://knowledge/{name}")
+    def knowledge_root_resource(name: str) -> str:
+        """Read a top-level file directly under knowledge/ (e.g. knowledge.yml).
+
+        Rejects any name that escapes the project's knowledge/ directory.
+        """
+        return _read_knowledge_file(name)
+
+    @mcp.resource("wren://knowledge/{subdir}/{name}")
+    def knowledge_nested_resource(subdir: str, name: str) -> str:
+        """Read a file under a knowledge/ subdirectory (rules/*.md, sql/*.md, ...).
+
+        Rejects any path that escapes the project's knowledge/ directory.
+        """
+        return _read_knowledge_file(f"{subdir}/{name}")
 
 
 def _register_prompts(mcp: FastMCP) -> None:
@@ -420,11 +598,14 @@ def _register_prompts(mcp: FastMCP) -> None:
             f"{intro}"
             "Follow this workflow to answer a data question:\n"
             "1. Read the `wren://mdl` resource and use `list_models` / "
-            "`describe_model` to understand the schema.\n"
+            "`describe_model` to understand the schema; for schema, read "
+            "`wren://mdl` or use `get_context` / `describe_schema`; browse "
+            "project knowledge via `list_knowledge` + the "
+            "`wren://knowledge/{path}` resource.\n"
             "2. Call `get_instructions` for business rules that affect how to "
             "interpret the data.\n"
             "3. Call `recall_queries` for proven NL->SQL exemplars similar to "
-            "the question.\n"
+            "the question, or `list_stored_queries` to browse all of them.\n"
             "4. Write SQL in the project's dialect, validate it with `dry_run`, "
             "then execute it with `run_sql`.\n"
             "5. For named metrics, prefer `query_cube` over hand-written "

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -1,0 +1,451 @@
+"""FastMCP server exposing WrenEngine query + context/knowledge tools.
+
+Named ``mcp_server.py`` (not a ``mcp/`` package) so it never shadows the
+top-level ``mcp`` SDK package on import. This module imports the SDK at
+module scope — callers must only import it from inside a command body that
+has already verified the ``mcp`` extra is installed (see ``serve_cli.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+DEFAULT_ROW_LIMIT = 1000
+MAX_ROW_LIMIT = 10000
+
+
+@dataclass
+class ServeContext:
+    """Shared state captured once at startup and used by every tool handler."""
+
+    project: Path
+    engine: Any  # wren.engine.WrenEngine
+    allow_write: bool
+    no_connect: bool
+
+
+def _table_to_result(table, limit_requested: int | None) -> dict:
+    """Serialize a pyarrow.Table into the MCP result shape."""
+    try:
+        rows = table.to_pandas().to_dict(orient="records")
+    except Exception:
+        pydict = table.to_pydict()
+        columns = list(pydict.keys())
+        row_count = len(next(iter(pydict.values()), []))
+        rows = [{col: pydict[col][i] for col in columns} for i in range(row_count)]
+    columns = [f.name for f in table.schema]
+    row_count = len(rows)
+    truncated = limit_requested is not None and row_count >= limit_requested
+    return {
+        "columns": columns,
+        "rows": rows,
+        "row_count": row_count,
+        "truncated": truncated,
+    }
+
+
+def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
+    if not ctx.no_connect:
+
+        @mcp.tool(
+            annotations=ToolAnnotations(title="Run SQL", readOnlyHint=True),
+        )
+        def run_sql(sql: str, limit: int | None = None, format: str = "json") -> dict:
+            """Execute a SQL query through the Wren semantic layer and return rows.
+
+            SQL is written against MDL model names, not raw database tables.
+            Applies a default cap of 1000 rows when ``limit`` is not given, and
+            a hard maximum of 10000 rows regardless of the requested limit.
+            """
+            effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
+            effective_limit = min(effective_limit, MAX_ROW_LIMIT)
+            table = ctx.engine.query(sql, effective_limit)
+            return _table_to_result(table, effective_limit)
+
+        @mcp.tool(
+            annotations=ToolAnnotations(title="Dry Run SQL", readOnlyHint=True),
+        )
+        def dry_run(sql: str) -> dict:
+            """Validate SQL against the connected data source without returning rows.
+
+            Cheap way to check a query is valid before calling ``run_sql``.
+            Raises on failure with the engine's error message.
+            """
+            ctx.engine.dry_run(sql)
+            return {"ok": True}
+
+        @mcp.tool(
+            annotations=ToolAnnotations(title="Query Cube", readOnlyHint=True),
+        )
+        def query_cube(
+            cube: str | None = None,
+            measures: list[str] | None = None,
+            dimensions: list[str] | None = None,
+            time_dimension: str | None = None,
+            filters: list[str] | None = None,
+            limit: int | None = None,
+            offset: int | None = None,
+            sql_only: bool = False,
+        ) -> dict:
+            """Run a structured cube (metric) query and return aggregated rows.
+
+            Mirrors ``wren cube query``. ``time_dimension`` uses the CLI spec
+            format ``name:granularity[:start,end]``; ``filters`` use
+            ``dim:op[:value]`` (comma-separated values for ``in``/``not_in``).
+            Set ``sql_only=True`` to see the generated SQL without executing it.
+            """
+            from wren_core import cube_query_to_sql  # noqa: PLC0415
+
+            from wren import context  # noqa: PLC0415
+            from wren.cube_cli import _build_cube_query  # noqa: PLC0415
+
+            if not cube or not measures:
+                raise ValueError("query_cube requires 'cube' and at least one measure.")
+
+            cube_query = _build_cube_query(
+                cube,
+                ",".join(measures),
+                ",".join(dimensions or []),
+                time_dimension,
+                filters or [],
+                limit,
+                offset,
+            )
+            mdl_json = json.dumps(context.build_json(ctx.project))
+            sql = cube_query_to_sql(json.dumps(cube_query), mdl_json)
+
+            if sql_only:
+                return {"sql": sql}
+
+            effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
+            effective_limit = min(effective_limit, MAX_ROW_LIMIT)
+            table = ctx.engine.query(sql, effective_limit)
+            return _table_to_result(table, effective_limit)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Dry Plan SQL", readOnlyHint=True),
+    )
+    def dry_plan(sql: str) -> str:
+        """Expand SQL through the MDL semantic layer and return the target-dialect SQL.
+
+        No database connection is used — this only shows what would run.
+        """
+        return ctx.engine.dry_plan(sql)
+
+
+def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Get MDL", readOnlyHint=True),
+    )
+    def get_mdl() -> dict:
+        """Return the full compiled MDL (models, relationships, cubes) as JSON."""
+        from wren.context import build_json  # noqa: PLC0415
+
+        return build_json(ctx.project)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Models", readOnlyHint=True),
+    )
+    def list_models() -> dict:
+        """List the semantic models available to query, with column counts.
+
+        Returns ``{"models": [...]}``.
+        """
+        from wren.context import load_models  # noqa: PLC0415
+
+        models = load_models(ctx.project)
+        result = []
+        for model in models:
+            description = model.get("description")
+            if description is None:
+                description = (model.get("properties") or {}).get("description")
+            result.append(
+                {
+                    "name": model.get("name"),
+                    "description": description,
+                    "column_count": len(model.get("columns", []) or []),
+                }
+            )
+        return {"models": result}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Describe Model", readOnlyHint=True),
+    )
+    def describe_model(name: str) -> dict:
+        """Describe a model's columns, primary key, ref SQL, and relationships."""
+        from wren.context import load_models, load_relationships  # noqa: PLC0415
+
+        models = load_models(ctx.project)
+        model = next((m for m in models if m.get("name") == name), None)
+        if model is None:
+            raise ValueError(f"Model '{name}' not found.")
+
+        columns = [
+            {
+                "name": col.get("name"),
+                "type": col.get("type"),
+                "description": col.get("description")
+                or (col.get("properties") or {}).get("description"),
+            }
+            for col in model.get("columns", []) or []
+        ]
+
+        relationships = [
+            rel
+            for rel in load_relationships(ctx.project)
+            if name in (rel.get("models") or [])
+        ]
+
+        return {
+            "name": model.get("name"),
+            "columns": columns,
+            "primary_key": model.get("primary_key"),
+            "ref_sql": model.get("ref_sql"),
+            "relationships": relationships,
+        }
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Get Data Source", readOnlyHint=True),
+    )
+    def get_data_source() -> dict:
+        """Return the project's configured data source (SQL dialect)."""
+        from wren.context import load_project_config  # noqa: PLC0415
+
+        return {"data_source": load_project_config(ctx.project).get("data_source")}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Cubes", readOnlyHint=True),
+    )
+    def list_cubes() -> dict:
+        """List cubes defined in the project with their measures/dimensions.
+
+        Returns ``{"cubes": [...]}``.
+        """
+        from wren.context import load_cubes  # noqa: PLC0415
+
+        cubes = load_cubes(ctx.project)
+        result = []
+        for cube in cubes:
+            result.append(
+                {
+                    "name": cube.get("name"),
+                    "base_object": cube.get("base_object"),
+                    "measures": [m.get("name") for m in cube.get("measures", []) or []],
+                    "dimensions": [
+                        d.get("name") for d in cube.get("dimensions", []) or []
+                    ],
+                    "time_dimensions": [
+                        td.get("name") for td in cube.get("time_dimensions", []) or []
+                    ],
+                }
+            )
+        return {"cubes": result}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Describe Cube", readOnlyHint=True),
+    )
+    def describe_cube(name: str) -> dict:
+        """Return the full definition of a cube (measures, dimensions, etc)."""
+        from wren.context import load_cubes  # noqa: PLC0415
+
+        cubes = load_cubes(ctx.project)
+        cube = next((c for c in cubes if c.get("name") == name), None)
+        if cube is None:
+            raise ValueError(f"Cube '{name}' not found.")
+        return cube
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Functions", readOnlyHint=True),
+    )
+    def list_functions() -> dict:
+        """List SQL functions available for the project's data source.
+
+        No database connection is required — functions are registered per
+        data source at session-context construction time. Returns
+        ``{"functions": [...]}``.
+        """
+        from wren.mdl import get_session_context  # noqa: PLC0415
+
+        session = get_session_context(
+            ctx.engine.manifest_str,
+            ctx.engine.function_path,
+            None,
+            ctx.engine.data_source.name,
+        )
+        return {"functions": [f.to_dict() for f in session.get_available_functions()]}
+
+
+def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Get Instructions", readOnlyHint=True),
+    )
+    def get_instructions() -> dict:
+        """Return business rules and instructions from knowledge/rules/*.md."""
+        from wren.context import load_rules  # noqa: PLC0415
+
+        content, used_legacy = load_rules(ctx.project)
+        return {"instructions": content or "", "used_legacy": used_legacy}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Recall Queries", readOnlyHint=True),
+    )
+    def recall_queries(question: str, limit: int = 3) -> dict:
+        """Recall confirmed NL->SQL examples similar to the given question.
+
+        Works with the ``memory`` extra (semantic search) or falls back to a
+        dependency-free token-overlap search over knowledge/sql/*.md. Returns
+        ``{"matches": [...]}``.
+        """
+        from wren.memory.index_backend import get_index  # noqa: PLC0415
+
+        try:
+            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
+
+            mem_path = str(_default_memory_path())
+        except ImportError:
+            mem_path = str(ctx.project / ".wren" / "memory")
+
+        idx = get_index(ctx.project, mem_path)
+        return {"matches": idx.search(question, limit=limit)}
+
+
+def _register_write_tools(mcp: FastMCP, ctx: ServeContext) -> None:
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Store Query", readOnlyHint=False),
+    )
+    def store_query(
+        nl_query: str,
+        sql_query: str,
+        datasource: str | None = None,
+        tags: str | None = None,
+    ) -> dict:
+        """Persist a confirmed NL->SQL pair to knowledge/sql/ for future recall.
+
+        Always writes the markdown source of truth. Also indexes into LanceDB
+        when the ``memory`` extra is installed (best-effort).
+        """
+        from wren.memory.markdown import write_query_markdown  # noqa: PLC0415
+
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+        md_path = write_query_markdown(
+            ctx.project, nl_query, sql_query, datasource=datasource, tags=tag_list
+        )
+
+        try:
+            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
+            from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+            MemoryStore(path=str(_default_memory_path())).store_query(
+                nl_query, sql_query, datasource=datasource, tags=tags
+            )
+        except ModuleNotFoundError as e:
+            if (e.name or "").split(".")[0] not in {
+                "lancedb",
+                "sentence_transformers",
+                "pyarrow",
+            }:
+                raise
+
+        return {"path": str(md_path)}
+
+
+def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
+    @mcp.resource("wren://mdl", mime_type="application/json")
+    def mdl_resource() -> str:
+        """The compiled MDL (models, relationships, cubes) as JSON."""
+        from wren.context import build_json  # noqa: PLC0415
+
+        return json.dumps(build_json(ctx.project))
+
+    @mcp.resource("wren://instructions", mime_type="text/markdown")
+    def instructions_resource() -> str:
+        """Business rules and instructions from knowledge/rules/*.md."""
+        from wren.context import load_rules  # noqa: PLC0415
+
+        content, _used_legacy = load_rules(ctx.project)
+        return content or ""
+
+    @mcp.resource("wren://project", mime_type="application/json")
+    def project_resource() -> str:
+        """Summary of wren_project.yml (name, catalog, schema, data source)."""
+        from wren.context import (  # noqa: PLC0415
+            get_schema_version,
+            load_project_config,
+        )
+
+        config = load_project_config(ctx.project)
+        return json.dumps(
+            {
+                "name": config.get("name"),
+                "catalog": config.get("catalog"),
+                "schema": config.get("schema"),
+                "data_source": config.get("data_source"),
+                "schema_version": get_schema_version(ctx.project),
+            }
+        )
+
+
+def _register_prompts(mcp: FastMCP) -> None:
+    @mcp.prompt()
+    def wren_workflow(question: str | None = None) -> str:
+        """SOP for answering a data question with the wren MCP tools."""
+        intro = f'The user asked: "{question}"\n\n' if question else ""
+        return (
+            f"{intro}"
+            "Follow this workflow to answer a data question:\n"
+            "1. Read the `wren://mdl` resource and use `list_models` / "
+            "`describe_model` to understand the schema.\n"
+            "2. Call `get_instructions` for business rules that affect how to "
+            "interpret the data.\n"
+            "3. Call `recall_queries` for proven NL->SQL exemplars similar to "
+            "the question.\n"
+            "4. Write SQL in the project's dialect, validate it with `dry_run`, "
+            "then execute it with `run_sql`.\n"
+            "5. For named metrics, prefer `query_cube` over hand-written "
+            "aggregate SQL.\n"
+            "6. Once the answer is confirmed correct, optionally call "
+            "`store_query` to persist the NL->SQL pair for future recall."
+        )
+
+
+def build_server(ctx: ServeContext) -> FastMCP:
+    """Build and register all tools on a FastMCP server instance."""
+    mcp = FastMCP("wren")
+
+    _register_query_tools(mcp, ctx)
+    _register_context_tools(mcp, ctx)
+    _register_knowledge_tools(mcp, ctx)
+    if ctx.allow_write:
+        _register_write_tools(mcp, ctx)
+    _register_resources(mcp, ctx)
+    _register_prompts(mcp)
+
+    return mcp
+
+
+def run_server(
+    ctx: ServeContext,
+    *,
+    transport: str = "stdio",
+    host: str = "127.0.0.1",
+    port: int = 8080,
+) -> None:
+    """Build the FastMCP server and run it on the given transport."""
+    mcp = build_server(ctx)
+
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+    elif transport == "http":
+        mcp.settings.host = host
+        mcp.settings.port = port
+        logger.info(f"Serving wren MCP over streamable-http at {host}:{port}")
+        mcp.run(transport="streamable-http")
+    else:
+        raise ValueError(f"Unsupported transport '{transport}'.")

--- a/core/wren/src/wren/serve_cli.py
+++ b/core/wren/src/wren/serve_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import atexit
 import json
 import os
+import shlex
 import shutil
 import sys
 from pathlib import Path
@@ -79,7 +80,9 @@ def _print_connection_help(
 
     echo(line)
     if transport == "http":
-        url = f"http://{host}:{port}/mcp"
+        # A wildcard bind host isn't a connectable client target — show loopback.
+        display_host = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host
+        url = f"http://{display_host}:{port}/mcp"
         echo(" wren MCP server — Streamable HTTP")
         echo(f"   URL: {url}")
         echo("")
@@ -94,13 +97,14 @@ def _print_connection_help(
         echo(" Press Ctrl+C to stop.")
     else:
         args = _serve_args(project, profile, allow_write, no_connect)
-        argline = " ".join(args)
-        env_flag = f" -e WREN_HOME={wren_home}" if wren_home else ""
+        # Shell-quote every token so paths with spaces stay copy-pasteable.
+        cmd = " ".join(shlex.quote(t) for t in [wren_cmd, *args])
+        env_flag = f" -e {shlex.quote('WREN_HOME=' + wren_home)}" if wren_home else ""
         echo(" wren MCP server — stdio (your MCP client spawns this process)")
         echo("")
         echo(" Register with a client:")
-        echo(f"   Claude Code   claude mcp add wren{env_flag} -- {wren_cmd} {argline}")
-        echo(f"   Codex         codex mcp add wren{env_flag} -- {wren_cmd} {argline}")
+        echo(f"   Claude Code   claude mcp add wren{env_flag} -- {cmd}")
+        echo(f"   Codex         codex mcp add wren{env_flag} -- {cmd}")
         echo("")
         echo(" Or add to an IDE MCP config (Claude Desktop / Cursor / VS Code):")
         server: dict = {"command": wren_cmd, "args": args}

--- a/core/wren/src/wren/serve_cli.py
+++ b/core/wren/src/wren/serve_cli.py
@@ -1,0 +1,159 @@
+"""Typer sub-app for ``wren serve`` commands."""
+
+from __future__ import annotations
+
+import atexit
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+serve_app = typer.Typer(
+    name="serve",
+    help="Serve wren capabilities to external clients (MCP, ...).",
+)
+
+_SOURCE_FILES = ("wren_project.yml", "relationships.yml")
+_SOURCE_DIRS = ("models", "views", "cubes")
+
+
+def _mdl_is_stale(project: Path, mdl_path: Path) -> bool:
+    """Return True if any project source file is newer than mdl_path."""
+    mdl_mtime = mdl_path.stat().st_mtime
+
+    for name in _SOURCE_FILES:
+        f = project / name
+        if f.exists() and f.stat().st_mtime > mdl_mtime:
+            return True
+
+    for dirname in _SOURCE_DIRS:
+        d = project / dirname
+        if not d.is_dir():
+            continue
+        for f in d.rglob("*"):
+            if f.is_file() and f.stat().st_mtime > mdl_mtime:
+                return True
+
+    return False
+
+
+@serve_app.command("mcp")
+def serve_mcp(
+    transport: Annotated[
+        str,
+        typer.Option("--transport", help="Transport: stdio or http."),
+    ] = "stdio",
+    host: Annotated[
+        str, typer.Option("--host", help="Bind host for --transport http.")
+    ] = "127.0.0.1",
+    port: Annotated[
+        int, typer.Option("--port", help="Bind port for --transport http.")
+    ] = 8080,
+    project: Annotated[
+        Optional[Path],
+        typer.Option("--project", help="Override project root."),
+    ] = None,
+    profile: Annotated[
+        Optional[str],
+        typer.Option("--profile", help="Connection profile name."),
+    ] = None,
+    allow_write: Annotated[
+        bool,
+        typer.Option("--allow-write", help="Enable the store_query write tool."),
+    ] = False,
+    no_connect: Annotated[
+        bool,
+        typer.Option(
+            "--no-connect",
+            help="Transpile-only mode: disable run_sql, dry_run, and query_cube.",
+        ),
+    ] = False,
+) -> None:
+    """Serve wren's query + context/knowledge tools as an MCP server.
+
+    Backed by an in-process WrenEngine — no ibis-server, no HTTP engine.
+    """
+    if transport not in {"stdio", "http"}:
+        typer.echo(
+            f"Error: unsupported --transport '{transport}'. Use stdio or http.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    try:
+        import mcp  # noqa: F401, PLC0415
+    except ImportError:
+        typer.echo(
+            "Install the MCP extra: pip install 'wrenai[mcp]'",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    from loguru import logger  # noqa: PLC0415
+
+    from wren.cli import _build_engine  # noqa: PLC0415
+    from wren.context import discover_project_path  # noqa: PLC0415
+
+    try:
+        project_path = discover_project_path(str(project) if project else None)
+    except SystemExit as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1)
+
+    # Resolve the MDL path from the already-discovered project root rather
+    # than delegating to cli._require_mdl(None), which re-discovers the
+    # project from cwd and would silently ignore --project.
+    mdl_path = project_path / "target" / "mdl.json"
+    if not mdl_path.exists():
+        typer.echo(
+            f"Error: project found at {project_path} but target/mdl.json missing.\n"
+            "  Hint: run `wren context build` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if _mdl_is_stale(project_path, mdl_path):
+        logger.warning(
+            "MDL may be stale — re-run `wren context build`",
+        )
+
+    connection_info = None
+    if profile is not None:
+        import json  # noqa: PLC0415
+
+        from wren.profile import (  # noqa: PLC0415
+            MissingSecretError,
+            expand_profile_secrets,
+            list_profiles,
+        )
+
+        profiles = list_profiles()
+        if profile not in profiles:
+            typer.echo(f"Error: profile '{profile}' not found.", err=True)
+            raise typer.Exit(1)
+        prof_dict = dict(profiles[profile])
+        ds = prof_dict.pop("datasource", None)
+        if ds is None:
+            typer.echo(f"Error: profile '{profile}' has no datasource.", err=True)
+            raise typer.Exit(1)
+        try:
+            prof_dict = expand_profile_secrets(prof_dict)
+        except MissingSecretError as e:
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1)
+        connection_info = json.dumps({"datasource": ds, **prof_dict})
+
+    engine = _build_engine(
+        str(mdl_path), connection_info, None, conn_required=not no_connect
+    )
+    atexit.register(lambda: engine.close() if hasattr(engine, "close") else None)
+
+    from wren.mcp_server import ServeContext, run_server  # noqa: PLC0415
+
+    ctx = ServeContext(
+        project=project_path,
+        engine=engine,
+        allow_write=allow_write,
+        no_connect=no_connect,
+    )
+    run_server(ctx, transport=transport, host=host, port=port)

--- a/core/wren/src/wren/serve_cli.py
+++ b/core/wren/src/wren/serve_cli.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import atexit
+import json
+import os
+import shutil
+import sys
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -37,6 +41,79 @@ def _mdl_is_stale(project: Path, mdl_path: Path) -> bool:
     return False
 
 
+def _serve_args(
+    project: Path, profile: str | None, allow_write: bool, no_connect: bool
+) -> list[str]:
+    """Reconstruct the stdio `serve mcp` args for a client config."""
+    args = ["serve", "mcp", "--project", str(project)]
+    if profile:
+        args += ["--profile", profile]
+    if allow_write:
+        args.append("--allow-write")
+    if no_connect:
+        args.append("--no-connect")
+    return args
+
+
+def _print_connection_help(
+    *,
+    transport: str,
+    host: str,
+    port: int,
+    project: Path,
+    profile: str | None,
+    allow_write: bool,
+    no_connect: bool,
+) -> None:
+    """Print client-registration guidance.
+
+    Always to stderr — on stdio transport, stdout is the MCP protocol channel
+    and must not be polluted.
+    """
+    wren_cmd = shutil.which("wren") or sys.argv[0] or "wren"
+    wren_home = os.environ.get("WREN_HOME")
+    line = "─" * 68
+
+    def echo(msg: str = "") -> None:
+        typer.echo(msg, err=True)
+
+    echo(line)
+    if transport == "http":
+        url = f"http://{host}:{port}/mcp"
+        echo(" wren MCP server — Streamable HTTP")
+        echo(f"   URL: {url}")
+        echo("")
+        echo(" Register with a client:")
+        echo(f"   Claude Code   claude mcp add --transport http wren {url}")
+        echo(f"   Codex         codex mcp add wren --url {url}")
+        echo(
+            "   Inspector     npx @modelcontextprotocol/inspector   "
+            "(Streamable HTTP → the URL above)"
+        )
+        echo("")
+        echo(" Press Ctrl+C to stop.")
+    else:
+        args = _serve_args(project, profile, allow_write, no_connect)
+        argline = " ".join(args)
+        env_flag = f" -e WREN_HOME={wren_home}" if wren_home else ""
+        echo(" wren MCP server — stdio (your MCP client spawns this process)")
+        echo("")
+        echo(" Register with a client:")
+        echo(f"   Claude Code   claude mcp add wren{env_flag} -- {wren_cmd} {argline}")
+        echo(f"   Codex         codex mcp add wren{env_flag} -- {wren_cmd} {argline}")
+        echo("")
+        echo(" Or add to an IDE MCP config (Claude Desktop / Cursor / VS Code):")
+        server: dict = {"command": wren_cmd, "args": args}
+        if wren_home:
+            server["env"] = {"WREN_HOME": wren_home}
+        config = {"mcpServers": {"wren": server}}
+        for cfg_line in json.dumps(config, indent=2).splitlines():
+            echo(f"   {cfg_line}")
+        echo("")
+        echo(" Waiting for a client on stdin…")
+    echo(line)
+
+
 @serve_app.command("mcp")
 def serve_mcp(
     transport: Annotated[
@@ -66,6 +143,14 @@ def serve_mcp(
         typer.Option(
             "--no-connect",
             help="Transpile-only mode: disable run_sql, dry_run, and query_cube.",
+        ),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress the client-registration help banner.",
         ),
     ] = False,
 ) -> None:
@@ -156,4 +241,14 @@ def serve_mcp(
         allow_write=allow_write,
         no_connect=no_connect,
     )
+    if not quiet:
+        _print_connection_help(
+            transport=transport,
+            host=host,
+            port=port,
+            project=project_path,
+            profile=profile,
+            allow_write=allow_write,
+            no_connect=no_connect,
+        )
     run_server(ctx, transport=transport, host=host, port=port)

--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -57,6 +57,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -897,6 +906,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -975,6 +993,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1272,6 +1317,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -2135,6 +2211,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2150,6 +2240,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2390,6 +2485,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.3.32"
 source = { registry = "https://pypi.org/simple" }
@@ -2519,6 +2628,129 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]
@@ -2886,6 +3118,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/61/12/c3f7533fde302fcd59bebcd4c2e46d5bf0eef21f183c67995bbb010fb578/sqlglot-29.0.1.tar.gz", hash = "sha256:0010b4f77fb996c8d25dd4b16f3654e6da163ff1866ceabc70b24e791c203048", size = 5760786, upload-time = "2026-02-23T21:41:20.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/c9/f58c3a17beb650700f9d2eccd410726b6d96df8953663700764ca48636c7/sqlglot-29.0.1-py3-none-any.whl", hash = "sha256:06a473ea6c2b3632ac67bd38e687a6860265bf4156e66b54adeda15d07f00c65", size = 611448, upload-time = "2026-02-23T21:41:18.008Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
 ]
 
 [[package]]
@@ -3332,6 +3577,7 @@ all = [
     { name = "inquirerpy" },
     { name = "jinja2" },
     { name = "lancedb" },
+    { name = "mcp", extra = ["cli"] },
     { name = "mysqlclient" },
     { name = "oracledb" },
     { name = "psycopg", extra = ["binary"] },
@@ -3369,6 +3615,9 @@ main = [
     { name = "python-multipart" },
     { name = "starlette" },
     { name = "uvicorn" },
+]
+mcp = [
+    { name = "mcp", extra = ["cli"] },
 ]
 memory = [
     { name = "lancedb" },
@@ -3429,6 +3678,7 @@ requires-dist = [
     { name = "lancedb", marker = "extra == 'memory'", specifier = ">=0.6" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "lxml", specifier = ">=6.1.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.19" },
     { name = "mysqlclient", marker = "extra == 'mysql'", specifier = ">=2.2" },
     { name = "opendal", specifier = ">=0.45" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=2" },
@@ -3457,9 +3707,9 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.29" },
     { name = "wren-core-py", specifier = ">=0.7.1" },
     { name = "wrenai", extras = ["interactive", "ui"], marker = "extra == 'main'" },
-    { name = "wrenai", extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "athena", "oracle", "spark", "main", "memory"], marker = "extra == 'all'" },
+    { name = "wrenai", extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "athena", "oracle", "spark", "main", "memory", "mcp"], marker = "extra == 'all'" },
 ]
-provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "interactive", "ui", "main", "all"]
+provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "interactive", "ui", "mcp", "main", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/docs/core/guides/mcp.md
+++ b/docs/core/guides/mcp.md
@@ -37,10 +37,15 @@ Add `--allow-write` to enable `store_query` (off by default — the server is
 otherwise read-only), or `--no-connect` for a transpile-only server that never
 touches the database (`run_sql` / `dry_run` / `query_cube` are disabled).
 
+On startup the server prints ready-to-copy registration commands for exactly the
+invocation you ran — a `claude mcp add` / `codex mcp add` line for HTTP, and those
+plus a JSON `mcpServers` block for stdio. Pass `--quiet` to silence it.
+
 ## Wire it into a client
 
-Most desktop/IDE MCP clients take a JSON config that spawns the server over
-stdio:
+The startup banner already prints the commands below filled in for your project;
+this section explains them. Most desktop/IDE MCP clients take a JSON config that
+spawns the server over stdio:
 
 ```json
 {

--- a/docs/core/guides/mcp.md
+++ b/docs/core/guides/mcp.md
@@ -68,11 +68,19 @@ version — keep it local.
 - **Query tools** — `run_sql`, `dry_run`, `dry_plan`, `query_cube`
 - **Schema tools** — `get_mdl`, `list_models`, `describe_model`,
   `get_data_source`, `list_cubes`, `describe_cube`, `list_functions`
-- **Knowledge tools** — `get_instructions`, `recall_queries`, and
+- **Knowledge tools** — `get_instructions`, `recall_queries`, `get_context`,
+  `describe_schema`, `list_stored_queries`, `list_knowledge`, and
   (behind `--allow-write`) `store_query`
-- **Resources** — `wren://mdl`, `wren://instructions`, `wren://project`
+- **Resources** — `wren://mdl`, `wren://instructions`, `wren://project`,
+  `wren://agents`, `wren://knowledge/{path}`
 - **Prompt** — `wren_workflow`, a ready-made SOP for schema → instructions →
   recall → dry-run → run → store
+
+`get_context` and `list_stored_queries` prefer the `memory` extra (embedding
+search, full query history) but fall back to dependency-free reads over
+`knowledge/` when it isn't installed — the same degradation `recall_queries`
+already does. `describe_schema` needs no extra at all: it's the plain-text
+counterpart to `get_mdl`, sized for pasting into an LLM prompt.
 
 See the [CLI reference](../reference/cli.md#wren-serve--mcp-server) for every
 flag and tool signature.
@@ -84,6 +92,10 @@ server-side — only SQL text, query results, and metadata cross the MCP
 boundary. The server never auto-builds the MDL; if project source files are
 newer than `target/mdl.json` it logs a staleness warning but keeps serving the
 existing manifest, so re-run `wren context build` after model changes.
+
+The `wren://knowledge/{path}` resource resolves the requested path and
+verifies it stays inside the project's `knowledge/` directory before reading
+it — a path that would escape (e.g. `../wren_project.yml`) is rejected.
 
 ## See also
 

--- a/docs/core/guides/mcp.md
+++ b/docs/core/guides/mcp.md
@@ -1,0 +1,92 @@
+---
+sidebar_label: Serve an MCP server
+---
+
+# Serve an MCP server
+
+`wren serve mcp` exposes a Wren project's query, schema, and business-knowledge
+tools to any MCP client — Claude Desktop, Claude Code, Cursor, or another IDE.
+The server runs in-process against the compiled MDL and the active connection
+profile: no ibis-server, no separate backend, just the CLI you already have
+installed.
+
+## Before you start
+
+- A Wren project with `target/mdl.json` built (`wren context build`).
+- A connection profile bound (`wren profile add` / `wren context set-profile`),
+  unless you only need the schema/transpile tools (`--no-connect`).
+- The `mcp` extra: `pip install 'wrenai[mcp]'` (working from a `core/wren`
+  checkout: `just install-extra mcp`).
+
+## Start the server
+
+```bash
+cd my-project
+wren serve mcp
+```
+
+Runs `stdio` by default — the mode a client that spawns `wren` as a child
+process expects. Use `--transport http` for a local server other tools
+connect to instead:
+
+```bash
+wren serve mcp --transport http --host 127.0.0.1 --port 8080
+```
+
+Add `--allow-write` to enable `store_query` (off by default — the server is
+otherwise read-only), or `--no-connect` for a transpile-only server that never
+touches the database (`run_sql` / `dry_run` / `query_cube` are disabled).
+
+## Wire it into a client
+
+Most desktop/IDE MCP clients take a JSON config that spawns the server over
+stdio:
+
+```json
+{
+  "mcpServers": {
+    "wren": {
+      "command": "wren",
+      "args": ["serve", "mcp"],
+      "cwd": "/path/to/your/project"
+    }
+  }
+}
+```
+
+`cwd` must be inside the project (or pass `--project /path/to/project` in
+`args` instead). Restart the client after adding the config.
+
+For a server other machines/processes connect to, run
+`wren serve mcp --transport http --port 8080` and point the client at the
+Streamable HTTP endpoint on that host/port instead of spawning a process.
+HTTP binds to `127.0.0.1` by default and ships no bearer-token auth in this
+version — keep it local.
+
+## What the client gets
+
+- **Query tools** — `run_sql`, `dry_run`, `dry_plan`, `query_cube`
+- **Schema tools** — `get_mdl`, `list_models`, `describe_model`,
+  `get_data_source`, `list_cubes`, `describe_cube`, `list_functions`
+- **Knowledge tools** — `get_instructions`, `recall_queries`, and
+  (behind `--allow-write`) `store_query`
+- **Resources** — `wren://mdl`, `wren://instructions`, `wren://project`
+- **Prompt** — `wren_workflow`, a ready-made SOP for schema → instructions →
+  recall → dry-run → run → store
+
+See the [CLI reference](../reference/cli.md#wren-serve--mcp-server) for every
+flag and tool signature.
+
+## Security notes
+
+Connection credentials are resolved from the profile once at startup and stay
+server-side — only SQL text, query results, and metadata cross the MCP
+boundary. The server never auto-builds the MDL; if project source files are
+newer than `target/mdl.json` it logs a staleness warning but keeps serving the
+existing manifest, so re-run `wren context build` after model changes.
+
+## See also
+
+- [CLI reference — `wren serve`](../reference/cli.md#wren-serve--mcp-server)
+- [Manage project](manage_project.md) — project layout and `target/mdl.json`
+- [Connect your database](connect.md) — set up the profile the server queries through

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -402,6 +402,13 @@ Requires the `mcp` extra: `pip install 'wrenai[mcp]'`.
 | `--profile` | active profile | Connection profile name |
 | `--allow-write` | off | Enable the `store_query` write tool |
 | `--no-connect` | off | Transpile-only mode: disable `run_sql`, `dry_run`, `query_cube` |
+| `--quiet` / `-q` | off | Suppress the client-registration help banner |
+
+On startup the server prints (to stderr) ready-to-copy registration commands for
+the running invocation — a `claude mcp add` / `codex mcp add` command for
+`--transport http`, and those plus a JSON `mcpServers` config block for stdio
+(reflecting `--project`, `--profile`, `--allow-write`, and `WREN_HOME`). Pass
+`--quiet` to suppress it.
 
 Requires `target/mdl.json` to exist (`wren context build` first) — errors with
 a hint otherwise. If project source files (`models/`, `views/`, `cubes/`,

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -428,17 +428,29 @@ default; there is no bearer-token auth in this version — treat it as local-onl
 |---|---|
 | Query | `run_sql`, `dry_run`, `dry_plan`, `query_cube` |
 | Schema | `get_mdl`, `list_models`, `describe_model`, `get_data_source`, `list_cubes`, `describe_cube`, `list_functions` |
-| Knowledge | `get_instructions`, `recall_queries` |
+| Knowledge | `get_instructions`, `recall_queries`, `get_context`, `describe_schema`, `list_stored_queries`, `list_knowledge` |
 | Write (`--allow-write`) | `store_query` |
 
 `run_sql`, `dry_run`, and `query_cube` are disabled under `--no-connect`.
 `store_query` is only registered when `--allow-write` is passed.
 
+The knowledge tools degrade gracefully without the `memory` extra:
+`get_context` (semantic schema retrieval, the schema-axis twin of
+`recall_queries`) falls back to the full plain-text schema description;
+`describe_schema` (the human-readable counterpart to `get_mdl`) needs no
+optional dependency at all; `list_stored_queries` enumerates every NL→SQL
+pair (not just a semantic top-k) from `knowledge/sql/*.md`; `list_knowledge`
+lists every file readable via the `wren://knowledge/{path}` resource below.
+
 ### Resources & prompt
 
 - `wren://mdl` — compiled MDL JSON
 - `wren://instructions` — business rules from `knowledge/rules/*.md`
-- `wren://project` — project name / catalog / schema / data source / schema_version
+- `wren://project` — project name / catalog / schema / data source / schema_version / knowledge_schema_version
+- `wren://agents` — the project's `AGENTS.md`, if present
+- `wren://knowledge/{path}` — read any file under `knowledge/` (e.g.
+  `wren://knowledge/knowledge.yml`, `wren://knowledge/rules/general.md`);
+  rejects any path that escapes the project's `knowledge/` directory
 - `wren_workflow` prompt — packages the schema → instructions → recall →
   dry-run → run_sql → query_cube → store SOP for a connecting agent
 

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -377,6 +377,81 @@ validation rules.
 
 ---
 
+## `wren serve` — MCP Server
+
+Serve the project's query, schema, and knowledge tools to MCP clients (Claude
+Desktop/Code, Cursor, any MCP-capable IDE) as a local MCP server. The server
+embeds the engine in-process — no ibis-server, no separate backend — so it
+runs from a bare project checkout as long as `wren context build` has run.
+
+### `wren serve mcp`
+
+```bash
+wren serve mcp                                  # stdio (default) — client spawns this as a child process
+wren serve mcp --transport http --port 8080     # local Streamable HTTP for multiple / remote clients
+```
+
+Requires the `mcp` extra: `pip install 'wrenai[mcp]'`.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--transport` | `stdio` | `stdio` or `http` |
+| `--host` | `127.0.0.1` | Bind host, `--transport http` only |
+| `--port` | `8080` | Bind port, `--transport http` only |
+| `--project` | discovered | Override project root |
+| `--profile` | active profile | Connection profile name |
+| `--allow-write` | off | Enable the `store_query` write tool |
+| `--no-connect` | off | Transpile-only mode: disable `run_sql`, `dry_run`, `query_cube` |
+
+Requires `target/mdl.json` to exist (`wren context build` first) — errors with
+a hint otherwise. If project source files (`models/`, `views/`, `cubes/`,
+`relationships.yml`, `wren_project.yml`) are newer than `target/mdl.json`, it
+warns that the MDL may be stale but still serves it — it never auto-builds.
+
+### Client wiring (stdio)
+
+```json
+{
+  "command": "wren",
+  "args": ["serve", "mcp"],
+  "cwd": "/path/to/project"
+}
+```
+
+For `--transport http`, connect the client to the Streamable HTTP endpoint at
+`http://<host>:<port>` instead of spawning a process. Binds to `127.0.0.1` by
+default; there is no bearer-token auth in this version — treat it as local-only.
+
+### Tools
+
+| Group | Tools |
+|---|---|
+| Query | `run_sql`, `dry_run`, `dry_plan`, `query_cube` |
+| Schema | `get_mdl`, `list_models`, `describe_model`, `get_data_source`, `list_cubes`, `describe_cube`, `list_functions` |
+| Knowledge | `get_instructions`, `recall_queries` |
+| Write (`--allow-write`) | `store_query` |
+
+`run_sql`, `dry_run`, and `query_cube` are disabled under `--no-connect`.
+`store_query` is only registered when `--allow-write` is passed.
+
+### Resources & prompt
+
+- `wren://mdl` — compiled MDL JSON
+- `wren://instructions` — business rules from `knowledge/rules/*.md`
+- `wren://project` — project name / catalog / schema / data source / schema_version
+- `wren_workflow` prompt — packages the schema → instructions → recall →
+  dry-run → run_sql → query_cube → store SOP for a connecting agent
+
+### Security
+
+Connection secrets are resolved from the profile once at server startup and
+never cross the MCP boundary — only SQL text, query results, and metadata are
+exposed to the client.
+
+See the [MCP guide](../guides/mcp.md) for a walkthrough of wiring a client.
+
+---
+
 ## `wren skills` — Agent Workflow Guides
 
 The CLI ships its own agent skill content. Use this on any AI client (the


### PR DESCRIPTION
## What

Adds `wren serve mcp` — an in-process MCP server that exposes a Wren project's **query**, **semantic-model**, and **business-knowledge** tools to MCP clients (Claude Desktop/Code, Cursor, IDEs). It drives the same in-process `WrenEngine` the CLI already uses, so it needs **no ibis-server and no separate service** — just the CLI installed in a project directory.

Run it from inside a wren project:

```bash
wren serve mcp                                # stdio (default) — client spawns as child process
wren serve mcp --transport http --port 8080   # local Streamable HTTP
```

## Surface

- **14 tools**
  - _query_: `run_sql`, `dry_run`, `dry_plan`, `query_cube`
  - _schema_: `get_mdl`, `list_models`, `describe_model`, `get_data_source`, `list_cubes`, `describe_cube`, `list_functions`
  - _knowledge_: `get_instructions`, `recall_queries`, `store_query`
- **3 resources**: `wren://mdl`, `wren://instructions`, `wren://project`
- **1 prompt**: `wren_workflow` (schema → instructions → recall → dry-run → run → cube → store SOP)

## Behavior / flags

- `--transport stdio|http` (default `stdio`), `--host`/`--port` (http, binds `127.0.0.1`)
- `--project`, `--profile`
- `--allow-write` gates `store_query` (server is read-only otherwise)
- `--no-connect` yields a transpile-only server (disables `run_sql`/`dry_run`/`query_cube`)
- Requires a prior `wren context build`; checks `target/mdl.json` freshness at startup and warns if stale (never auto-builds)
- Connection secrets stay server-side (resolved from the profile at startup); only SQL/results/metadata cross the MCP boundary

## Packaging

New optional extra `mcp = ["mcp[cli]>=1.19"]` (folded into `all`); the SDK is lazy-imported inside the command so the CLI degrades cleanly when the extra is absent (`pip install 'wrenai[mcp]'`).

## Docs

- New guide `docs/core/guides/mcp.md`
- `wren serve` section in `docs/core/reference/cli.md`
- README quick-start step + `core/wren/.claude/CLAUDE.md` command list

## Testing

- `ruff format --check` + `ruff check` clean on new/changed files
- Package test suite: 1084 passed (remaining failures/errors are missing optional DB drivers in the local env, unrelated to this change)
- End-to-end smoke tested with a real MCP client over **both stdio and streamable-http** against a DuckDB-backed project + an `order_metrics` cube: all 14 tools, 3 resources, and the prompt verified returning correct results

## Notes for reviewers

- New files: `core/wren/src/wren/serve_cli.py` (Typer `serve` group), `core/wren/src/wren/mcp_server.py` (FastMCP app).
- Two behaviors surfaced during implementation: cube dimensions can't traverse relationships (existing wren-core limitation), and FastMCP serializes bare-list tool returns as one content block per element — list tools therefore wrap results in a dict (`{"models": [...]}` etc.) for a single clean JSON block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wren serve mcp` to expose Wren project query, schema, and knowledge capabilities via an MCP server.
  * Supports stdio (default) and local HTTP transport, with optional profile-based connection setup.
  * Added `--allow-write` to enable storing query examples and `--no-connect` for connection-free operation.
* **Documentation**
  * Added an MCP guide and expanded the CLI reference with prerequisites (build `target/mdl.json`), tool/resource coverage, and client registration examples.
* **Improvements**
  * Emits a startup warning when compiled project metadata appears out of date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->