### PR TITLE
feat(wren): expand MCP knowledge access

### DIFF
--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -339,6 +339,130 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         idx = get_index(ctx.project, mem_path)
         return {"matches": idx.search(question, limit=limit)}
 
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Get Context", readOnlyHint=True),
+    )
+    def get_context(
+        question: str,
+        limit: int = 5,
+        item_type: str | None = None,
+        model_name: str | None = None,
+    ) -> dict:
+        """Semantic retrieval of the schema fragments relevant to a question.
+
+        The schema-axis twin of ``recall_queries``: instead of NL->SQL
+        exemplars, this returns models/columns/cubes ranked by relevance.
+        Uses embedding search when the ``memory`` extra is installed and the
+        schema has been indexed (``wren memory index``); otherwise falls back
+        to the full plain-text schema description (same content as
+        ``describe_schema``).
+        """
+        from wren.context import build_json  # noqa: PLC0415
+        from wren.memory import schema_indexer  # noqa: PLC0415
+
+        manifest = build_json(ctx.project)
+        try:
+            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
+            from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+            store = MemoryStore(path=str(_default_memory_path()))
+            return store.get_context(
+                manifest,
+                question,
+                limit=limit,
+                item_type=item_type,
+                model_name=model_name,
+            )
+        except Exception:
+            return {
+                "strategy": "full",
+                "schema": schema_indexer.describe_schema(manifest),
+                "note": (
+                    "Install wrenai[memory] and run `wren memory index` for "
+                    "embedding-based schema search on large schemas."
+                ),
+            }
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="Describe Schema", readOnlyHint=True),
+    )
+    def describe_schema() -> dict:
+        """Return the full MDL schema as a structured plain-text description.
+
+        The human-readable counterpart to ``get_mdl`` (JSON) — suitable for
+        pasting directly into an LLM prompt. No optional dependencies
+        required.
+        """
+        from wren.context import build_json  # noqa: PLC0415
+        from wren.memory import schema_indexer  # noqa: PLC0415
+
+        return {"schema": schema_indexer.describe_schema(build_json(ctx.project))}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Stored Queries", readOnlyHint=True),
+    )
+    def list_stored_queries(
+        source: str | None = None, limit: int | None = None
+    ) -> dict:
+        """Enumerate stored NL->SQL pairs from knowledge/sql/.
+
+        Unlike ``recall_queries`` (semantic top-k for a question), this lists
+        every stored pair, optionally filtered by ``source`` tag (e.g.
+        "user", "seed"). Returns ``{"queries": [...]}``.
+        """
+        try:
+            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
+            from wren.memory.store import MemoryStore  # noqa: PLC0415
+
+            store = MemoryStore(path=str(_default_memory_path()))
+            rows, _total = store.list_queries(
+                source=source,
+                limit=limit if limit is not None else MAX_ROW_LIMIT,
+            )
+            return {"queries": [_normalize_value(row) for row in rows]}
+        except Exception:
+            from wren.memory.markdown import load_query_pairs  # noqa: PLC0415
+
+            pairs = load_query_pairs(ctx.project)
+            if source:
+                pairs = [p for p in pairs if p.get("source", "user") == source]
+            if limit is not None:
+                pairs = pairs[:limit]
+            queries = [
+                {
+                    "nl_query": p["nl"],
+                    "sql_query": p["sql"],
+                    "datasource": p.get("datasource", ""),
+                    "tags": p.get("tags", ""),
+                    "source": p.get("source", "user"),
+                    "path": p.get("path"),
+                }
+                for p in pairs
+            ]
+            return {"queries": queries}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(title="List Knowledge", readOnlyHint=True),
+    )
+    def list_knowledge() -> dict:
+        """List knowledge files readable via the wren://knowledge/{path} resource.
+
+        Walks knowledge/ recursively (knowledge.yml, rules/*.md, sql/*.md) and
+        reports whether AGENTS.md exists at the project root.
+        """
+        knowledge_dir = ctx.project / "knowledge"
+        files: list[str] = []
+        if knowledge_dir.is_dir():
+            files = sorted(
+                str(p.relative_to(knowledge_dir))
+                for p in knowledge_dir.rglob("*")
+                if p.is_file()
+            )
+        return {
+            "files": files,
+            "agents": (ctx.project / "AGENTS.md").exists(),
+        }
+
 
 def _register_write_tools(mcp: FastMCP, ctx: ServeContext) -> None:
     @mcp.tool(
@@ -395,6 +519,7 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
     def project_resource() -> str:
         """Summary of wren_project.yml (name, catalog, schema, data source)."""
         from wren.context import (  # noqa: PLC0415
+            get_knowledge_schema_version,
             get_schema_version,
             load_project_config,
         )
@@ -407,8 +532,47 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
                 "schema": config.get("schema"),
                 "data_source": config.get("data_source"),
                 "schema_version": get_schema_version(ctx.project),
+                "knowledge_schema_version": get_knowledge_schema_version(ctx.project),
             }
         )
