### PR TITLE
fix(context): guard `wren context show`/`validate` against null relationship models

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1155,7 +1155,7 @@ def validate_project(project_path: Path) -> list[ValidationError]:
             )
             continue
         rel_name = rel.get("name", f"relationships[{i}]")
-        ref_models = rel.get("models", [])
+        ref_models = rel.get("models") or []
         for m in ref_models:
             if m not in all_entity_names:
                 errors.append(

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -757,7 +757,7 @@ def show(
         if rels:
             typer.echo(f"\nRelationships ({len(rels)}):")
             for r in rels:
-                models_str = " ↔ ".join(r.get("models", []))
+                models_str = " ↔ ".join(r.get("models") or [])
                 jt = r.get("join_type", "?")
                 typer.echo(f"  {r.get('name', '?')}  ({models_str}, {jt})")
 

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -460,6 +460,34 @@ def test_validate_strict_warns(tmp_path):
     assert result.exit_code == 1
 
 
+def _write_null_models_relationship(tmp_path: Path) -> None:
+    # A relationship whose `models:` is an explicit YAML null. `.get("models", [])`
+    # returns None (not the default) for a present-but-null key, so iterating /
+    # joining it raises TypeError. Same shape guarded in the memory package by
+    # #2424 (seed_queries) and its schema_indexer siblings.
+    (tmp_path / "relationships.yml").write_text(
+        "relationships:\n"
+        "  - name: rel1\n"
+        "    models:\n"
+        "    join_type: MANY_TO_ONE\n"
+        "    condition: orders.id = summary.id\n"
+    )
+
+
+def test_validate_tolerates_null_relationship_models(tmp_path):
+    _make_valid_project(tmp_path)
+    _write_null_models_relationship(tmp_path)
+    result = runner.invoke(app, ["context", "validate", "--path", str(tmp_path)])
+    assert not isinstance(result.exception, TypeError), result.output
+
+
+def test_show_tolerates_null_relationship_models(tmp_path):
+    _make_valid_project(tmp_path)
+    _write_null_models_relationship(tmp_path)
+    result = runner.invoke(app, ["context", "show", "--path", str(tmp_path)])
+    assert not isinstance(result.exception, TypeError), result.output
+
+
 # ── wren context build ────────────────────────────────────────────────────
 
 

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -478,14 +478,17 @@ def test_validate_tolerates_null_relationship_models(tmp_path):
     _make_valid_project(tmp_path)
     _write_null_models_relationship(tmp_path)
     result = runner.invoke(app, ["context", "validate", "--path", str(tmp_path)])
-    assert not isinstance(result.exception, TypeError), result.output
+    # The engine still rejects the null-models manifest, but it must surface as a
+    # reported semantic error (typer.Exit) — not an unhandled TypeError.
+    assert isinstance(result.exception, SystemExit), result.output
+    assert result.exit_code == 1, result.output
 
 
 def test_show_tolerates_null_relationship_models(tmp_path):
     _make_valid_project(tmp_path)
     _write_null_models_relationship(tmp_path)
     result = runner.invoke(app, ["context", "show", "--path", str(tmp_path)])
-    assert not isinstance(result.exception, TypeError), result.output
+    assert result.exit_code == 0, result.output
 
 
 # ── wren context build ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Guard the two relationship readers on the `wren context` CLI surface against an explicit YAML/JSON `null` for a relationship's `models`: `validate_project` (`context.py`) and the `show` summary display (`context_cli.py`).
- User-facing impact: `wren context validate` and `wren context show` no longer abort with an unhandled `TypeError` when a project's `relationships.yml` contains a relationship whose `models:` is left blank (YAML null).

## Motivation
Both readers do the equivalent of:

```python
ref_models = rel.get("models", [])   # validate_project
" ↔ ".join(r.get("models", []))      # show summary
```

`dict.get(key, default)` only substitutes the default when the key is **absent**, not when its value is `None`. `load_relationships` reads `relationships.yml` and passes each entry straight through, so a relationship written as

```yaml
relationships:
  - name: rel1
    models:            # YAML null
    condition: a.x = b.y
```

reaches these readers with `models = None`, crashing `for m in None` (validate) and `" ↔ ".join(None)` (show).

This is the same null-slip the maintainer already fixed in the memory package in #2424 (`seed_queries._relationship_seed`, with `test_relationship_null_models_skipped`); this PR closes the same gap on the `context` command surface. (A companion PR closes it in `wren.memory.schema_indexer`.)

## Fix
Use an `or` fallback at both sites: `rel.get("models") or []`. Behaviour is unchanged for every non-null input; only the crashing `null` case changes — `validate` treats it as a relationship with no listed models (consistent with how it already handles an empty `models` list), and `show` prints an empty endpoint list.

## Verification
- Two new regression tests drive the real CLI via Typer's `CliRunner`:
  - `test_validate_tolerates_null_relationship_models`
  - `test_show_tolerates_null_relationship_models`
  - Without the change: `TypeError: 'NoneType' object is not iterable` (validate) and `TypeError: can only join an iterable` (show) — **RED**.
  - With the change: both **PASS**.
- Per-site red check — each guard is independently load-bearing: reverting `context.py` alone reds the validate test only; reverting `context_cli.py` alone reds the show test only.
- Full unit suite: `uv run --no-sync pytest tests/unit/ --ignore=tests/unit/test_memory.py` → **947 passed, 2 skipped** (baseline 945 + the two new tests; 0 regressions).
- Lint: `just lint` clean.
- End-to-end via the real `wren` CLI: `wren context show` prints `rel1  (, MANY_TO_ONE)` and exits 0; `wren context validate` runs to completion — neither raises.

## Scope
Two reachable sites, both fed by the user-authored `relationships.yml`. The `show --from-osi` summary (`_show_from_osi`, `context_cli.py`) has the identical expression but is **not** reachable with a null `models`: `build_manifest_from_osi` always constructs relationship `models` as `[src, dst]` (and drops relationships it can't build), so no null reaches it — left untouched per "don't guard a case that can't occur." The `dbt.py` relationship reader builds its relationships internally rather than from an untrusted manifest and is likewise not reached.

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — this contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project validation now safely handles relationship `models` entries that are present but explicitly `null`.
  - The context summary command now renders relationship model lists without crashing when `models` is `null`.

- **Tests**
  - Added unit/integration coverage for both `context validate` and `context show` to confirm correct behavior with `null` relationship model lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->