### PR TITLE
fix(mssql): sanitize brackets in connection-URL userinfo before parse

### DIFF
--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -337,12 +337,44 @@ def _build_mssql_connection(connection_info):
     )
 
 
+def _parse_mssql_connection_url(url: str):
+    """Parse an MSSQL URL after escaping raw brackets in userinfo only.
+
+    ``urllib.parse.urlparse`` treats ``[`` / ``]`` anywhere in the netloc as
+    IPv6 host delimiters. That is correct for hosts like ``mssql://[::1]/db``
+    but it raises ``ValueError`` on raw credentials such as
+    ``mssql://user:p[a]ss@host/db``. Sanitise only the userinfo segment so
+    valid IPv6 hosts still parse. Mirrors the MySQL connector helper.
+    """
+    scheme_idx = url.find("://")
+    if scheme_idx == -1:
+        return urlparse(url)
+
+    prefix = url[: scheme_idx + 3]
+    rest = url[scheme_idx + 3 :]
+
+    authority_end = len(rest)
+    for separator in "/?#":
+        idx = rest.find(separator)
+        if idx != -1:
+            authority_end = min(authority_end, idx)
+
+    authority = rest[:authority_end]
+    if "@" not in authority:
+        return urlparse(url)
+
+    userinfo, hostinfo = authority.rsplit("@", 1)
+    sanitized_userinfo = userinfo.replace("[", "%5B").replace("]", "%5D")
+    sanitized_url = f"{prefix}{sanitized_userinfo}@{hostinfo}{rest[authority_end:]}"
+    return urlparse(sanitized_url)
+
+
 def _connect_mssql_from_url(
     connection_url: str, base_kwargs: dict[str, Any] | None = None
 ):
     """Parse a ``mssql://user:pass@host:port/database`` URL and open a
     pyodbc connection using the same code path as the typed-info builder."""
-    parsed = urlparse(connection_url)
+    parsed = _parse_mssql_connection_url(connection_url)
     if parsed.scheme != "mssql":
         raise WrenError(
             ErrorCode.INVALID_CONNECTION_INFO,

--- a/core/wren/tests/unit/test_mssql_connection.py
+++ b/core/wren/tests/unit/test_mssql_connection.py
@@ -95,6 +95,35 @@ def test_mssql_url_preserves_literal_plus_in_user_and_password() -> None:
     assert parts["PWD"] == "p+wd"
 
 
+def test_mssql_url_with_brackets_in_credentials() -> None:
+    """Raw ``[`` / ``]`` in userinfo must not be treated as IPv6 host
+    delimiters. Plain ``urlparse`` raises ValueError on such a URL; the
+    connector sanitises the userinfo segment first (mirrors MySQL).
+    """
+    fake = _FakePyodbc()
+    with patch("wren.connector.mssql.pyodbc", fake):
+        _connect_mssql_from_url("mssql://user:p[a]ss@host:1433/db")
+
+    parts = _parse_conn_str(fake.connect.call_args)
+    assert parts["UID"] == "user"
+    assert parts["PWD"] == "p[a]ss"
+    assert parts["SERVER"] == "host,1433"
+    assert parts["DATABASE"] == "db"
+
+
+def test_mssql_url_preserves_ipv6_host() -> None:
+    """A legitimate bracketed IPv6 host must still parse correctly; only
+    the userinfo segment is sanitised."""
+    fake = _FakePyodbc()
+    with patch("wren.connector.mssql.pyodbc", fake):
+        _connect_mssql_from_url("mssql://user:pass@[::1]:1433/db")
+
+    parts = _parse_conn_str(fake.connect.call_args)
+    assert parts["SERVER"] == "::1,1433"
+    assert parts["UID"] == "user"
+    assert parts["PWD"] == "pass"
+
+
 def test_mssql_url_without_credentials_uses_trusted_connection() -> None:
     """A URL with no userinfo should route through Trusted_Connection=yes
     rather than failing the URL validator."""


### PR DESCRIPTION
## Summary

- `mssql://` connection URLs containing `[` or `]` in the userinfo (username/password) crashed with `ValueError` from `urlparse`'s IPv6 netloc check.
- Bracketed credentials now parse, while legitimate bracketed IPv6 hosts still work.

## Motivation

`_connect_mssql_from_url` called `urlparse(connection_url)` directly. Python's `urlparse` treats `[`/`]` anywhere in the netloc as IPv6 host delimiters, so a URL like `mssql://user:p[a]ss@host:1433/db` raises `ValueError: 'host' does not appear to be an IPv4 or IPv6 address` before any connection is attempted — the credential can never be used.

The MySQL connector already solved this exact problem with `_parse_mysql_connection_url`, which escapes brackets in the userinfo segment only. This change mirrors that helper for MSSQL (`_parse_mssql_connection_url`), keeping valid IPv6 hosts (`mssql://user:pass@[::1]:1433/db`) intact.

## Verification

```
$ uv run pytest tests/unit/test_mssql_connection.py -q
18 passed in 0.90s
```

Regression test proof (fails without the fix):
```
$ git stash push -- src/wren/connector/mssql.py
$ uv run pytest tests/unit/test_mssql_connection.py -k "brackets or ipv6" -q
FAILED ...test_mssql_url_with_brackets_in_credentials - ValueError: 'host' does not appear to be an IPv4 or IPv6 address
1 failed, 1 passed
```
The `ipv6` test passes both with and without the fix, confirming no regression for legitimate bracketed IPv6 hosts.

Apache-2.0 path (`core/**`). One commit, two files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MSSQL connection URLs so credentials containing `[` or `]` are parsed correctly.
  * Preserved support for valid IPv6 hosts in bracketed form while avoiding confusion with bracket characters in the username/password portion.

* **Tests**
  * Added coverage for URLs with bracket characters in credentials.
  * Added coverage to confirm IPv6 host parsing still works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->