+
+    @mcp.resource("wren://agents", mime_type="text/markdown")
+    def agents_resource() -> str:
+        """The project's AGENTS.md, if present."""
+        agents_path = ctx.project / "AGENTS.md"
+        return agents_path.read_text(encoding="utf-8") if agents_path.exists() else ""
+
+    def _read_knowledge_file(rel_path: str) -> str:
+        """Read ``<project>/knowledge/<rel_path>``, rejecting escapes.
+
+        Shared by both knowledge resource templates below.
+        """
+        knowledge_dir = (ctx.project / "knowledge").resolve()
+        target = (ctx.project / "knowledge" / rel_path).resolve()
+        if not target.is_relative_to(knowledge_dir) or not target.is_file():
+            raise ValueError(f"Invalid knowledge path: '{rel_path}'.")
+        return target.read_text(encoding="utf-8")
+
+    # The installed MCP SDK matches each `{param}` against a single path
+    # segment (`[^/]+`), so one `{path}` placeholder cannot span a slash
+    # (e.g. "rules/general.md"). knowledge/ is only ever one level deep in
+    # practice (knowledge.yml at the root; rules/*.md, sql/*.md, ... one
+    # directory down), so two templates cover the real layout.
+    @mcp.resource("wren://knowledge/{name}")
+    def knowledge_root_resource(name: str) -> str:
+        """Read a top-level file directly under knowledge/ (e.g. knowledge.yml).
+
+        Rejects any name that escapes the project's knowledge/ directory.
+        """
+        return _read_knowledge_file(name)
+
+    @mcp.resource("wren://knowledge/{subdir}/{name}")
+    def knowledge_nested_resource(subdir: str, name: str) -> str:
+        """Read a file under a knowledge/ subdirectory (rules/*.md, sql/*.md, ...).
+
+        Rejects any path that escapes the project's knowledge/ directory.
+        """
+        return _read_knowledge_file(f"{subdir}/{name}")
 
 
 def _register_prompts(mcp: FastMCP) -> None:
@@ -420,11 +584,14 @@ def _register_prompts(mcp: FastMCP) -> None:
             f"{intro}"
             "Follow this workflow to answer a data question:\n"
             "1. Read the `wren://mdl` resource and use `list_models` / "
-            "`describe_model` to understand the schema.\n"
+            "`describe_model` to understand the schema; for schema, read "
+            "`wren://mdl` or use `get_context` / `describe_schema`; browse "
+            "project knowledge via `list_knowledge` + the "
+            "`wren://knowledge/{path}` resource.\n"
             "2. Call `get_instructions` for business rules that affect how to "
             "interpret the data.\n"
             "3. Call `recall_queries` for proven NL->SQL exemplars similar to "
-            "the question.\n"
+            "the question, or `list_stored_queries` to browse all of them.\n"
             "4. Write SQL in the project's dialect, validate it with `dry_run`, "
             "then execute it with `run_sql`.\n"
             "5. For named metrics, prefer `query_cube` over hand-written "

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -373,7 +373,9 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
                 item_type=item_type,
                 model_name=model_name,
             )
