### PR TITLE
fix(spark): strip trailing semicolon before sql/dry_run

### DIFF
--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -1,7 +1,22 @@
+import re
+
 import pyarrow as pa
 
 from wren.connector.base import ConnectorABC
 from wren.model import SparkConnectionInfo
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip trailing ``;`` / whitespace so Spark Connect does not treat input as multi-statement.
+
+    ``SparkSession.sql`` / connect clients commonly reject or mishandle a trailing
+    semicolon when composing limits or dry-runs. Only the terminating run is
+    removed so ``SELECT ';'`` literals stay intact — same pattern as postgres /
+    redshift / duckdb connectors.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class SparkConnector(ConnectorABC):
@@ -22,7 +37,7 @@ class SparkConnector(ConnectorABC):
         )
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        df = self.connection.sql(sql).toPandas()
+        df = self.connection.sql(_strip_trailing_semicolon(sql)).toPandas()
         if hasattr(df, "attrs") and df.attrs:
             df.attrs = {
                 k: v
@@ -35,7 +50,7 @@ class SparkConnector(ConnectorABC):
         return arrow_table
 
     def dry_run(self, sql: str) -> None:
-        self.connection.sql(sql).limit(0).count()
+        self.connection.sql(_strip_trailing_semicolon(sql)).limit(0).count()
 
     def close(self) -> None:
         if self._closed:

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -1,22 +1,7 @@
-import re
-
 import pyarrow as pa
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import SparkConnectionInfo
-
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip trailing ``;`` / whitespace so Spark Connect does not treat input as multi-statement.
-
-    ``SparkSession.sql`` / connect clients commonly reject or mishandle a trailing
-    semicolon when composing limits or dry-runs. Only the terminating run is
-    removed so ``SELECT ';'`` literals stay intact — same pattern as postgres /
-    redshift / duckdb connectors.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class SparkConnector(ConnectorABC):
@@ -37,7 +22,7 @@ class SparkConnector(ConnectorABC):
         )
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        df = self.connection.sql(_strip_trailing_semicolon(sql)).toPandas()
+        df = self.connection.sql(strip_trailing_semicolon(sql)).toPandas()
         if hasattr(df, "attrs") and df.attrs:
             df.attrs = {
                 k: v
@@ -50,7 +35,7 @@ class SparkConnector(ConnectorABC):
         return arrow_table
 
     def dry_run(self, sql: str) -> None:
-        self.connection.sql(_strip_trailing_semicolon(sql)).limit(0).count()
+        self.connection.sql(strip_trailing_semicolon(sql)).limit(0).count()
 
     def close(self) -> None:
         if self._closed:

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -1,0 +1,42 @@
+"""Trailing-semicolon stripping for the Spark connector (mocked session)."""
+
+from unittest.mock import MagicMock
+
+from wren.connector.spark import SparkConnector, _strip_trailing_semicolon
+
+
+def _make_mock_connector() -> tuple[SparkConnector, MagicMock]:
+    connector = SparkConnector.__new__(SparkConnector)
+    session = MagicMock()
+    connector.connection = session
+    connector._closed = False
+    return connector, session
+
+
+def test_query_strips_trailing_semicolon_before_sql() -> None:
+    connector, session = _make_mock_connector()
+    df = MagicMock()
+    df.attrs = {}
+    dfto = MagicMock()
+    # pandas DF mock for pa.Table.from_pandas
+    import pandas as pd
+
+    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2, 3]})
+    connector.query("SELECT 1;", limit=2)
+    session.sql.assert_called_once_with("SELECT 1")
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, session = _make_mock_connector()
+    connector.dry_run("SELECT 1;  \n")
+    session.sql.assert_called_once_with("SELECT 1")
+    session.sql.return_value.limit.assert_called_once_with(0)
+
+
+def test_helper_preserves_semicolon_inside_string_literal() -> None:
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_no_trailing_semicolon_unchanged() -> None:
+    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import MagicMock
 
-from wren.connector.spark import SparkConnector, _strip_trailing_semicolon
+from wren.connector.base import strip_trailing_semicolon
+from wren.connector.spark import SparkConnector
 
 
 def _make_mock_connector() -> tuple[SparkConnector, MagicMock]:
@@ -32,8 +33,8 @@ def test_dry_run_strips_trailing_semicolon() -> None:
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:
     sql = "SELECT 'a;b' AS x"
-    assert _strip_trailing_semicolon(sql) == sql
+    assert strip_trailing_semicolon(sql) == sql
 
 
 def test_helper_no_trailing_semicolon_unchanged() -> None:
-    assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+    assert strip_trailing_semicolon("SELECT 1") == "SELECT 1"

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -15,9 +15,6 @@ def _make_mock_connector() -> tuple[SparkConnector, MagicMock]:
 
 def test_query_strips_trailing_semicolon_before_sql() -> None:
     connector, session = _make_mock_connector()
-    df = MagicMock()
-    df.attrs = {}
-    dfto = MagicMock()
     # pandas DF mock for pa.Table.from_pandas
     import pandas as pd
 


### PR DESCRIPTION
## Summary

- Strip trailing `;` / whitespace before Spark Connect `sql()` in both `query` and `dry_run`.
- Client SQL ending in a semicolon no longer fails or mis-parses on Spark Connect.

## Motivation

Postgres/redshift/duckdb/databricks/datafusion already sanitize trailing semicolons before plan/execute paths. Spark still passed raw SQL into `SparkSession.sql(...)`, so statements like `SELECT 1;` hit Connect/parser multi-statement roughness and pouch provenance protection. Reuse the terminating-run strip helper so literals such as `SELECT ';'` stay intact while terminal `;` is removed.

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_spark_semicolon.py -q` — 4 passed
- Mocked session: `query("SELECT 1;", limit=2)` calls `sql("SELECT 1")`; dry_run strips trailing whitespace+semicolon
- Did NOT change: client-side Arrow slice limit behavior

## License

`core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spark SQL execution by automatically removing trailing semicolons (and surrounding whitespace/newlines) before running queries.
  * Ensured semicolons inside string literals remain unchanged.
  * Preserved dry-run behavior, including keeping the limit at zero.
* **Tests**
  * Added unit coverage for trailing-semicolon normalization for both query execution and dry-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->