### PR TITLE
fix(snowflake): push LIMIT into SQL and strip trailing semicolon

### DIFF
--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -3,10 +3,33 @@
 from __future__ import annotations
 
 import pyarrow as pa
-import snowflake.connector
-
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+
+import re
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip terminating ``;`` / whitespace for Snowflake execute/describe.
+
+    Snowflake accepts ``SELECT 1;`` as a single statement in some clients, but
+    other engines we subprocess-mirror reject trailing terminal semicolons, and
+    describe() paths are safer with a cleaned statement. Only the terminal run
+    is removed so ``SELECT ';'`` stays intact.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
+
+
+def _apply_limit(sql: str, limit: int) -> str:
+    """Push LIMIT into the Snowflake SQL text.
+
+    Client-side Arrow slicing still downloads a full result stage. Append
+    ``LIMIT n`` after stripping a trailing semicolon so the warehouse can
+    short-circuit, matching Athena/MySQL append style.
+    """
+    return f"{_strip_trailing_semicolon(sql)}\nLIMIT {int(limit)}"
 
 
 def _build_connection_params(connection_info) -> dict:
@@ -40,6 +63,8 @@ def _build_connection_params(connection_info) -> dict:
 
 
 def make_snowflake_connection(connection_info):
+    import snowflake.connector  # noqa: PLC0415
+
     return snowflake.connector.connect(**_build_connection_params(connection_info))
 
 
@@ -48,34 +73,50 @@ class SnowflakeConnector(ConnectorABC):
         self.connection = make_snowflake_connection(connection_info)
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        exec_sql = _apply_limit(sql, limit) if limit is not None else sql
         try:
             with self.connection.cursor() as cursor:
-                cursor.execute(sql)
+                cursor.execute(exec_sql)
                 arrow_table = cursor.fetch_arrow_all()
-        except snowflake.connector.errors.ProgrammingError as e:
+        except Exception as e:
+            # Map Snowflake ProgrammingError when the driver is installed; any
+            # other exception is re-raised so infrastructure failures stay loud.
+            try:
+                import snowflake.connector  # noqa: PLC0415
+
+                if not isinstance(e, snowflake.connector.errors.ProgrammingError):
+                    raise
+            except ImportError:
+                raise
             raise WrenError(
                 ErrorCode.INVALID_SQL,
                 str(e),
                 phase=ErrorPhase.SQL_EXECUTION,
-                metadata={DIALECT_SQL: sql},
+                metadata={DIALECT_SQL: exec_sql},
             ) from e
 
         if arrow_table is None:
             return pa.table({})
-        if limit is not None:
-            return arrow_table.slice(0, limit)
         return arrow_table
 
     def dry_run(self, sql: str) -> None:
+        cleaned = _strip_trailing_semicolon(sql)
         try:
             with self.connection.cursor() as cursor:
-                cursor.describe(sql)
-        except snowflake.connector.errors.ProgrammingError as e:
+                cursor.describe(cleaned)
+        except Exception as e:
+            try:
+                import snowflake.connector  # noqa: PLC0415
+
+                if not isinstance(e, snowflake.connector.errors.ProgrammingError):
+                    raise
+            except ImportError:
+                raise
             raise WrenError(
                 ErrorCode.INVALID_SQL,
                 str(e),
                 phase=ErrorPhase.SQL_DRY_RUN,
-                metadata={DIALECT_SQL: sql},
+                metadata={DIALECT_SQL: cleaned},
             ) from e
 
     def close(self) -> None:

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 import pyarrow as pa
+
 from wren.connector.base import ConnectorABC
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
-
-import re
 
 _TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
 

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -23,14 +23,37 @@ def _strip_trailing_semicolon(sql: str) -> str:
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
+def _has_outer_limit(sql: str) -> bool:
+    """True when *sql* already ends with a top-level LIMIT or FETCH.
+
+    Only the outer tail is inspected so a subquery ``LIMIT`` inside parentheses
+    or a string literal does not suppress pushdown. Rough but safe: after
+    stripping a trailing semicolon, look for LIMIT/FETCH as the last clause.
+    """
+    cleaned = _strip_trailing_semicolon(sql).rstrip()
+    # Drop a trailing closers? Keep simple — music box MySQL still appends; we
+    # only skip when the outermost statement clearly already limits rows.
+    tail = cleaned.split("\n")[-1].strip()
+    return bool(re.match(r"(?i)^(LIMIT|FETCH)\b", tail)) or bool(
+        re.search(r"(?i)\bLIMIT\s+\d+(\s+OFFSET\s+\d+)?\s*\Z", cleaned)
+        or re.search(r"(?i)\bFETCH\s+(FIRST|NEXT)\b.*\bROWS?\b\s*\Z", cleaned)
+    )
+
+
 def _apply_limit(sql: str, limit: int) -> str:
     """Push LIMIT into the Snowflake SQL text.
 
     Client-side Arrow slicing still downloads a full result stage. Append
     ``LIMIT n`` after stripping a trailing semicolon so the warehouse can
     short-circuit, matching Athena/MySQL append style.
+
+    If the outer statement already has a LIMIT/FETCH, leave it unchanged to
+    avoid ``... LIMIT 10\\nLIMIT 5`` (CodeRabbit #2466).
     """
