### PR TITLE
fix(duckdb): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/duckdb.py
+++ b/core/wren/src/wren/connector/duckdb.py
@@ -77,14 +77,16 @@ class DuckDBConnector(ConnectorABC):
 
         When ``limit`` is provided the query is wrapped in a ``LIMIT`` clause
         so only that many rows are fetched.
+
+        Trailing statement terminators are always stripped so client-pasted
+        ``SELECT …;`` behaves the same on limited and unlimited paths.
         """
+        stripped = strip_trailing_semicolon(sql)
         if limit is not None:
-            # Strip the terminating run of ``;`` / whitespace before wrapping so
-            # the subquery stays valid SQL (e.g. ``SELECT 1;`` must not become
-            # ``SELECT * FROM (SELECT 1;) AS _q LIMIT ...``). Semicolons inside
-            # string literals are preserved.
-            stripped = strip_trailing_semicolon(sql)
+            # Subquery wrap rejects an interior terminator after strip.
             sql = f"SELECT * FROM ({stripped}) AS _q LIMIT {int(limit)}"
+        else:
+            sql = stripped
         return self.connection.execute(sql).fetch_arrow_table()
 
     def dry_run(self, sql: str) -> None:

--- a/core/wren/tests/unit/test_duckdb_semicolon_unlimited.py
+++ b/core/wren/tests/unit/test_duckdb_semicolon_unlimited.py
@@ -1,0 +1,38 @@
+"""DuckDB unlimited query strips trailing semicolon like limit wrap."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+from wren.connector.duckdb import DuckDBConnector
+
+pytestmark = pytest.mark.unit
+
+
+def test_unlimited_query_strips_trailing_semicolon():
+    connector = DuckDBConnector.__new__(DuckDBConnector)
+    connector.connection = MagicMock()
+    connector.connection.execute.return_value.fetch_arrow_table.return_value = (
+        pa.table({"x": [1]})
+    )
+
+    connector.query("SELECT 1 AS x;  ")
+
+    connector.connection.execute.assert_called_once_with("SELECT 1 AS x")
+
+
+def test_limited_query_still_wraps_after_strip():
+    connector = DuckDBConnector.__new__(DuckDBConnector)
+    connector.connection = MagicMock()
+    connector.connection.execute.return_value.fetch_arrow_table.return_value = (
+        pa.table({"x": [1]})
+    )
+
+    connector.query("SELECT 1 AS x;", limit=2)
+
+    connector.connection.execute.assert_called_once_with(
+        "SELECT * FROM (SELECT 1 AS x) AS _q LIMIT 2"
+    )


### PR DESCRIPTION
## Summary

- Strip trailing `;` for DuckDB limited *and* unlimited `query()` paths.

## Motivation

Clients paste terminated SQL. LIMIT path stripped; unlimited did not, so behavior depended on limit presence.

## Verification

- Without fix: unlimited execute keeps `;` (test fail)
- With fix: pytest tests/unit/test_duckdb_semicolon_unlimited.py → 2 passed
- Apache-2.0 core/**

## Files

- core/wren/src/wren/connector/duckdb.py
- core/wren/tests/unit/test_duckdb_semicolon_unlimited.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DuckDB query handling by consistently stripping trailing semicolons and extra trailing whitespace before execution.
  * Ensured behavior is consistent whether a row limit is provided or omitted.

* **Tests**
  * Added unit test coverage to verify trailing semicolons are removed for unlimited queries.
  * Added unit test coverage to confirm limited queries are still wrapped appropriately after semicolon stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->