### PR TITLE
fix(snowflake): push LIMIT into SQL and strip trailing semicolon on wrap

### DIFF
--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 import pyarrow as pa
 
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
-
-
-import re
 
 _TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
 
@@ -21,7 +20,6 @@ def _strip_trailing_semicolon(sql: str) -> str:
     postgres/redshift connectors.
     """
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
-
 
 
 def _build_connection_params(connection_info) -> dict:

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -3,10 +3,25 @@
 from __future__ import annotations
 
 import pyarrow as pa
-import snowflake.connector
 
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+
+
+import re
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip terminating ``;`` / whitespace so we can wrap SQL as a subquery.
+
+    Snowflake rejects ``SELECT 1;`` inside a subquery. Only the trailing run is
+    removed so semicolons inside string literals stay intact. Mirrors
+    postgres/redshift connectors.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
+
 
 
 def _build_connection_params(connection_info) -> dict:
@@ -40,7 +55,15 @@ def _build_connection_params(connection_info) -> dict:
 
 
 def make_snowflake_connection(connection_info):
+    import snowflake.connector  # noqa: PLC0415
+
     return snowflake.connector.connect(**_build_connection_params(connection_info))
+
+
+def _programming_error():
+    import snowflake.connector  # noqa: PLC0415
+
+    return snowflake.connector.errors.ProgrammingError
 
 
 class SnowflakeConnector(ConnectorABC):
@@ -48,29 +71,38 @@ class SnowflakeConnector(ConnectorABC):
         self.connection = make_snowflake_connection(connection_info)
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Push LIMIT into Snowflake when requested so we do not download a
+        # full result set only to slice it in Python. Wrap as a subquery so a
+        # trailing semicolon in the user SQL cannot break composition, and so
+        # statements that already contain an ORDER BY keep their ordering
+        # under the outer LIMIT.
+        executed = sql
+        if limit is not None:
+            executed = (
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
+                f"AS _wren_sub LIMIT {int(limit)}"
+            )
         try:
             with self.connection.cursor() as cursor:
-                cursor.execute(sql)
+                cursor.execute(executed)
                 arrow_table = cursor.fetch_arrow_all()
-        except snowflake.connector.errors.ProgrammingError as e:
+        except _programming_error() as e:
             raise WrenError(
                 ErrorCode.INVALID_SQL,
                 str(e),
                 phase=ErrorPhase.SQL_EXECUTION,
-                metadata={DIALECT_SQL: sql},
+                metadata={DIALECT_SQL: executed},
             ) from e
 
         if arrow_table is None:
             return pa.table({})
-        if limit is not None:
-            return arrow_table.slice(0, limit)
         return arrow_table
 
     def dry_run(self, sql: str) -> None:
         try:
             with self.connection.cursor() as cursor:
                 cursor.describe(sql)
-        except snowflake.connector.errors.ProgrammingError as e:
+        except _programming_error() as e:
             raise WrenError(
                 ErrorCode.INVALID_SQL,
                 str(e),

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -76,9 +76,12 @@ class SnowflakeConnector(ConnectorABC):
         # under the outer LIMIT.
         executed = sql
         if limit is not None:
+            # Place the user SQL on its own line so a trailing line comment
+            # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
             executed = (
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
-                f"AS _wren_sub LIMIT {int(limit)}"
+                "SELECT * FROM (\n"
+                f"{_strip_trailing_semicolon(sql)}\n"
+                f") AS _wren_sub LIMIT {int(limit)}"
             )
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/tests/unit/test_snowflake_limit_pushdown.py
+++ b/core/wren/tests/unit/test_snowflake_limit_pushdown.py
@@ -1,0 +1,43 @@
+"""Snowflake connector pushes LIMIT into SQL instead of Python slicing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+from wren.connector.snowflake import SnowflakeConnector, _strip_trailing_semicolon
+
+pytestmark = pytest.mark.unit
+
+
+def test_strip_trailing_semicolon_preserves_interior():
+    assert _strip_trailing_semicolon("SELECT 'a;b' FROM t;  ") == "SELECT 'a;b' FROM t"
+
+
+def test_query_pushes_limit_into_sql_and_strips_semicolon():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    cursor.fetch_arrow_all.return_value = pa.table({"x": [1, 2]})
+
+    table = connector.query("SELECT 1 AS x;", limit=5)
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (SELECT 1 AS x) AS _wren_sub LIMIT 5"
+    )
+    assert table.num_rows == 2
+
+
+def test_query_without_limit_runs_original_sql():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    cursor.fetch_arrow_all.return_value = pa.table({})
+
+    connector.query("SELECT 1")
+
+    cursor.execute.assert_called_once_with("SELECT 1")

--- a/core/wren/tests/unit/test_snowflake_limit_pushdown.py
+++ b/core/wren/tests/unit/test_snowflake_limit_pushdown.py
@@ -26,9 +26,25 @@ def test_query_pushes_limit_into_sql_and_strips_semicolon():
     table = connector.query("SELECT 1 AS x;", limit=5)
 
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (SELECT 1 AS x) AS _wren_sub LIMIT 5"
+        "SELECT * FROM (\nSELECT 1 AS x\n) AS _wren_sub LIMIT 5"
     )
     assert table.num_rows == 2
+
+
+def test_query_limit_survives_trailing_line_comment():
+    # A trailing `-- comment` in the user SQL must not swallow the wrapper's
+    # closing paren, alias, or LIMIT clause; the newline terminates it.
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    cursor.fetch_arrow_all.return_value = pa.table({"x": [1]})
+
+    connector.query("SELECT 1 AS x  -- pick one", limit=5)
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 AS x  -- pick one\n) AS _wren_sub LIMIT 5"
+    )
 
 
 def test_query_without_limit_runs_original_sql():


### PR DESCRIPTION
## Summary

- Push `query(..., limit=N)` into Snowflake SQL via `SELECT * FROM (<sql>) AS _wren_sub LIMIT N`.
- Strip a trailing semicolon before wrapping so `;`-terminated user SQL cannot break composition.
- Lazy-import `snowflake.connector` so unit tests do not require the optional extra.

## Motivation

The previous path ran the full statement and used `arrow_table.slice(0, limit)`. Large queries paid full scan + transfer cost on the client even when Aster only needed a sample/page. Other connectors (postgres/redshift/clickhouse/trino) already apply LIMIT server-side; Snowflake was the outlier. Trailing-semicolon strip matches the established wrap helpers.

## Verification

- `PYTHONPATH=src pytest tests/unit/test_snowflake_limit_pushdown.py` → **3 passed**
- Asserted executed SQL for `SELECT 1 AS x;` + `limit=5` is  
  `SELECT * FROM (SELECT 1 AS x) AS _wren_sub LIMIT 5`
- Without `limit`, original SQL is executed unchanged.

## License

`core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Snowflake query execution with `limit` by pushing the LIMIT into the SQL run on Snowflake rather than slicing results in Python.
  * More reliable SQL wrapping by stripping only a trailing semicolon/whitespace (while keeping semicolons inside quoted strings and respecting line-comment boundaries).
  * Updated Snowflake diagnostics so reported SQL reflects the actual composed query that was executed (including for `dry_run`).
* **Tests**
  * Added unit coverage for trailing-semicolon cleanup, LIMIT pushdown SQL rewriting, and the no-limit execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->