### PR TITLE
docs: refresh core docs to current context-layer terminology

### DIFF
--- a/docs/core/concepts/agent_learning.md
+++ b/docs/core/concepts/agent_learning.md
@@ -10,15 +10,15 @@ sidebar_label: How does the agent learn from your context?
 
 A first-day analyst does not know which table is canonical. Neither does an agent. Both get better through the same path: a guided start, focused questions, and a record of what worked.
 
-The difference is that an agent forgets between sessions unless your tooling stores the learning somewhere reviewable. Wren AI captures that learning in four explicit places (MDL, instructions, memory, and skills) so the agent picks up where the team left off, every time.
+The difference is that an agent forgets between sessions unless your tooling stores the learning somewhere reviewable. Wren AI captures that learning in four explicit places (MDL, business rules, confirmed NL→SQL pairs, and the memory index) so the agent picks up where the team left off, every time.
 
-## The two beats: scaffold fast, enrich deep
+## Two phases: scaffold fast, enrich deep
 
-Wren AI runs the agent through two beats whenever you set up a new project.
+Wren AI runs the agent through two phases whenever you set up a new project.
 
-**Beat 1: Scaffold fast.** The `generate-mdl` guide drives the agent through schema discovery, type normalization, and an initial MDL project. The agent can already query through that modeled layer in a few minutes. The MDL is rough but functional. It covers what the database can tell you about itself.
+**Phase 1: Scaffold fast.** The `generate-mdl` guide drives the agent through schema discovery, type normalization, and an initial MDL project. The agent can already query through that modeled layer in a few minutes. The MDL is rough but functional. It covers what the database can tell you about itself.
 
-**Beat 2: Enrich deep.** Structure is only the start. The hard business meaning lives in docs, decks, Slack threads, and analyst SQL. The `enrich-context` workflow brings that meaning in through two modes:
+**Phase 2: Enrich deep.** Structure is only the start. The hard business meaning lives in docs, decks, Slack threads, and analyst SQL. The `enrich-context` workflow brings that meaning in through two modes:
 
 - **Grill mode**: the agent asks one focused question at a time ("which is the canonical `orders` table?", "what does `status = 4` mean?", "should `active customer` exclude internal users?"). You answer; the agent patches MDL or `knowledge/` (rules and NL→SQL pairs).
 - **Auto-pilot mode**: drop PDFs, glossaries, handbooks, and SQL history into `<project>/raw/`. The agent reads them, proposes context changes with evidence, and waits for review.

--- a/docs/core/concepts/correctness.md
+++ b/docs/core/concepts/correctness.md
@@ -27,7 +27,7 @@ Five layers sit between the agent's question and the database:
 |---|---|---|
 | **Skills** | Encode the workflow the agent must follow | The agent cannot skip "check memory" or "validate before execute" |
 | **MDL** | Declare every table, column, and relationship the agent is allowed to use | The agent can only name modeled objects, so undeclared columns and legacy tables are invisible |
-| **Memory** | Index MDL + instructions + past NL-SQL pairs; retrieve only what matters per question | The agent reads the relevant slice, not a generic schema dump |
+| **Memory** | Index MDL + `knowledge/` + past NL-SQL pairs; retrieve only what matters per question | The agent reads the relevant slice, not a generic schema dump |
 | **Plan + validate** | Expand modeled SQL into the exact SQL that will run, before any DB call | Bad references fail at plan time with a clear error, not silently in production |
 | **Connectors** | Execute the planned SQL against the source | Type, dialect, and permission checks happen here |
 
@@ -46,7 +46,7 @@ Two common failure modes:
 - **Dump the whole schema** into the prompt → the model gets confused by irrelevant tables.
 - **Let the model guess** which tables are relevant → it picks the wrong one.
 
-Memory does neither. It indexes MDL + `instructions.md` + confirmed NL-SQL pairs, and retrieves only the slice that matches the question. The agent reads `customers`, `orders`, and the approved revenue calculation, not 500 tables.
+Memory does neither. It indexes MDL + `knowledge/rules/` + confirmed NL-SQL pairs (`knowledge/sql/`), and retrieves only the slice that matches the question. The agent reads `customers`, `orders`, and the approved revenue calculation, not 500 tables.
 
 ### Plan + validate: errors fail visibly
 
