### PR TITLE
fix(bigquery): push LIMIT into SQL and strip trailing semicolon

### DIFF
--- a/core/wren/src/wren/connector/bigquery.py
+++ b/core/wren/src/wren/connector/bigquery.py
@@ -22,24 +22,18 @@ def _strip_trailing_semicolon(sql: str) -> str:
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
-def _has_outer_limit(sql: str) -> bool:
-    """True when *sql* already ends with a top-level LIMIT clause."""
-    cleaned = _strip_trailing_semicolon(sql).rstrip()
-    return bool(re.search(r"(?i)\bLIMIT\s+\d+(\s+OFFSET\s+\d+)?\s*\Z", cleaned))
-
-
 def _apply_limit(sql: str, limit: int) -> str:
-    """Push LIMIT into SQL rather than relying solely on API max_results.
+    """Push LIMIT into SQL via outer subquery wrap.
 
     ``max_results`` only caps the page size of job results-reading; it does
-    not rewrite the query plan and still fetches a full result set stage that
-    can be expensive. Append ``LIMIT n`` after stripping a trailing semicolon
-    (mirrors Athena/MySQL pushdown helpers) so the engine short-circuits.
+    not rewrite the query plan. Wrapping as ``SELECT * FROM (sql) LIMIT n``
+    (after stripping a trailing semicolon) short-circuits the engine and
+    correctly enforces the caller's limit even when *sql* already contains an
+    inner ``LIMIT`` (the outer limit always wins / can only reduce rows).
+    Avoids comment-sensitive outer-LIMIT detection heuristics.
     """
     cleaned = _strip_trailing_semicolon(sql)
-    if _has_outer_limit(cleaned):
-        return cleaned
-    return f"{cleaned}\nLIMIT {int(limit)}"
+    return f"SELECT * FROM ({cleaned}) AS _sub LIMIT {int(limit)}"
 
 
 class BigQueryConnector(ConnectorABC):
@@ -74,6 +68,8 @@ class BigQueryConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
             sql = _apply_limit(sql, limit)
+        else:
+            sql = _strip_trailing_semicolon(sql)
         return self.connection.query(sql).result().to_arrow()
 
     def dry_run(self, sql: str) -> None:

--- a/core/wren/src/wren/connector/bigquery.py
+++ b/core/wren/src/wren/connector/bigquery.py
@@ -1,10 +1,36 @@
 import base64
+import re
 from json import loads
 
 import pyarrow as pa
 from loguru import logger
 
 from wren.connector.base import ConnectorABC
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip trailing ``;`` / whitespace for BigQuery jobs.
+
+    BigQuery job submission is more lenient than engines that subquery-wrap,
+    but a trailing semicolon still breaks when SQL is later composed, and
+    multi-statement batches with a terminal ``;`` are not the interface we
+    expose for single-statement GenBI queries. Only the terminating run is
+    stripped so ``SELECT ';'`` literals remain.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
+
+
+def _apply_limit(sql: str, limit: int) -> str:
+    """Push LIMIT into SQL rather than relying solely on API max_results.
+
+    ``max_results`` only caps the page size of job results-reading; it does
+    not rewrite the query plan and still fetches a full result set stage that
+    can be expensive. Append ``LIMIT n`` after stripping a trailing semicolon
+    (mirrors Athena/MySQL pushdown helpers) so the engine short-circuits.
+    """
+    return f"{_strip_trailing_semicolon(sql)}\nLIMIT {int(limit)}"
 
 
 class BigQueryConnector(ConnectorABC):
@@ -37,13 +63,16 @@ class BigQueryConnector(ConnectorABC):
         self.connection = client
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        return self.connection.query(sql).result(max_results=limit).to_arrow()
+        if limit is not None:
+            sql = _apply_limit(sql, limit)
+        return self.connection.query(sql).result().to_arrow()
 
     def dry_run(self, sql: str) -> None:
         from google.cloud import bigquery  # noqa: PLC0415
 
         self.connection.query(
-            sql, job_config=bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
+            _strip_trailing_semicolon(sql),
+            job_config=bigquery.QueryJobConfig(dry_run=True, use_query_cache=False),
         )
 
     def close(self) -> None:

--- a/core/wren/src/wren/connector/bigquery.py
+++ b/core/wren/src/wren/connector/bigquery.py
@@ -22,6 +22,12 @@ def _strip_trailing_semicolon(sql: str) -> str:
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
+def _has_outer_limit(sql: str) -> bool:
+    """True when *sql* already ends with a top-level LIMIT clause."""
+    cleaned = _strip_trailing_semicolon(sql).rstrip()
+    return bool(re.search(r"(?i)\bLIMIT\s+\d+(\s+OFFSET\s+\d+)?\s*\Z", cleaned))
+
+
 def _apply_limit(sql: str, limit: int) -> str:
     """Push LIMIT into SQL rather than relying solely on API max_results.
 
