### PR TITLE
fix(mssql): strip trailing semicolons before sqlglot LIMIT rewrite

### DIFF
--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime as dtlib
 import json
-import re
 import urllib.parse
 import uuid
 from contextlib import closing
@@ -20,7 +19,7 @@ try:
 except ImportError:  # pragma: no cover
     pyodbc = None
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import MSSqlConnectionInfo
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
@@ -28,18 +27,6 @@ from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 # cursor.description so we can register an output converter that decodes the
 # raw 20-byte payload into a timezone-aware datetime.
 MSSQL_DATETIMEOFFSET_TYPE_CODE = -155
-
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip the terminating run of ``;`` / whitespace before sqlglot parse.
-
-    sqlglot parses ``SELECT 1;;`` as a ``Block``, not a bare ``Select``, so
-    LIMIT injection and pagination flatten silently no-op. Terminating-run
-    strip matches postgres/canner/mysql helpers.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class MSSqlConnector(ConnectorABC):
@@ -115,7 +102,7 @@ class MSSqlConnector(ConnectorABC):
         if limit is None:
             return sql
 
-        sql = _strip_trailing_semicolon(sql)
+        sql = strip_trailing_semicolon(sql)
 
         try:
             parsed = parse_one(sql, dialect=input_dialect)
@@ -133,7 +120,7 @@ class MSSqlConnector(ConnectorABC):
     ) -> str:
         """Collapse an outer ``LIMIT`` wrapped around a single subquery into
         the inner Select's ``LIMIT`` — undoes the v4 paginate-wrap pattern."""
-        sql_query = _strip_trailing_semicolon(sql_query)
+        sql_query = strip_trailing_semicolon(sql_query)
         try:
             parsed = parse_one(sql_query, dialect=input_dialect)
             if not isinstance(parsed, exp.Select) or not parsed.args.get("limit"):

--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import re
-
 import datetime as dtlib
 import json
+import re
 import urllib.parse
 import uuid
 from contextlib import closing
@@ -41,8 +40,6 @@ def _strip_trailing_semicolon(sql: str) -> str:
     strip matches postgres/canner/mysql helpers.
     """
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
-
-
 
 
 class MSSqlConnector(ConnectorABC):

--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import datetime as dtlib
 import json
 import urllib.parse
@@ -27,6 +29,20 @@ from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 # cursor.description so we can register an output converter that decodes the
 # raw 20-byte payload into a timezone-aware datetime.
 MSSQL_DATETIMEOFFSET_TYPE_CODE = -155
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def _strip_trailing_semicolon(sql: str) -> str:
+    """Strip the terminating run of ``;`` / whitespace before sqlglot parse.
+
+    sqlglot parses ``SELECT 1;;`` as a ``Block``, not a bare ``Select``, so
+    LIMIT injection and pagination flatten silently no-op. Terminating-run
+    strip matches postgres/canner/mysql helpers.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
+
+
 
 
 class MSSqlConnector(ConnectorABC):
@@ -102,6 +118,8 @@ class MSSqlConnector(ConnectorABC):
         if limit is None:
             return sql
 
+        sql = _strip_trailing_semicolon(sql)
+
         try:
             parsed = parse_one(sql, dialect=input_dialect)
         except Exception:
@@ -118,6 +136,7 @@ class MSSqlConnector(ConnectorABC):
     ) -> str:
         """Collapse an outer ``LIMIT`` wrapped around a single subquery into
         the inner Select's ``LIMIT`` — undoes the v4 paginate-wrap pattern."""
+        sql_query = _strip_trailing_semicolon(sql_query)
         try:
             parsed = parse_one(sql_query, dialect=input_dialect)
             if not isinstance(parsed, exp.Select) or not parsed.args.get("limit"):

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -52,7 +52,7 @@ class RedshiftConnector(ConnectorABC):
         else:
             # Unlimited path also rejects trailing ``;`` for single statements
             # depending on driver/session settings — strip for consistency.
-            sql = _strip_trailing_semicolon(sql)
+            sql = strip_trailing_semicolon(sql)
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             cols = [desc[0] for desc in cursor.description]

--- a/core/wren/tests/unit/test_mssql_semicolon.py
+++ b/core/wren/tests/unit/test_mssql_semicolon.py
@@ -10,9 +10,12 @@ def test_helper_strips_multi_semicolon():
 
 def test_raw_cursor_sql_injects_limit_after_multi_semicolon():
     out = MSSqlConnector._raw_cursor_sql("SELECT 1;;", 5)
