### PR TITLE
refactor(connector): share strip_trailing_semicolon in base

### DIFF
--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -11,29 +11,14 @@ from __future__ import annotations
 import contextlib
 import datetime as dtlib
 import json
-import re
 from decimal import Decimal as PyDecimal
 from typing import Any
 
 import pyarrow as pa
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip any trailing ``;`` characters and surrounding whitespace.
-
-    ``dry_run`` runs ``EXPLAIN {sql}``; Athena (Trino-flavoured) rejects a
-    trailing semicolon there (``EXPLAIN SELECT 1;`` → syntax error). Only the
-    terminating run of semicolons/whitespace is stripped, so semicolons inside
-    string literals (e.g. ``SELECT 'a;b'``) are preserved. Mirrors the
-    trino/postgres/mysql connectors, which already strip before EXPLAIN or
-    subquery-wrapping.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 # Athena's DB-API cursor returns Trino-style type names. We delegate the
@@ -347,7 +332,7 @@ class AthenaConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
-                cursor.execute(f"EXPLAIN {_strip_trailing_semicolon(sql)}")
+                cursor.execute(f"EXPLAIN {strip_trailing_semicolon(sql)}")
         except (WrenError, TimeoutError):
             raise
         except Exception as e:

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -310,7 +310,7 @@ class AthenaConnector(ConnectorABC):
             # guard this.)
             executed = (
                 "SELECT * FROM (\n"
-                f"{_strip_trailing_semicolon(sql)}\n"
+                f"{strip_trailing_semicolon(sql)}\n"
                 f") AS _wren_sub LIMIT {int(limit)}"
             )
         try:

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -20,7 +20,6 @@ from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
 
-
 # Athena's DB-API cursor returns Trino-style type names. We delegate the
 # lexing to sqlglot so we get nested type support (array<row<a int, b varchar>>,
 # decimal(p, s), map<K, V>, etc.) for free.

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -19,7 +19,6 @@ import pyarrow as pa
 from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
-
 # Athena's DB-API cursor returns Trino-style type names. We delegate the
 # lexing to sqlglot so we get nested type support (array<row<a int, b varchar>>,
 # decimal(p, s), map<K, V>, etc.) for free.

--- a/core/wren/src/wren/connector/base.py
+++ b/core/wren/src/wren/connector/base.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 
 import pyarrow as pa
+
+_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+
+def strip_trailing_semicolon(sql: str) -> str:
+    """Strip any trailing ``;`` characters and surrounding whitespace.
+
+    Connectors often subquery-wrap or EXPLAIN user SQL. Engines reject a
+    trailing semicolon inside those forms (e.g. ``SELECT * FROM (SELECT 1;)``
+    or ``EXPLAIN SELECT 1;``). Only the *terminating* run of semicolons and
+    whitespace is removed, so semicolons inside string literals
+    (``SELECT 'a;b'``) are preserved.
+    """
+    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class ConnectorABC(ABC):

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -10,7 +10,6 @@ postgres wire).
 from __future__ import annotations
 
 import json
-import re
 from decimal import ROUND_HALF_EVEN
 from decimal import Decimal as PyDecimal
 from typing import Any
@@ -18,7 +17,7 @@ from typing import Any
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
 # Postgres OID → Arrow type. Canner publishes Trino-style values over the
@@ -118,19 +117,6 @@ def _arrow_type(column) -> pa.DataType:
     return _PG_OID_TO_ARROW.get(column.type_code, pa.string())
 
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip any trailing ``;`` characters and surrounding whitespace.
-
-    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _t LIMIT N`` breaks when
-    ``sql`` ends in a semicolon — Postgres/Canner reject ``SELECT 1;`` inside
-    a subquery. We only strip the *terminating* run of semicolons/whitespace,
-    so semicolons inside string literals (e.g. ``SELECT 'a;b' FROM t``) are
-    preserved.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _coerce_decimal(value, target_type: pa.DataType):
@@ -262,7 +248,7 @@ class CannerConnector(ConnectorABC):
 
         if limit is not None:
             sql = (
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _t LIMIT {limit}"
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _t LIMIT {limit}"
             )
 
         try:
