### PR TITLE
ci(core): automate Rust core crate releases via release-please

### DIFF
--- a/.github/workflows/publish-wren-crates.yml
+++ b/.github/workflows/publish-wren-crates.yml
@@ -1,0 +1,72 @@
+name: Publish Rust core crates to crates.io
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version number (e.g. 0.2.0)"
+        required: true
+        type: string
+      tag_name:
+        description: "Git tag to checkout (e.g. wren-semantic-core-v0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build + publish crates to crates.io
+    runs-on: ubuntu-latest
+    # Required by the crates.io Trusted Publisher config (Environment name:
+    # crates-io). The 'crates-io' environment must exist under repo
+    # Settings → Environments.
+    environment: crates-io
+    permissions:
+      contents: read
+      # Needed for the OIDC token exchange with crates.io (Trusted Publishing).
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name }}
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            core/wren-core/target/
+          key: crates-cargo-${{ hashFiles('core/wren-core/Cargo.toml', 'core/wren-core-base/Cargo.toml') }}
+          restore-keys: crates-cargo-
+
+      # Mints a short-lived crates.io token via OIDC — no stored secret.
+      - name: Authenticate to crates.io (Trusted Publishing)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      # Publish bottom-up: each downstream crate pins the exact version of its
+      # in-repo dependency, so the upstream crate must be live on the index
+      # first. `cargo publish` (cargo >= 1.66) blocks until the just-published
+      # crate is available before returning, so the chain resolves in order.
+      - name: Publish wren-manifest-macro
+        run: cargo publish --manifest-path core/wren-core-base/manifest-macro/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish wren-core-base
+        run: cargo publish --manifest-path core/wren-core-base/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish wren-semantic-core
+        run: cargo publish --manifest-path core/wren-core/core/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,11 @@ jobs:
       wren-pydantic--release_created: ${{ steps.release.outputs['sdk/wren-pydantic--release_created'] }}
       wren-pydantic--tag_name: ${{ steps.release.outputs['sdk/wren-pydantic--tag_name'] }}
       wren-pydantic--version: ${{ steps.release.outputs['sdk/wren-pydantic--version'] }}
+      # The three Rust core crates share one version via the linked-versions
+      # plugin and release together, so gating on wren-semantic-core covers all.
+      wren-semantic-core--release_created: ${{ steps.release.outputs['core/wren-core--release_created'] }}
+      wren-semantic-core--tag_name: ${{ steps.release.outputs['core/wren-core--tag_name'] }}
+      wren-semantic-core--version: ${{ steps.release.outputs['core/wren-core--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -103,6 +108,21 @@ jobs:
     with:
       version: ${{ needs.release-please.outputs['wren-pydantic--version'] }}
       tag_name: ${{ needs.release-please.outputs['wren-pydantic--tag_name'] }}
+    permissions:
+      contents: read
+      id-token: write
+
+  # Publishes wren-manifest-macro, wren-core-base, and wren-semantic-core to
+  # crates.io bottom-up in one run. The three crates are linked to a single
+  # version, so a release always bumps all three together — gating on the
+  # wren-semantic-core output is sufficient.
+  publish-wren-crates:
+    needs: release-please
+    if: needs.release-please.outputs['wren-semantic-core--release_created'] == 'true'
+    uses: ./.github/workflows/publish-wren-crates.yml
+    with:
+      version: ${{ needs.release-please.outputs['wren-semantic-core--version'] }}
+      tag_name: ${{ needs.release-please.outputs['wren-semantic-core--tag_name'] }}
     permissions:
       contents: read
       id-token: write

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,8 @@
   "core/wren": "0.12.0",
   "core/wren-core-wasm": "0.4.1",
   "sdk/wren-langchain": "0.2.0",
-  "sdk/wren-pydantic": "0.2.0"
+  "sdk/wren-pydantic": "0.2.0",
+  "core/wren-core-base/manifest-macro": "0.1.0",
+  "core/wren-core-base": "0.1.0",
+  "core/wren-core": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -71,9 +71,14 @@
     },
     "core/wren-core": {
       "component": "wren-semantic-core",
-      "release-type": "rust",
+      "release-type": "simple",
       "bump-minor-pre-major": true,
       "extra-files": [
+        {
+          "path": "Cargo.toml",
+          "type": "toml",
+          "jsonpath": "$.workspace.package.version"
+        },
         {
           "path": "Cargo.toml",
           "type": "toml",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -51,6 +51,46 @@
       "extra-files": [
         "src/wren_pydantic/__init__.py"
       ]
+    },
+    "core/wren-core-base/manifest-macro": {
+      "component": "wren-manifest-macro",
+      "release-type": "rust",
+      "bump-minor-pre-major": true
+    },
+    "core/wren-core-base": {
+      "component": "wren-core-base",
+      "release-type": "rust",
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "path": "Cargo.toml",
+          "type": "toml",
+          "jsonpath": "$.dependencies.wren-manifest-macro.version"
+        }
+      ]
+    },
+    "core/wren-core": {
+      "component": "wren-semantic-core",
+      "release-type": "rust",
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "path": "Cargo.toml",
+          "type": "toml",
+          "jsonpath": "$.workspace.dependencies.wren-core-base.version"
+        }
+      ]
     }
