### PR TITLE
fix(sdk): URL-decode ClickHouse connection-URL credentials and database

### DIFF
--- a/core/wren/src/wren/model/data_source.py
+++ b/core/wren/src/wren/model/data_source.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import urllib
 from enum import StrEnum, auto
 from typing import Any
-from urllib.parse import unquote_plus
+from urllib.parse import unquote
 
 from wren.model import (
     AthenaConnectionInfo,
@@ -173,17 +173,21 @@ class DataSource(StrEnum):
                 ErrorCode.INVALID_CONNECTION_INFO,
                 "Invalid connection URL for ClickHouse",
             )
+        # Credentials and the database name are percent-encoded in the URL
+        # (e.g. a password ``p@ss/w:rd`` is written ``p%40ss%2Fw%3Ard``). Decode
+        # with ``unquote`` (not ``unquote_plus``) so a literal ``+`` in a
+        # credential survives instead of being turned into a space.
         kwargs = {}
         if parsed.username:
-            kwargs["user"] = parsed.username
+            kwargs["user"] = unquote(parsed.username)
         if parsed.password:
-            kwargs["password"] = unquote_plus(parsed.password)
+            kwargs["password"] = unquote(parsed.password)
         if parsed.hostname:
             kwargs["host"] = parsed.hostname
         if parsed.port:
             kwargs["port"] = str(parsed.port)
         if database := parsed.path[1:]:
-            kwargs["database"] = database
+            kwargs["database"] = unquote(database)
         parsed_kwargs = dict(urllib.parse.parse_qsl(parsed.query))
         if "secure" in parsed_kwargs:
             kwargs["secure"] = self._safe_strtobool(parsed_kwargs["secure"])

--- a/core/wren/tests/unit/test_clickhouse_url.py
+++ b/core/wren/tests/unit/test_clickhouse_url.py
@@ -1,0 +1,42 @@
+"""Regression tests for ClickHouse connection-URL credential decoding.
+
+``DataSource.clickhouse._build_connection_info`` parses a ``connectionUrl`` and
+must percent-decode the username, password, and database. Two bugs are covered:
+
+1. The password was decoded with ``unquote_plus``, which turns a literal ``+``
+   (a valid password character) into a space.
+2. The username and database were not decoded at all, so percent-escapes such
+   as ``%40`` survived as literal text.
+"""
+
+from urllib.parse import quote
+
+from wren.model.data_source import DataSource
+
+
+def _info(url: str):
+    return DataSource.clickhouse._build_connection_info({"connectionUrl": url})
+
+
+def test_plus_in_password_is_preserved():
+    # A literal '+' in the password must stay a '+', not become a space
+    # (the bug: unquote_plus decodes '+' -> ' ').
+    url = "clickhouse://user:pa+ss@localhost:8123/mydb"
+    info = _info(url)
+    assert info.password.get_secret_value() == "pa+ss"
+
+
+def test_username_and_database_are_decoded():
+    user = quote("us@er", safe="")
+    db = quote("my db", safe="")
+    url = f"clickhouse://{user}:secret@localhost:8123/{db}"
+    info = _info(url)
+    assert info.user == "us@er"
+    assert info.database == "my db"
+
+
+def test_special_chars_in_password_decoded():
+    pwd = quote("p@ss/w:rd", safe="")
+    url = f"clickhouse://user:{pwd}@localhost:8123/mydb"
+    info = _info(url)
+    assert info.password.get_secret_value() == "p@ss/w:rd"


### PR DESCRIPTION
## Summary

- `DataSource.clickhouse` now URL-decodes the **username**, **password**, and **database** parsed from a `connectionUrl`.
- The password is decoded with `unquote` instead of `unquote_plus`, so a literal `+` in a password is preserved instead of being turned into a space.

## Motivation

`_handle_clickhouse_url` in `core/wren/src/wren/model/data_source.py`:

- decoded the password with `unquote_plus`, which maps `+` → space. A ClickHouse password containing a `+` therefore silently connected with the wrong credential.
- did **not** decode the username or database at all, so percent-escapes (e.g. `%40` for `@`, `%20` for a space) survived as literal text and produced auth/lookup failures.

This brings the SDK path in line with the connector-level handling already used for `mssql` and `mysql`, which use `unquote`.

## Verification

```
$ python -m pytest tests/unit/test_clickhouse_url.py -q
3 passed

# on current main (git stash of the fix):
FAILED test_plus_in_password_is_preserved     (pa ss != pa+ss)
FAILED test_username_and_database_are_decoded  (us%40er != us@er)
2 failed, 1 passed
```

The new regression tests fail on `main` and pass with the fix. `ruff format` and `ruff check` clean. Change is confined to Apache-2.0 `core/wren/**`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse connection URL handling so percent-encoded usernames, passwords, and database names are decoded correctly.
  * Preserved literal `+` characters in credentials instead of converting them to spaces.

* **Tests**
  * Added coverage for ClickHouse connection parsing to verify decoding behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->