### PR TITLE
fix(oracle): sanitize brackets in connection-URL userinfo before parse

### DIFF
--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -21,6 +21,38 @@ from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 _TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
 
 
+def _parse_oracle_connection_url(url: str):
+    """Parse an Oracle URL after escaping raw brackets in userinfo only.
+
+    ``urllib.parse.urlparse`` treats ``[`` / ``]`` anywhere in the netloc as
+    IPv6 host delimiters. That is correct for hosts like ``oracle://[::1]/db``
+    but it raises ``ValueError`` on raw credentials such as
+    ``oracle://user:p[a]ss@host/svc``. Sanitise only the userinfo segment so
+    valid IPv6 hosts still parse. Mirrors the MySQL connector helper.
+    """
+    scheme_idx = url.find("://")
+    if scheme_idx == -1:
+        return urlparse(url)
+
+    prefix = url[: scheme_idx + 3]
+    rest = url[scheme_idx + 3 :]
+
+    authority_end = len(rest)
+    for separator in "/?#":
+        idx = rest.find(separator)
+        if idx != -1:
+            authority_end = min(authority_end, idx)
+
+    authority = rest[:authority_end]
+    if "@" not in authority:
+        return urlparse(url)
+
+    userinfo, hostinfo = authority.rsplit("@", 1)
+    sanitized_userinfo = userinfo.replace("[", "%5B").replace("]", "%5D")
+    sanitized_url = f"{prefix}{sanitized_userinfo}@{hostinfo}{rest[authority_end:]}"
+    return urlparse(sanitized_url)
+
+
 def _strip_trailing_semicolon(sql: str) -> str:
     """Strip any trailing ``;`` characters and surrounding whitespace.
 
@@ -119,7 +151,7 @@ def _build_oracle_arrow_table(cursor) -> pa.Table:
 def _make_oracle_connection(connection_info):
     if hasattr(connection_info, "connection_url") and connection_info.connection_url:
         url = connection_info.connection_url.get_secret_value()
-        parsed = urlparse(url)
+        parsed = _parse_oracle_connection_url(url)
         # urlparse leaves percent-encoded characters in the userinfo/path, so
         # decode them here. Credentials routinely contain reserved characters
         # (``@ / : ?``) that MUST be percent-encoded in the URL; without

--- a/core/wren/tests/unit/test_oracle_url_decode.py
+++ b/core/wren/tests/unit/test_oracle_url_decode.py
@@ -58,6 +58,38 @@ def test_connection_url_decodes_percent_encoded_credentials(monkeypatch):
     assert captured["service_name"] == "svc"
 
 
+def test_connection_url_with_brackets_in_credentials(monkeypatch):
+    # Raw ``[`` / ``]`` in userinfo must not be treated as IPv6 host
+    # delimiters. Plain urlparse raises ValueError on such a URL; the
+    # connector sanitises the userinfo segment first (mirrors MySQL).
+    captured = _capture_connect(monkeypatch)
+    info = SimpleNamespace(
+        connection_url=_Secret("oracle://user:p[a]ss@host:1521/svc")
+    )
+    _make_oracle_connection(info)
+
+    assert captured["user"] == "user"
+    assert captured["password"] == "p[a]ss"
+    assert captured["host"] == "host"
+    assert captured["port"] == 1521
+    assert captured["service_name"] == "svc"
+
+
+def test_connection_url_preserves_ipv6_host(monkeypatch):
+    # A legitimate bracketed IPv6 host must still parse; only the userinfo
+    # segment is sanitised.
+    captured = _capture_connect(monkeypatch)
+    info = SimpleNamespace(
+        connection_url=_Secret("oracle://user:pass@[::1]:1521/svc")
+    )
+    _make_oracle_connection(info)
+
+    assert captured["host"] == "::1"
+    assert captured["user"] == "user"
+    assert captured["password"] == "pass"
+    assert captured["port"] == 1521
+
+
 def test_connection_url_preserves_literal_plus_in_credentials(monkeypatch):
     # ``+`` in userinfo is a literal plus, not a space — unquote (not
     # unquote_plus) must leave it intact.


### PR DESCRIPTION
## Summary

- `oracle://` connection URLs containing `[` or `]` in the userinfo (username/password) crashed with `ValueError` from `urlparse`'s IPv6 netloc check.
- Bracketed credentials now parse, while legitimate bracketed IPv6 hosts still work.

## Motivation

`_make_oracle_connection` called `urlparse(url)` directly. Python's `urlparse` treats `[`/`]` anywhere in the netloc as IPv6 host delimiters, so a URL like `oracle://user:p[a]ss@host:1521/svc` raises `ValueError: 'host' does not appear to be an IPv4 or IPv6 address` before any connection is attempted — the credential can never be used.

The MySQL connector already solved this exact problem with `_parse_mysql_connection_url`, which escapes brackets in the userinfo segment only. This change mirrors that helper for Oracle (`_parse_oracle_connection_url`), keeping valid IPv6 hosts (`oracle://user:pass@[::1]:1521/svc`) intact.

## Verification

```
$ uv run pytest tests/unit/test_oracle_url_decode.py -q
4 passed in 0.20s
```

Regression test proof (fails without the fix):
```
$ git stash push -- src/wren/connector/oracle.py
$ uv run pytest tests/unit/test_oracle_url_decode.py -k "brackets or ipv6" -q
FAILED ...test_connection_url_with_brackets_in_credentials - ValueError: 'host' does not appear to be an IPv4 or IPv6 address
1 failed, 1 passed
```
The `ipv6` test passes both with and without the fix, confirming no regression for legitimate bracketed IPv6 hosts.

Apache-2.0 path (`core/**`). One commit, two files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle connection URL handling so credentials containing `[` or `]` no longer break parsing.
  * Preserved correct handling of IPv6 host addresses while decoding connection details.
* **Tests**
  * Added coverage for bracketed credentials in the connection URL.
  * Added coverage to ensure IPv6 hosts remain unchanged during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->