### PR TITLE
fix(profile): mask all registry-sensitive fields in `wren profile debug`

### DIFF
--- a/core/wren/src/wren/profile.py
+++ b/core/wren/src/wren/profile.py
@@ -321,10 +321,45 @@ def resolve_connection(
     return None, {}
 
 
+def _registry_sensitive_keys() -> set[str]:
+    """Lower-cased connection-field names and aliases the field registry marks
+    sensitive (``SecretStr``) in **any** datasource model.
+
+    The registry (``model/field_registry.py``) is the single source of truth for
+    field sensitivity; consulting it keeps ``debug`` from drifting out of sync
+    with the models. The name heuristic below covers only common substrings and
+    misses SecretStr fields like ``pat``, ``connection_url``, ``dsn`` and
+    ``ssl_ca``. The set spans all datasources because a profile may carry a
+    cross-datasource secret (e.g. ``connection_url``); over-masking a benign key
+    in a diagnostic dump is harmless, under-masking a secret is not.
+    """
+    from wren.model.field_registry import (  # noqa: PLC0415
+        get_datasource_options,
+        get_fields,
+        get_variants,
+    )
+
+    keys: set[str] = set()
+    for datasource in get_datasource_options():
+        for variant in get_variants(datasource) or [None]:
+            try:
+                fields = get_fields(datasource, variant=variant)
+            except ValueError:
+                continue
+            for field in fields:
+                if field.sensitive:
+                    keys.add(field.name.lower())
+                    if field.alias:
+                        keys.add(field.alias.lower())
+    return keys
+
+
 def debug_profile(name: str | None = None) -> dict[str, Any]:
     """Return diagnostic info for a profile (or the active one).
 
-    Masks sensitive fields (password, credentials, secret, token).
+    Masks fields the connection-field registry marks sensitive (``SecretStr``),
+    plus a name heuristic (password, credentials, secret, token, ...) for keys
+    the registry does not know about.
     """
     if name is None:
         name = get_active_name()
@@ -351,9 +386,15 @@ def debug_profile(name: str | None = None) -> dict[str, Any]:
         "http_path",
         "role_arn",
     }
+    registry_sensitive = _registry_sensitive_keys()
     masked = {}
     for k, v in profile.items():
-        if k.lower() in _SENSITIVE or any(s in k.lower() for s in _SENSITIVE):
+        kl = k.lower()
+        if (
+            kl in registry_sensitive
+            or kl in _SENSITIVE
+            or any(s in kl for s in _SENSITIVE)
+        ):
             masked[k] = "***"
         else:
             masked[k] = v

--- a/core/wren/tests/unit/test_profile_env_expansion.py
+++ b/core/wren/tests/unit/test_profile_env_expansion.py
@@ -180,3 +180,28 @@ def test_debug_profile_returns_literal_placeholder(tmp_path, monkeypatch):
     # The raw stored value should also still be the placeholder
     raw = profile_mod._load_raw()["profiles"]["pg"]
     assert raw["password"] == "${PG_PW}"
+
+
+def test_debug_masks_registry_sensitive_fields(tmp_path, monkeypatch):
+    """Fields the connection-field registry marks SecretStr, but whose names match
+    no substring in the local heuristic (``pat``, ``connection_url``, ``dsn``,
+    ``ssl_ca``, and the camelCase alias ``clientId``), must still be masked when a
+    literal value is stored. ``debug`` must not diverge from the field registry —
+    the single source of truth for field sensitivity."""
+    monkeypatch.setattr(profile_mod, "_WREN_HOME", tmp_path)
+    monkeypatch.setattr(profile_mod, "_PROFILES_FILE", tmp_path / "profiles.yml")
+
+    cases = [
+        ("canner_p", {"datasource": "canner", "host": "h", "pat": "SECRET"}, "pat"),
+        (
+            "url_p",
+            {"datasource": "postgres", "connection_url": "postgresql://u:PW@h/db"},
+            "connection_url",
+        ),
+        ("oracle_p", {"datasource": "oracle", "dsn": "admin/PW@h:1521/db"}, "dsn"),
+        ("mysql_p", {"datasource": "mysql", "ssl_ca": "CERT"}, "ssl_ca"),
+        ("dbx_p", {"datasource": "databricks", "clientId": "abc"}, "clientId"),
+    ]
+    for name, prof, key in cases:
+        profile_mod.add_profile(name, prof)
+        assert profile_mod.debug_profile(name)["config"][key] == "***", key