@@ -54,7 +54,7 @@ Memory does neither. It indexes MDL + `instructions.md` + confirmed NL-SQL pairs
 
 - Catalog and schema resolution
 - Relationship joins inlined as CTEs
-- Policy filters from `instructions.md` injected
+- Policy filters from your business rules (`knowledge/rules/`) injected
 - Column-level access enforced
 
 If a column name is wrong, dry-plan returns the available columns. If a relationship is missing, it says so. The agent retries with the right info instead of running broken SQL and reporting a wrong number.

--- a/docs/core/concepts/correctness.md
+++ b/docs/core/concepts/correctness.md
@@ -27,7 +27,7 @@ Five layers sit between the agent's question and the database:
 |---|---|---|
 | **Skills** | Encode the workflow the agent must follow | The agent cannot skip "check memory" or "validate before execute" |
 | **MDL** | Declare every table, column, and relationship the agent is allowed to use | The agent can only name modeled objects, so undeclared columns and legacy tables are invisible |
-| **Memory** | Index MDL + `knowledge/` + past NL-SQL pairs; retrieve only what matters per question | The agent reads the relevant slice, not a generic schema dump |
+| **Memory** | Index MDL + `knowledge/rules/` + `knowledge/sql/`; retrieve only what matters per question | The agent reads the relevant slice, not a generic schema dump |
 | **Plan + validate** | Expand modeled SQL into the exact SQL that will run, before any DB call | Bad references fail at plan time with a clear error, not silently in production |
 | **Connectors** | Execute the planned SQL against the source | Type, dialect, and permission checks happen here |
 

--- a/docs/core/concepts/memory_system.md
+++ b/docs/core/concepts/memory_system.md
@@ -73,7 +73,7 @@ This loop gives the agent two kinds of grounding:
 
 ## Memory is not a replacement for MDL
 
-Memory does not define your semantic layer. MDL does.
+Memory does not define your semantics. MDL does.
 
 Memory helps agents find and reuse context, but the durable contract still lives in project files: models, relationships, views, cubes, and `knowledge/`. If a definition is important enough to govern future behavior, put it in MDL or `knowledge/rules/`, then re-index memory.
 

--- a/docs/core/concepts/oss_vs_commercial.md
+++ b/docs/core/concepts/oss_vs_commercial.md
@@ -20,7 +20,6 @@ Wren AI Commercial is the same engine built for a team. It runs as a hosted clou
 
 | Capability | Open source | Commercial |
 | --- | :---: | :---: |
-| Free and fully self-hosted | ✅ | ✅ |
 | Fully managed cloud | ❌ | ✅ |
 | CLI and SDK for your own agents | ✅ | ✅ |
 | MCP server and hosted REST API | ❌ | ✅ |

--- a/docs/core/concepts/stack_position.md
+++ b/docs/core/concepts/stack_position.md
@@ -50,7 +50,7 @@ Above Wren AI sit the **agents** that ask questions. Below it sits the **data in
 
 ### You have no semantic layer
 
-Start with Wren AI's context layer. The `generate-mdl` guide scaffolds an MDL project from your warehouse schema in a few minutes — your first set of trusted semantic definitions, with the rest of the context layer (instructions, memory, governance) growing around them. Enrich it over time with the grill / auto-pilot workflow.
+Start with Wren AI's context layer. The `generate-mdl` guide scaffolds an MDL project from your warehouse schema in a few minutes — your first set of trusted semantic definitions, with the rest of the context layer (`knowledge/rules/`, memory, governance) growing around them. Enrich it over time with the grill / auto-pilot workflow.
 
 ### You have a transformation pipeline (dbt, Coalesce, in-house)
 

