### PR TITLE
fix(core): address Rust 1.97 Clippy warnings

### DIFF
--- a/core/wren-core/core/src/logical_plan/analyze/access_control.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/access_control.rs
@@ -1054,7 +1054,7 @@ mod test {
                 Err(_) => {}
                 _ => panic!(
                     "should be error: {}",
-                    &headers.get("session_id").unwrap().as_ref().unwrap()
+                    headers.get("session_id").unwrap().as_ref().unwrap()
                 ),
             }
         }

--- a/core/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -787,7 +787,7 @@ fn collect_model_required_fields(
                 return plan_err!("Only support calculated field with expression");
             }
             .alias(column.name.clone());
-            debug!("Required Calculated field: {}", &expr_plan);
+            debug!("Required Calculated field: {}", expr_plan);
             required_fields
                 .entry(relation_ref.clone())
                 .or_default()
@@ -800,7 +800,7 @@ fn collect_model_required_fields(
                 Arc::clone(&session_state_ref),
                 Arc::clone(&session_properties),
             )?;
-            debug!("Required field: {}", &expr_plan);
+            debug!("Required field: {}", expr_plan);
             required_fields
                 .entry(relation_ref.clone())
                 .or_default()

--- a/core/wren-core/core/src/mdl/cube.rs
+++ b/core/wren-core/core/src/mdl/cube.rs
@@ -271,7 +271,7 @@ fn resolve_measures(
                 let mut sorted_deps = deps.clone();
                 sorted_deps.sort_by_key(|d| std::cmp::Reverse(d.len()));
                 for dep in sorted_deps {
-                    let replacement = format!("({})", &resolved[dep]);
+                    let replacement = format!("({})", resolved[dep]);
                     // NoExpand keeps `$1`, `$$tag$$` etc. literal — without it
                     // Regex::replace_all would treat them as capture-group templates
                     // and corrupt SQL expressions that contain `$`.

--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -215,7 +215,7 @@ impl WrenMDL {
             });
         });
         WrenMDL {
-            catalog_schema_prefix: format!("{}.{}.", &manifest.catalog, &manifest.schema),
+            catalog_schema_prefix: format!("{}.{}.", manifest.catalog, manifest.schema),
             manifest,
             qualified_references: qualifed_references,
             register_tables: HashMap::new(),

--- a/core/wren-core/sqllogictest/src/engine/normalize.rs
+++ b/core/wren-core/sqllogictest/src/engine/normalize.rs
@@ -43,7 +43,7 @@ pub(crate) fn convert_batches(batches: Vec<RecordBatch>) -> Result<Vec<Vec<Strin
                 return Err(DFSqlLogicTestError::DataFusion(DataFusionError::Internal(
                     format!(
                         "Schema mismatch. Previously had\n{:#?}\n\nGot:\n{:#?}",
-                        &schema,
+                        schema,
                         batch.schema()
                     ),
                 )));

--- a/core/wren-core/wren-example/examples/row-level-access-control.rs
+++ b/core/wren-core/wren-example/examples/row-level-access-control.rs
@@ -87,7 +87,7 @@ async fn main() -> datafusion::common::Result<()> {
     println!("#####################");
     println!(
         "session_tenant_id: {}",
-        &properties
+        properties
             .get("session_tenant_id")
             .unwrap()
             .clone()
@@ -95,7 +95,7 @@ async fn main() -> datafusion::common::Result<()> {
     );
     println!(
         "session_department: {}",
-        &properties
+        properties
             .get("session_department")
             .unwrap()
             .clone()
@@ -103,11 +103,11 @@ async fn main() -> datafusion::common::Result<()> {
     );
     println!(
         "session_user_id: {}",
-        &properties.get("session_user_id").unwrap().clone().unwrap()
+        properties.get("session_user_id").unwrap().clone().unwrap()
     );
     println!(
         "session_role: {}",
-        &properties.get("session_role").unwrap().clone().unwrap()
+        properties.get("session_role").unwrap().clone().unwrap()
     );
 
     let sql = "select * from wren.test.documents";


### PR DESCRIPTION
## Summary

Rust 1.97 introduced the `useless_borrows_in_formatting` Clippy lint. Because CI treats warnings as errors, redundant references in formatting macros caused the Rust workflow to fail.

This PR removes those unnecessary borrows without changing runtime behavior.

## Verification

- `cargo +1.97.0 clippy --all-targets --all-features -- -D warnings`
- Cargo check
- Rust test suite

> Some Wren SDK CI jobs currently fail because the required Cargo lockfile update has not reached `main` yet. The fix is available in #2478; these jobs should pass after it is merged and this branch is rebased onto the updated `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for schema mismatch and access-control related error messages to make diagnostics easier to read.
  * Corrected expression formatting during measure dependency resolution, improving the accuracy of generated diagnostic output.
* **Documentation / Examples**
  * Updated the row-level access control example’s session-property printing for cleaner, more straightforward output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->