### PR TITLE
fix(core): prune inaccessible CLS columns in wildcard expansion instead of denying

### DIFF
--- a/core/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -1046,6 +1046,25 @@ impl ModelSourceNode {
                     if column.is_calculated {
                         continue;
                     }
+                    // Prune columns the caller cannot access under column-level
+                    // security instead of denying. This is an *implicit* all-columns
+                    // expansion (a `count(*)`, or the throwaway inner plan built for
+                    // a model scan referenced with a table alias, whose required
+                    // columns are keyed by the alias so the model is wildcard-
+                    // expanded). A protected column the query never explicitly
+                    // selected must be dropped here — matching `SELECT *` semantics —
+                    // not turned into a hard permission error. Explicit references
+                    // still deny, because they arrive as named required fields (the
+                    // non-wildcard branch / ModelPlanNodeBuilder::build), not here.
+                    let (is_valid, _) = validate_clac_rule(
+                        model.name(),
+                        &column,
+                        &session_properties,
+                        Some(Arc::clone(&analyzed_wren_mdl)),
+                    )?;
+                    if !is_valid {
+                        continue;
+                    }
                     fields_buffer.insert((
                         Some(TableReference::bare(quoted(model.name()))),
                         Arc::new(Field::new(

--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -3094,6 +3094,135 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_clac_unreferenced_column_pruned_not_denied() -> Result<()> {
+        // A CLS-protected column the query does NOT reference must be pruned,
+        // not denied — even when the model is referenced with a table alias
+        // (which builds a throwaway inner plan with empty required fields, so the
+        // model gets wildcard-expanded), and for `count(*)`. Before the fix, an
+        // aliased scan of `customer` — or `count(*)` — that never selected
+        // `c_name` still denied `customer.c_name`.
+        let ctx = create_wren_ctx(None, None);
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("customer")
+                    .table_reference("customer")
+                    .column(ColumnBuilder::new("c_custkey", "int").build())
+                    .column(
+                        ColumnBuilder::new("c_name", "string")
+                            .column_level_access_control(
+                                "cls rule",
+                                vec![SessionProperty::new_required("session_level")],
+                                ColumnLevelOperator::Equals,
+                                "1",
+                            )
+                            .build(),
+                    )
+                    .column(
+                        ColumnBuilder::new("c_secret", "string")
+                            .column_level_access_control(
+                                "cls rule 2",
+                                vec![SessionProperty::new_required("session_level")],
+                                ColumnLevelOperator::Equals,
+                                "2",
+                            )
+                            .build(),
+                    )
+                    .primary_key("c_custkey")
+                    .build(),
+            )
+            .model(
+                ModelBuilder::new("orders")
+                    .table_reference("orders")
+                    .column(ColumnBuilder::new("o_orderkey", "int").build())
+                    .column(ColumnBuilder::new("o_custkey", "int").build())
+                    .primary_key("o_orderkey")
+                    .build(),
+            )
+            .relationship(
+                RelationshipBuilder::new("customer_orders")
+                    .model("customer")
+                    .model("orders")
+                    .join_type(JoinType::OneToMany)
+                    .condition("customer.c_custkey = orders.o_custkey")
+                    .build(),
+            )
+            .build();
+
+        // session_level=0 → NO access to the protected columns (c_name, c_secret).
+        let headers = Arc::new(build_headers(&[(
+            "session_level".to_string(),
+            Some("0".to_string()),
+        )]));
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest.clone(),
+            headers.clone(),
+            Mode::Unparse,
+        )?);
+
+        // The protected columns are never referenced → each of these must succeed
+        // with them pruned, not denied.
+        let prune_cases = [
+            ("unaliased join", "SELECT customer.c_custkey, orders.o_orderkey FROM customer JOIN orders ON customer.c_custkey = orders.o_custkey"),
+            ("aliased join", "SELECT e.c_custkey, o.o_orderkey FROM customer e JOIN orders o ON e.c_custkey = o.o_custkey"),
+            ("aliased standalone", "SELECT e.c_custkey FROM customer e"),
+            ("unaliased standalone", "SELECT customer.c_custkey FROM customer"),
+            ("aliased count(*)", "SELECT count(*) FROM customer e"),
+            ("unaliased count(*)", "SELECT count(*) FROM customer"),
+            ("qualified wildcard", "SELECT e.* FROM customer e"),
+            ("bare wildcard", "SELECT * FROM customer"),
+        ];
+        for (label, sql) in prune_cases {
+            if let Err(e) = transform_sql_with_ctx(
+                &ctx,
+                Arc::clone(&analyzed_mdl),
+                &[],
+                headers.clone(),
+                sql,
+            )
+            .await
+            {
+                panic!(
+                    "[{label}] unreferenced CLS column should be pruned, not denied: {e}"
+                );
+            }
+        }
+
+        // An EXPLICIT reference to a protected column must still be denied, wherever
+        // it appears — the fix only prunes columns the query never references.
+        let deny_cases = [
+            ("aliased explicit select", "SELECT e.c_custkey, e.c_name FROM customer e JOIN orders o ON e.c_custkey = o.o_custkey"),
+            ("aliased explicit standalone", "SELECT e.c_name FROM customer e"),
+            ("unaliased explicit select", "SELECT c_name FROM customer"),
+            ("second protected column", "SELECT e.c_secret FROM customer e"),
+            ("explicit in WHERE", "SELECT e.c_custkey FROM customer e WHERE e.c_name = 'x'"),
+            ("explicit in GROUP BY", "SELECT count(*) FROM customer e GROUP BY e.c_name"),
+            ("explicit in JOIN ON", "SELECT e.c_custkey FROM customer e JOIN orders o ON e.c_name = o.o_custkey"),
+        ];
+        for (label, sql) in deny_cases {
+            match transform_sql_with_ctx(
+                &ctx,
+                Arc::clone(&analyzed_mdl),
+                &[],
+                headers.clone(),
+                sql,
+            )
+            .await
+            {
+                Ok(out) => {
+                    panic!("[{label}] must deny explicit CLS reference, got: {out}")
+                }
+                Err(e) => assert!(
+                    e.to_string().contains("violates access control rule"),
+                    "[{label}] expected CLS denial, got: {e}"
+                ),
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_calc_primary_key() -> Result<()> {
         let ctx = create_wren_ctx(None, None);
         let manifest = ManifestBuilder::new()


### PR DESCRIPTION
## Problem

Column-level access control (CLAC/CLS) denies **any** query that references a model with a **table alias**, even when the protected column is never selected. `SELECT * FROM model` correctly prunes an inaccessible CLS column, but `SELECT alias.other_col FROM model alias` (or a join using an alias) fails with `Access denied to column … violates access control rule …`. `SELECT count(*) FROM model` on a model with a CLS column is denied for the same reason.

## Root cause

For `FROM customer c`, the plan is `Projection → SubqueryAlias(c) → TableScan(customer)`. `ModelAnalyzeRule` collects required columns keyed by the alias `c`, but the bottom-up transform processes the inner bare `TableScan(customer)` first with no alias, looks required columns up under the model name, and finds none. That builds a throwaway inner `ModelPlanNode` with **empty** required fields, which triggers the wildcard expansion in `RelationChain::source` (`ModelSourceNode::new`). That loop expanded every physical column and called `get_remote_column_exp` per column, which hard-denies via `validate_clac_rule`. `analyze_subquery_alias_model` later rebuilds the node correctly with the alias's required columns, but the throwaway build errors first.

`SELECT *` avoids this because it doesn't route through the empty-required wildcard path.

## Fix

In the wildcard-expansion loop, prune columns the caller cannot access (`validate_clac_rule` + `continue`) instead of denying — matching `SELECT *` semantics. This path is an *implicit* all-columns expansion (`count(*)`, or the aliased throwaway plan); a protected column the query never explicitly selected should be dropped, not turned into a hard error. Explicit references still deny, because they arrive as named required fields through `ModelPlanNodeBuilder::build` (the non-wildcard branch), not this path. Pruning a column can only ever remove it, so it cannot widen access.

## Tests

Adds `test_clac_unreferenced_column_pruned_not_denied`:
- **Pruned (must succeed):** aliased/unaliased join, aliased/unaliased standalone, aliased/unaliased `count(*)`, model-qualified `alias.*`, and bare `*` — none reference the protected columns.
- **Still denied (must error with "violates access control rule"):** explicit reference to a protected column in SELECT (aliased and unaliased), a second protected column, and references in WHERE, GROUP BY, and JOIN ON.

Verified locally against `main`: the new test passes and the fix is a minimal, localized change in `ModelSourceNode::new`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard queries now omit columns the caller is not allowed to access, instead of failing with a permission error.
  * Protected columns that are not explicitly referenced are now safely pruned, including in aliased queries and `count(*)`/`*` scenarios.
  * Explicitly referenced protected columns continue to return access-denied errors as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->