-  }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "wren-rust-core",
+      "components": [
+        "wren-manifest-macro",
+        "wren-core-base",
+        "wren-semantic-core"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## What & why

The Rust core crates were published to crates.io manually. This adds an automated release
line for them via release-please + a reusable publish workflow, matching how the Python
(`wren-core-py`, `wren`) and npm (`wren-core-wasm`) packages are already released.

Three publishable crates form a bottom-up dependency chain:

| crates.io name | path | depends on |
| --- | --- | --- |
| `wren-manifest-macro` | `core/wren-core-base/manifest-macro` | — |
| `wren-core-base` | `core/wren-core-base` | `wren-manifest-macro` |
| `wren-semantic-core` | `core/wren-core` (workspace member `core`) | `wren-core-base` |

## Changes

- **`release-please-config.json`** — add the three crates as `release-type: rust` packages,
  grouped with the **`linked-versions`** plugin so they always share one version and land in a
  single release PR. Cross-crate pinned dependency requirements are kept in sync with
  `type: "toml"` `extra-files` updaters (same mechanism already used for the `uv.lock` bumps).
- **`.release-please-manifest.json`** — seed the three paths at the current `0.1.0`.
- **`.github/workflows/publish-wren-crates.yml`** (new) — reusable workflow that publishes the
  chain bottom-up in one run. Uses **crates.io Trusted Publishing** (`rust-lang/crates-io-auth-action`,
  OIDC, no stored token) — the same token-less pattern as the PyPI/npm publishers. `cargo publish`
  blocks until each crate is live on the index before the next, so the pinned deps resolve in order.
- **`.github/workflows/release-please.yml`** — expose the `wren-semantic-core` outputs and add a
  `publish-wren-crates` job gated on `release_created` (linked crates release together, so gating
  on the top crate covers all three).

## Verification

- `cargo publish --dry-run` passes for all three crates (each packages and builds cleanly).
- `actionlint` clean on both workflow files.
- `release-please release-pr --dry-run` against this branch parses the config and resolves all
  three new packages as `rust` with the `linked-versions` plugin, no errors.

## Follow-up (one-time, repo-admin — not in this PR)

Trusted Publishing needs a one-time setup before the first automated publish:

1. On crates.io, add a Trusted Publisher for each of the three crates → repo `Canner/WrenAI`,
   workflow `publish-wren-crates.yml`, environment `crates-io`.
2. Create the `crates-io` GitHub environment under repo Settings → Environments (mirrors the
   existing `npm` / `pypi` environments).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated crates.io publishing for the core Rust crates when a semantic core release is created.
  * Extended automated release metadata to propagate version and tag details for downstream publishing.
  * Ensured publish runs in the correct dependency order to support successful crate releases.
* **Chores**
  * Improved release automation configuration to include additional core components and linked version extraction.
  * Enabled secure, tokenless authentication and build caching during publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->