@@ -284,7 +270,7 @@ class CannerConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         import psycopg  # noqa: PLC0415
 
-        wrapped = f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _t LIMIT 0"
+        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _t LIMIT 0"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(wrapped)

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -117,8 +117,6 @@ def _arrow_type(column) -> pa.DataType:
     return _PG_OID_TO_ARROW.get(column.type_code, pa.string())
 
 
-
-
 def _coerce_decimal(value, target_type: pa.DataType):
     if value is None or not isinstance(value, PyDecimal):
         return value
@@ -247,9 +245,7 @@ class CannerConnector(ConnectorABC):
         import psycopg  # noqa: PLC0415
 
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _t LIMIT {limit}"
-            )
+            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _t LIMIT {limit}"
 
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -21,7 +21,7 @@ import sqlglot.errors
 from loguru import logger
 from sqlglot.expressions import DataType
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import (
     DIALECT_SQL,
     DatabaseTimeoutError,
@@ -381,19 +381,6 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
 # --------------------------------------------------------------------------
 
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip the terminating run of ``;`` characters and surrounding whitespace.
-
-    Matches the canner helper of the same name. Wrapping user SQL as
-    ``SELECT * FROM ({sql}) AS _wren_sub LIMIT N`` breaks when ``sql`` ends
-    in a semicolon — ClickHouse rejects ``SELECT 1;`` inside a subquery. Only
-    the terminating run is removed so semicolons inside string literals
-    (e.g. ``SELECT 'a;b'``) are preserved.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class ClickHouseConnector(ConnectorABC):
@@ -408,7 +395,7 @@ class ClickHouseConnector(ConnectorABC):
         # Strip the terminating run of ``;`` / whitespace before wrapping —
         # ``SELECT * FROM (SELECT 1;) AS _wren_sub LIMIT N`` is invalid SQL.
         # Semicolons inside string literals are preserved.
-        stripped = _strip_trailing_semicolon(sql)
+        stripped = strip_trailing_semicolon(sql)
         statement = stripped
         if limit is not None:
             statement = f"SELECT * FROM ({stripped}) AS _wren_sub LIMIT {limit}"
@@ -426,7 +413,7 @@ class ClickHouseConnector(ConnectorABC):
         return _build_clickhouse_arrow_table(result)
 
     def dry_run(self, sql: str) -> None:
-        stripped = _strip_trailing_semicolon(sql)
+        stripped = strip_trailing_semicolon(sql)
         try:
             self.connection.query(f"SELECT * FROM ({stripped}) AS _wren_sub LIMIT 0")
         except _ClickHouseDbError as e:

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -381,8 +381,6 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
 # --------------------------------------------------------------------------
 
 
-
-
 class ClickHouseConnector(ConnectorABC):
     """Native ``clickhouse-connect`` connector that bypasses ``ibis-project``."""
 

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -10,7 +10,6 @@ column-by-column to that schema.
 from __future__ import annotations
 
 import json
-import re
 from decimal import Decimal as PyDecimal
 from typing import Any
 from urllib.parse import parse_qsl, unquote, urlparse

--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -1,29 +1,15 @@
-import re
 from contextlib import closing
 
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import (
     DatabricksConnectionUnion,
     DatabricksServicePrincipalConnectionInfo,
     DatabricksTokenConnectionInfo,
 )
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip any trailing ``;`` characters and surrounding whitespace.
-
-    ``dry_run`` wraps user SQL as ``SELECT * FROM ({sql}) AS sub LIMIT 0``; a
-    trailing semicolon (``SELECT 1;``) becomes a syntax error inside the
-    subquery. Only the terminating run of semicolons/whitespace is stripped,
-    so semicolons inside string literals (e.g. ``SELECT 'a;b'``) are preserved.
-    Mirrors the postgres/canner/trino/clickhouse connectors.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _connection_kwargs(connection_info: DatabricksConnectionUnion) -> dict[str, str]:
@@ -74,7 +60,7 @@ class DatabricksConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
             )
 
     def close(self) -> None:

