### PR TITLE
ci(core): sync downstream lockfile during Rust releases

### DIFF
--- a/core/wren-core-wasm/Cargo.lock
+++ b/core/wren-core-wasm/Cargo.lock
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "wren-core-base"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "wren-manifest-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quote",
  "syn",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "wren-semantic-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "csv",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,7 +56,19 @@
     "core/wren-core-base/manifest-macro": {
       "component": "wren-manifest-macro",
       "release-type": "rust",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "path": "/core/wren-core-py/Cargo.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-manifest-macro')].version"
+        },
+        {
+          "path": "/core/wren-core-wasm/Cargo.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-manifest-macro')].version"
+        }
+      ]
     },
     "core/wren-core-base": {
       "component": "wren-core-base",
@@ -67,6 +79,16 @@
           "path": "Cargo.toml",
           "type": "toml",
           "jsonpath": "$.dependencies.wren-manifest-macro.version"
+        },
+        {
+          "path": "/core/wren-core-py/Cargo.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-core-base')].version"
+        },
+        {
+          "path": "/core/wren-core-wasm/Cargo.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-core-base')].version"
         }
       ]
     },
@@ -84,6 +106,16 @@
           "path": "Cargo.toml",
           "type": "toml",
           "jsonpath": "$.workspace.dependencies.wren-core-base.version"
+        },
+        {
+          "path": "/core/wren-core-py/Cargo.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-semantic-core')].version"
+        },
+        {
+          "path": "/core/wren-core-wasm/Cargo.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='wren-semantic-core')].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Keep `core/wren-core-py/Cargo.lock` synchronized when the linked Rust core crates are released.

Release Please now updates the three corresponding lockfile entries in the release PR, preventing locked downstream builds from failing after a version bump.

## Verification

- Validated against the Release Please version bundled by `release-please-action@v4`
- Verified the generated lockfile with `cargo metadata --locked`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated release version tracking for additional Rust component packages.
  * Release metadata now derives component versions from Cargo lockfiles instead of manifest-based selectors, improving consistency and accuracy across builds.
  * Updates include sourcing the relevant core and semantic-core component versions from the appropriate lockfiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->