### PR TITLE
fix(redshift): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -65,6 +65,10 @@ class RedshiftConnector(ConnectorABC):
                 f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
                 f"AS _q LIMIT {int(limit)}"
             )
+        else:
+            # Unlimited path also rejects trailing ``;`` for single statements
+            # depending on driver/session settings — strip for consistency.
+            sql = _strip_trailing_semicolon(sql)
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             cols = [desc[0] for desc in cursor.description]

--- a/core/wren/tests/unit/test_redshift_semicolon.py
+++ b/core/wren/tests/unit/test_redshift_semicolon.py
@@ -49,3 +49,11 @@ def test_helper_preserves_semicolon_inside_string_literal() -> None:
 
 def test_helper_no_trailing_semicolon_unchanged() -> None:
     assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+
+
+def test_query_without_limit_strips_trailing_semicolon() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.query("SELECT 1;")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT 1"
+    assert not sent.endswith(";")


### PR DESCRIPTION
## Summary

- Redshift `query()` now strips a terminating semicolon/whitespace run even when `limit is None`.
- Keeps behavior aligned with the limited-query wrap path and other connectors that sanitize client SQL before execute.

## Motivation

Limited Redshift queries already subquery-wrap after stripping trailing ``;``. The unlimited path executed raw SQL, so client SQL ending with ``;`` could still fail depending on session/driver batching. Strip for both paths (string-literal-safe terminating-run regex already used by this connector).

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_redshift_semicolon.py -q` — 5 passed
- Real behavior: `query("SELECT 1;")` sends `SELECT 1` on the unlimited path.

Apache path: `core/wren/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redshift query execution when no row limit is specified by stripping trailing semicolons and surrounding whitespace.
  * Ensures submitted SQL is normalized consistently whether a limit is provided or not.
* **Tests**
  * Added a unit test to verify unlimited queries don’t send SQL that ends with `;`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->