--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -11,7 +11,6 @@ from wren.model import (
 )
 
 
-
 def _connection_kwargs(connection_info: DatabricksConnectionUnion) -> dict[str, str]:
     kwargs = {
         "server_hostname": connection_info.server_hostname,

--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -1,32 +1,16 @@
 from __future__ import annotations
 
 import io
-import re
 from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.ipc as ipc
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import DataFusionConnectionInfo
 from wren.model.error import ErrorCode, WrenError
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip the terminating run of ``;`` characters and surrounding whitespace.
-
-    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _q LIMIT N`` breaks when
-    ``sql`` ends in a semicolon — DataFusion rejects ``SELECT 1;`` inside a
-    subquery (``sql parser error: Expected: an expression, found: ;``). Only
-    the *terminating* run of semicolons/whitespace is stripped, so semicolons
-    inside string literals (e.g. ``SELECT 'a;b' FROM t``) are preserved.
-    Mirrors the postgres/redshift/duckdb connectors, which already strip
-    before subquery-wrapping.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class DataFusionConnector(ConnectorABC):
@@ -48,7 +32,7 @@ class DataFusionConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
             sql = (
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
                 f"AS _q LIMIT {int(limit)}"
             )
         ipc_bytes = self.ctx.query(sql)

--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -12,7 +12,6 @@ from wren.model import DataFusionConnectionInfo
 from wren.model.error import ErrorCode, WrenError
 
 
-
 class DataFusionConnector(ConnectorABC):
     """DataFusion-native connector for local file analysis.
 

--- a/core/wren/src/wren/connector/duckdb.py
+++ b/core/wren/src/wren/connector/duckdb.py
@@ -13,7 +13,6 @@ from wren.model import (
 from wren.model.error import ErrorCode, WrenError
 
 
-
 def _escape_sql(value: str) -> str:
     return value.replace("'", "''")
 

--- a/core/wren/src/wren/connector/duckdb.py
+++ b/core/wren/src/wren/connector/duckdb.py
@@ -1,11 +1,10 @@
 import os
-import re
 
 import opendal
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import (
     GcsFileConnectionInfo,
     MinioFileConnectionInfo,
@@ -13,19 +12,6 @@ from wren.model import (
 )
 from wren.model.error import ErrorCode, WrenError
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip the terminating run of ``;`` characters and surrounding whitespace.
-
-    Matches the canner/clickhouse/trino helpers of the same name. Wrapping
-    user SQL as ``SELECT * FROM ({sql}) AS _q LIMIT N`` breaks when ``sql``
-    ends in a semicolon — ``SELECT 1;`` is invalid inside a subquery. Only the
-    terminating run is removed so semicolons inside string literals
-    (e.g. ``SELECT ';' AS x``) are preserved.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _escape_sql(value: str) -> str:
@@ -98,7 +84,7 @@ class DuckDBConnector(ConnectorABC):
             # the subquery stays valid SQL (e.g. ``SELECT 1;`` must not become
             # ``SELECT * FROM (SELECT 1;) AS _q LIMIT ...``). Semicolons inside
             # string literals are preserved.
-            stripped = _strip_trailing_semicolon(sql)
+            stripped = strip_trailing_semicolon(sql)
             sql = f"SELECT * FROM ({stripped}) AS _q LIMIT {int(limit)}"
         return self.connection.execute(sql).fetch_arrow_table()
 
@@ -113,7 +99,7 @@ class DuckDBConnector(ConnectorABC):
         statement then becomes a natural syntax error inside the subquery, and
         no rows are materialized.
         """
-        stripped = _strip_trailing_semicolon(sql)
+        stripped = strip_trailing_semicolon(sql)
         self.connection.execute(f"SELECT * FROM ({stripped}) AS _q LIMIT 0")
 
     def _attach_database(self, connection_info) -> None:

--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -18,7 +18,7 @@ from functools import cache
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon, strip_trailing_semicolon
 from wren.model.data_source import DataSource
 from wren.model.error import ErrorCode, WrenError
 
@@ -35,7 +35,7 @@ def _apply_limit(sql: str, limit: int) -> str:
     SELECT projects two columns with the same name (e.g. a join that selects
     ``a.id`` and ``b.id``).
     """
-    return f"{sql.rstrip().rstrip(';').rstrip()}\nLIMIT {limit}"
+    return f"{strip_trailing_semicolon(sql)}\nLIMIT {limit}"
 
 
 def _coerce_limit(limit: int | None) -> int | None:
@@ -99,7 +99,7 @@ class MySqlConnector(ConnectorABC):
         # subquery-wrapping side-steps ``ER_DUP_FIELDNAME`` for queries that
         # surface duplicate column names. We strip a trailing semicolon to
         # match the same compose-ability we use for ``query``'s LIMIT path.
-        explain_sql = f"EXPLAIN {sql.rstrip().rstrip(';').rstrip()}"
+        explain_sql = f"EXPLAIN {strip_trailing_semicolon(sql)}"
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(explain_sql)
             cursor.fetchall()

--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -18,7 +18,11 @@ from functools import cache
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC, strip_trailing_semicolon, strip_trailing_semicolon
+from wren.connector.base import (
+    ConnectorABC,
+    strip_trailing_semicolon,
+    strip_trailing_semicolon,
+)
 from wren.model.data_source import DataSource
 from wren.model.error import ErrorCode, WrenError
 

--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -21,7 +21,6 @@ from loguru import logger
 from wren.connector.base import (
     ConnectorABC,
     strip_trailing_semicolon,
-    strip_trailing_semicolon,
 )
 from wren.model.data_source import DataSource
 from wren.model.error import ErrorCode, WrenError

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -15,9 +15,6 @@ except ImportError:  # pragma: no cover
     oracledb = None
 
 from wren.connector.base import ConnectorABC, strip_trailing_semicolon
-
-# Back-compat private alias used by unit tests.
-_strip_trailing_semicolon = strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
 

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -1,6 +1,5 @@
 """Native oracledb connector — bypasses ibis oracle backend."""
 
-import re
 from decimal import Decimal as PyDecimal
 from urllib.parse import unquote, urlparse
 
@@ -15,11 +14,11 @@ try:
 except ImportError:  # pragma: no cover
     oracledb = None
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
+
+# Back-compat private alias used by unit tests.
+_strip_trailing_semicolon = strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
-
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
 
 def _parse_oracle_connection_url(url: str):
     """Parse an Oracle URL after escaping raw brackets in userinfo only.
@@ -52,19 +51,6 @@ def _parse_oracle_connection_url(url: str):
     sanitized_url = f"{prefix}{sanitized_userinfo}@{hostinfo}{rest[authority_end:]}"
     return urlparse(sanitized_url)
 
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip any trailing ``;`` characters and surrounding whitespace.
-
-    Both ``query`` (with a limit) and ``dry_run`` wrap user SQL as
-    ``SELECT * FROM ({sql}) t WHERE ROWNUM <= N``. Oracle rejects a trailing
-    semicolon inside a subquery (``ORA-00911: invalid character``), so a query
-    that ends in ``;`` fails even though it runs fine standalone. Only the
-    terminating run of semicolons/whitespace is stripped, so semicolons inside
-    string literals (e.g. ``SELECT 'a;b'``) are preserved. Mirrors the
-    postgres/canner/trino/clickhouse connectors.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _ora_number_type(precision, scale) -> pa.DataType:
@@ -197,7 +183,7 @@ class OracleConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
             sql = (
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) t "
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) t "
                 f"WHERE ROWNUM <= {limit}"
             )
         try:
