### PR TITLE
fix(databricks): strip trailing semicolon before query execute

### DIFF
--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -50,6 +50,8 @@ class DatabricksConnector(ConnectorABC):
             )
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Strip terminating ;/whitespace before execute (matches dry_run).
+        sql = _strip_trailing_semicolon(sql)
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             if limit is not None:

--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -51,7 +51,7 @@ class DatabricksConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         # Strip terminating ;/whitespace before execute (matches dry_run).
-        sql = _strip_trailing_semicolon(sql)
+        sql = strip_trailing_semicolon(sql)
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             if limit is not None:

--- a/core/wren/tests/unit/test_databricks_semicolon.py
+++ b/core/wren/tests/unit/test_databricks_semicolon.py
@@ -44,3 +44,19 @@ def test_helper_preserves_semicolon_inside_string_literal() -> None:
 
 def test_helper_no_trailing_semicolon_unchanged() -> None:
     assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+
+
+def test_query_strips_trailing_semicolon_before_execute() -> None:
+    connector, cursor = _make_mock_connector()
+    cursor.fetchall_arrow.return_value = None
+    cursor.fetchmany_arrow.return_value = None
+    # Anything truthy so limit branch not needed
+    mconn_cursor = cursor
+    # execute should observe stripped SQL - fetchall path when limit None
+    try:
+        connector.query("SELECT 1;;")
+    except Exception:
+        # mock may return None from fetchall_arrow — only care about execute SQL
+        pass
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT 1"


### PR DESCRIPTION
## Summary

- Apply `_strip_trailing_semicolon` on the Databricks `query` path before `cursor.execute`, matching `dry_run`.
- Regression test asserts `SELECT 1;;` reaches the driver as `SELECT 1`.

## Motivation

Asymmetry with dry_run left multi-terminator SQL only partially hardened.

Apache-2.0 path: `core/wren/**`.

## Verification

```
.....                                                                    [100%]
5 passed in 0.17s
```

## Duplicates

No open PR for query-path strip (prior #2422 was dry_run only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Databricks query execution when user SQL includes trailing semicolons and surrounding whitespace.
  * Queries now remove trailing semicolons before being sent for execution (matching existing dry-run behavior).
* **Tests**
  * Added a unit test to confirm trailing semicolons are stripped prior to calling cursor execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->