--- a/docs/core/concepts/stack_position.md
+++ b/docs/core/concepts/stack_position.md
@@ -26,7 +26,7 @@ sidebar_label: Where does Wren AI sit in my stack?
 └──────────────────────────────────────────────────────┘
 ```
 
-Three things sit above Wren AI: the **agents** that ask questions. Three things sit below: the **data infrastructure** that stores the answers. Wren AI is the layer in between that turns "I can see schema" into "I know what the business means."
+Above Wren AI sit the **agents** that ask questions. Below it sits the **data infrastructure** that stores the answers. Wren AI is the layer in between that turns "I can see schema" into "I know what the business means."
 
 ## What it does NOT replace
 
@@ -50,7 +50,7 @@ Three things sit above Wren AI: the **agents** that ask questions. Three things 
 
 ### You have no semantic layer
 
-Wren AI can be your first one. The `generate-mdl` guide scaffolds an MDL project from your warehouse schema in a few minutes. Enrich it over time with the grill / auto-pilot workflow.
+Start with Wren AI's context layer. The `generate-mdl` guide scaffolds an MDL project from your warehouse schema in a few minutes — your first set of trusted semantic definitions, with the rest of the context layer (instructions, memory, governance) growing around them. Enrich it over time with the grill / auto-pilot workflow.
 
 ### You have a transformation pipeline (dbt, Coalesce, in-house)
 
@@ -58,7 +58,7 @@ Keep it. Point Wren AI at the **output tables** of your pipeline. The MDL descri
 
 ### You have a semantic layer
 
-Wren AI does not compete with it for the data team. It gives the **agents** the same definitions through a structure agents can read and reason about: MDL files, structured retrieval, memory of past answers, governed execution primitives. Think of it as the agent-native projection of the semantic layer you already use.
+Wren AI does not compete with it for the data team. Its context layer gives the **agents** the same definitions through a structure agents can read and reason about: MDL files, structured retrieval, memory of past answers, governed execution primitives. Think of it as the agent-native projection of the semantic layer you already use.
 
 ### You have multiple warehouses
 

--- a/docs/core/concepts/what_is_context.md
+++ b/docs/core/concepts/what_is_context.md
@@ -10,7 +10,7 @@ Wren AI exists to turn that scattered meaning into an open, machine-readable con
 
 ## Why schema is not enough
 
-Your agent sees schema. It reads column names, catches types, and may even parse semantic-layer YAML. But schema does not tell the whole story:
+Your agent sees schema. It reads column names, catches types, and may even parse the metric definitions you already maintain. But schema does not tell the whole story:
 
 - `status = 4` means refunded
 - `loyalty_v3` is the table your team actually uses
@@ -41,9 +41,9 @@ Together, these layers form the context layer.
 
 ## Context vs. semantic layer
 
-A semantic layer is one important part of context. It defines business-facing models, relationships, calculations, and reusable logic so people and tools do not have to query raw tables directly.
+"Semantic layer" is the industry's name for tools like the dbt Semantic Layer, Cube, or LookML. They define business-facing models, relationships, calculations, and reusable logic so people and tools do not have to query raw tables directly. That job matters, and it is one important part of context — in Wren AI, those semantic definitions live in MDL.
 
-A context layer is broader. It includes the semantic layer, then adds the knowledge an autonomous agent needs to behave well in the real world:
+A context layer is broader. Around the semantic definitions, it adds the knowledge an autonomous agent needs to behave well in the real world:
 
 - which definitions are trusted
 - which tables should be preferred
@@ -53,7 +53,7 @@ A context layer is broader. It includes the semantic layer, then adds the knowle
 - which past examples should guide the next query
 - how to validate, retry, repair, and evaluate generated SQL
 
-Traditional semantic layers were designed mostly for dashboards and BI workflows. Wren AI is designed for a world where agents, applications, and humans all need the same trusted answer through different interfaces.
+Semantic layers were designed mostly for dashboards and BI workflows. The context layer is designed for a world where agents, applications, and humans all need the same trusted answer through different interfaces.
 
 ## How Wren AI represents context
 
@@ -65,9 +65,9 @@ Wren AI does not treat context as a single prompt or a hidden product feature. I
 
 MDL helps an agent map a question like "top customers by revenue" to the right models, joins, and calculations instead of reconstructing logic from raw warehouse structure.
 
-### Instructions: business and operational guidance
+### Knowledge rules: business and operational guidance
 
-Project instructions capture guidance that may not belong in a model definition: preferred terminology, default filters, table selection rules, caveats, and policies the agent should follow.
+Business rules under `knowledge/rules/` capture guidance that may not belong in a model definition: preferred terminology, default filters, table selection rules, caveats, and policies the agent should follow.
 
 This is where business meaning starts to become operational. The agent is not only told what exists; it is told how your team expects the data to be used.
 
@@ -77,7 +77,7 @@ Most text-to-SQL systems treat every question like the first question. Wren AI a
 
 Memory has two jobs:
 
-- **Schema context retrieval** - index MDL and instructions, then retrieve the relevant models, columns, relationships, and guidance for each question.
+- **Schema context retrieval** - index MDL and `knowledge/rules/`, then retrieve the relevant models, columns, relationships, and guidance for each question.
 - **Query recall** - store confirmed natural-language-to-SQL pairs so similar future questions can use proven examples.
 
 This turns usage into a learning loop. The context layer becomes more useful as your team asks, corrects, and confirms more questions.
@@ -117,7 +117,7 @@ Wren AI exposes these as primitives the agent can orchestrate instead of hiding 
 
 ## Where context comes from
 
-The first version of context usually comes from the database. Wren AI can scaffold MDL from tables, columns, types, and relationships so the agent has a working structural and semantic layer quickly.
+The first version of context usually comes from the database. Wren AI can scaffold MDL from tables, columns, types, and relationships so the agent has a working structural and semantic foundation quickly.
 
 The deeper context comes from everywhere else:
 
@@ -135,7 +135,7 @@ That is why Wren AI is designed around the workflow **scaffold fast, then enrich
 ## In short
 
 - **Schema** tells an agent what exists.
-- **Semantic layer** tells an agent what the data means.
+- **Semantic definitions** tell an agent what the data means.
 - **Context layer** tells an agent how the business uses the data, how to act safely, and what has worked before.
 
 Wren AI is the open context layer for AI agents: portable, inspectable, versionable, and shared across every agent and app that needs trusted business data.

--- a/docs/core/concepts/why_wren.md
+++ b/docs/core/concepts/why_wren.md
@@ -40,7 +40,7 @@ A few distinctions worth being precise about:
   hand, in their UI. Wren has agents *generate* them from your context and
   deploy them to your own hosting.
 - **vs. a bare semantic layer** (dbt Semantic Layer, Cube): those define metrics
-  from the schema. Wren adds the company knowledge that isn't in the schema
+  from the schema. Wren's context layer adds the company knowledge that isn't in the schema
   (enum meanings, units, policy, proven examples) and a generative-BI output on
   top. See [How does the agent learn from your context?](/oss/concepts/agent_learning).
 

--- a/docs/core/get_started/installation.md
+++ b/docs/core/get_started/installation.md
@@ -38,7 +38,7 @@ The agent will check your environment, install Python dependencies, create a con
 
 ## 3. Start asking questions
 
-Once onboarding finishes, just ask your agent business questions in natural language. The agent uses Wren AI's semantic layer to resolve schema, recall similar past queries, and generate accurate SQL.
+Once onboarding finishes, just ask your agent business questions in natural language. The agent uses Wren AI's context layer to resolve schema, recall similar past queries, and generate accurate SQL.
 
 ```text
 How many customers placed more than one order this month?