@@ -217,7 +203,7 @@ class OracleConnector(ConnectorABC):
             try:
                 with self.connection.cursor() as cursor:
                     cursor.execute(
-                        f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) t "
+                        f"SELECT * FROM ({strip_trailing_semicolon(sql)}) t "
                         f"WHERE ROWNUM <= 0"
                     )
             except oracledb.DatabaseError as e:

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -52,7 +52,6 @@ def _parse_oracle_connection_url(url: str):
     return urlparse(sanitized_url)
 
 
-
 def _ora_number_type(precision, scale) -> pa.DataType:
     if scale is not None and scale > 0:
         p = min(int(precision), 38) if precision else 38

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -20,6 +20,7 @@ from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 _strip_trailing_semicolon = strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
+
 def _parse_oracle_connection_url(url: str):
     """Parse an Oracle URL after escaping raw brackets in userinfo only.
 

--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -24,7 +24,6 @@ from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
 
-
 # Map of well-known PostgreSQL OIDs to Arrow types. OIDs that we have not
 # explicitly mapped fall back to ``pa.string()`` (see ``_get_pg_arrow_type``).
 _PG_OID_TO_ARROW: dict[int, pa.DataType] = {
@@ -252,7 +251,9 @@ class PostgresConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
-            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
+            sql = (
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
+            )
 
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -23,7 +23,6 @@ from loguru import logger
 from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
-
 # Map of well-known PostgreSQL OIDs to Arrow types. OIDs that we have not
 # explicitly mapped fall back to ``pa.string()`` (see ``_get_pg_arrow_type``).
 _PG_OID_TO_ARROW: dict[int, pa.DataType] = {

--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -13,7 +13,6 @@ It avoids the ibis-framework dependency entirely, which gives us:
 from __future__ import annotations
 
 import json
-import re
 from decimal import ROUND_HALF_EVEN
 from decimal import Decimal as PyDecimal
 
@@ -21,23 +20,9 @@ import psycopg
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip any trailing ``;`` characters and surrounding whitespace.
-
-    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _sub LIMIT N`` breaks when
-    ``sql`` ends in a semicolon — Postgres rejects ``SELECT 1;`` inside a
-    subquery (``syntax error at or near ";"``). Only the *terminating* run of
-    semicolons/whitespace is stripped, so semicolons inside string literals
-    (e.g. ``SELECT 'a;b' FROM t``) are preserved. Mirrors the canner/trino/
-    clickhouse connectors, which already strip before subquery-wrapping.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 # Map of well-known PostgreSQL OIDs to Arrow types. OIDs that we have not
@@ -267,7 +252,7 @@ class PostgresConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
-            sql = f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
+            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
 
         try:
             with self.connection.cursor() as cursor:
@@ -286,7 +271,7 @@ class PostgresConnector(ConnectorABC):
             ) from e
 
     def dry_run(self, sql: str) -> None:
-        wrapped = f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
+        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(wrapped)

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -13,7 +13,6 @@ from wren.model import (
 from wren.model.error import ErrorCode, WrenError
 
 
-
 class RedshiftConnector(ConnectorABC):
     def __init__(self, connection_info: RedshiftConnectionUnion):
         import redshift_connector  # noqa: PLC0415

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -1,11 +1,10 @@
-import re
 from contextlib import closing
 
 import pandas as pd
 import pyarrow as pa
 from loguru import logger
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import (
     RedshiftConnectionInfo,
     RedshiftConnectionUnion,
@@ -13,20 +12,6 @@ from wren.model import (
 )
 from wren.model.error import ErrorCode, WrenError
 
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip any trailing ``;`` characters and surrounding whitespace.
-
-    Wrapping user SQL as ``SELECT * FROM ({sql}) AS _q LIMIT N`` breaks when
-    ``sql`` ends in a semicolon — Redshift rejects ``SELECT 1;`` inside a
-    subquery (``syntax error at or near ";"``). Only the *terminating* run of
-    semicolons/whitespace is stripped, so semicolons inside string literals
-    (e.g. ``SELECT 'a;b' FROM t``) are preserved. Mirrors the postgres/canner/
-    trino/clickhouse connectors, which already strip before subquery-wrapping.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 class RedshiftConnector(ConnectorABC):
@@ -62,7 +47,7 @@ class RedshiftConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
             sql = (
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
                 f"AS _q LIMIT {int(limit)}"
             )
         with closing(self.connection.cursor()) as cursor:
@@ -75,7 +60,7 @@ class RedshiftConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(
-                f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
             )
 
     def close(self) -> None:

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -2,24 +2,10 @@
 
 from __future__ import annotations
 
-import re
-
 import pyarrow as pa
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
-
-_TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
-
-
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip terminating ``;`` / whitespace so we can wrap SQL as a subquery.
-
-    Snowflake rejects ``SELECT 1;`` inside a subquery. Only the trailing run is
-    removed so semicolons inside string literals stay intact. Mirrors
-    postgres/redshift connectors.
-    """
-    return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 
 def _build_connection_params(connection_info) -> dict:
