### PR TITLE
fix(core-py): sync Rust crate versions in Cargo.lock

### DIFF
--- a/core/wren-core-py/Cargo.lock
+++ b/core/wren-core-py/Cargo.lock
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "wren-core-base"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "serde",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "wren-manifest-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quote",
  "syn",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "wren-semantic-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "csv",


### PR DESCRIPTION
## Summary

The Rust core release in #2467 bumped `wren-core-base`, `wren-manifest-macro`, and `wren-semantic-core` to `0.2.0`, but `core/wren-core-py/Cargo.lock` still referenced `0.1.0`.

As a result, subsequent Wren SDK CI runs failed during `maturin build` because Cargo could not update the lockfile with `--locked`.

This PR synchronizes the three versions in the lockfile.

## Verification

- `cargo metadata --locked` with Rust 1.96 and 1.97
- `maturin build`
- Rust and Python tests