### PR TITLE
fix(canner): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -244,8 +244,15 @@ class CannerConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         import psycopg  # noqa: PLC0415
 
+        # Always strip a trailing statement terminator. Unlimited queries still
+        # go to execute() raw; ``SELECT 1;`` is fine for single-shot clients, but
+        # multi-semicolon whitespace after tools paste (``SELECT 1; ;``) and
+        # empty trailing statements can produce Protocol/syntax noise/door. More
+        # importantly we keep composition consistent with the limited path so
+        # callers can always end SQL with ``;`` without branching.
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _t LIMIT {limit}"
+            sql = f"SELECT * FROM ({sql}) AS _t LIMIT {limit}"
 
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/tests/unit/test_canner_semicolon.py
+++ b/core/wren/tests/unit/test_canner_semicolon.py
@@ -9,7 +9,8 @@ from unittest.mock import MagicMock
 import pyarrow as pa
 import pytest
 
-from wren.connector.canner import CannerConnector, _strip_trailing_semicolon
+from wren.connector.base import strip_trailing_semicolon as _strip_trailing_semicolon
+from wren.connector.canner import CannerConnector
 
 pytestmark = pytest.mark.unit
 

--- a/core/wren/tests/unit/test_canner_semicolon.py
+++ b/core/wren/tests/unit/test_canner_semicolon.py
@@ -1,0 +1,69 @@
+"""Canner connector strips trailing ; on limited and unlimited query paths."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wren.connector.canner import CannerConnector, _strip_trailing_semicolon
+
+pytestmark = pytest.mark.unit
+
+
+def test_strip_helper():
+    assert _strip_trailing_semicolon("SELECT 1; ; \n") == "SELECT 1"
+    assert _strip_trailing_semicolon("SELECT 'a;b'") == "SELECT 'a;b'"
+
+
+def test_query_unlimited_strips_trailing_semicolon():
+    connector = CannerConnector.__new__(CannerConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    # Build arrow path may need description - mock _build if used
+    # Patch cursor execute only and short-circuit table build via side effect
+    import wren.connector.canner as canner_mod
+
+    def _fake_table(cur):
+        import pyarrow as pa
+
+        return pa.table({"x": [1]})
+
+    # Find helper name used
+    # Use elev: make fetch via execute and intercept
+    # Simpler: mock _build_arrow_table if exists
+    if hasattr(canner_mod, "_build_arrow_table"):
+        canner_mod._build_arrow_table = _fake_table  # type: ignore
+    elif hasattr(canner_mod, "_build_pg_arrow_table"):
+        canner_mod._build_pg_arrow_table = _fake_table  # type: ignore
+    else:
+        # last resort: fail loudly with attrs
+        raise AssertionError(dir(canner_mod)[:50])
+
+    connector.query("SELECT 1 AS x;")
+
+    cursor.execute.assert_called_once_with("SELECT 1 AS x")
+
+
+def test_query_limited_strips_before_wrap():
+    connector = CannerConnector.__new__(CannerConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    import wren.connector.canner as canner_mod
+    import pyarrow as pa
+
+    def _fake_table(cur):
+        return pa.table({"x": [1]})
+
+    if hasattr(canner_mod, "_build_arrow_table"):
+        canner_mod._build_arrow_table = _fake_table  # type: ignore
+    else:
+        canner_mod._build_pg_arrow_table = _fake_table  # type: ignore
+
+    connector.query("SELECT 1 AS x;", limit=3)
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (SELECT 1 AS x) AS _t LIMIT 3"
+    )

--- a/core/wren/tests/unit/test_canner_semicolon.py
+++ b/core/wren/tests/unit/test_canner_semicolon.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from unittest.mock import MagicMock
 
+import pyarrow as pa
 import pytest
 
 from wren.connector.canner import CannerConnector, _strip_trailing_semicolon
@@ -16,51 +19,52 @@ def test_strip_helper():
     assert _strip_trailing_semicolon("SELECT 'a;b'") == "SELECT 'a;b'"
 
 
-def test_query_unlimited_strips_trailing_semicolon():
+@pytest.fixture
+def fake_psycopg(monkeypatch):
+    """CannerConnector.query() does ``import psycopg`` at call time.
+
+    The unit-test image doesn't install psycopg, so provide a stub with the
+    ``errors.QueryCanceled`` attribute the except-clause references.
+    """
+    mod = types.ModuleType("psycopg")
+    errors = types.ModuleType("psycopg.errors")
+
+    class QueryCanceled(Exception):
+        pass
+
+    errors.QueryCanceled = QueryCanceled
+    mod.errors = errors
+    monkeypatch.setitem(sys.modules, "psycopg", mod)
+    monkeypatch.setitem(sys.modules, "psycopg.errors", errors)
+    return mod
+
+
+def _make_connector():
     connector = CannerConnector.__new__(CannerConnector)
     connector.connection = MagicMock()
     cursor = MagicMock()
     connector.connection.cursor.return_value.__enter__.return_value = cursor
-    # Build arrow path may need description - mock _build if used
-    # Patch cursor execute only and short-circuit table build via side effect
-    import wren.connector.canner as canner_mod
+    return connector, cursor
 
-    def _fake_table(cur):
-        import pyarrow as pa
 
-        return pa.table({"x": [1]})
-
-    # Find helper name used
-    # Use elev: make fetch via execute and intercept
-    # Simpler: mock _build_arrow_table if exists
-    if hasattr(canner_mod, "_build_arrow_table"):
-        canner_mod._build_arrow_table = _fake_table  # type: ignore
-    elif hasattr(canner_mod, "_build_pg_arrow_table"):
-        canner_mod._build_pg_arrow_table = _fake_table  # type: ignore
-    else:
-        # last resort: fail loudly with attrs
-        raise AssertionError(dir(canner_mod)[:50])
+def test_query_unlimited_strips_trailing_semicolon(monkeypatch, fake_psycopg):
+    connector, cursor = _make_connector()
+    monkeypatch.setattr(
+        "wren.connector.canner._build_arrow_table",
+        lambda cur: pa.table({"x": [1]}),
+    )
 
     connector.query("SELECT 1 AS x;")
 
     cursor.execute.assert_called_once_with("SELECT 1 AS x")
 
 
-def test_query_limited_strips_before_wrap():
-    connector = CannerConnector.__new__(CannerConnector)
-    connector.connection = MagicMock()
-    cursor = MagicMock()
-    connector.connection.cursor.return_value.__enter__.return_value = cursor
-    import wren.connector.canner as canner_mod
-    import pyarrow as pa
-
-    def _fake_table(cur):
-        return pa.table({"x": [1]})
-
-    if hasattr(canner_mod, "_build_arrow_table"):
-        canner_mod._build_arrow_table = _fake_table  # type: ignore
-    else:
-        canner_mod._build_pg_arrow_table = _fake_table  # type: ignore
+def test_query_limited_strips_before_wrap(monkeypatch, fake_psycopg):
+    connector, cursor = _make_connector()
+    monkeypatch.setattr(
+        "wren.connector.canner._build_arrow_table",
+        lambda cur: pa.table({"x": [1]}),
+    )
 
     connector.query("SELECT 1 AS x;", limit=3)
 


### PR DESCRIPTION
## Summary

- Always strip trailing `;` in Canner `query()` (limited and unlimited).
- Keeps pasted client SQL twice-terminated from failing inconsistently vs dry_run/limit wrap.

## Motivation

Limited path already stripped before subquery wrap; unlimited pasted `SELECT …;` with extra terminator whitespace differed. Align execute path.

## Verification

- Without fix: unlimited execute keeps trailing `;` (test fail)
- With fix: `pytest tests/unit/test_canner_semicolon.py` → 3 passed
- Apache-2.0 `core/**`

## Files

- core/wren/src/wren/connector/canner.py
- core/wren/tests/unit/test_canner_semicolon.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL execution by consistently stripping trailing semicolons (and trailing whitespace/newlines) before running queries.
  * Ensured identical semicolon handling for both unlimited queries and queries using a row limit wrapper.
  * Kept semicolons inside quoted SQL strings unchanged.
* **Tests**
  * Added unit coverage for semicolon handling in both unlimited and limited query paths, including trailing whitespace/newline scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->