### PR TITLE
fix(wren): align MCP handlers with ServeContext and query limits

### DIFF
--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -219,6 +219,8 @@ jobs:
         working-directory: core/wren
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -69,8 +69,13 @@ jobs:
         # Run the whole tests/unit/ tree rather than filtering on `-m unit`:
         # the marker is opt-in, so any unmarked file (e.g. test_context_cli.py)
         # was silently skipped. Exclude test_memory.py — it needs the `memory`
-        # extra and runs in the dedicated `memory tests` job below.
-        run: uv run --no-sync pytest tests/unit/ -v --ignore=tests/unit/test_memory.py
+        # extra and runs in the dedicated `memory tests` job below. Exclude
+        # test_mcp_server.py — it needs the `mcp` extra and runs in the
+        # dedicated `mcp tests` job below.
+        run: |
+          uv run --no-sync pytest tests/unit/ -v \
+            --ignore=tests/unit/test_memory.py \
+            --ignore=tests/unit/test_mcp_server.py
 
   test-connector:
     name: ${{ matrix.datasource }} tests
@@ -205,3 +210,40 @@ jobs:
         env:
           WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
         run: uv run --no-sync pytest tests/unit/test_memory.py -v
+
+  test-mcp:
+    name: mcp tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core/wren
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./core/wren-core-py/target/
+          key: ${{ runner.os }}-cargo-wren-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build wren-core-py wheel
+        working-directory: core/wren-core-py
+        run: |
+          uv sync --locked --no-install-project
+          uv run --no-sync maturin build
+      - name: Install dependencies
+        run: |
+          uv sync --locked --extra mcp
+          uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
+      - name: Run mcp tests
+        run: uv run --no-sync pytest tests/unit/test_mcp_server.py -v

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
@@ -32,6 +32,11 @@ class ServeContext:
     engine: Any  # wren.engine.WrenEngine
     allow_write: bool
     no_connect: bool
+
+
+def _memory_path(ctx: ServeContext) -> str:
+    """Return the project-local memory path derived solely from ctx.project."""
+    return str(ctx.project / ".wren" / "memory")
 
 
 def _normalize_value(value: Any) -> Any:
@@ -71,10 +76,36 @@ def _table_to_result(table, *, truncated: bool) -> dict:
 
 
 def _query_with_limit_probe(ctx: ServeContext, sql: str, limit: int | None) -> dict:
-    """Run ``sql`` capped at ``MAX_ROW_LIMIT``, probing one extra row to detect truncation."""
+    """Run arbitrary SQL with a connector-applied N+1 truncation probe.
+
+    The connector owns dialect-specific row limiting for opaque user SQL. The
+    requested limit is capped at ``MAX_ROW_LIMIT`` before the probe is applied.
+    """
+    if limit is not None and limit < 0:
+        raise ValueError(f"run_sql limit must be non-negative, got {limit}.")
     effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
     effective_limit = min(effective_limit, MAX_ROW_LIMIT)
     table = ctx.engine.query(sql, effective_limit + 1)
+    truncated = table.num_rows > effective_limit
+    if truncated:
+        table = table.slice(0, effective_limit)
+    return _table_to_result(table, truncated=truncated)
+
+
+def _query_cube_with_limit_probe(
+    ctx: ServeContext, build_sql: Callable[[int], str], limit: int | None
+) -> dict:
+    """Run cube SQL with an embedded N+1 truncation probe.
+
+    The generated SQL carries the row cap, and the connector receives no
+    additional limit. This preserves valid ``LIMIT``/``OFFSET`` ordering for
+    append-style connectors and bounds connectors that materialize results
+    before Python slicing.
+    """
+    effective_limit = DEFAULT_ROW_LIMIT if limit is None else limit
+    effective_limit = min(effective_limit, MAX_ROW_LIMIT)
+    sql = build_sql(effective_limit + 1)
+    table = ctx.engine.query(sql, None)
     truncated = table.num_rows > effective_limit
     if truncated:
         table = table.slice(0, effective_limit)
@@ -93,6 +124,7 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
             SQL is written against MDL model names, not raw database tables.
             Applies a default cap of 1000 rows when ``limit`` is not given, and
             a hard maximum of 10000 rows regardless of the requested limit.
