### PR TITLE
fix(trino): strip multi trailing semicolons before subquery wrap

### DIFF
--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -8,9 +8,9 @@ lex with sqlglot to build an equivalent PyArrow schema.
 from __future__ import annotations
 
 import contextlib
-import re
 import datetime as dtlib
 import json
+import re
 from decimal import Decimal as PyDecimal
 from urllib.parse import parse_qsl, unquote, urlparse
 

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -8,6 +8,7 @@ lex with sqlglot to build an equivalent PyArrow schema.
 from __future__ import annotations
 
 import contextlib
+import re
 import datetime as dtlib
 import json
 from decimal import Decimal as PyDecimal
@@ -359,13 +360,19 @@ def _import_trino():
         ) from e
 
 
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip trailing whitespace and an optional final semicolon.
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
 
-    Wrapping ``SELECT * FROM ({sql}) AS _sub LIMIT N`` breaks if ``sql`` ends
-    with ``;`` because the parser sees ``...; ) AS _sub...``.
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip the terminating run of ``;`` characters and surrounding whitespace.
+
+    Wrapping ``SELECT * FROM ({sql}) AS _sub LIMIT N`` breaks when ``sql`` ends
+    with one or more semicolons (``SELECT 1;`` / ``SELECT 1;;``) because the
+    parser sees ``...; ) AS _sub...``. Only the *terminating* run is stripped so
+    semicolons inside string literals are preserved. Mirrors postgres/canner/
+    clickhouse.
     """
-    return sql.rstrip().removesuffix(";").rstrip()
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class TrinoConnector(ConnectorABC):

--- a/core/wren/tests/unit/test_trino_parser.py
+++ b/core/wren/tests/unit/test_trino_parser.py
@@ -150,6 +150,8 @@ def test_build_trino_column_struct_tuple_to_dict() -> None:
         ("SELECT 1; -- trailing", "SELECT 1; -- trailing"),
         # Terminating run only — internal statement separators stay.
         ("SELECT 1; SELECT 2;", "SELECT 1; SELECT 2"),
+        # Semicolons inside string literals are preserved.
+        ("SELECT 'hello;';", "SELECT 'hello;'"),
     ],
 )
 def test_strip_trailing_semicolon(raw: str, expected: str) -> None:

--- a/core/wren/tests/unit/test_trino_parser.py
+++ b/core/wren/tests/unit/test_trino_parser.py
@@ -145,8 +145,10 @@ def test_build_trino_column_struct_tuple_to_dict() -> None:
         ("SELECT 1;", "SELECT 1"),
         ("SELECT 1  ;  ", "SELECT 1"),
         ("SELECT 1\n;\n", "SELECT 1"),
+        ("SELECT 1;;", "SELECT 1"),
+        ("SELECT 1; ;\n", "SELECT 1"),
         ("SELECT 1; -- trailing", "SELECT 1; -- trailing"),
-        # Only the final semicolon is stripped — internal ones stay.
+        # Terminating run only — internal statement separators stay.
         ("SELECT 1; SELECT 2;", "SELECT 1; SELECT 2"),
     ],
 )

--- a/core/wren/tests/unit/test_trino_parser.py
+++ b/core/wren/tests/unit/test_trino_parser.py
@@ -152,6 +152,8 @@ def test_build_trino_column_struct_tuple_to_dict() -> None:
         ("SELECT 1; SELECT 2;", "SELECT 1; SELECT 2"),
         # Semicolons inside string literals are preserved.
         ("SELECT 'hello;';", "SELECT 'hello;'"),
+        # A literal semicolon with no terminating separator is untouched.
+        ("SELECT 'hello;'", "SELECT 'hello;'"),
     ],
 )
 def test_strip_trailing_semicolon(raw: str, expected: str) -> None:


### PR DESCRIPTION
## Summary

- Strengthen Trino `_strip_trailing_semicolon` to drop the full terminating run of `;` / whitespace (not just one `removesuffix(";")`).
- `SELECT 1;;` / `; ;\n` no longer break limit/dry_run subquery wraps.

## Motivation

Limit/dry_run wrap user SQL as `SELECT * FROM ({sql}) AS _sub LIMIT N`. A single trailing semicolon was handled, but double terminators (common from copy-paste / client dsn tooling) still left `;)` in the wrapped SQL. Aligns with postgres/canner/clickhouse.

Apache-2.0 path: `core/wren/**` only.

## Verification

```
........                                                                 [100%]
8 passed in 0.23s
```

Python check on main (behavior proof):

- before: `"SELECT 1;;".rstrip().removesuffix(";").rstrip()` → `"SELECT 1;"` (still broken)
- after: helper → `"SELECT 1"`

## Duplicates

No open issue/PR solely for multi-semicolon Trino strip (semicolon work historically landed one-terminator helpers). Focused non-shim fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Trino SQL handling by stripping only a terminating run of trailing semicolons (including surrounding whitespace), while preserving semicolons elsewhere (including within string literals).
* **Tests**
  * Expanded unit test coverage with additional edge cases for multiple trailing semicolons and semicolons followed by spaces/newlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->