### PR TITLE
fix(snowflake): strip trailing semicolon before dry_run describe

### DIFF
--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -100,9 +100,12 @@ class SnowflakeConnector(ConnectorABC):
         return arrow_table
 
     def dry_run(self, sql: str) -> None:
+        # ``describe`` still fails when the statement is terminated with ``;``
+        # (ProgrammingError: unexpected ';'). Strip only the trailing run.
+        cleaned = _strip_trailing_semicolon(sql)
         try:
             with self.connection.cursor() as cursor:
-                cursor.describe(sql)
+                cursor.describe(cleaned)
         except _programming_error() as e:
             raise WrenError(
                 ErrorCode.INVALID_SQL,

--- a/core/wren/tests/unit/test_snowflake_limit_pushdown.py
+++ b/core/wren/tests/unit/test_snowflake_limit_pushdown.py
@@ -57,3 +57,25 @@ def test_query_without_limit_runs_original_sql():
     connector.query("SELECT 1")
 
     cursor.execute.assert_called_once_with("SELECT 1")
+
+
+def test_dry_run_strips_trailing_semicolon_before_describe():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+
+    connector.dry_run("SELECT 1 AS x;")
+
+    cursor.describe.assert_called_once_with("SELECT 1 AS x")
+
+
+def test_dry_run_preserves_interior_semicolon_in_literal():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+
+    connector.dry_run("SELECT 'a;b' FROM t;  \n")
+
+    cursor.describe.assert_called_once_with("SELECT 'a;b' FROM t")


### PR DESCRIPTION
## Summary

- Strip trailing semicolon before Snowflake `cursor.describe` dry runs.
- Mirrors the existing `_strip_trailing_semicolon` used for query LIMIT wrap.

## Motivation

SQL clients often terminate statements with `;`. `describe("SELECT 1;")` fails with ProgrammingError while `query` already strips. Dry-run then reports invalid SQL for valid statements.

## Verification

- Without fix: dry_run describe keeps trailing `;` (test AssertionError)
- With fix: `pytest tests/unit/test_snowflake_limit_pushdown.py` → 6 passed
- Path: Apache-2.0 `core/**`

## Files

- core/wren/src/wren/connector/snowflake.py
- core/wren/tests/unit/test_snowflake_limit_pushdown.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Snowflake SQL validation for statements ending with a semicolon.
  * Preserved semicolons inside quoted string values during validation.
* **Tests**
  * Added coverage to verify trailing-semicolon handling and preservation of semicolons within SQL literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->