-    return f"{_strip_trailing_semicolon(sql)}\nLIMIT {int(limit)}"
+    cleaned = _strip_trailing_semicolon(sql)
+    if _has_outer_limit(cleaned):
+        return cleaned
+    return f"{cleaned}\nLIMIT {int(limit)}"
 
 
 def _build_connection_params(connection_info) -> dict:

--- a/core/wren/tests/unit/test_snowflake_limit.py
+++ b/core/wren/tests/unit/test_snowflake_limit.py
@@ -1,0 +1,45 @@
+"""Snowflake LIMIT pushdown + trailing-semicolon strip (mocked cursor)."""
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+
+from wren.connector.snowflake import (
+    SnowflakeConnector,
+    _apply_limit,
+    _strip_trailing_semicolon,
+)
+
+
+def _make_mock_connector() -> tuple[SnowflakeConnector, MagicMock]:
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    cursor = MagicMock()
+    cursor.fetch_arrow_all.return_value = pa.table({"x": [1, 2, 3]})
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor
+    conn.cursor.return_value.__exit__.return_value = False
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_query_pushes_limit_and_strips_semicolon() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.query("SELECT 1;", limit=2)
+    cursor.execute.assert_called_once_with("SELECT 1\nLIMIT 2")
+
+
+def test_query_without_limit_passes_sql_through() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.query("SELECT 1")
+    cursor.execute.assert_called_once_with("SELECT 1")
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;  \n")
+    cursor.describe.assert_called_once_with("SELECT 1")
+
+
+def test_helpers() -> None:
+    assert _strip_trailing_semicolon("SELECT ';' AS x") == "SELECT ';' AS x"
+    assert _apply_limit("SELECT 1;", 5) == "SELECT 1\nLIMIT 5"


### PR DESCRIPTION
## Summary

- Snowflake `query(..., limit=N)` now appends `LIMIT N` after stripping a trailing semicolon instead of only slicing the Arrow table client-side.
- `dry_run`/`describe` also strip trailing `;`.

## Motivation

Client-side `arrow_table.slice(0, limit)` still schedules and materializes a full warehouse result stage for previews. Arrangements already used for Athena/MySQL (append LIMIT) and postgres-family subquery wraps keep the work for previews on the engine. Same helper strips a pure terminal semicolon so describe/execute do not trip multi-statement quirks.

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_snowflake_limit.py -q` — 4 passed
- Mocked cursor: `query("SELECT 1;", limit=2)` executes `SELECT 1\nLIMIT 2`; dry_run describes `SELECT 1`
- Did NOT change: auth/private_key/session_parameter wiring

## License

`core/wren/**` only (Apache-2.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Snowflake query handling by pushing requested row limits into the SQL sent to the database, with safeguards to avoid duplicating existing outer limit clauses.
  - Consistently strips trailing semicolons and extra whitespace before executing queries and performing dry runs.
  - Broadened invalid-SQL handling to standardize diagnostics for programming errors while preserving other error behavior.

- **Tests**
  - Added unit tests validating limit pushdown, semicolon stripping, correct SQL passthrough without limits, and cleaned-SQL behavior for dry runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->