+            Negative limits are rejected.
             """
             return _query_with_limit_probe(ctx, sql, limit)
 
@@ -135,23 +167,32 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
 
             if not cube or not measures:
                 raise ValueError("query_cube requires 'cube' and at least one measure.")
+            if limit is not None and limit < 0:
+                raise ValueError(f"query_cube limit must be non-negative, got {limit}.")
 
-            cube_query = _build_cube_query(
-                cube,
-                ",".join(measures),
-                ",".join(dimensions or []),
-                time_dimension,
-                filters or [],
-                limit,
-                offset,
-            )
             mdl_json = json.dumps(context.build_json(ctx.project))
-            sql = cube_query_to_sql(json.dumps(cube_query), mdl_json)
+
+            def build_sql(row_limit: int | None) -> str:
+                """Build cube SQL with the caller-supplied row limit.
+
+                SQL-only requests supply the user limit; execution supplies
+                the probe limit.
+                """
+                cube_query = _build_cube_query(
+                    cube,
+                    ",".join(measures),
+                    ",".join(dimensions or []),
+                    time_dimension,
+                    filters or [],
+                    row_limit,
+                    offset,
+                )
+                return cube_query_to_sql(json.dumps(cube_query), mdl_json)
 
             if sql_only:
-                return {"sql": sql}
+                return {"sql": build_sql(limit)}
 
-            return _query_with_limit_probe(ctx, sql, limit)
+            return _query_cube_with_limit_probe(ctx, build_sql, limit)
 
     @mcp.tool(
         annotations=ToolAnnotations(title="Dry Plan SQL", readOnlyHint=True),
@@ -329,12 +370,7 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         """
         from wren.memory.index_backend import get_index  # noqa: PLC0415
 
-        try:
-            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
-
-            mem_path = str(_default_memory_path())
-        except ImportError:
-            mem_path = str(ctx.project / ".wren" / "memory")
+        mem_path = _memory_path(ctx)
 
         idx = get_index(ctx.project, mem_path)
         return {"matches": idx.search(question, limit=limit)}
@@ -362,10 +398,9 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
 
         manifest = build_json(ctx.project)
         try:
-            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
             from wren.memory.store import MemoryStore  # noqa: PLC0415
 
