### PR TITLE
fix(datafusion): strip trailing semicolon on unlimited query and dry_run

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -51,12 +51,14 @@ class DataFusionConnector(ConnectorABC):
                 f"SELECT * FROM ({_strip_trailing_semicolon(sql)}) "
                 f"AS _q LIMIT {int(limit)}"
             )
+        else:
+            sql = _strip_trailing_semicolon(sql)
         ipc_bytes = self.ctx.query(sql)
         reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))
         return reader.read_all()
 
     def dry_run(self, sql: str) -> None:
-        self.ctx.dry_run(sql)
+        self.ctx.dry_run(_strip_trailing_semicolon(sql))
 
     def close(self) -> None:
         pass

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -49,7 +49,7 @@ def test_query_without_limit_is_unwrapped() -> None:
     connector.query("SELECT 1;")
     (sent,), _ = ctx.query.call_args
     # No limit -> no subquery wrapping; passed through verbatim.
-    assert sent == "SELECT 1;"
+    assert sent == "SELECT 1"
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:
@@ -59,3 +59,19 @@ def test_helper_preserves_semicolon_inside_string_literal() -> None:
 
 def test_helper_no_trailing_semicolon_unchanged() -> None:
     assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+
+
+def test_query_without_limit_strips_trailing_semicolon() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.query("SELECT 1;")
+    (sent,), _ = ctx.query.call_args
+    assert sent == "SELECT 1"
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, ctx = _make_mock_connector()
+    if not hasattr(ctx, "dry_run"):
+        ctx.dry_run = MagicMock()
+    connector.dry_run("SELECT 1;")
+    (sent,), _ = ctx.dry_run.call_args
+    assert sent == "SELECT 1"


### PR DESCRIPTION
## Summary

- DataFusion unlimited `query()` and `dry_run()` strip terminating semicolon/whitespace runs before `ctx.query` / `ctx.dry_run`.
- Aligns with the existing limited-query subquery wrap sanitization.

## Motivation

Limited queries already strip before wrap. Unlimited/`dry_run` still forwarded raw client SQL ending in ``;``, which DataFusion rejects for single-statement execution depending on path. Reuse the connector's terminating-run helper.

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_datafusion_semicolon.py -q` — all passed
- `query("SELECT 1;")` without limit sends `SELECT 1`.

Apache path: `core/wren/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL execution by consistently removing trailing semicolons before running statements, including cases without a row limit.
  * Ensured dry-run validation applies the same SQL normalization as normal query execution.

* **Tests**
  * Updated and expanded unit tests to verify trailing semicolon stripping for both query execution (no limit) and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->