@@ -80,7 +66,7 @@ class SnowflakeConnector(ConnectorABC):
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
             executed = (
                 "SELECT * FROM (\n"
-                f"{_strip_trailing_semicolon(sql)}\n"
+                f"{strip_trailing_semicolon(sql)}\n"
                 f") AS _wren_sub LIMIT {int(limit)}"
             )
         try:

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -359,7 +359,6 @@ def _import_trino():
         ) from e
 
 
-
 class TrinoConnector(ConnectorABC):
     """Native trino DB-API connector that bypasses ibis-project."""
 
@@ -389,7 +388,9 @@ class TrinoConnector(ConnectorABC):
         trino = _import_trino()
 
         if limit is not None:
-            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
+            sql = (
+                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
+            )
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(sql)

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -19,7 +19,7 @@ import sqlglot.errors
 from loguru import logger
 from sqlglot.expressions import ColumnDef, DataType
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import (
     DIALECT_SQL,
     ErrorCode,
@@ -359,14 +359,6 @@ def _import_trino():
         ) from e
 
 
-def _strip_trailing_semicolon(sql: str) -> str:
-    """Strip trailing whitespace and an optional final semicolon.
-
-    Wrapping ``SELECT * FROM ({sql}) AS _sub LIMIT N`` breaks if ``sql`` ends
-    with ``;`` because the parser sees ``...; ) AS _sub...``.
-    """
-    return sql.rstrip().removesuffix(";").rstrip()
-
 
 class TrinoConnector(ConnectorABC):
     """Native trino DB-API connector that bypasses ibis-project."""