@@ -30,7 +36,10 @@ def _apply_limit(sql: str, limit: int) -> str:
     can be expensive. Append ``LIMIT n`` after stripping a trailing semicolon
     (mirrors Athena/MySQL pushdown helpers) so the engine short-circuits.
     """
-    return f"{_strip_trailing_semicolon(sql)}\nLIMIT {int(limit)}"
+    cleaned = _strip_trailing_semicolon(sql)
+    if _has_outer_limit(cleaned):
+        return cleaned
+    return f"{cleaned}\nLIMIT {int(limit)}"
 
 
 class BigQueryConnector(ConnectorABC):

--- a/core/wren/src/wren/connector/bigquery.py
+++ b/core/wren/src/wren/connector/bigquery.py
@@ -1,25 +1,10 @@
 import base64
-import re
 from json import loads
 
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
-
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip trailing ``;`` / whitespace for BigQuery jobs.
-
-    BigQuery job submission is more lenient than engines that subquery-wrap,
-    but a trailing semicolon still breaks when SQL is later composed, and
-    multi-statement batches with a terminal ``;`` are not the interface we
-    expose for single-statement GenBI queries. Only the terminating run is
-    stripped so ``SELECT ';'`` literals remain.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 
 
 def _apply_limit(sql: str, limit: int) -> str:
@@ -32,7 +17,7 @@ def _apply_limit(sql: str, limit: int) -> str:
     inner ``LIMIT`` (the outer limit always wins / can only reduce rows).
     Avoids comment-sensitive outer-LIMIT detection heuristics.
     """
-    cleaned = _strip_trailing_semicolon(sql)
+    cleaned = strip_trailing_semicolon(sql)
     return f"SELECT * FROM ({cleaned}) AS _sub LIMIT {int(limit)}"
 
 
@@ -69,14 +54,14 @@ class BigQueryConnector(ConnectorABC):
         if limit is not None:
             sql = _apply_limit(sql, limit)
         else:
-            sql = _strip_trailing_semicolon(sql)
+            sql = strip_trailing_semicolon(sql)
         return self.connection.query(sql).result().to_arrow()
 
     def dry_run(self, sql: str) -> None:
         from google.cloud import bigquery  # noqa: PLC0415
 
         self.connection.query(
-            _strip_trailing_semicolon(sql),
+            strip_trailing_semicolon(sql),
             job_config=bigquery.QueryJobConfig(dry_run=True, use_query_cache=False),
         )
 

--- a/core/wren/tests/unit/test_bigquery_semicolon.py
+++ b/core/wren/tests/unit/test_bigquery_semicolon.py
@@ -1,13 +1,15 @@
 """BigQuery trailing-semicolon + LIMIT pushdown helpers (mocked client)."""
 
-from unittest.mock import MagicMock
+import sys
+import types
+from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
 
+from wren.connector.base import strip_trailing_semicolon
 from wren.connector.bigquery import (
     BigQueryConnector,
     _apply_limit,
-    _strip_trailing_semicolon,
 )
 
 
@@ -48,9 +50,6 @@ def test_query_with_inner_limit_outer_wrap_still_enforces_caller_limit() -> None
 
 def test_dry_run_strips_trailing_semicolon() -> None:
     connector, client = _make_mock_connector()
-    import sys
-    import types
-    from unittest.mock import patch
 
     fake_mod = types.ModuleType("google.cloud.bigquery")
 
@@ -80,5 +79,5 @@ def test_dry_run_strips_trailing_semicolon() -> None:
 
 
 def test_helper_preserves_literal_semicolon() -> None:
-    assert _strip_trailing_semicolon("SELECT ';' AS x") == "SELECT ';' AS x"
+    assert strip_trailing_semicolon("SELECT ';' AS x") == "SELECT ';' AS x"
     assert _apply_limit("SELECT 1;", 3) == "SELECT * FROM (SELECT 1) AS _sub LIMIT 3"

