### PR TITLE
fix(athena): push LIMIT into SQL and strip trailing semicolon on wrap

### DIFF
--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -315,13 +315,20 @@ class AthenaConnector(ConnectorABC):
         self.connection = connect(**_build_connect_kwargs(connection_info))
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Push LIMIT into Athena when requested so Presto/Trino-flavoured
+        # engines can stop early instead of us downloading a full result and
+        # slicing in Python. Subquery-wrap + trailing-semicolon strip keeps
+        # composition valid for client SQL terminated with ``;``.
+        executed = sql
+        if limit is not None:
+            executed = (
+                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
+                f"AS _wren_sub LIMIT {int(limit)}"
+            )
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
-                cursor.execute(sql)
-                table = _build_athena_arrow_table(cursor)
-            if limit is not None:
-                table = table.slice(0, limit)
-            return table
+                cursor.execute(executed)
+                return _build_athena_arrow_table(cursor)
         except (WrenError, TimeoutError):
             raise
         except Exception as e:
@@ -329,7 +336,7 @@ class AthenaConnector(ConnectorABC):
                 ErrorCode.INVALID_SQL,
                 str(e),
                 phase=ErrorPhase.SQL_EXECUTION,
-                metadata={DIALECT_SQL: sql},
+                metadata={DIALECT_SQL: executed},
             ) from e
 
     def dry_run(self, sql: str) -> None:

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -321,9 +321,13 @@ class AthenaConnector(ConnectorABC):
         # composition valid for client SQL terminated with ``;``.
         executed = sql
         if limit is not None:
+            # Multiline wrap: trailing `--` line comments must not eat the
+            # closing `) AS _wren_sub LIMIT n` (goldmedal review on #2457;
+            # same guard as Snowflake #2456).
             executed = (
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
-                f"AS _wren_sub LIMIT {int(limit)}"
+                "SELECT * FROM (\n"
+                f"{_strip_trailing_semicolon(sql)}\n"
+                f") AS _wren_sub LIMIT {int(limit)}"
             )
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -321,9 +321,10 @@ class AthenaConnector(ConnectorABC):
         # composition valid for client SQL terminated with ``;``.
         executed = sql
         if limit is not None:
-            # Multiline wrap: trailing `--` line comments must not eat the
-            # closing `) AS _wren_sub LIMIT n` (goldmedal review on #2457;
-            # same guard as Snowflake #2456).
+            # Multiline wrap so a trailing `-- line comment` in the inner SQL
+            # is terminated by the newline instead of swallowing the closing
+            # `) AS _wren_sub LIMIT n`. (Single-line sibling connectors don't
+            # guard this.)
             executed = (
                 "SELECT * FROM (\n"
                 f"{_strip_trailing_semicolon(sql)}\n"

--- a/core/wren/tests/unit/test_athena_connector.py
+++ b/core/wren/tests/unit/test_athena_connector.py
@@ -237,7 +237,7 @@ def test_connector_query_returns_arrow_table_and_respects_limit():
     assert table.num_rows == 2
     assert table.column("id").to_pylist() == [1, 2]
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (SELECT id, name FROM t) AS _wren_sub LIMIT 2"
+        "SELECT * FROM (\nSELECT id, name FROM t\n) AS _wren_sub LIMIT 2"
     )
 
 

--- a/core/wren/tests/unit/test_athena_connector.py
+++ b/core/wren/tests/unit/test_athena_connector.py
@@ -224,9 +224,11 @@ def test_connector_query_passes_kwargs_and_kills_on_interrupt():
 
 
 def test_connector_query_returns_arrow_table_and_respects_limit():
+    # limit is pushed into SQL; the driver is expected to return only
+    # the limited result (as Athena would). Assert pushdown shape too.
     cursor = _make_cursor(
         [("id", "integer"), ("name", "varchar")],
-        [(1, "a"), (2, "b"), (3, "c")],
+        [(1, "a"), (2, "b")],
     )
     _pyathena_connection_mock.cursor.return_value = cursor
 
@@ -234,7 +236,9 @@ def test_connector_query_returns_arrow_table_and_respects_limit():
     table = conn.query("SELECT id, name FROM t", limit=2)
     assert table.num_rows == 2
     assert table.column("id").to_pylist() == [1, 2]
-    cursor.execute.assert_called_once_with("SELECT id, name FROM t")
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (SELECT id, name FROM t) AS _wren_sub LIMIT 2"
+    )
 
 
 def test_connector_query_wraps_driver_errors():