@@ -397,7 +389,7 @@ class TrinoConnector(ConnectorABC):
         trino = _import_trino()
 
         if limit is not None:
-            sql = f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
+            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(sql)
@@ -417,7 +409,7 @@ class TrinoConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         trino = _import_trino()
 
-        wrapped = f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
+        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(wrapped)

--- a/core/wren/tests/connectors/test_canner.py
+++ b/core/wren/tests/connectors/test_canner.py
@@ -18,9 +18,9 @@ import pytest
 from wren.connector.canner import (
     CannerConnector,
     _arrow_type,
-    _build_column,
-    _strip_trailing_semicolon,
+    _build_column
 )
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 from wren.model import CannerConnectionInfo
 
 psycopg = pytest.importorskip("psycopg")

--- a/core/wren/tests/connectors/test_postgres.py
+++ b/core/wren/tests/connectors/test_postgres.py
@@ -264,7 +264,7 @@ class TestPostgresConnectorTypes:
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
-from wren.connector.postgres import _strip_trailing_semicolon
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 
 def _make_mock_connector() -> tuple[PostgresConnector, MagicMock]:

--- a/core/wren/tests/unit/test_athena_limit_pushdown.py
+++ b/core/wren/tests/unit/test_athena_limit_pushdown.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from wren.connector.athena import AthenaConnector, _strip_trailing_semicolon
+from wren.connector.athena import AthenaConnector
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 pytestmark = pytest.mark.unit
 