-        except Exception:
+        except ImportError:
+            # Only the missing `memory` extra falls back to full-text; real
+            # index/embedding errors from an installed store surface as-is.
             return {
                 "strategy": "full",
                 "schema": schema_indexer.describe_schema(manifest),
@@ -453,10 +455,12 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         knowledge_dir = ctx.project / "knowledge"
         files: list[str] = []
         if knowledge_dir.is_dir():
+            # Only list what the wren://knowledge/{name} and
+            # wren://knowledge/{subdir}/{name} templates can serve: top-level
+            # files and one directory level down. Deeper files aren't readable.
+            candidates = [*knowledge_dir.glob("*"), *knowledge_dir.glob("*/*")]
             files = sorted(
-                str(p.relative_to(knowledge_dir))
-                for p in knowledge_dir.rglob("*")
-                if p.is_file()
+                str(p.relative_to(knowledge_dir)) for p in candidates if p.is_file()
             )
         return {
             "files": files,
@@ -540,7 +544,12 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
     def agents_resource() -> str:
         """The project's AGENTS.md, if present."""
         agents_path = ctx.project / "AGENTS.md"
-        return agents_path.read_text(encoding="utf-8") if agents_path.exists() else ""
+        if not agents_path.exists():
+            return ""
+        try:
+            return agents_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError("AGENTS.md is not valid UTF-8 text.") from e
 
     def _read_knowledge_file(rel_path: str) -> str:
         """Read ``<project>/knowledge/<rel_path>``, rejecting escapes.
@@ -551,7 +560,12 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
         target = (ctx.project / "knowledge" / rel_path).resolve()
         if not target.is_relative_to(knowledge_dir) or not target.is_file():
             raise ValueError(f"Invalid knowledge path: '{rel_path}'.")
-        return target.read_text(encoding="utf-8")
+        try:
+            return target.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Knowledge file is not valid UTF-8 text: '{rel_path}'."
+            ) from e
 
     # The installed MCP SDK matches each `{param}` against a single path
     # segment (`[^/]+`), so one `{path}` placeholder cannot span a slash

--- a/docs/core/guides/mcp.md
+++ b/docs/core/guides/mcp.md
@@ -68,11 +68,19 @@ version — keep it local.
 - **Query tools** — `run_sql`, `dry_run`, `dry_plan`, `query_cube`
 - **Schema tools** — `get_mdl`, `list_models`, `describe_model`,
   `get_data_source`, `list_cubes`, `describe_cube`, `list_functions`
-- **Knowledge tools** — `get_instructions`, `recall_queries`, and
+- **Knowledge tools** — `get_instructions`, `recall_queries`, `get_context`,
+  `describe_schema`, `list_stored_queries`, `list_knowledge`, and
   (behind `--allow-write`) `store_query`
-- **Resources** — `wren://mdl`, `wren://instructions`, `wren://project`
+- **Resources** — `wren://mdl`, `wren://instructions`, `wren://project`,
+  `wren://agents`, `wren://knowledge/{path}`
 - **Prompt** — `wren_workflow`, a ready-made SOP for schema → instructions →
   recall → dry-run → run → store
+
+`get_context` and `list_stored_queries` prefer the `memory` extra (embedding
+search, full query history) but fall back to dependency-free reads over
+`knowledge/` when it isn't installed — the same degradation `recall_queries`
+already does. `describe_schema` needs no extra at all: it's the plain-text
+counterpart to `get_mdl`, sized for pasting into an LLM prompt.
 
 See the [CLI reference](../reference/cli.md#wren-serve--mcp-server) for every
 flag and tool signature.
@@ -84,6 +92,10 @@ server-side — only SQL text, query results, and metadata cross the MCP
 boundary. The server never auto-builds the MDL; if project source files are
 newer than `target/mdl.json` it logs a staleness warning but keeps serving the
 existing manifest, so re-run `wren context build` after model changes.
+
+The `wren://knowledge/{path}` resource resolves the requested path and
+verifies it stays inside the project's `knowledge/` directory before reading
+it — a path that would escape (e.g. `../wren_project.yml`) is rejected.
 
 ## See also
 

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -428,17 +428,29 @@ default; there is no bearer-token auth in this version — treat it as local-onl
 |---|---|
 | Query | `run_sql`, `dry_run`, `dry_plan`, `query_cube` |
 | Schema | `get_mdl`, `list_models`, `describe_model`, `get_data_source`, `list_cubes`, `describe_cube`, `list_functions` |
-| Knowledge | `get_instructions`, `recall_queries` |
+| Knowledge | `get_instructions`, `recall_queries`, `get_context`, `describe_schema`, `list_stored_queries`, `list_knowledge` |
 | Write (`--allow-write`) | `store_query` |
 
 `run_sql`, `dry_run`, and `query_cube` are disabled under `--no-connect`.
 `store_query` is only registered when `--allow-write` is passed.
 
+The knowledge tools degrade gracefully without the `memory` extra:
+`get_context` (semantic schema retrieval, the schema-axis twin of
+`recall_queries`) falls back to the full plain-text schema description;
+`describe_schema` (the human-readable counterpart to `get_mdl`) needs no
+optional dependency at all; `list_stored_queries` enumerates every NL→SQL
+pair (not just a semantic top-k) from `knowledge/sql/*.md`; `list_knowledge`
+lists every file readable via the `wren://knowledge/{path}` resource below.
+
 ### Resources & prompt
 
 - `wren://mdl` — compiled MDL JSON
 - `wren://instructions` — business rules from `knowledge/rules/*.md`
-- `wren://project` — project name / catalog / schema / data source / schema_version
+- `wren://project` — project name / catalog / schema / data source / schema_version / knowledge_schema_version
+- `wren://agents` — the project's `AGENTS.md`, if present
+- `wren://knowledge/{path}` — read any file under `knowledge/` (e.g.
+  `wren://knowledge/knowledge.yml`, `wren://knowledge/rules/general.md`);
+  rejects any path that escapes the project's `knowledge/` directory
 - `wren_workflow` prompt — packages the schema → instructions → recall →
   dry-run → run_sql → query_cube → store SOP for a connecting agent
 


### PR DESCRIPTION
Follow-up to #2438 (based on `feat/serve-mcp`; retarget to `main` once #2438 merges).

## What

Broadens what `wren serve mcp` exposes as **knowledge** — previously just `get_instructions` (business rules) and `recall_queries` (NL→SQL pairs). Adds semantic schema retrieval, full schema description, stored-query listing, and generic access to any file under `knowledge/`.

## New tools (all read-only)

| Tool | Purpose |
| --- | --- |
| `get_context(question, …)` | Semantic **schema** retrieval — the schema-axis twin of `recall_queries`. Uses the memory index for large schemas; falls back to full `describe_schema` text (+ a hint to `pip install 'wrenai[memory]'` and `wren memory index`) when the extra/index is absent. |
| `describe_schema()` | Full schema as human-readable plaintext (the readable twin of `get_mdl`'s JSON). |
| `list_stored_queries(source?, limit?)` | Enumerate **all** stored NL→SQL pairs (via `MemoryStore`, or a `knowledge/sql/*.md` fallback). |
| `list_knowledge()` | List files under `knowledge/` (+ whether `AGENTS.md` exists) so a client knows what to read. |

## New resources

- `wren://agents` — the project's `AGENTS.md`
- `wren://knowledge/{path}` — serve any file under `knowledge/` (rules, sql, knowledge.yml)
- `wren://project` enriched with `knowledge_schema_version`

## Security

`wren://knowledge/{path}` has a directory-traversal guard: the resolved target must satisfy `is_relative_to(<project>/knowledge)` and `is_file()`, else it raises. Verified server-side with raw, un-normalized URIs (not relying on client URL normalization) — `wren://knowledge/../wren_project.yml` is rejected.

## Note on FastMCP templates

`mcp[cli]` URI-template placeholders are single-segment (`[^/]+`), so a single `{path}` can't span `/`. Implemented as two templates (`wren://knowledge/{name}` + `wren://knowledge/{subdir}/{name}`), covering the one-level `knowledge/` layout (`rules/`, `sql/`, …).

## Testing

- `ruff format`/`ruff check` clean
- End-to-end stdio smoke test against a DuckDB project **exercising the fallback (no-`memory`-extra) paths**: 9/9 checks pass, including the traversal-rejection assertion. `get_context` correctly returns `strategy="full"` + the install hint; `list_stored_queries`/`list_knowledge` read from `knowledge/`; `wren://agents` and `wren://knowledge/*` resources resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more knowledge browsing options, including schema context lookup, schema descriptions, stored query listings, and project knowledge file discovery.
  * Added new resources for accessing agent notes and knowledge files directly from the server.

* **Bug Fixes**
  * Improved fallback behavior when optional knowledge features are unavailable, so schema and query information still remains accessible.
  * Added safer handling for knowledge file access, including invalid text and path-escape protection.

* **Documentation**
  * Updated MCP and CLI docs to cover the expanded tools, resources, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->