### PR TITLE
fix(trino): sanitize bracketed userinfo and URL-decode credentials

### DIFF
--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -295,13 +295,45 @@ def _build_trino_connect_kwargs(connection_info) -> dict:
     return out
 
 
+def _parse_trino_connection_url(url: str):
+    """Parse a Trino URL after escaping raw brackets in userinfo only.
+
+    ``urllib.parse.urlparse`` treats ``[`` / ``]`` anywhere in the netloc as
+    IPv6 host delimiters. That is correct for hosts like ``trino://alice@[::1]``
+    but it breaks on raw credentials such as ``trino://user:p[a]ss@host/c/s``.
+    Sanitise only the userinfo segment so valid IPv6 hosts still parse.
+    Mirrors the MySQL connector helper.
+    """
+    scheme_idx = url.find("://")
+    if scheme_idx == -1:
+        return urlparse(url)
+
+    prefix = url[: scheme_idx + 3]
+    rest = url[scheme_idx + 3 :]
+
+    authority_end = len(rest)
+    for separator in "/?#":
+        idx = rest.find(separator)
+        if idx != -1:
+            authority_end = min(authority_end, idx)
+
+    authority = rest[:authority_end]
+    if "@" not in authority:
+        return urlparse(url)
+
+    userinfo, hostinfo = authority.rsplit("@", 1)
+    sanitized_userinfo = userinfo.replace("[", "%5B").replace("]", "%5D")
+    sanitized_url = f"{prefix}{sanitized_userinfo}@{hostinfo}{rest[authority_end:]}"
+    return urlparse(sanitized_url)
+
+
 def _parse_trino_url(url: str, extra_kwargs: dict | None) -> dict:
     """Parse a ``trino://[user[:pwd]@]host[:port][/catalog[/schema]][?...]`` URL.
 
     Returns the same ``_password`` sentinel-key shape as
     :func:`_build_trino_connect_kwargs`.
     """
-    parsed = urlparse(url)
+    parsed = _parse_trino_connection_url(url)
     if parsed.scheme not in {"trino", "trino+https"}:
         raise WrenError(
             ErrorCode.INVALID_CONNECTION_INFO,
@@ -322,9 +354,10 @@ def _parse_trino_url(url: str, extra_kwargs: dict | None) -> dict:
     if extra_kwargs:
         query_kwargs.update(extra_kwargs)
 
-    # urlparse leaves percent-encoded characters in userinfo/path, so decode
-    # them before they reach Trino. Use unquote (not unquote_plus) so a
-    # literal ``+`` in a credential is preserved.
+    # urlparse leaves percent-encoded characters (including the brackets we
+    # pre-escaped above) in userinfo/path — decode with unquote so raw and
+    # percent-encoded credentials both land as the intended string. Use
+    # unquote (not unquote_plus) so a literal ``+`` is preserved.
     out: dict = {
         "host": parsed.hostname,
         "port": int(parsed.port or 8080),

--- a/core/wren/tests/unit/test_trino_parser.py
+++ b/core/wren/tests/unit/test_trino_parser.py
@@ -193,6 +193,22 @@ def test_parse_trino_url_preserves_literal_plus_in_userinfo() -> None:
     assert out["_password"] == "pw+1"
 
 
+
+
+def test_parse_trino_url_allows_raw_brackets_in_password() -> None:
+    """Raw '[' / ']' in userinfo must not raise ValueError from urlparse."""
+    out = _parse_trino_url("trino://user:p[a]ss@host:8080/catalog/schema", None)
+    assert out["user"] == "user"
+    assert out["_password"] == "p[a]ss"
+    assert out["host"] == "host"
+
+
+def test_parse_trino_url_preserves_ipv6_host_with_bracketed_password() -> None:
+    out = _parse_trino_url("trino://user:p[a]ss@[::1]:8080/catalog/schema", None)
+    assert out["host"] == "::1"
+    assert out["_password"] == "p[a]ss"
+
+
 def test_parse_trino_url_rejects_bad_scheme() -> None:
     with pytest.raises(WrenError) as exc:
         _parse_trino_url("http://alice@host:8080/c/s", None)


### PR DESCRIPTION
## Summary

- Escape raw `[` / `]` in Trino URL userinfo before `urlparse` so bracketed passwords no longer raise ValueError on IPv6 netloc checks.
- Keep real IPv6 host parsing (`[::1]`) intact and continue URL-decoding credentials/catalog/schema with `unquote` (not `unquote_plus`) so literal `+` is preserved.
- Move the pure Docker-free URL-parser regression tests into `tests/unit/test_trino_parser.py` so the `test-unit` CI job covers them (CodeRabbit nitpick).

## Motivation

Follows / completes #2435.

Passwords containing raw brackets in `trino://` connection URLs crash `urllib.parse.urlparse` because it treats any bare `[` / `]` in netloc as IPv6 markers. This is a small, MySQL-style sanitizer limited to the userinfo segment.

## Verification

- Local pure-helper checks on `_parse_trino_url`:
  - `trino://user:p[a]ss@host:8080/catalog/schema` → password `p[a]ss`
  - `trino://user:p[a]ss@[::1]:8080/catalog/schema` → host `::1`, password `p[a]ss`
  - percent-encoded creds still decode
  - literal `+` preserved
- Diff is 2 files only vs `main`.
- Earlier CI reds on #2455 were Cargo.lock `--locked` maturin failures across unit/postgres/mysql/ui/memory (infra/stale, shared with other open PRs), not trino-logic failures.

## Notes

#2455 closed after a force-push mishap; this is a clean single-commit recreate on current `main` with the CodeRabbit nitpick applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Trino connection URL parsing when credentials include literal square brackets (`[`/`]`), ensuring they no longer break parsing and are retained correctly.
  * Correctly preserves literal `+` characters in credentials and decodes `%`-escapes as expected.
  * Maintains proper parsing of IPv6 hosts in bracket notation (`[::1]`) even when the password contains bracket characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->