@@ -29,7 +30,9 @@ def test_query_pushes_limit_into_sql():
         # contextlib.closing expects .close()
         cursor.close = MagicMock()
         # wrap closing: connection.cursor() is used as CM via closing()
-        with patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)):
+        with patch(
+            "wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)
+        ):
             connector.query("SELECT 1;", limit=3)
 
     cursor.execute.assert_called_once_with(
@@ -54,9 +57,12 @@ def test_query_without_limit_runs_original_sql():
     connector.connection = MagicMock()
     cursor = MagicMock()
     cursor.close = MagicMock()
-    with patch(
-        "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
-    ), patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)):
+    with (
+        patch(
+            "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
+        ),
+        patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)),
+    ):
         connector.connection.cursor.return_value = cursor
         connector.query("SELECT 1")
     cursor.execute.assert_called_once_with("SELECT 1")
@@ -68,9 +74,12 @@ def test_query_limit_survives_trailing_line_comment():
     connector.connection = MagicMock()
     cursor = MagicMock()
     cursor.close = MagicMock()
-    with patch(
-        "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
-    ), patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)):
+    with (
+        patch(
+            "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
+        ),
+        patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)),
+    ):
         connector.connection.cursor.return_value = cursor
         connector.query("SELECT 1 -- pick", limit=3)
     cursor.execute.assert_called_once_with(

--- a/core/wren/tests/unit/test_athena_semicolon.py
+++ b/core/wren/tests/unit/test_athena_semicolon.py
@@ -8,7 +8,8 @@ assert on the executed SQL, so no AWS connection is required.
 
 from unittest.mock import MagicMock
 
-from wren.connector.athena import AthenaConnector, _strip_trailing_semicolon
+from wren.connector.athena import AthenaConnector
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 
 def _make_mock_connector() -> tuple[AthenaConnector, MagicMock]:

--- a/core/wren/tests/unit/test_databricks_semicolon.py
+++ b/core/wren/tests/unit/test_databricks_semicolon.py
@@ -8,7 +8,8 @@ and assert on the executed SQL, so no Databricks connection is required.
 
 from unittest.mock import MagicMock
 
-from wren.connector.databricks import DatabricksConnector, _strip_trailing_semicolon
+from wren.connector.databricks import DatabricksConnector
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 
 def _make_mock_connector() -> tuple[DatabricksConnector, MagicMock]:

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -16,8 +16,9 @@ import pyarrow.ipc as ipc
 
 from wren.connector.datafusion import (
     DataFusionConnector,
-    _strip_trailing_semicolon,
+    
 )
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 
 def _make_mock_connector() -> tuple[DataFusionConnector, MagicMock]:

--- a/core/wren/tests/unit/test_oracle_semicolon.py
+++ b/core/wren/tests/unit/test_oracle_semicolon.py
@@ -18,8 +18,9 @@ pytest.importorskip("oracledb")
 from wren.connector import oracle as oracle_mod  # noqa: E402
 from wren.connector.oracle import (  # noqa: E402
     OracleConnector,
-    _strip_trailing_semicolon,
+    
 )
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 
 def _make_mock_connector() -> tuple[OracleConnector, MagicMock]:

--- a/core/wren/tests/unit/test_redshift_semicolon.py
+++ b/core/wren/tests/unit/test_redshift_semicolon.py
@@ -10,7 +10,8 @@ required. Mirrors the postgres connector's semicolon tests.
 from contextlib import closing  # noqa: F401  (kept for parity / import safety)
 from unittest.mock import MagicMock
 
-from wren.connector.redshift import RedshiftConnector, _strip_trailing_semicolon
+from wren.connector.redshift import RedshiftConnector
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 
 
 def _make_mock_connector() -> tuple[RedshiftConnector, MagicMock]:

--- a/core/wren/tests/unit/test_snowflake_limit_pushdown.py
+++ b/core/wren/tests/unit/test_snowflake_limit_pushdown.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock
 import pyarrow as pa
 import pytest
 
-from wren.connector.snowflake import SnowflakeConnector, _strip_trailing_semicolon
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
+from wren.connector.snowflake import SnowflakeConnector
 
 pytestmark = pytest.mark.unit
 

--- a/core/wren/tests/unit/test_strip_trailing_semicolon.py
+++ b/core/wren/tests/unit/test_strip_trailing_semicolon.py
@@ -1,0 +1,22 @@
+"""Shared strip_trailing_semicolon helper (connector base)."""
+
+import pytest
+
+from wren.connector.base import strip_trailing_semicolon
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("SELECT 1", "SELECT 1"),
+        ("SELECT 1;", "SELECT 1"),
+        ("SELECT 1;  \n", "SELECT 1"),
+        ("SELECT 1 ; ;", "SELECT 1"),
+        ("SELECT 1;;\n\t", "SELECT 1"),
+        ("SELECT 'a;b' AS x", "SELECT 'a;b' AS x"),
+        ("SELECT 'a;b' AS x;", "SELECT 'a;b' AS x"),
+        ("SELECT 'a;b' AS x ; ;  ", "SELECT 'a;b' AS x"),
+    ],
+)
+def test_strip_trailing_semicolon(raw: str, expected: str) -> None:
+    assert strip_trailing_semicolon(raw) == expected