--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -1,16 +1,24 @@
+---
+sidebar_label: Quickstart (jaffle_shop)
+---
+
+import ArchStrip from '@site/src/components/ArchStrip';
+
 # Quick Start: Wren CLI with jaffle_shop
 
 Ask natural-language questions of the **jaffle_shop** dataset using **Wren AI CLI** and **Claude Code**. No cloud database, no Docker, no extra infrastructure.
 
 > **Time:** ~15 minutes
 >
-> **What you'll get:** A local semantic layer + memory system that lets an AI agent write accurate SQL by understanding your data's meaning, not just its schema.
+> **What you'll get:** A local context layer + memory system that lets an AI agent write accurate SQL by understanding your data's meaning, not just its schema.
+
+<ArchStrip variant="cli" />
 
 ## Terms used in this guide
 
 This guide drops three things on you in the first few steps. Skim before you start:
 
-- **Wren CLI (`wren`)**: the Python CLI that runs all of this. Connects to a database, holds your modeling files, executes SQL through the semantic layer, manages a local memory index. ([CLI reference →](/oss/reference/cli))
+- **Wren CLI (`wren`)**: the Python CLI that runs all of this. Connects to a database, holds your modeling files, executes SQL through the context layer, manages a local memory index. ([CLI reference →](/oss/reference/cli))
 - **MDL (Modeling Definition Language)**: YAML files under `models/`, `views/`, and `relationships.yml` that describe your tables, columns, and joins in business terms. The agent reads MDL instead of guessing from raw schema. ([MDL concept →](/oss/concepts/what_is_mdl) · [Wren project guide →](/oss/reference/mdl))
 - **jaffle_shop**: a public sample database from dbt Labs. We use it so you do not need to bring your own database to follow this quickstart. It is a fictional ecommerce business with `customers`, `orders`, `products`, and `supplies`. *(Want to skip jaffle_shop and use your own database? Finish the install in step 2 then jump to [Connect your database](/oss/guides/connect).)*
 - **Skills**: markdown workflow guides that tell an AI coding agent (Claude Code, Openclaw, Hermes, Codex, etc.) how to operate the CLI. You install one `wren` discovery stub; it fetches the guides from the CLI on demand. Two guides drive this quickstart: `generate-mdl` (one-time scaffolding) and `usage` (day-to-day querying). ([Skills concept →](/oss/reference/skills))
