### PR TITLE
fix(trino): coerce verify=false URL/kwargs for SSL connections

### DIFF
--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -265,6 +265,62 @@ def _build_trino_arrow_table(cursor) -> pa.Table:
     )
 
 
+
+def _coerce_trino_verify(value):
+    """Normalize a ``verify`` SSL override for ``trino.dbapi.connect``.
+
+    Trino's client accepts ``verify`` as a bool or a CA path. Connection URLs
+    and form kwargs always deliver strings, so ``?verify=false`` must not be
+    treated as a truthy path. Returns the coerced value, or ``None`` when the
+    key should be omitted (leave package defaults).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    text = str(value).strip()
+    if text == "":
+        return None
+    low = text.lower()
+    if low in {"0", "false", "no", "off"}:
+        return False
+    if low in {"1", "true", "yes", "on"}:
+        return True
+    # Treat as CA bundle / cert path.
+    return text
+
+
+def _apply_trino_ssl_overrides(connect_kwargs: dict) -> dict:
+    """Mutate connect kwargs so SSL verify overrides are real booleans/paths.
+
+    Users connecting to private Trino (OpenShift, corporate CA) often need
+    ``verify=false`` or a custom CA. Without coercion, the string ``"false"``
+    is truthy and still attempts system CA verification (#1502).
+    """
+    if "verify" in connect_kwargs:
+        coerced = _coerce_trino_verify(connect_kwargs.pop("verify"))
+        if coerced is not None:
+            connect_kwargs["verify"] = coerced
+    # Alias common misspellings / UI keys
+    if "ssl_verify" in connect_kwargs and "verify" not in connect_kwargs:
+        coerced = _coerce_trino_verify(connect_kwargs.pop("ssl_verify"))
+        if coerced is not None:
+            connect_kwargs["verify"] = coerced
+    elif "ssl_verify" in connect_kwargs:
+        connect_kwargs.pop("ssl_verify", None)
+    if "insecure" in connect_kwargs and "verify" not in connect_kwargs:
+        insecure = _coerce_trino_verify(connect_kwargs.pop("insecure"))
+        if insecure is True:
+            connect_kwargs["verify"] = False
+        elif insecure is False:
+            connect_kwargs["verify"] = True
+    elif "insecure" in connect_kwargs:
+        connect_kwargs.pop("insecure", None)
+    return connect_kwargs
+
+
 def _build_trino_connect_kwargs(connection_info) -> dict:
     """Build kwargs for ``trino.dbapi.connect`` from either a typed
     ``TrinoConnectionInfo`` or a generic ``ConnectionUrl``.
@@ -292,7 +348,7 @@ def _build_trino_connect_kwargs(connection_info) -> dict:
         "_password": password,
     }
     out.update(kwargs)
-    return out
+    return _apply_trino_ssl_overrides(out)
 
 
 def _parse_trino_url(url: str, extra_kwargs: dict | None) -> dict:
@@ -337,7 +393,7 @@ def _parse_trino_url(url: str, extra_kwargs: dict | None) -> dict:
     if parsed.scheme == "trino+https":
         out["http_scheme"] = "https"
     out.update(query_kwargs)
-    return out
+    return _apply_trino_ssl_overrides(out)
 
 
 _TRINO_IMPORT_HINT = (

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -317,6 +317,11 @@ def _apply_trino_ssl_overrides(connect_kwargs: dict) -> dict:
             connect_kwargs["verify"] = True
     elif "insecure" in connect_kwargs:
         connect_kwargs.pop("insecure", None)
+    if connect_kwargs.get("verify") is False:
+        logger.warning(
+            "Trino SSL certificate verification is disabled (verify=false); "
+            "the connection will not validate the server certificate."
+        )
     return connect_kwargs
 
 

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -265,7 +265,6 @@ def _build_trino_arrow_table(cursor) -> pa.Table:
     )
 
 
-
 def _coerce_trino_verify(value):
     """Normalize a ``verify`` SSL override for ``trino.dbapi.connect``.
 

--- a/core/wren/tests/unit/test_trino_ssl_verify.py
+++ b/core/wren/tests/unit/test_trino_ssl_verify.py
@@ -1,0 +1,32 @@
+"""Trino SSL verify coercion (#1502)."""
+
+from wren.connector.trino import (
+    _apply_trino_ssl_overrides,
+    _coerce_trino_verify,
+    _parse_trino_url,
+)
+
+
+def test_coerce_false_strings():
+    assert _coerce_trino_verify("false") is False
+    assert _coerce_trino_verify("FALSE") is False
+    assert _coerce_trino_verify("0") is False
+
+
+def test_coerce_true_and_path():
+    assert _coerce_trino_verify("true") is True
+    assert _coerce_trino_verify("/etc/ssl/certs/ca.pem") == "/etc/ssl/certs/ca.pem"
+
+
+def test_parse_url_verify_false_query_param():
+    kwargs = _parse_trino_url(
+        "trino+https://alice@trino.example:443/cat/sch?verify=false", None
+    )
+    assert kwargs["http_scheme"] == "https"
+    assert kwargs["verify"] is False
+
+
+def test_apply_insecure_alias():
+    out = _apply_trino_ssl_overrides({"host": "h", "insecure": "true"})
+    assert out["verify"] is False
+    assert "insecure" not in out

--- a/core/wren/tests/unit/test_trino_ssl_verify.py
+++ b/core/wren/tests/unit/test_trino_ssl_verify.py
@@ -30,3 +30,9 @@ def test_apply_insecure_alias():
     out = _apply_trino_ssl_overrides({"host": "h", "insecure": "true"})
     assert out["verify"] is False
     assert "insecure" not in out
+
+
+def test_apply_ssl_verify_alias():
+    out = _apply_trino_ssl_overrides({"host": "h", "ssl_verify": "false"})
+    assert out["verify"] is False
+    assert "ssl_verify" not in out


### PR DESCRIPTION
## Summary

- Coerce Trino ``verify`` / ``ssl_verify`` / ``insecure`` connection overrides from string URL/query kwargs into real bools or CA paths before ``trino.dbapi.connect``.
- ``?verify=false`` on ``trino+https://`` no longer leaves a truthy string that still enforces system CA checks.

## Motivation

Closes #1502.

Users connecting to private/OpenShift Trino with self-signed certs set ``verify=false`` (or want a CA path). Because kwargs/query params are strings, ``\"false\"`` is truthy and verification still fails with ``CERTIFICATE_VERIFY_FAILED``.

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_trino_ssl_verify.py -q` — 4 passed
- Real behavior: `_parse_trino_url(..., ?verify=false)` yields `verify is False`.

Apache path: `core/wren/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Trino SSL connection handling so `verify` values passed via connection options or URLs are interpreted correctly.
  * Properly handles common inputs like `"true"`, `"false"`, and `"0"` as booleans, not certificate paths.
  * Added support for SSL aliases such as `ssl_verify` and `insecure`, including correct mapping/removal of those fields.
  * Preserves CA certificate file paths for secure connections and emits a warning when SSL verification is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->