### PR DESCRIPTION
## Summary
- `wren profile debug` promises to mask sensitive fields, but decides sensitivity from a hardcoded substring list that diverges from the field registry. Five `SecretStr` connection fields whose names match no substring are printed **in plaintext**: `pat` (Canner PAT), `connection_url` / `connectionUrl` (full DB URL with embedded password), `dsn` (Oracle, may embed credentials), `ssl_ca` / `sslCA` (MySQL CA material), and the `clientId` alias (Databricks service principal).
- Fix: derive the mask set from the field registry — the declared single source of truth for field sensitivity — keeping the substring heuristic as a fallback for keys the registry doesn't know about.

## Motivation
`debug_profile` masks via a private substring list:

```python
_SENSITIVE = {"password", "credentials", "secret", "token", ...}
if k.lower() in _SENSITIVE or any(s in k.lower() for s in _SENSITIVE):
    masked[k] = "***"
```

This is a parallel, hand-maintained copy of "what is sensitive" that has drifted from the models. The declared contract says these must be masked:
- `debug_profile` docstring: *"Masks sensitive fields …"*
- CLI help (`wren profile debug`): *"Show resolved profile config (sensitive fields masked)."*
- `profile.py` module docstring: *"The stored YAML keeps the placeholders so `wren profile debug` never prints an actual secret."*
- `.claude/CLAUDE.md`: the field registry (`model/field_registry.py`) is the *"Single source of truth for per-datasource connection fields, derived from Pydantic models"* — and it derives sensitivity from `SecretStr` (`FieldDef.sensitive`). `pat`, `connection_url`, `dsn`, `ssl_ca` are all `SecretStr` in `model/__init__.py`.

The interactive prompt path (`profile_cli.py`) already consults `FieldDef.sensitive` from the registry; only `debug_profile` re-derived sensitivity from its own list and drifted.

Reachability: profiles may store literal secrets (the module supports `${VAR}` placeholders but does not require them — `wren profile add`, `--from-file`, and `wren profile import dbt` all write literal values). The repo's own `test_debug_masks_sensitive` stores literal secrets and asserts they are masked. For these five fields, the literal is printed in full.

## Fix
Add `_registry_sensitive_keys()`, which returns the lower-cased names **and aliases** of every field the registry marks `SecretStr` across all datasource models, and union it into the mask check. The substring heuristic is kept as a fallback for keys the registry doesn't cover (e.g. custom kwargs). The change is purely additive — it never un-masks anything that was masked before.

## Verification
- New regression test `test_debug_masks_registry_sensitive_fields` (in `tests/unit/`, the CI-run tree) stores literal `pat` / `connection_url` / `dsn` / `ssl_ca` / `clientId` and asserts each is `***`.
  - Without the change: `assert 'SECRET' == '***'` — **RED**.
  - With the change: **PASS**.
- Red check: neutralising the registry lookup reds the new test while the existing `test_debug_masks_sensitive` (host visible; password/token/credentials/private_key masked) stays green — the fix is load-bearing and does not over-mask benign fields.
- Change set (this widens masking, so both directions checked): newly masked keys are exactly `{pat, dsn, ssl_ca, sslca, connection_url, connectionurl, clientid}` — all verified to be `SecretStr` fields; nothing benign is newly masked, and nothing previously masked is dropped (union).
- Full unit suite: `uv run --no-sync pytest tests/unit/ --ignore=tests/unit/test_memory.py` → **946 passed, 2 skipped** (baseline 945 + the new test; 0 regressions). Lint clean.
- End-to-end via the real `add_profile` + `debug_profile`: `pat` and `connection_url` mask to `***`; `host` stays visible.

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — this contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection of sensitive connection and configuration values in debug profile output.
  * Sensitive fields are now masked consistently across supported field naming formats, including literal stored values.

* **Tests**
  * Added coverage verifying that registered sensitive fields are masked correctly in debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->