@@ -184,7 +192,7 @@ This creates:
 ├── views/                  # reusable SQL views
 ├── cubes/                  # pre-aggregation metrics
 ├── relationships.yml       # table join definitions
-└── instructions.md         # business rules for the AI
+└── knowledge/              # business rules + NL→SQL pairs for the AI
 ```
 
 The generated `wren_project.yml` contains default values for `catalog` and `schema`:
@@ -267,7 +275,7 @@ Behind the scenes, Claude Code uses the **usage** guide to:
 
 1. **Fetch context** (`wren memory fetch`): find relevant tables and columns for your question
 2. **Recall examples** (`wren memory recall`): find similar past queries
-3. **Write SQL** using the semantic layer (model names, not raw table names)
+3. **Write SQL** using the context layer (model names, not raw table names)
 4. **Execute** (`wren --sql "..."`): run through the Wren engine
 5. **Store** (`wren memory store`): save successful NL-SQL pairs for future recall
 
@@ -374,7 +382,9 @@ After setup, your project directory looks like this:
 │   └── revenue/
 │       └── metadata.yml        # measures + dimensions for aggregation
 ├── relationships.yml           # e.g. orders → customers (many_to_one)
-├── instructions.md             # your business rules
+├── knowledge/
+│   ├── rules/                  # your business rules
+│   └── sql/                    # confirmed NL→SQL pairs (wren memory store)
 ├── .wren/
 │   └── memory/                 # LanceDB index (auto-managed)
 └── target/
@@ -383,7 +393,7 @@ After setup, your project directory looks like this:
 
 Key files to customize:
 
-- **`instructions.md`**: Add business rules, naming conventions, or query guidelines. Use `##` headings to organize by topic. Example:
+- **`knowledge/rules/`**: Add business rules, naming conventions, or query guidelines — one markdown file per topic, organized with `##` headings. Example (`knowledge/rules/conventions.md`):
 
   ```markdown
   ## Naming Conventions

--- a/docs/core/guides/cubes.md
+++ b/docs/core/guides/cubes.md
@@ -86,7 +86,7 @@ Add a cube when:
 Do **not** add a cube when:
 
 - The metric is exploratory or one-off (a SQL query is fine)
-- The metric definition is still under debate (write it in `instructions.md` first)
+- The metric definition is still under debate (write it in `knowledge/rules/` first)
 - There is no clear grain (cubes need explicit measures + dimensions)
 
 ## When to come back here

--- a/docs/core/guides/dbt-integration.md
+++ b/docs/core/guides/dbt-integration.md
@@ -1,6 +1,6 @@
 # dbt Integration
 
-Import a dbt project into Wren AI to query dbt models through the Wren semantic layer.
+Import a dbt project into Wren AI to query dbt models through the Wren context layer.
 
 ## What Wren Imports
 

--- a/docs/core/guides/manage_project.md
+++ b/docs/core/guides/manage_project.md
@@ -257,7 +257,7 @@ in the [Migration reference](/oss/reference/migration).
 - Adding a new environment (staging / preview / customer X)
 - Onboarding a new teammate (point them at `~/.wren/profiles.yml` setup)
 - A schema_version bump shows up in a release
-- Migrating from another semantic layer manifest
+- Migrating from another tool's semantic-layer manifest
 
 ## See also
 

--- a/docs/core/guides/model.md
+++ b/docs/core/guides/model.md
@@ -8,7 +8,7 @@ Turn your warehouse schema into an agent-readable MDL project that captures your
 
 ## What you'll end up with
 
-- A Wren project directory with `wren_project.yml`, `models/`, `views/`, `relationships.yml`, and `instructions.md`
+- A Wren project directory with `wren_project.yml`, `models/`, `views/`, `relationships.yml`, and `knowledge/`
 - A compiled `target/mdl.json` ready for the engine
 - A memory index over the modeled schema, so agents can fetch relevant context per question
 - A first query that runs through MDL, not against raw tables
@@ -36,7 +36,7 @@ The first pass is rough but functional. The agent produces:
 - **One model per physical table** with explicit column declarations (no `SELECT *` ambiguity)
 - **Type normalization** through `wren utils parse-type` so the manifest types are canonical
 - **Primary keys and relationships** inferred from foreign-key metadata where the connector exposes them
-- **Empty `instructions.md`** for you to fill with business rules
+- **An empty `knowledge/` base** for you to fill with business rules (`knowledge/rules/`)
 
 Everything is YAML you can review and version. Nothing is locked behind a UI.
 
@@ -73,7 +73,7 @@ wren memory index
 
 - A new table or domain enters your warehouse
 - Schema drift breaks an existing model
-- Your team agrees on a new metric definition worth promoting from `instructions.md` into a calculated field
+- Your team agrees on a new metric definition worth promoting from `knowledge/rules/` into a calculated field
 - An AI coding agent suggests a structural change worth reviewing
 
 ## See also

--- a/docs/core/introduction.mdx
+++ b/docs/core/introduction.mdx
@@ -1,6 +1,6 @@
 # Wren AI
 
-*Open-source GenBI: let your AI agents generate, deploy, and govern dashboards from any database, grounded in a context layer they can actually trust, across 22+ data sources.*
+*Open-source GenBI: your AI agents generate, deploy, and govern dashboards on the databases you already have, grounded in a context layer they can actually trust.*
 
 <iframe src="https://ghbtns.com/github-btn.html?user=Canner&repo=WrenAI&type=star&count=true&size=large" frameBorder="0" scrolling="0" height="50" title="Wren AI"></iframe>
 
@@ -10,15 +10,15 @@ Generative BI is only as good as the context it stands on. So underneath GenBI, 
 
 The goal is simple: **agents that produce trustworthy BI, not plausible guesses**, on one governed context layer that every data consumer, human or agent, can share.
 
-## GenBI in three beats
+## GenBI in three moves
 
-| Beat | What the agent does | Powered by |
+| Move | What the agent does | Powered by |
 | --- | --- | --- |
 | **Generate** | Turns a business question into governed SQL and charts | MDL planning, schema retrieval, dry-plan validation |
 | **Deploy** | Ships the answer as a shareable, browser-side dashboard | [`wren-core-wasm`](/oss/sdk/wasm) → Vercel / Cloudflare Pages |
-| **Know** | Captures the business meaning that keeps it all correct | MDL, `instructions.md`, memory (reviewable, Git-friendly) |
+| **Know** | Captures the business meaning that keeps it all correct | MDL, `knowledge/`, memory (reviewable, Git-friendly) |
 
-The rest of this page explains the layer that makes the *Generate* and *Deploy* beats trustworthy, the **Know** beat, because that is where correctness comes from.
+The rest of this page focuses on **Know**, because that is where correctness comes from: *Generate* and *Deploy* are only as trustworthy as the context underneath them.
 
 ## Why Wren AI exists
 
@@ -83,10 +83,10 @@ Behind the scenes, Wren AI:
 1. Looks up `customers` in the MDL
 2. Resolves it to the physical table declared in `table_reference`
 3. Drops columns not declared in the model (e.g. `email`, `phone`), keeping them invisible to the agent
-4. Applies any rules from `instructions.md` (default filters, canonical tables, business definitions)
+4. Applies your business rules from `knowledge/rules/` (default filters, canonical tables, business definitions)
 5. Returns rows
 
-From there, the same context drives the *Deploy* beat: ask your agent to turn an answer into a dashboard and it builds a browser-side GenBI app from the project and ships it to your own hosting. See [Build & deploy a GenBI app](/oss/guides/genbi).
+From there, the same context drives the *Deploy* move: ask your agent to turn an answer into a dashboard and it builds a browser-side GenBI app from the project and ships it to your own hosting. See [Build & deploy a GenBI app](/oss/guides/genbi).
 
 ## What is in the open core
 
@@ -110,7 +110,7 @@ The active arcs are end-to-end context enrichment, richer GenBI (more chart type
 2. [Quickstart with `jaffle_shop` sample data](/oss/get_started/quickstart)
 3. [Connect your own database](/oss/guides/connect)
 4. [Build & deploy a GenBI app](/oss/guides/genbi): the *Generate* + *Deploy* payoff
-5. [Concepts](/oss/concepts/what_is_context): the design ideas behind the *Know* beat
+5. [Concepts](/oss/concepts/what_is_context): the design ideas behind the *Know* move
 
 ## A note on the "GenBI" name
 

--- a/docs/core/reference/skills.md
+++ b/docs/core/reference/skills.md
@@ -128,7 +128,7 @@ User says "install wren" / "set up wren"
 | **One step per round-trip** | Avoids overwhelming the user; keeps each turn focused |
 | **Never ask for credentials in chat** | Host, port, user, password, tokens all go through `.env` only |
 | **Never invent connection field names** | Always run `wren docs connection-info <ds>` to introspect real fields |
-| **Never query the database before MDL is built** | Forces the agent to scaffold a semantic layer first |
+| **Never query the database before MDL is built** | Forces the agent to scaffold a context layer first |
 
 ### When to trigger
 
@@ -186,7 +186,7 @@ The skill includes a two-layer error diagnosis strategy:
 | **DB-level** | `wren dry-plan` succeeds but execution fails | Type mismatch, permissions, dialect issues |
 
 The agent checks `dry-plan` output first to isolate whether the error is
-in the semantic layer or the database.
+in the context layer or the database.
 
 ### Additional workflows
 

--- a/docs/core/sdk/langchain.md
+++ b/docs/core/sdk/langchain.md
@@ -1,6 +1,6 @@
 # wren-langchain
 
-LangChain and LangGraph integration for Wren AI. Attach a CLI-prepared Wren project to your agent as a toolkit, with the semantic layer doing schema resolution, memory recall, and SQL execution.
+LangChain and LangGraph integration for Wren AI. Attach a CLI-prepared Wren project to your agent as a toolkit, with the context layer doing schema resolution, memory recall, and SQL execution.
 
 **Use this SDK when**: you're building a LangChain or LangGraph agent that needs to answer data questions against a Wren project. For one-shot CLI use, the `wren` command is fine on its own.
 
@@ -96,7 +96,7 @@ Wren-aware system prompt that adapts to enabled tools and includes your project'
 
 | Tool | Purpose |
 |---|---|
-| `wren_query` | Execute SQL through Wren's semantic layer; returns rows (capped at 1000) |
+| `wren_query` | Execute SQL through Wren's context layer; returns rows (capped at 1000) |
 | `wren_dry_plan` | Plan SQL without execution; verifies it targets MDL models correctly |
 | `wren_list_models` | List project models with column counts and descriptions |
 | `wren_fetch_context` | Retrieve schema and business context for a natural-language question |

--- a/docs/core/sdk/pydantic.md
+++ b/docs/core/sdk/pydantic.md
@@ -1,6 +1,6 @@
 # wren-pydantic
 
-Pydantic AI integration for Wren AI. Attach a CLI-prepared Wren project to your agent as a toolkit, with the semantic layer doing schema resolution, memory recall, and SQL execution.
+Pydantic AI integration for Wren AI. Attach a CLI-prepared Wren project to your agent as a toolkit, with the context layer doing schema resolution, memory recall, and SQL execution.
 
 **Use this SDK when**: you're building a [Pydantic AI](https://ai.pydantic.dev) agent that needs to answer data questions against a Wren project. For one-shot CLI use, the `wren` command is fine on its own.
 
@@ -96,7 +96,7 @@ Wren-aware instructions string that adapts to enabled tools and includes your pr
 
 | Tool | Returns | Purpose |
 |---|---|---|
-| `wren_query` | `WrenQueryResult` | Execute SQL through Wren's semantic layer; capped at 1000 rows |
+| `wren_query` | `WrenQueryResult` | Execute SQL through Wren's context layer; capped at 1000 rows |
 | `wren_dry_plan` | `str` | Plan SQL without execution; verifies it targets MDL models correctly |
 | `wren_list_models` | `list[ModelSummary]` | List project models with column counts and descriptions |
 | `wren_fetch_context` | `FetchContextResult` | Retrieve schema and business context for a natural-language question |

--- a/docs/core/sdk/wasm.md
+++ b/docs/core/sdk/wasm.md
@@ -243,7 +243,7 @@ Schema column types (case-insensitive): `int8`/`int16`/`int32`/`int64`,
 
 ### `engine.query(sql)`
 
-Execute a SQL query through the semantic layer. Returns parsed rows.
+Execute a SQL query through the context layer. Returns parsed rows.
 
 ```typescript
 async query(sql: string): Promise<Record<string, unknown>[]>