-            store = MemoryStore(path=str(_default_memory_path()))
+            store = MemoryStore(path=_memory_path(ctx))
             return store.get_context(
                 manifest,
                 question,
@@ -413,10 +448,9 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         "user", "seed"). Returns ``{"queries": [...]}``.
         """
         try:
-            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
             from wren.memory.store import MemoryStore  # noqa: PLC0415
 
-            store = MemoryStore(path=str(_default_memory_path()))
+            store = MemoryStore(path=_memory_path(ctx))
             rows, _total = store.list_queries(
                 source=source,
                 limit=limit if limit is not None else MAX_ROW_LIMIT,
@@ -491,10 +525,9 @@ def _register_write_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         )
 
         try:
-            from wren.memory.cli import _default_memory_path  # noqa: PLC0415
             from wren.memory.store import MemoryStore  # noqa: PLC0415
 
-            MemoryStore(path=str(_default_memory_path())).store_query(
+            MemoryStore(path=_memory_path(ctx)).store_query(
                 nl_query, sql_query, datasource=datasource, tags=tags
             )
         except Exception as e:
@@ -589,30 +622,54 @@ def _register_resources(mcp: FastMCP, ctx: ServeContext) -> None:
         return _read_knowledge_file(f"{subdir}/{name}")
 
 
-def _register_prompts(mcp: FastMCP) -> None:
+def _workflow_text(ctx: ServeContext, question: str | None = None) -> str:
+    """Build the `wren_workflow` prompt body, reflecting the registered tool set.
+
+    The run_sql/dry_run/query_cube steps only apply when `ctx.no_connect` is
+    False; the store_query step only applies when `ctx.allow_write` is True.
+    Steps are numbered sequentially after gating so the list stays 1..N with
+    no gaps regardless of which flags are set.
+    """
+    intro = f'The user asked: "{question}"\n\n' if question else ""
+    steps = [
+        "Read the `wren://mdl` resource and use `list_models` / "
+        "`describe_model` to understand the schema; for schema, read "
+        "`wren://mdl` or use `get_context` / `describe_schema`; browse "
+        "project knowledge via `list_knowledge` + the "
+        "`wren://knowledge/{path}` resource.",
+        "Call `get_instructions` for business rules that affect how to "
+        "interpret the data.",
+        "Call `recall_queries` for proven NL->SQL exemplars similar to "
+        "the question, or `list_stored_queries` to browse all of them.",
+    ]
+    if ctx.no_connect:
+        steps.append(
+            "Write SQL in the project's dialect and expand it with "
+            "`dry_plan` to inspect the target-dialect SQL (no database "
+            "connection is available in this mode)."
+        )
+    else:
+        steps.append(
+            "Write SQL in the project's dialect, validate it with "
+            "`dry_run`, then execute it with `run_sql`."
+        )
+        steps.append(
+            "For named metrics, prefer `query_cube` over hand-written aggregate SQL."
+        )
+    if ctx.allow_write:
+        steps.append(
+            "Once the answer is confirmed correct, optionally call "
+            "`store_query` to persist the NL->SQL pair for future recall."
+        )
+    numbered = "\n".join(f"{i}. {step}" for i, step in enumerate(steps, start=1))
+    return f"{intro}Follow this workflow to answer a data question:\n{numbered}"
+
+
+def _register_prompts(mcp: FastMCP, ctx: ServeContext) -> None:
     @mcp.prompt()
     def wren_workflow(question: str | None = None) -> str:
         """SOP for answering a data question with the wren MCP tools."""
-        intro = f'The user asked: "{question}"\n\n' if question else ""
-        return (
-            f"{intro}"
-            "Follow this workflow to answer a data question:\n"
-            "1. Read the `wren://mdl` resource and use `list_models` / "
-            "`describe_model` to understand the schema; for schema, read "
-            "`wren://mdl` or use `get_context` / `describe_schema`; browse "
-            "project knowledge via `list_knowledge` + the "
-            "`wren://knowledge/{path}` resource.\n"
-            "2. Call `get_instructions` for business rules that affect how to "
-            "interpret the data.\n"
-            "3. Call `recall_queries` for proven NL->SQL exemplars similar to "
-            "the question, or `list_stored_queries` to browse all of them.\n"
-            "4. Write SQL in the project's dialect, validate it with `dry_run`, "
-            "then execute it with `run_sql`.\n"
-            "5. For named metrics, prefer `query_cube` over hand-written "
-            "aggregate SQL.\n"
-            "6. Once the answer is confirmed correct, optionally call "
-            "`store_query` to persist the NL->SQL pair for future recall."
-        )
+        return _workflow_text(ctx, question)
 
 
 def build_server(ctx: ServeContext) -> FastMCP:
@@ -625,7 +682,7 @@ def build_server(ctx: ServeContext) -> FastMCP:
     if ctx.allow_write:
         _register_write_tools(mcp, ctx)
     _register_resources(mcp, ctx)
-    _register_prompts(mcp)
+    _register_prompts(mcp, ctx)
 
     return mcp
 

--- a/core/wren/tests/unit/test_mcp_server.py
+++ b/core/wren/tests/unit/test_mcp_server.py
@@ -1,0 +1,352 @@
+"""MCP handler tests for project context, capability gating, and query limits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("mcp")
+
+import pyarrow as pa  # noqa: E402
+
+from wren.mcp_server import ServeContext, _workflow_text, build_server  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+V5_GOLDEN = Path(__file__).resolve().parents[4] / "examples" / "v5-jaffle"
+
+
+def _get_tool(mcp, name: str):
+    """Return a registered tool implementation for handler-level tests.
+
+    FastMCP registry access is isolated here so the tests can call synchronous
+    handlers without exercising transport serialization.
+    """
+    return mcp._tool_manager._tools[name].fn
+
+
+def _make_ctx(tmp_path: Path, **overrides) -> ServeContext:
+    defaults = dict(
+        project=tmp_path,
+        engine=Mock(),
+        allow_write=False,
+        no_connect=False,
+    )
+    defaults.update(overrides)
+    return ServeContext(**defaults)
+
+
+# ── Memory handlers use ServeContext.project ────────────────────────────────
+
+
+def test_recall_queries_uses_ctx_project(tmp_path, monkeypatch):
+    proj_a = tmp_path / "projA"
+    proj_b = tmp_path / "projB"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    monkeypatch.chdir(proj_a)
+
+    ctx = _make_ctx(proj_b)
+    mcp = build_server(ctx)
+    recall_queries = _get_tool(mcp, "recall_queries")
+
+    captured = {}
+
+    def fake_get_index(project, mem_path):
+        captured["project"] = project
+        captured["mem_path"] = mem_path
+        return Mock(search=lambda question, limit: [])
+
+    monkeypatch.setattr("wren.memory.index_backend.get_index", fake_get_index)
+
+    recall_queries(question="revenue")
+
+    assert captured["project"] == proj_b
+    assert captured["mem_path"] == str(proj_b / ".wren" / "memory")
+    assert captured["mem_path"] != str(proj_a / ".wren" / "memory")
+
+
+def test_get_context_uses_ctx_project(tmp_path, monkeypatch):
+    proj_a = tmp_path / "projA"
+    proj_b = tmp_path / "projB"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    monkeypatch.chdir(proj_a)
+
+    ctx = _make_ctx(proj_b)
+    mcp = build_server(ctx)
+    get_context = _get_tool(mcp, "get_context")
+
+    monkeypatch.setattr("wren.context.build_json", lambda project: {})
+
+    captured = {}
+
+    class FakeStore:
+        def __init__(self, path):
+            captured["path"] = path
+
+        def get_context(self, manifest, question, **kwargs):
+            return {"strategy": "fake"}
+
+    monkeypatch.setattr("wren.memory.store.MemoryStore", FakeStore)
+
+    get_context(question="revenue")
+
+    assert captured["path"] == str(proj_b / ".wren" / "memory")
+    assert captured["path"] != str(proj_a / ".wren" / "memory")
+
+
+def test_list_stored_queries_uses_ctx_project(tmp_path, monkeypatch):
+    proj_a = tmp_path / "projA"
+    proj_b = tmp_path / "projB"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    monkeypatch.chdir(proj_a)
+
+    ctx = _make_ctx(proj_b)
+    mcp = build_server(ctx)
+    list_stored_queries = _get_tool(mcp, "list_stored_queries")
+
+    captured = {}
+
+    class FakeStore:
+        def __init__(self, path):
+            captured["path"] = path
+
+        def list_queries(self, **kwargs):
+            return [], 0
+
+    monkeypatch.setattr("wren.memory.store.MemoryStore", FakeStore)
+
+    list_stored_queries()
+
+    assert captured["path"] == str(proj_b / ".wren" / "memory")
+    assert captured["path"] != str(proj_a / ".wren" / "memory")
+
+
+def test_store_query_uses_ctx_project(tmp_path, monkeypatch):
+    proj_a = tmp_path / "projA"
+    proj_b = tmp_path / "projB"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    monkeypatch.chdir(proj_a)
+
+    ctx = _make_ctx(proj_b, allow_write=True)
+    mcp = build_server(ctx)
+    store_query = _get_tool(mcp, "store_query")
+
+    captured = {}
+
+    class FakeStore:
+        def __init__(self, path):
+            captured["path"] = path
+
+        def store_query(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr("wren.memory.store.MemoryStore", FakeStore)
+
+    store_query(nl_query="revenue", sql_query="SELECT 1")
+
+    assert captured["path"] == str(proj_b / ".wren" / "memory")
+    assert captured["path"] != str(proj_a / ".wren" / "memory")
+
+
+# ── Workflow prompt reflects registered tools ───────────────────────────────
+
+
+def test_workflow_text_connected_writable_mentions_query_and_write_tools(tmp_path):
+    ctx = _make_ctx(tmp_path, allow_write=True, no_connect=False)
+    text = _workflow_text(ctx)
+    assert "run_sql" in text
+    assert "query_cube" in text
+    assert "store_query" in text
+
+
+def test_workflow_text_no_connect_omits_connect_tools(tmp_path):
+    ctx = _make_ctx(tmp_path, allow_write=True, no_connect=True)
+    text = _workflow_text(ctx)
+    assert "run_sql" not in text
+    assert "dry_run" not in text
+    assert "query_cube" not in text
+    assert "dry_plan" in text
+
+
+def test_workflow_text_no_write_omits_store_query(tmp_path):
+    ctx = _make_ctx(tmp_path, allow_write=False, no_connect=False)
+    text = _workflow_text(ctx)
+    assert "store_query" not in text
+
+
+# ── Query limits reject invalid values ──────────────────────────────────────
+
+
+def test_run_sql_negative_limit_rejected(tmp_path):
+    engine = Mock()
+    engine.query.return_value = pa.table({"value": []})
+    ctx = _make_ctx(tmp_path, engine=engine)
+    mcp = build_server(ctx)
+    run_sql = _get_tool(mcp, "run_sql")
+
+    with pytest.raises(ValueError, match="non-negative"):
+        run_sql(sql="SELECT 1", limit=-1)
+
+    engine.query.assert_not_called()
+
+
+# ── Cube queries embed truncation probes in generated SQL ──────────────────
+#
+# The generated SQL owns the row cap, and the connector receives `limit=None`.
+# This preserves generated LIMIT/OFFSET ordering and bounds connectors that
+# materialize results before slicing.
+
+
+def test_query_cube_sql_only_uses_user_limit():
+    """SQL-only output uses the user-requested limit."""
+    ctx = _make_ctx(V5_GOLDEN, engine=Mock())
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    result = query_cube(
+        cube="order_metrics",
+        measures=["total_revenue", "order_count"],
+        dimensions=["customer_id"],
+        limit=5,
+        sql_only=True,
+    )
+
+    sql = result["sql"].upper()
+    assert "LIMIT 5" in sql
+    assert "LIMIT 6" not in sql
+
+
+def test_query_cube_offset_forwarded_in_sql_only():
+    """Offset must survive into the displayed SQL alongside the user's limit."""
+    ctx = _make_ctx(V5_GOLDEN, engine=Mock())
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    result = query_cube(
+        cube="order_metrics",
+        measures=["total_revenue"],
+        dimensions=["customer_id"],
+        limit=5,
+        offset=10,
+        sql_only=True,
+    )
+
+    assert "OFFSET 10" in result["sql"].upper()
+
+
+def test_query_cube_execution_bakes_probe_into_sql_not_connector():
+    """Execution embeds N+1 in cube SQL and disables connector limiting."""
+    engine = Mock()
+    seen = {}
+
+    def fake_query(sql, limit):
+        seen["sql"] = sql
+        seen["limit"] = limit
+        return pa.table({"customer_id": list(range(3))})
+
+    engine.query = fake_query
+
+    ctx = _make_ctx(V5_GOLDEN, engine=engine)
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    query_cube(
+        cube="order_metrics",
+        measures=["total_revenue"],
+        dimensions=["customer_id"],
+        limit=3,
+        offset=10,
+    )
+
+    # The generated SQL owns the probe limit, so the connector receives None.
+    assert seen["limit"] is None
+    sql = seen["sql"].upper()
+    assert sql.count("LIMIT") == 1, f"expected exactly one LIMIT clause: {sql}"
+    assert "LIMIT 4" in sql  # effective_limit(3) + 1
+    assert "OFFSET 10" in sql
+
+
+def test_query_cube_truncation_probe_detects_truncation():
+    """An N+1 result is truncated and sliced to the requested size."""
+    engine = Mock()
+
+    def fake_query(sql, limit):
+        assert limit is None
+        assert "LIMIT 4" in sql.upper()  # effective_limit(3) + 1
+        # Return the probe row alongside the requested rows.
+        return pa.table({"customer_id": list(range(4))})
+
+    engine.query = fake_query
+
+    ctx = _make_ctx(V5_GOLDEN, engine=engine)
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    result = query_cube(
+        cube="order_metrics",
+        measures=["total_revenue", "order_count"],
+        dimensions=["customer_id"],
+        limit=3,
+    )
+
+    assert result["truncated"] is True
+    assert result["row_count"] == 3
+
+
+def test_query_cube_not_truncated_when_rows_fit():
+    """When the cube yields exactly `limit` rows (no n+1 overflow), the
+    result must not be marked truncated."""
+    engine = Mock()
+
+    def fake_query(sql, limit):
+        assert limit is None
+        return pa.table({"customer_id": list(range(3))})
+
+    engine.query = fake_query
+
+    ctx = _make_ctx(V5_GOLDEN, engine=engine)
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    result = query_cube(
+        cube="order_metrics",
+        measures=["total_revenue", "order_count"],
+        dimensions=["customer_id"],
+        limit=3,
+    )
+
+    assert result["truncated"] is False
+    assert result["row_count"] == 3
+
+
+def test_query_cube_negative_limit_rejected_consistently():
+    """Execution and SQL-only reject negative limits before SQL generation."""
+    engine = Mock()
+    engine.query = lambda sql, limit: pa.table({"customer_id": []})
+
+    ctx = _make_ctx(V5_GOLDEN, engine=engine)
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    with pytest.raises(ValueError, match="non-negative"):
+        query_cube(
+            cube="order_metrics",
+            measures=["total_revenue"],
+            dimensions=["customer_id"],
+            limit=-1,
+        )
+
+    with pytest.raises(ValueError, match="non-negative"):
+        query_cube(
+            cube="order_metrics",
+            measures=["total_revenue"],
+            dimensions=["customer_id"],
+            limit=-1,
+            sql_only=True,
+        )


### PR DESCRIPTION
## Summary

#2438 introduced `wren serve mcp` and centralized the selected project,
engine, and capability flags in `ServeContext`.

This follow-up builds on that foundation by using the startup context
consistently across memory tools and workflow guidance, refining cube query
limit handling, and adding dedicated MCP test coverage.

## Changes

- Use `ServeContext.project` as the source of truth for all MCP memory paths,
  keeping memory access aligned with the project selected through `--project`.
- Generate the `wren_workflow` prompt from the active capabilities.
- Embed the cube N+1 truncation probe in generated SQL and execute it without
  applying a second connector limit:
  - preserve the caller's limit in SQL-only output
  - keep the truncation probe bounded in generated SQL regardless of how
    individual connectors implement their `limit` argument
  - preserve valid `LIMIT`/`OFFSET` ordering for MySQL and Doris
- Reject negative limits consistently for `run_sql` and `query_cube`.
- Add 14 handler-level MCP tests and a dedicated `test-mcp` CI job with the
  optional `mcp` dependency.

## Workflow capabilities

| Server flags | Query guidance | `store_query` |
| --- | --- | --- |
| Default | `dry_run` → `run_sql`, with `query_cube` for metrics | Omitted |
| `--allow-write` | `dry_run` → `run_sql`, with `query_cube` for metrics | Included |
| `--no-connect` | `dry_plan` | Omitted |
| `--no-connect --allow-write` | `dry_plan` | Included |

The generated workflow only references tools registered for the active
server configuration, with contiguous step numbering in every mode.

## Test plan

- `uv lock --check`
- `uv run --no-sync ruff format --check src/wren/mcp_server.py tests/unit/test_mcp_server.py`
- `uv run --no-sync ruff check src/wren/mcp_server.py tests/unit/test_mcp_server.py`
- `uv run --no-sync pytest tests/unit/test_mcp_server.py -q`
  - 14 passed
- `uv run --no-sync pytest tests/unit -q`
  - 1007 passed, 43 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP memory storage path handling to correctly use the project’s `.wren/memory` directory.
  * Added validation to reject negative `limit` values for SQL and cube queries.
  * Refined cube query truncation behavior (including correct `LIMIT`/`OFFSET` handling) and consistent `truncated`/`row_count` reporting, including SQL-only output.
  * Updated MCP workflow prompts to dynamically match connection and write capabilities.

* **Tests**
  * Expanded unit tests covering memory paths, workflow prompt generation, negative-limit validation, and cube truncation logic.

* **Chores**
  * Split MCP server tests into a dedicated CI job for clearer, targeted execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->