-    # MSSQL paginates via OFFSET 0 ROWS FETCH NEXT n ROWS ONLY — assert the
-    # limit-injection marker directly rather than a weak catch-all.
-    assert "FETCH NEXT" in out.upper()
+    # sqlglot tsql may emit TOP n for simple Select (e.g. "SELECT TOP 5 1")
+    # or OFFSET/FETCH for paginated shapes. Either limits correctly after
+    # multi-semicolon strip (without TOP/FETCH, LIMIT injection failed).
+    upper = out.upper()
+    assert "TOP" in upper or "FETCH NEXT" in upper, upper
+    assert "5" in out
     # Must not leave the double terminator which becomes a Block parse
     assert ";;" not in out
 

--- a/core/wren/tests/unit/test_mssql_semicolon.py
+++ b/core/wren/tests/unit/test_mssql_semicolon.py
@@ -1,11 +1,12 @@
 """MSSQL trailing-semicolon strip before sqlglot LIMIT rewrite."""
 
-from wren.connector.mssql import MSSqlConnector, _strip_trailing_semicolon
+from wren.connector.base import strip_trailing_semicolon
+from wren.connector.mssql import MSSqlConnector
 
 
 def test_helper_strips_multi_semicolon():
-    assert _strip_trailing_semicolon("SELECT 1;;") == "SELECT 1"
-    assert _strip_trailing_semicolon("SELECT 1; ;") == "SELECT 1"
+    assert strip_trailing_semicolon("SELECT 1;;") == "SELECT 1"
+    assert strip_trailing_semicolon("SELECT 1; ;") == "SELECT 1"
 
 
 def test_raw_cursor_sql_injects_limit_after_multi_semicolon():

--- a/core/wren/tests/unit/test_mssql_semicolon.py
+++ b/core/wren/tests/unit/test_mssql_semicolon.py
@@ -10,7 +10,9 @@ def test_helper_strips_multi_semicolon():
 
 def test_raw_cursor_sql_injects_limit_after_multi_semicolon():
     out = MSSqlConnector._raw_cursor_sql("SELECT 1;;", 5)
-    assert "FETCH NEXT" in out.upper() or "TOP" in out.upper() or "LIMIT" in out.upper() or "5" in out
+    # MSSQL paginates via OFFSET 0 ROWS FETCH NEXT n ROWS ONLY — assert the
+    # limit-injection marker directly rather than a weak catch-all.
+    assert "FETCH NEXT" in out.upper()
     # Must not leave the double terminator which becomes a Block parse
     assert ";;" not in out
 

--- a/core/wren/tests/unit/test_mssql_semicolon.py
+++ b/core/wren/tests/unit/test_mssql_semicolon.py
@@ -1,0 +1,20 @@
+"""MSSQL trailing-semicolon strip before sqlglot LIMIT rewrite."""
+
+from wren.connector.mssql import MSSqlConnector, _strip_trailing_semicolon
+
+
+def test_helper_strips_multi_semicolon():
+    assert _strip_trailing_semicolon("SELECT 1;;") == "SELECT 1"
+    assert _strip_trailing_semicolon("SELECT 1; ;") == "SELECT 1"
+
+
+def test_raw_cursor_sql_injects_limit_after_multi_semicolon():
+    out = MSSqlConnector._raw_cursor_sql("SELECT 1;;", 5)
+    assert "FETCH NEXT" in out.upper() or "TOP" in out.upper() or "LIMIT" in out.upper() or "5" in out
+    # Must not leave the double terminator which becomes a Block parse
+    assert ";;" not in out
+
+
+def test_raw_cursor_sql_no_limit_unchanged_except_strip_not_required():
+    # limit None returns original (including trailing ;) — execute path allows it
+    assert MSSqlConnector._raw_cursor_sql("SELECT 1;", None) == "SELECT 1;"


### PR DESCRIPTION
## Summary

- Strip the terminating `;`/whitespace run before MSSQL sqlglot parse paths (`_raw_cursor_sql` with limit, `_flatten_pagination_limit`).
- `SELECT 1;;` previously parsed as a `Block`, so LIMIT injection silently no-oped and the driver still saw multi-statement noise.

## Motivation

Apache-2.0 `core/wren/**`. Proof on sqlglot tsql:

- `SELECT 1;` → Select
- `SELECT 1;;` / `SELECT 1; ;` → Block (LIMIT rewrite skipped)

## Verification

```
...                                                                      [100%]
3 passed in 0.17s
```

## Duplicates

No open PR for this sqlglot/Block interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSSQL processing of SQL statements with trailing semicolons and surrounding whitespace, including multiple terminators.
  * Made pagination/limit rewriting more reliable for semicolon-terminated queries.
  * Preserves the expected SQL output when no pagination limit is requested.
* **Tests**
  * Added unit tests covering trailing-semicolon stripping and correct MSSQL pagination behavior for semicolon-terminated input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->