### PR DESCRIPTION
## What & why

`docs/core` prose had drifted behind the product's current vocabulary and the
v5 project layout. This refreshes the published narrative so it matches how
Wren AI Core actually works today.

### Narrative / terminology
- **"semantic layer" → "context layer"** throughout the prose.
- **`instructions.md` → `knowledge/` layout** (`knowledge/rules/` for business
  rules, `knowledge/sql/` for confirmed NL→SQL pairs) — the current v5 layout.
  `instructions.md` remains documented as **deprecated but still read** for
  back-compat, so migration guidance is unchanged.
- Reworded the "beats" metaphor to **"moves" / "phases"**, plus prose cleanups
  in `what_is_context`, `stack_position`, and `agent_learning`.

### Functional fix
- Corrected the LangChain and Pydantic SDK compatibility tables to
  **`wrenai >= 0.7.0`**, matching the actual dependency declared in each SDK's
  `pyproject.toml`.

## Scope
Docs only — no code changes. 17 files under `docs/core/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reframed terminology across the docs to emphasize Wren’s **context layer** and **knowledge rules** (replacing “semantic layer” and “instructions” wording).
  * Updated setup/quickstart and guides to show `knowledge/` (including `knowledge/rules/` and `knowledge/sql/`) as the place for business rules and examples.
  * Clarified how the memory system indexes (MDL + knowledge + confirmed NL→SQL pairs) and how plan validation injects policy filters.
  * Refreshed wording in concepts and SDK/skills references for correctness and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->