### PR TITLE
fix(mysql): strip multi trailing semicolons before LIMIT/EXPLAIN

### DIFF
--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -10,9 +10,8 @@ only differs in how the connection is opened.
 
 from __future__ import annotations
 
-import re
-
 import json
+import re
 from contextlib import closing
 from decimal import Decimal as PyDecimal
 from functools import cache
@@ -35,7 +34,6 @@ def _strip_trailing_semicolon(sql: str) -> str:
     *between* trailing semicolons (``SELECT 1; ;`` → still ends with ``;``).
     """
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
-
 
 
 def _apply_limit(sql: str, limit: int) -> str:

--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -10,6 +10,8 @@ only differs in how the connection is opened.
 
 from __future__ import annotations
 
+import re
+
 import json
 from contextlib import closing
 from decimal import Decimal as PyDecimal
@@ -22,20 +24,34 @@ from wren.connector.base import ConnectorABC
 from wren.model.data_source import DataSource
 from wren.model.error import ErrorCode, WrenError
 
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip the terminating run of ``;`` / whitespace.
+
+    ``EXPLAIN`` and ``LIMIT`` appends break when user SQL ends in one or more
+    semicolons, and ``str.rstrip().rstrip(";")`` fails when whitespace appears
+    *between* trailing semicolons (``SELECT 1; ;`` → still ends with ``;``).
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
+
+
 
 def _apply_limit(sql: str, limit: int) -> str:
     """Append ``LIMIT n`` to a user-supplied SQL string.
 
-    Strips any trailing semicolon and whitespace, then appends ``LIMIT n``.
-    ``limit`` MUST already be validated as a non-negative ``int`` by the caller
-    — this helper does not re-validate to keep the call site explicit.
+    Strips the terminating run of semicolons/whitespace, then appends
+    ``LIMIT n``. ``limit`` MUST already be validated as a non-negative ``int``
+    by the caller — this helper does not re-validate to keep the call site
+    explicit.
 
     Wrapping the user SQL in ``SELECT * FROM (...) AS _sub LIMIT n`` was
     rejected because it fails with ``ER_DUP_FIELDNAME`` whenever the inner
     SELECT projects two columns with the same name (e.g. a join that selects
     ``a.id`` and ``b.id``).
     """
-    return f"{sql.rstrip().rstrip(';').rstrip()}\nLIMIT {limit}"
+    return f"{_strip_trailing_semicolon(sql)}\nLIMIT {limit}"
 
 
 def _coerce_limit(limit: int | None) -> int | None:
@@ -99,7 +115,7 @@ class MySqlConnector(ConnectorABC):
         # subquery-wrapping side-steps ``ER_DUP_FIELDNAME`` for queries that
         # surface duplicate column names. We strip a trailing semicolon to
         # match the same compose-ability we use for ``query``'s LIMIT path.
-        explain_sql = f"EXPLAIN {sql.rstrip().rstrip(';').rstrip()}"
+        explain_sql = f"EXPLAIN {_strip_trailing_semicolon(sql)}"
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(explain_sql)
             cursor.fetchall()

--- a/core/wren/tests/unit/test_mysql_semicolon.py
+++ b/core/wren/tests/unit/test_mysql_semicolon.py
@@ -19,3 +19,8 @@ def test_helper_preserves_semicolon_in_string_literal():
 
 def test_helper_double_semicolon():
     assert _strip_trailing_semicolon("SELECT 1;;") == "SELECT 1"
+
+
+def test_helper_strips_trailing_whitespace_without_semicolons():
+    # Trailing whitespace is removed even when no semicolon is present.
+    assert _strip_trailing_semicolon("SELECT 1   \n") == "SELECT 1"

--- a/core/wren/tests/unit/test_mysql_semicolon.py
+++ b/core/wren/tests/unit/test_mysql_semicolon.py
@@ -1,0 +1,21 @@
+"""Trailing-semicolon stripping for MySQL LIMIT/EXPLAIN builders."""
+
+from wren.connector.mysql import _apply_limit, _strip_trailing_semicolon
+
+
+def test_apply_limit_strips_trailing_semicolon():
+    assert _apply_limit("SELECT 1;", 5) == "SELECT 1\nLIMIT 5"
+
+
+def test_apply_limit_strips_multi_semicolon_with_interior_space():
+    # rstrip(';') chain leaves a semicolon when whitespace sits between semis.
+    assert _apply_limit("SELECT 1; ;", 3) == "SELECT 1\nLIMIT 3"
+
+
+def test_helper_preserves_semicolon_in_string_literal():
+    sql = "SELECT 'a;b' AS x"
+    assert _strip_trailing_semicolon(sql) == sql
+
+
+def test_helper_double_semicolon():
+    assert _strip_trailing_semicolon("SELECT 1;;") == "SELECT 1"


### PR DESCRIPTION
## Summary

- Replace MySQL `sql.rstrip().rstrip(";").rstrip()` with a terminating-run regex strip before `LIMIT` injection and `EXPLAIN`.
- Fixes `SELECT 1; ;` style inputs that still ended with `;` and broke EXPLAIN/LIMIT rewrite.

## Motivation

Chained `rstrip` only removes a contiguous run of `;` after whitespace strip. When whitespace appears **between** trailing semicolons, a `;` remains. Apache-2.0 path: `core/wren/**`.

## Verification

```
....                                                                     [100%]
4 passed in 0.31s
```

Proof without the fix: `"SELECT 1; ;".rstrip().rstrip(";").rstrip()` → `'SELECT 1;'`.

## Duplicates

No open PR on MySQL multi-semicolon strip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL/Doris SQL generation by more reliably trimming trailing semicolons, including multiple semicolons separated by whitespace.
  * `LIMIT` queries and `EXPLAIN` dry-runs now construct SQL consistently after semicolon trimming.
  * Preserves semicolons that appear inside quoted string literals.

* **Tests**
  * Added unit coverage for single/double trailing semicolons, multiple trailing semicolons with interior whitespace, and semicolons inside string literals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->