### PR TITLE
fix(ci): set group-pull-request-title-pattern for rust-core release group

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
+  "group-pull-request-title-pattern": "chore${scope}: release wren-rust-core libraries",
   "packages": {
     "core/wren-core-py": {
       "component": "wren-core-py",


### PR DESCRIPTION
## Problem

The merge of the rust-core release PR (#2467) did **not** create releases/tags and the crates.io publish never ran. Root cause is a known release-please bug ([#2306](https://github.com/googleapis/release-please/issues/2306)):

The `linked-versions` plugin emits a grouped release PR titled `chore(main): release wren-rust-core libraries` (no version). Without a matching `group-pull-request-title-pattern`, release-please rejects it on merge —

```
✖ Bad pull request title: 'chore(main): release wren-rust-core libraries'
```

— so it creates no releases/tags, `release_created` stays false, and `publish-wren-crates` is skipped. The version bump itself worked: all three crates + the manifest are at 0.2.0 on `main`, just untagged/unpublished.

## Fix

Add the matching pattern so the grouped PR is recognized both when generated and when parsed on merge:

```json
"group-pull-request-title-pattern": "chore${scope}: release wren-rust-core libraries"
```

## Effect after merge

On the next Release Please run, release-please re-detects the already-merged, still-untagged #2467, now parses its title successfully, and creates the `wren-manifest-macro-v0.2.0` / `wren-core-base-v0.2.0` / `wren-semantic-core-v0.2.0` releases → `release_created` becomes true → `publish-wren-crates` runs and publishes 0.2.0 to crates.io (bottom-up, via Trusted Publishing).

No source or version changes — config only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the title format for grouped release pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->