--- a/core/wren/tests/unit/test_trino_parser.py
+++ b/core/wren/tests/unit/test_trino_parser.py
@@ -17,9 +17,9 @@ import pytest
 from wren.connector.trino import (
     _build_trino_column,
     _parse_trino_data_type,
-    _parse_trino_url,
-    _strip_trailing_semicolon,
+    _parse_trino_url
 )
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
 from wren.model.error import ErrorCode, WrenError
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Move `strip_trailing_semicolon` (regex terminating-run) into `wren.connector.base` and migrate connectors onto it.
- Unifies multi-semicolon behavior (including trino/mysql) and removes 10 local helper copies.

## Motivation

Closes #2441.

Per-connector copies of `_strip_trailing_semicolon` drifted (regex run vs single `removesuffix` / `rstrip`). Maintainers agreed in the #2430 review thread to consolidate on one helper in `connector/base.py`. Scope is `core/wren` only (Apache-2.0).

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_strip_trailing_semicolon.py tests/unit/test_athena_semicolon.py tests/unit/test_databricks_semicolon.py tests/unit/test_redshift_semicolon.py tests/unit/test_oracle_semicolon.py tests/unit/test_datafusion_semicolon.py tests/unit/test_trino_parser.py::test_strip_trailing_semicolon tests/connectors/test_postgres.py -k "strip or semicolon" -q` — 38 passed
- `tests/connectors/test_canner.py -k strip` — 7 passed
- Did NOT change: connector query/dry_run control flow beyond the shared helper

Real behavior proof (shared helper):
`strip_trailing_semicolon("SELECT 1 ; ;") == "SELECT 1"`
`strip_trailing_semicolon("SELECT 'a;b' AS x;") == "SELECT 'a;b' AS x"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL handling across supported connectors by consistently removing only trailing semicolons (and surrounding whitespace) before wrapping queries and generating dry-run SQL.
  - Preserves semicolons inside quoted string literals.
  - Reduces failures in limited-result queries, including `EXPLAIN`-style dry runs.

- **Refactor**
  - Consolidated trailing-semicolon stripping into a shared helper used by multiple connectors.

- **Tests**
  - Added unit test coverage for the shared trailing-semicolon behavior.
  - Updated connector tests to use the centralized semicolon-handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->