### PR TITLE
chore(core): publish Rust core crates to crates.io as wren-semantic-core

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Wren is an open-source semantic engine for MCP clients and AI agents. It translates SQL queries through a semantic layer (MDL — Modeling Definition Language) and executes them against 22+ data sources (PostgreSQL, BigQuery, Snowflake, Spark, etc.). The Rust engine is powered by Apache DataFusion (Canner fork).
+Wren is an open-source semantic engine for MCP clients and AI agents. It translates SQL queries through a semantic layer (MDL — Modeling Definition Language) and executes them against 22+ data sources (PostgreSQL, BigQuery, Snowflake, Spark, etc.). The Rust engine is powered by Apache DataFusion (upstream, crates.io v53).
 
 The previous WrenAI services (`wren-ui/`, `wren-ai-service/`, `wren-launcher/`, `docker/`, `deployment/`) were moved to the `legacy/v1` branch (tag `v1-final`) as of the wren-engine import. Active development is focused on the Open Context Engine.
 
@@ -12,8 +12,8 @@ The previous WrenAI services (`wren-ui/`, `wren-ai-service/`, `wren-launcher/`, 
 
 ```
 core/
-├── wren-core/        Rust semantic engine (Cargo workspace)
-├── wren-core-base/   Shared Rust crate — manifest types (Model, Column, Metric, Relationship, View) + ManifestBuilder
+├── wren-core/        Rust semantic engine (Cargo workspace; crates.io: wren-semantic-core, lib name wren_core)
+├── wren-core-base/   Shared Rust crate — manifest types (Model, Column, Metric, Relationship, View) + ManifestBuilder (crates.io: wren-core-base)
 ├── wren-core-py/     PyO3 bindings exposing wren-core to Python (PyPI: wren-core)
 ├── wren-core-wasm/   WebAssembly build of wren-core for in-browser semantic SQL (npm: wren-core-wasm)
 ├── wren/             Python SDK and CLI — `wren` command, profile/context/memory management (PyPI: wrenai)
@@ -83,7 +83,7 @@ Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend. Opti
 SQL query
   → wren CLI / wren-core-py
   → wren-core (Rust): MDL analysis → logical plan → optimization
-  → DataFusion (query planning, Canner fork canner/v49.0.1)
+  → DataFusion (query planning, upstream crates.io v53)
   → connector-specific SQL (Ibis / sqlglot)
   → native execution on the target data source
 ```
@@ -110,6 +110,6 @@ SQL query
 - **Commits**: Conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`, `perf:`, `deps:`). Releases are automated via release-please with independent release lines per module.
 - **Rust**: format with `cargo fmt`, lint with `clippy -D warnings`, TOML with `taplo`.
 - **Python**: format and lint with `ruff` (line-length 88, target Python 3.11). Both `core/wren-core-py` and `core/wren` use uv.
-- **DataFusion fork**: `https://github.com/Canner/datafusion.git` branch `canner/v49.0.1`.
+- **DataFusion**: upstream `datafusion` v53 from crates.io (no longer the Canner fork).
 - **Snapshot testing**: wren-core uses `insta` for Rust snapshot tests.
 - **CI**: Per-module path-filtered workflows trigger only on changes inside that module.

--- a/core/wren-core-base/Cargo.toml
+++ b/core/wren-core-base/Cargo.toml
@@ -3,6 +3,11 @@ name = "wren-core-base"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
+description = "Shared MDL manifest types for the Wren semantic engine"
+homepage = "https://getwren.ai"
+repository = "https://github.com/Canner/WrenAI"
+keywords = ["sql", "semantic-layer", "mdl", "manifest", "wren"]
+categories = ["database"]
 
 [features]
 python-binding = ["dep:pyo3"]
@@ -11,7 +16,7 @@ default = []
 [dependencies]
 pyo3 = { version = "0.26.0", features = ["extension-module"], optional = true }
 serde = { version = "1.0.201", features = ["derive", "rc"] }
-wren-manifest-macro = { path = "manifest-macro" }
+wren-manifest-macro = { path = "manifest-macro", version = "0.1.0" }
 serde_json = { version = "1.0.117" }
 serde_with = { version = "3.11.0" }
 sqlparser = { version = "0.58.0", features = ["visitor"] }

--- a/core/wren-core-base/LICENSE
+++ b/core/wren-core-base/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canner, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/core/wren-core-base/manifest-macro/Cargo.toml
+++ b/core/wren-core-base/manifest-macro/Cargo.toml
@@ -3,6 +3,11 @@ name = "wren-manifest-macro"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
+description = "Proc macro for generating Python-binding manifest types for the Wren semantic engine"
+homepage = "https://getwren.ai"
+repository = "https://github.com/Canner/WrenAI"
+keywords = ["macro", "proc-macro", "pyo3", "wren", "mdl"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [dependencies]
 syn = { version = "2.0", default-features = false, features = [

--- a/core/wren-core-base/manifest-macro/LICENSE
+++ b/core/wren-core-base/manifest-macro/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canner, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/core/wren-core-py/Cargo.lock
+++ b/core/wren-core-py/Cargo.lock
@@ -2267,16 +2267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph-evcxr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c164f0ab4e02b69ff6172de80d9c1a31a9dd21c15c7b728b632442a19c9fd96"
-dependencies = [
- "base64",
- "petgraph",
-]
-
-[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,28 +3594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wren-core"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "csv",
- "datafusion",
- "datafusion-session",
- "env_logger",
- "itertools",
- "log",
- "parking_lot",
- "petgraph",
- "petgraph-evcxr",
- "regex",
- "serde",
- "serde_json",
- "serde_with",
- "tokio",
- "wren-core-base",
-]
-
-[[package]]
 name = "wren-core-base"
 version = "0.1.0"
 dependencies = [
@@ -3653,8 +3621,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "wren-core",
  "wren-core-base",
+ "wren-semantic-core",
 ]
 
 [[package]]
@@ -3663,6 +3631,26 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "wren-semantic-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "csv",
+ "datafusion",
+ "datafusion-session",
+ "itertools",
+ "log",
+ "parking_lot",
+ "petgraph",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio",
+ "wren-core-base",
 ]
 
 [[package]]

--- a/core/wren-core-py/Cargo.toml
+++ b/core/wren-core-py/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py311"] }
-wren-core = { path = "../wren-core/core" }
+wren-core = { path = "../wren-core/core", package = "wren-semantic-core" }
 wren-core-base = { path = "../wren-core-base", features = ["python-binding"] }
 datafusion-common = "53.0.0"
 base64 = "0.22.1"

--- a/core/wren-core-wasm/Cargo.lock
+++ b/core/wren-core-wasm/Cargo.lock
@@ -62,56 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,12 +502,6 @@ dependencies = [
  "chrono",
  "phf",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -1423,29 +1367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,12 +1965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,30 +1978,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "jobserver"
@@ -2381,12 +2272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,16 +2376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph-evcxr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c164f0ab4e02b69ff6172de80d9c1a31a9dd21c15c7b728b632442a19c9fd96"
-dependencies = [
- "base64",
- "petgraph",
-]
-
-[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,21 +2404,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -3601,12 +3461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,28 +4003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wren-core"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "csv",
- "datafusion",
- "datafusion-session",
- "env_logger",
- "itertools",
- "log",
- "parking_lot",
- "petgraph",
- "petgraph-evcxr",
- "regex",
- "serde",
- "serde_json",
- "serde_with",
- "tokio",
- "wren-core-base",
-]
-
-[[package]]
 name = "wren-core-base"
 version = "0.1.0"
 dependencies = [
@@ -4205,8 +4037,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "wren-core",
  "wren-core-base",
+ "wren-semantic-core",
 ]
 
 [[package]]
@@ -4215,6 +4047,26 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "wren-semantic-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "csv",
+ "datafusion",
+ "datafusion-session",
+ "itertools",
+ "log",
+ "parking_lot",
+ "petgraph",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio",
+ "wren-core-base",
 ]
 
 [[package]]

--- a/core/wren-core-wasm/Cargo.toml
+++ b/core/wren-core-wasm/Cargo.toml
@@ -20,23 +20,30 @@ path = "src/lib.rs"
 # DataFusion enables zstd (C library) which cannot compile to WASM.
 # We read Parquet bytes → Arrow RecordBatch → MemTable ourselves.
 datafusion = { version = "53", default-features = false, features = [
-    "nested_expressions",
-    "crypto_expressions",
-    "datetime_expressions",
-    "encoding_expressions",
-    "regex_expressions",
-    "unicode_expressions",
-    "parquet",
-    "sql",
+  "nested_expressions",
+  "crypto_expressions",
+  "datetime_expressions",
+  "encoding_expressions",
+  "regex_expressions",
+  "unicode_expressions",
+  "parquet",
+  "sql",
 ] }
 
 object_store = { version = "0.13.1", features = ["aws", "http"] }
 
 # --- Arrow / Parquet ---
-arrow = { version = "58.1", default-features = false, features = ["json", "csv"] }
+arrow = { version = "58.1", default-features = false, features = [
+  "json",
+  "csv",
+] }
 # No zstd: requires C library (zstd-sys) which cannot compile to WASM.
 # Snappy and LZ4 are pure Rust and WASM-compatible.
-parquet = { version = "58.1", default-features = false, features = ["arrow", "snap", "lz4"] }
+parquet = { version = "58.1", default-features = false, features = [
+  "arrow",
+  "snap",
+  "lz4",
+] }
 
 # --- WASM bindings ---
 wasm-bindgen = "0.2"
@@ -49,7 +56,7 @@ console_error_panic_hook = "0.1"
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
 
 # --- Wren semantic layer (no multi-thread for WASM) ---
-wren-core = { path = "../wren-core/core", default-features = false }
+wren-core = { path = "../wren-core/core", default-features = false, package = "wren-semantic-core" }
 
 # --- Shared types (no DataFusion dependency, no Python binding) ---
 wren-core-base = { path = "../wren-core-base" }
@@ -73,9 +80,12 @@ log = "0.4"
 # --- WASM-specific: all getrandom versions need JS backend for wasm32 ---
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
-getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
-getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = [
+  "wasm_js",
+] }
+getrandom_04 = { package = "getrandom", version = "0.4", features = [
+  "wasm_js",
+] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-

--- a/core/wren-core/.claude/CLAUDE.md
+++ b/core/wren-core/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # wren-core
 
-Rust semantic engine for Wren Engine. Handles MDL analysis, query planning, logical plan optimization, and SQL generation via Apache DataFusion (Canner fork).
+Rust semantic engine for Wren Engine. Handles MDL analysis, query planning, logical plan optimization, and SQL generation via Apache DataFusion (upstream, crates.io v53). Published to crates.io as `wren-semantic-core` (lib name `wren_core`).
 
 ## Workspace Layout
 
@@ -38,7 +38,7 @@ taplo fmt                                               # Format Cargo.toml file
 
 ## Dependencies
 
-- **DataFusion fork**: `https://github.com/Canner/datafusion.git` branch `canner/v49.0.1`
+- **DataFusion**: upstream `datafusion` v53 from crates.io (no longer the Canner fork)
 - **wren-core-base**: Shared manifest types from `../wren-core-base`
 
 ## Known Limitations

--- a/core/wren-core/Cargo.toml
+++ b/core/wren-core/Cargo.toml
@@ -15,14 +15,14 @@ version = "0.1.0"
 [workspace.dependencies]
 async-trait = "0.1.89"
 datafusion = { version = "53", default-features = false, features = [
-  "nested_expressions",
-  "crypto_expressions",
-  "datetime_expressions",
-  "encoding_expressions",
-  "regex_expressions",
-  "unicode_expressions",
-  "parquet",
-  "sql",
+    "nested_expressions",
+    "crypto_expressions",
+    "datetime_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "unicode_expressions",
+    "parquet",
+    "sql",
 ] }
 datafusion-session = { version = "53", default-features = false }
 env_logger = "0.11.10"

--- a/core/wren-core/Cargo.toml
+++ b/core/wren-core/Cargo.toml
@@ -15,14 +15,14 @@ version = "0.1.0"
 [workspace.dependencies]
 async-trait = "0.1.89"
 datafusion = { version = "53", default-features = false, features = [
-    "nested_expressions",
-    "crypto_expressions",
-    "datetime_expressions",
-    "encoding_expressions",
-    "regex_expressions",
-    "unicode_expressions",
-    "parquet",
-    "sql",
+  "nested_expressions",
+  "crypto_expressions",
+  "datetime_expressions",
+  "encoding_expressions",
+  "regex_expressions",
+  "unicode_expressions",
+  "parquet",
+  "sql",
 ] }
 datafusion-session = { version = "53", default-features = false }
 env_logger = "0.11.10"
@@ -33,5 +33,5 @@ serde = { version = "1.0.201", features = ["derive", "rc"] }
 serde_json = { version = "1.0.149" }
 serde_with = { version = "3.18.0" }
 tokio = { version = "1.46", features = ["rt", "macros"] }
-wren-core = { path = "core" }
-wren-core-base = { path = "../wren-core-base" }
+wren-core = { path = "core", package = "wren-semantic-core" }
+wren-core-base = { path = "../wren-core-base", version = "0.1.0" }

--- a/core/wren-core/core/Cargo.toml
+++ b/core/wren-core/core/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
-name = "wren-core"
-include = ["src/**/*.rs", "Cargo.toml"]
+name = "wren-semantic-core"
+description = "Wren semantic engine — MDL-based semantic SQL layer and query planner built on Apache DataFusion"
+keywords = ["sql", "semantic-layer", "datafusion", "mdl", "query"]
+categories = ["database"]
+readme = "README.md"
+include = ["src/**/*.rs", "Cargo.toml", "LICENSE", "README.md"]
 version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
@@ -22,21 +26,19 @@ multi-thread = ["tokio/rt-multi-thread"]
 async-trait = { workspace = true }
 csv = "1.3.0"
 datafusion = { workspace = true, features = [
-    "nested_expressions",
-    "crypto_expressions",
-    "datetime_expressions",
-    "encoding_expressions",
-    "regex_expressions",
-    "unicode_expressions",
+  "nested_expressions",
+  "crypto_expressions",
+  "datetime_expressions",
+  "encoding_expressions",
+  "regex_expressions",
+  "unicode_expressions",
 ] }
 
 datafusion-session = { workspace = true }
-env_logger = { workspace = true }
 itertools = "0.14.0"
 log = { workspace = true }
 parking_lot = "0.12.3"
 petgraph = "0.8.2"
-petgraph-evcxr = "*"
 regex = "1.10.5"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -45,4 +47,5 @@ tokio = { workspace = true, features = ["rt", "macros"] }
 wren-core-base = { workspace = true }
 
 [dev-dependencies]
+env_logger = { workspace = true }
 insta = { workspace = true }

--- a/core/wren-core/core/Cargo.toml
+++ b/core/wren-core/core/Cargo.toml
@@ -26,12 +26,12 @@ multi-thread = ["tokio/rt-multi-thread"]
 async-trait = { workspace = true }
 csv = "1.3.0"
 datafusion = { workspace = true, features = [
-  "nested_expressions",
-  "crypto_expressions",
-  "datetime_expressions",
-  "encoding_expressions",
-  "regex_expressions",
-  "unicode_expressions",
+    "nested_expressions",
+    "crypto_expressions",
+    "datetime_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "unicode_expressions",
 ] }
 
 datafusion-session = { workspace = true }

--- a/core/wren-core/core/LICENSE
+++ b/core/wren-core/core/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canner, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/core/wren-core/core/README.md
+++ b/core/wren-core/core/README.md
@@ -1,0 +1,47 @@
+# wren-semantic-core
+
+The Rust semantic engine at the heart of [Wren AI](https://getwren.ai) — an open-source
+semantic layer for MCP clients and AI agents.
+
+`wren-semantic-core` takes a **MDL (Modeling Definition Language)** manifest plus a SQL query
+and rewrites the query through the semantic layer: resolving models, relationships, metrics
+and views, applying row-/column-level access control, and producing an optimized logical
+plan. It is built on [Apache DataFusion](https://datafusion.apache.org/).
+
+> The published crate is named `wren-semantic-core`; the library itself is imported as
+> `wren_core`.
+
+## Installation
+
+```toml
+[dependencies]
+wren-semantic-core = "0.1"
+```
+
+## Usage
+
+```rust
+use wren_core::mdl::AnalyzedWrenMDL;
+// Build an AnalyzedWrenMDL from a manifest, then transform SQL through the
+// semantic layer. See the API docs for the full flow.
+```
+
+Full API documentation is published on [docs.rs](https://docs.rs/wren-semantic-core).
+
+## What it does
+
+- **MDL analysis** — parse a manifest into models, columns, metrics, relationships and views.
+- **Query planning** — rewrite incoming SQL against the semantic layer into a DataFusion
+  logical plan, resolving relationship chains and expanding views.
+- **Access control** — apply row-level (RLAC) and column-level (CLAC) access rules.
+- **Optimization** — type coercion and timestamp simplification passes.
+
+## Learn more
+
+- Wren documentation: <https://docs.getwren.ai>
+- Project home: <https://getwren.ai>
+- Source: <https://github.com/Canner/WrenAI>
+
+## License
+
+Licensed under the [Apache License, Version 2.0](LICENSE).

--- a/core/wren-core/sqllogictest/Cargo.toml
+++ b/core/wren-core/sqllogictest/Cargo.toml
@@ -23,7 +23,7 @@ rust_decimal = { version = "1.27.0" }
 sqllogictest = "0.28.4"
 thiserror = "2.0.3"
 tokio = { workspace = true }
-wren-core = { path = "../core" }
+wren-core = { path = "../core", package = "wren-semantic-core" }
 
 itertools = "0.14.0"
 object_store = { version = "0.12.3", default-features = false }


### PR DESCRIPTION
## What & why

Prepares the Rust core crates for distribution on crates.io and publishes them as a
bottom-up chain: `wren-manifest-macro` → `wren-core-base` → `wren-semantic-core`.

The main package is renamed from `wren-core` to **`wren-semantic-core`** because the
`wren-core` name is already taken on crates.io by an unrelated project. The library name
stays `wren_core`, so all `use wren_core::…` paths and downstream crates
(`wren-core-py`, `wren-core-wasm`, sqllogictest, benchmarks) are unaffected — they now
reference the package via `package = "wren-semantic-core"`.

## Changes

- Rename package `wren-core` → `wren-semantic-core`; keep `[lib] name = "wren_core"`.
- Point all in-repo dependents at it via `package = "wren-semantic-core"`.
- Drop the unused `petgraph-evcxr = "*"` wildcard dependency (crates.io rejects `*`).
- Move test-only `env_logger` to `[dev-dependencies]`.
- Add publish metadata (`description`, `keywords`, `categories`) and Apache-2.0 `LICENSE`
  files to the three publishable crates.
- Add a crates.io-oriented `README.md` for `wren-semantic-core`.
- Pin `version` on the internal path dependencies so they resolve from the registry.
- Refresh `CLAUDE.md` docs: the engine builds on upstream DataFusion v53 from crates.io.

## Verification

- `cargo check --all-targets` passes on the `wren-core` workspace.
- All three crates published at `0.1.0`; a fresh crate depending on
  `wren-semantic-core = "0.1"` resolves the full chain from the crates.io registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reference upstream Apache DataFusion releases and aligned the SQL/query-planning descriptions accordingly.
  * Added/expanded READMEs for the core Rust package, including installation and basic usage/capabilities.

* **Chores**
  * Standardized crate/package naming to `wren-semantic-core` across related manifests and dependency declarations.
  * Synced package metadata (description, homepage, keywords, categories) and added/updated Apache 2.0 LICENSE files across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->