### PR TITLE
fix(memory): guard schema indexing against null relationship models

### DIFF
--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -141,7 +141,7 @@ def _describe_column(col: dict, lines: list[str]) -> None:
 
 def _describe_relationship(rel: dict, lines: list[str]) -> None:
     name = rel["name"]
-    models = rel.get("models", [])
+    models = rel.get("models") or []
     left = models[0] if len(models) > 0 else "?"
     right = models[1] if len(models) > 1 else "?"
     join_type = rel.get("joinType", "")
@@ -345,7 +345,7 @@ def _column_record(col: dict, model_name: str, mdl_h: str, now: datetime) -> dic
 
 def _relationship_record(rel: dict, mdl_h: str, now: datetime) -> dict:
     name = rel["name"]
-    models = rel.get("models", [])
+    models = rel.get("models") or []
     join_type = rel.get("joinType", "")
     condition = rel.get("condition", "")
 

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -199,6 +199,26 @@ class TestExtractSchemaItems:
         assert len(items) == 1
         assert items[0]["item_type"] == "model"
 
+    def test_relationship_null_models_tolerated(self):
+        # A relationship with an explicit JSON null for "models" must not crash
+        # the indexer. `.get("models", [])` returns None (not the default) when
+        # the key is present with a null value, so `len(None)` blows up. Mirrors
+        # the seed-query guard from #2424 (test_relationship_null_models_skipped)
+        # — the same dirty-manifest shape must be tolerated on the schema
+        # indexing/describe path, which never runs the seed step.
+        manifest = {
+            "models": [{"name": "orders", "columns": []}],
+            "relationships": [
+                {"name": "rel1", "models": None, "condition": "orders.c = x.c"}
+            ],
+        }
+        items = extract_schema_items(manifest)
+        rels = [i for i in items if i["item_type"] == "relationship"]
+        assert len(rels) == 1
+        assert rels[0]["item_name"] == "rel1"
+        # describe_schema reads the same field via a sibling helper.
+        describe_schema(manifest)
+
 
 # ── Cube fixture ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Guard the two relationship readers in `wren.memory.schema_indexer` (`_describe_relationship`, `_relationship_record`) against an explicit JSON `null` for a relationship's `models`.
- User-facing impact: a manifest with a null relationship `models` no longer aborts schema indexing / description with an unhandled `TypeError`. This reaches every documented `WrenMemory` entry point that touches relationships — `index_manifest()`, `describe_schema()`, `get_context()` — and the `wren memory index` / `wren memory fetch` CLI commands.

## Motivation
Both readers do:

```python
models = rel.get("models", [])
left = models[0] if len(models) > 0 else "?"
```

`dict.get(key, default)` only substitutes the default when the key is **absent**, not when its value is `None`. A manifest relationship with `"models": null` therefore passes `None` straight through, crashing `len(None)`.

This is the completion of #2424, which fixed the exact same null-slip in the sibling module `wren.memory.seed_queries` (`_relationship_seed`) with an explicit comment and regression test (`test_relationship_null_models_skipped`). The `schema_indexer` readers were the remaining sites in the same package — and `extract_schema_items` runs **before** the guarded seed step, so on the `index` path the #2424 fix never even executes. It also contradicts the indexer's own stated contract in `test_malformed_cube_entries_are_skipped`: *"the indexer should drop the bad entries and keep going so semantic memory rebuilds never fail on dirty manifests."*

The manifest is untrusted input — it is `json.loads`-ed straight from the user's `target/mdl.json`.

## Fix
Use an `or` fallback at both sites, matching #2424: `models = rel.get("models") or []`. Behaviour is unchanged for every non-null input (a present list, an absent key, an empty list); only the crashing `null` case changes — it is now treated like a short/empty `models` list and rendered with the existing `"?"` placeholder.

## Verification
- New regression test `TestExtractSchemaItems::test_relationship_null_models_tolerated` (drives both `extract_schema_items` and `describe_schema`):
  - Without the change: `TypeError: object of type 'NoneType' has no len()` (`schema_indexer.py:352`) — **RED**.
  - With the change: **PASS**.
- Per-site red check — each of the two guards is independently load-bearing:
  - revert `_relationship_record` only → red at `:352` (via `extract_schema_items`).
  - revert `_describe_relationship` only → red at `:145` (via `describe_schema`).
- Full unit suite (memory extra installed): `uv run --no-sync pytest tests/unit/` → **1022 passed, 2 skipped** (baseline 1021 + the one new test; 0 regressions).
- Lint: `just lint` → `ruff format --check` + `ruff check` both clean.
- End-to-end via the real public API: `extract_schema_items` / `describe_schema` on a manifest with `{"models": null}` return gracefully (`Relationship 'rel1': ? → ? …`) instead of raising.

## Scope
Scoped to the `wren.memory` package to complete #2424. The same `.get("models", [])` pattern appears on a different surface — the `wren context show` / `wren context validate` CLI (`context.py`, `context_cli.py`) — with its own reproduction and entry points; that is addressed in a companion PR. The `dbt.py` relationship reader builds its relationships internally (not from an untrusted manifest) and is not reached by this shape.

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — this contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema processing for relationships with missing or empty model information.
  * Prevented errors when describing schemas containing relationships with null model values.

* **Tests**
  * Added coverage to verify relationships remain available and schema descriptions complete successfully in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->