### PR TITLE
fix(datafusion): strip trailing semicolon before dry_run

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -56,7 +56,11 @@ class DataFusionConnector(ConnectorABC):
         return reader.read_all()
 
     def dry_run(self, sql: str) -> None:
-        self.ctx.dry_run(sql)
+        # Trailing semicolons break DataFusion's dry-run path the same way they
+        # break the LIMIT subquery wrap (``SELECT 1;`` is a multi-statement batch
+        # the planner rejects). Strip only the terminating run so ';' inside
+        # string literals stays intact — same helper already used by ``query``.
+        self.ctx.dry_run(_strip_trailing_semicolon(sql))
 
     def close(self) -> None:
         pass

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -59,3 +59,25 @@ def test_helper_preserves_semicolon_inside_string_literal() -> None:
 
 def test_helper_no_trailing_semicolon_unchanged() -> None:
     assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.dry_run("SELECT 1;")
+    (sent,), _ = ctx.dry_run.call_args
+    assert sent == "SELECT 1"
+    assert not sent.endswith(";")
+
+
+def test_dry_run_strips_semicolon_and_whitespace() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.dry_run("SELECT 1;  \n")
+    (sent,), _ = ctx.dry_run.call_args
+    assert sent == "SELECT 1"
+
+
+def test_dry_run_preserves_semicolon_inside_string_literal() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.dry_run("SELECT ';' AS x")
+    (sent,), _ = ctx.dry_run.call_args
+    assert sent == "SELECT ';' AS x"


### PR DESCRIPTION
## Summary

- Strip trailing semicolons in DataFusion `dry_run` via the existing helper already used by `query`.
- User SQL ending in `;` no longer fails validation while limit wraps already worked.

## Motivation

Other connectors (postgres, redshift, duckdb, databricks, athena) neutralize trailing semicolons before dry-run / subquery wrap. DataFusion already stripped before LIMIT wraps in `query`, but `dry_run` passed SQL through verbatim, so `SELECT 1;` still hit the parser as multi-statement / invalid at plan time. Reuse `_strip_trailing_semicolon` so dry-run matches query behavior without inventing a second path.

## Verification

- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_datafusion_semicolon.py -q` — 7 passed
- Real behavior proof (mocked ctx): `dry_run("SELECT 1;")` now invokes `ctx.dry_run("SELECT 1")`; `SELECT ';' AS x` preserved
- Did NOT change: query LIMIT-wrap path (already correct); Apache-2.0 path `core/**`

## License

Touches `core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `dry_run` SQL preprocessing by stripping only trailing semicolons and surrounding trailing whitespace/newlines.
  * Preserved semicolons inside quoted string literals.

* **Tests**
  * Added unit tests covering `dry_run("SELECT 1;")`, `dry_run("SELECT 1;  \n")`, and `dry_run("SELECT ';' AS x")`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->