--- a/core/wren/tests/unit/test_bigquery_semicolon.py
+++ b/core/wren/tests/unit/test_bigquery_semicolon.py
@@ -1,0 +1,72 @@
+"""BigQuery trailing-semicolon + LIMIT pushdown helpers (mocked client)."""
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+
+from wren.connector.bigquery import (
+    BigQueryConnector,
+    _apply_limit,
+    _strip_trailing_semicolon,
+)
+
+
+def _make_mock_connector() -> tuple[BigQueryConnector, MagicMock]:
+    connector = BigQueryConnector.__new__(BigQueryConnector)
+    client = MagicMock()
+    job = MagicMock()
+    result = MagicMock()
+    result.to_arrow.return_value = pa.table({"x": [1]})
+    job.result.return_value = result
+    client.query.return_value = job
+    connector.connection = client
+    return connector, client
+
+
+def test_query_pushes_limit_and_strips_semicolon() -> None:
+    connector, client = _make_mock_connector()
+    connector.query("SELECT 1;", limit=5)
+    (sent,), _ = client.query.call_args
+    assert sent == "SELECT 1\nLIMIT 5"
+    assert ";)" not in sent and not sent.rstrip().endswith(";")
+
+
+def test_query_without_limit_still_strips_only_when_composing_none() -> None:
+    connector, client = _make_mock_connector()
+    connector.query("SELECT 1")
+    (sent,), _ = client.query.call_args
+    assert sent == "SELECT 1"
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, client = _make_mock_connector()
+    fake_bq = type("BQ", (), {
+        "QueryJobConfig": staticmethod(lambda **kw: type("C", (), kw)()),
+    })
+    import sys
+    from unittest.mock import patch
+    with patch.dict(sys.modules, {"google": MagicMock(), "google.cloud": MagicMock(), "google.cloud.bigquery": fake_bq}):
+        # Still import-side effect free: inject simple stub
+        import types
+        fake_mod = types.ModuleType("google.cloud.bigquery")
+        class QueryJobConfig:
+            def __init__(self, dry_run=False, use_query_cache=True):
+                self.dry_run = dry_run
+                self.use_query_cache = use_query_cache
+        fake_mod.QueryJobConfig = QueryJobConfig
+        with patch.dict(sys.modules, {
+            "google": types.ModuleType("google"),
+            "google.cloud": types.ModuleType("google.cloud"),
+            "google.cloud.bigquery": fake_mod,
+            "google.oauth2": types.ModuleType("google.oauth2"),
+            "google.oauth2.service_account": types.ModuleType("google.oauth2.service_account"),
+        }):
+            connector.dry_run("SELECT 1;  \n")
+    (sent,), kwargs = client.query.call_args
+    assert sent == "SELECT 1"
+    assert kwargs["job_config"].dry_run is True
+
+
+def test_helper_preserves_literal_semicolon() -> None:
+    assert _strip_trailing_semicolon("SELECT ';' AS x") == "SELECT ';' AS x"
+    assert _apply_limit("SELECT 1;", 3) == "SELECT 1\nLIMIT 3"

--- a/core/wren/tests/unit/test_bigquery_semicolon.py
+++ b/core/wren/tests/unit/test_bigquery_semicolon.py
@@ -40,31 +40,27 @@ def test_query_without_limit_still_strips_only_when_composing_none() -> None:
 
 def test_dry_run_strips_trailing_semicolon() -> None:
     connector, client = _make_mock_connector()
-    fake_bq = type("BQ", (), {
-        "QueryJobConfig": staticmethod(lambda **kw: type("C", (), kw)()),
-    })
     import sys
+    import types
     from unittest.mock import patch
-    with patch.dict(sys.modules, {"google": MagicMock(), "google.cloud": MagicMock(), "google.cloud.bigquery": fake_bq}):
-        # Still import-side effect free: inject simple stub
-        import types
-        fake_mod = types.ModuleType("google.cloud.bigquery")
-        class QueryJobConfig:
-            def __init__(self, dry_run=False, use_query_cache=True):
-                self.dry_run = dry_run
-                self.use_query_cache = use_query_cache
-        fake_mod.QueryJobConfig = QueryJobConfig
-        with patch.dict(sys.modules, {
-            "google": types.ModuleType("google"),
-            "google.cloud": types.ModuleType("google.cloud"),
-            "google.cloud.bigquery": fake_mod,
-            "google.oauth2": types.ModuleType("google.oauth2"),
-            "google.oauth2.service_account": types.ModuleType("google.oauth2.service_account"),
-        }):
-            connector.dry_run("SELECT 1;  \n")
+    fake_mod = types.ModuleType("google.cloud.bigquery")
+    class QueryJobConfig:
+        def __init__(self, dry_run=False, use_query_cache=True):
+            self.dry_run = dry_run
+            self.use_query_cache = use_query_cache
+    fake_mod.QueryJobConfig = QueryJobConfig
+    with patch.dict(sys.modules, {
+        "google": types.ModuleType("google"),
+        "google.cloud": types.ModuleType("google.cloud"),
+        "google.cloud.bigquery": fake_mod,
+        "google.oauth2": types.ModuleType("google.oauth2"),
+        "google.oauth2.service_account": types.ModuleType("google.oauth2.service_account"),
+    }):
+        connector.dry_run("SELECT 1;  \n")
     (sent,), kwargs = client.query.call_args
     assert sent == "SELECT 1"
     assert kwargs["job_config"].dry_run is True
+    assert kwargs["job_config"].use_query_cache is False
 
 
 def test_helper_preserves_literal_semicolon() -> None:

--- a/core/wren/tests/unit/test_bigquery_semicolon.py
+++ b/core/wren/tests/unit/test_bigquery_semicolon.py
@@ -27,15 +27,23 @@ def test_query_pushes_limit_and_strips_semicolon() -> None:
     connector, client = _make_mock_connector()
     connector.query("SELECT 1;", limit=5)
     (sent,), _ = client.query.call_args
-    assert sent == "SELECT 1\nLIMIT 5"
+    assert sent == "SELECT * FROM (SELECT 1) AS _sub LIMIT 5"
     assert ";)" not in sent and not sent.rstrip().endswith(";")
 
 
-def test_query_without_limit_still_strips_only_when_composing_none() -> None:
+def test_query_without_limit_still_strips_semicolon() -> None:
     connector, client = _make_mock_connector()
-    connector.query("SELECT 1")
+    connector.query("SELECT 1;")
     (sent,), _ = client.query.call_args
     assert sent == "SELECT 1"
+
+
+def test_query_with_inner_limit_outer_wrap_still_enforces_caller_limit() -> None:
+    """Outer wrap always enforces caller limit (no fragile LIMIT detection)."""
+    connector, client = _make_mock_connector()
+    connector.query("SELECT 1 LIMIT 100", limit=5)
+    (sent,), _ = client.query.call_args
+    assert sent == "SELECT * FROM (SELECT 1 LIMIT 100) AS _sub LIMIT 5"
 
 
 def test_dry_run_strips_trailing_semicolon() -> None:
@@ -43,19 +51,27 @@ def test_dry_run_strips_trailing_semicolon() -> None:
     import sys
     import types
     from unittest.mock import patch
+
     fake_mod = types.ModuleType("google.cloud.bigquery")
+
     class QueryJobConfig:
         def __init__(self, dry_run=False, use_query_cache=True):
             self.dry_run = dry_run
             self.use_query_cache = use_query_cache
+
     fake_mod.QueryJobConfig = QueryJobConfig
-    with patch.dict(sys.modules, {
-        "google": types.ModuleType("google"),
-        "google.cloud": types.ModuleType("google.cloud"),
-        "google.cloud.bigquery": fake_mod,
-        "google.oauth2": types.ModuleType("google.oauth2"),
-        "google.oauth2.service_account": types.ModuleType("google.oauth2.service_account"),
-    }):
+    with patch.dict(
+        sys.modules,
+        {
+            "google": types.ModuleType("google"),
+            "google.cloud": types.ModuleType("google.cloud"),
+            "google.cloud.bigquery": fake_mod,
+            "google.oauth2": types.ModuleType("google.oauth2"),
+            "google.oauth2.service_account": types.ModuleType(
+                "google.oauth2.service_account"
+            ),
+        },
+    ):
         connector.dry_run("SELECT 1;  \n")
     (sent,), kwargs = client.query.call_args
     assert sent == "SELECT 1"
@@ -65,4 +81,4 @@ def test_dry_run_strips_trailing_semicolon() -> None:
 
 def test_helper_preserves_literal_semicolon() -> None:
     assert _strip_trailing_semicolon("SELECT ';' AS x") == "SELECT ';' AS x"
-    assert _apply_limit("SELECT 1;", 3) == "SELECT 1\nLIMIT 3"
+    assert _apply_limit("SELECT 1;", 3) == "SELECT * FROM (SELECT 1) AS _sub LIMIT 3"


### PR DESCRIPTION
## Summary

- BigQuery `query(..., limit=N)` now appends `LIMIT N` after stripping a trailing semicolon instead of relying only on `result(max_results=...)`.
- `dry_run` also strips trailing `;` for consistent single-statement validation.

## Motivation

`google.cloud.bigquery` `max_results` controls pagination of the results API; it does not push a limit into the job SQL, so expensive full-table scans still run when GenBI only needs a preview page. Other connectors already push limits into SQL (Athena append-LIMIT path, postgres subquery wrap). Match that pushdown and reuse the terminating-run semicolon strip so `SELECT 1;` cannot become multi-statement noise.

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_bigquery_semicolon.py -q` — 4 passed
- Mocked client: `query("SELECT 1;", limit=5)` submits `SELECT 1\nLIMIT 5`; dry_run sends `SELECT 1`
- Did NOT change: credentials/scopes path

## License

`core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BigQuery query handling by preprocessing SQL to strip trailing semicolons and apply the requested row limit via an in-SQL `LIMIT` clause when needed.
  * Updated dry-run behavior to ignore trailing semicolons while preserving the existing dry-run configuration.
  * Ensured semicolons within SQL string literals remain unchanged.
* **Tests**
  * Added unit tests covering semicolon stripping, `LIMIT` injection logic, and dry-run SQL/config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->