### PR TITLE
fix(postgres): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -249,10 +249,11 @@ class PostgresConnector(ConnectorABC):
         self._closed = False
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Strip terminating ``;`` even when no LIMIT wrapper is applied so
+        # client-pasted statements match dry_run / limited composition rules.
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
-            )
+            sql = f"SELECT * FROM ({sql}) AS _sub LIMIT {limit}"
 
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/tests/unit/test_postgres_semicolon_unlimited.py
+++ b/core/wren/tests/unit/test_postgres_semicolon_unlimited.py
@@ -1,0 +1,63 @@
+"""Postgres unlimited query strips trailing semicolon.
+
+``postgres`` imports ``psycopg`` at module load. Unit CI does not install the
+``postgres`` extra, so stub ``psycopg`` in ``sys.modules`` before importing the
+connector module (same pattern as canner unit tests for lazy import).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ensure_psycopg_stub() -> None:
+    if "psycopg" in sys.modules:
+        return
+    mod = types.ModuleType("psycopg")
+    errors = types.ModuleType("psycopg.errors")
+    sys.modules["psycopg"] = mod
+    sys.modules["psycopg.errors"] = errors
+    mod.errors = errors
+
+
+_ensure_psycopg_stub()
+
+import wren.connector.postgres as postgres_mod  # noqa: E402
+from wren.connector.postgres import PostgresConnector  # noqa: E402
+
+
+def test_unlimited_query_strips_trailing_semicolon(monkeypatch):
+    connector = PostgresConnector.__new__(PostgresConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    monkeypatch.setattr(
+        postgres_mod, "_build_pg_arrow_table", lambda cur: pa.table({"x": [1]})
+    )
+
+    connector.query("SELECT 1 AS x; \n")
+
+    cursor.execute.assert_called_once_with("SELECT 1 AS x")
+
+
+def test_limited_query_wraps_after_strip(monkeypatch):
+    connector = PostgresConnector.__new__(PostgresConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    monkeypatch.setattr(
+        postgres_mod, "_build_pg_arrow_table", lambda cur: pa.table({"x": [1]})
+    )
+
+    connector.query("SELECT 1 AS x;", limit=9)
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (SELECT 1 AS x) AS _sub LIMIT 9"
+    )


### PR DESCRIPTION
## Summary

- Strip trailing `;` on Postgres unlimited `query()` (same helper as LIMIT wrap / dry_run).

## Motivation

Unlimited path executed raw terminated SQL while limited/dry_run already stripped — inconsistent client paste behavior.

## Verification

- Without fix: execute keeps `;` (test fail)
- With fix: pytest tests/unit/test_postgres_semicolon_unlimited.py → 2 passed
- Apache-2.0 core/**

## Files

- core/wren/src/wren/connector/postgres.py
- core/wren/tests/unit/test_postgres_semicolon_unlimited.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL query handling by consistently removing trailing semicolons/whitespace from user-provided SQL before execution in both unlimited and limited result scenarios.
  * Ensured limit-wrapped queries are constructed from the cleaned SQL for consistent behavior.

* **Tests**
  * Added unit coverage verifying trailing semicolon stripping works for queries without a limit and for queries where a limit is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->