### PR TITLE
fix(clickhouse): sanitize brackets in connection-URL userinfo before parse

### DIFF
--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -245,7 +245,6 @@ def _parse_secure_flag(value: Any) -> bool:
     return bool(value)
 
 
-
 def _parse_clickhouse_connection_url(url: str):
     """Parse a ClickHouse URL after escaping raw brackets in userinfo only.
 

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -245,6 +245,39 @@ def _parse_secure_flag(value: Any) -> bool:
     return bool(value)
 
 
+
+def _parse_clickhouse_connection_url(url: str):
+    """Parse a ClickHouse URL after escaping raw brackets in userinfo only.
+
+    ``urllib.parse.urlparse`` treats ``[`` / ``]`` anywhere in the netloc as
+    IPv6 host delimiters. That is correct for hosts like
+    ``clickhouse://[::1]/db`` but it breaks on raw credentials such as
+    ``clickhouse://user:p[a]ss@host/db``. Sanitise only the userinfo segment so
+    valid IPv6 hosts still parse. Mirrors the MySQL connector helper.
+    """
+    scheme_idx = url.find("://")
+    if scheme_idx == -1:
+        return urlparse(url)
+
+    prefix = url[: scheme_idx + 3]
+    rest = url[scheme_idx + 3 :]
+
+    authority_end = len(rest)
+    for separator in "/?#":
+        idx = rest.find(separator)
+        if idx != -1:
+            authority_end = min(authority_end, idx)
+
+    authority = rest[:authority_end]
+    if "@" not in authority:
+        return urlparse(url)
+
+    userinfo, hostinfo = authority.rsplit("@", 1)
+    sanitized_userinfo = userinfo.replace("[", "%5B").replace("]", "%5D")
+    sanitized_url = f"{prefix}{sanitized_userinfo}@{hostinfo}{rest[authority_end:]}"
+    return urlparse(sanitized_url)
+
+
 def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
     """Translate ``ClickHouseConnectionInfo`` / ``ConnectionUrl`` into
     ``clickhouse_connect.get_client`` kwargs."""
@@ -252,7 +285,7 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
     # URL-based connection (``ConnectionUrl``).
     if hasattr(connection_info, "connection_url"):
         url = connection_info.connection_url.get_secret_value()
-        parsed = urlparse(url)
+        parsed = _parse_clickhouse_connection_url(url)
         if parsed.scheme not in {"clickhouse", "clickhouse+http", "clickhouse+https"}:
             raise WrenError(
                 ErrorCode.INVALID_CONNECTION_INFO,

--- a/core/wren/tests/unit/test_clickhouse_helpers.py
+++ b/core/wren/tests/unit/test_clickhouse_helpers.py
@@ -393,3 +393,22 @@ class TestClickHouseUrlKwargs:
             _FakeConnInfoFromUrl("clickhouse://user:pw@host/db?connect_timeout=10")
         )
         assert out["connect_timeout"] == "10"
+
+
+def test_clickhouse_url_allows_raw_brackets_in_password() -> None:
+    """Raw '[' / ']' in userinfo must not raise ValueError from urlparse."""
+    info = _FakeConnInfoFromUrl(
+        "clickhouse://user:p[a]ss@clickhouse-host:9000/analytics"
+    )
+    out = _build_clickhouse_client_kwargs(info)
+    assert out["username"] == "user"
+    assert out["password"] == "p[a]ss"
+    assert out["host"] == "clickhouse-host"
+
+
+def test_clickhouse_url_preserves_ipv6_host_with_bracketed_password() -> None:
+    info = _FakeConnInfoFromUrl("clickhouse://user:p[a]ss@[::1]:9000/analytics")
+    out = _build_clickhouse_client_kwargs(info)
+    assert out["host"] == "::1"
+    assert out["password"] == "p[a]ss"
+    assert out["username"] == "user"


### PR DESCRIPTION
## Summary

- Sanitize raw `[` / `]` in ClickHouse connection-URL userinfo before `urlparse`.
- Preserve legitimate IPv6 hosts that still need brackets around the host.

## Motivation

`urlparse` treats `[` / `]` anywhere in the netloc as IPv6 delimiters. A password like `p[a]ss` therefore raises `ValueError: Invalid IPv6 URL` and the connector never opens. Same root cause already fixed for MySQL / MSSQL / Oracle on this tree — ClickHouse was still on bare `urlparse`.

## Verification

- `PYTHONPATH=src pytest tests/unit/test_clickhouse_helpers.py` → **50 passed**
- Regression tests:
  - `test_clickhouse_url_allows_raw_brackets_in_password`
  - `test_clickhouse_url_preserves_ipv6_host_with_bracketed_password`
- Real behavior without fix: `clickhouse://user:p[a]ss@host:9000/db` → `ValueError: Invalid IPv6 URL`
- With fix: username `user`, password `p[a]ss`, host intact; `clickhouse://user:p[a]ss@[::1]:9000/db` keeps host `::1`.
- Did NOT change decoding of `%`-encoded characters, `unquote_plus` credential handling, secure-port defaults, or query wrapping.

## License

`core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ClickHouse connection URLs when credentials include special characters like `[` or `]`, preventing URL parsing failures.
  * Ensured IPv6 host addresses are parsed correctly while continuing to extract the right username and password from the URL.
* **Tests**
  * Added unit test coverage for bracketed credentials and IPv6 host edge cases in ClickHouse URL parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->