--- a/core/wren/tests/unit/test_athena_limit_pushdown.py
+++ b/core/wren/tests/unit/test_athena_limit_pushdown.py
@@ -1,0 +1,62 @@
+"""Athena connector pushes LIMIT into SQL instead of Python slicing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wren.connector.athena import AthenaConnector, _strip_trailing_semicolon
+
+pytestmark = pytest.mark.unit
+
+
+def test_strip_trailing_semicolon_preserves_interior():
+    assert _strip_trailing_semicolon("SELECT 'a;b';") == "SELECT 'a;b'"
+
+
+def test_query_pushes_limit_into_sql():
+    connector = AthenaConnector.__new__(AthenaConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    cursor.description = []
+    # builder path for empty description
+    connector.connection.cursor.return_value = cursor
+
+    with patch(
+        "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
+    ) as builder:
+        # contextlib.closing expects .close()
+        cursor.close = MagicMock()
+        # wrap closing: connection.cursor() is used as CM via closing()
+        with patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)):
+            connector.query("SELECT 1;", limit=3)
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (SELECT 1) AS _wren_sub LIMIT 3"
+    )
+    builder.assert_called_once()
+
+
+class _CM:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __enter__(self):
+        return self.obj
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_query_without_limit_runs_original_sql():
+    connector = AthenaConnector.__new__(AthenaConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    cursor.close = MagicMock()
+    with patch(
+        "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
+    ), patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)):
+        connector.connection.cursor.return_value = cursor
+        connector.query("SELECT 1")
+    cursor.execute.assert_called_once_with("SELECT 1")

--- a/core/wren/tests/unit/test_athena_limit_pushdown.py
+++ b/core/wren/tests/unit/test_athena_limit_pushdown.py
@@ -33,7 +33,7 @@ def test_query_pushes_limit_into_sql():
             connector.query("SELECT 1;", limit=3)
 
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (SELECT 1) AS _wren_sub LIMIT 3"
+        "SELECT * FROM (\nSELECT 1\n) AS _wren_sub LIMIT 3"
     )
     builder.assert_called_once()
 
@@ -60,3 +60,19 @@ def test_query_without_limit_runs_original_sql():
         connector.connection.cursor.return_value = cursor
         connector.query("SELECT 1")
     cursor.execute.assert_called_once_with("SELECT 1")
+
+
+def test_query_limit_survives_trailing_line_comment():
+    """Trailing `--` must not eat the wrap (goldmedal #2457)."""
+    connector = AthenaConnector.__new__(AthenaConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    cursor.close = MagicMock()
+    with patch(
+        "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
+    ), patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)):
+        connector.connection.cursor.return_value = cursor
+        connector.query("SELECT 1 -- pick", limit=3)
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 -- pick\n) AS _wren_sub LIMIT 3"
+    )


### PR DESCRIPTION
## Summary

- Push `query(..., limit=N)` into Athena SQL via `SELECT * FROM (<sql>) AS _wren_sub LIMIT N`.
- Strip a trailing semicolon before wrapping so `;`-terminated user SQL cannot break composition.

## Motivation

Previously the connector ran the full statement and used `table.slice(0, limit)`. Athena (Presto/Trino-flavoured) can stop early when LIMIT is in the plan; client-side slicing paid full scan + transfer cost. Same pattern as redshift/postgres/clickhouse/snowflake pushdown helpers.

## Verification

- `PYTHONPATH=src pytest tests/unit/test_athena_limit_pushdown.py` → **3 passed**
- Asserted executed SQL for `SELECT 1;` + `limit=3` is  
  `SELECT * FROM (SELECT 1) AS _wren_sub LIMIT 3`
- Without `limit`, original SQL is executed unchanged.

## License

`core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Athena query execution by pushing `limit` into the generated SQL via subquery wrapping and appending `LIMIT <n>` (instead of slicing results in Python).
  * Clean input SQL by removing only trailing semicolons/extra whitespace; trailing `--` comments are handled safely.
  * Enhanced error reporting by recording the exact composed SQL that was executed.

* **Tests**
  * Added coverage for trailing semicolon stripping (preserving semicolons inside quoted strings) and correct handling of trailing line comments.
  * Expanded Athena connector tests to verify SQL wrapping/`LIMIT` pushdown and that returned Arrow tables respect the requested row count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->