### PR TITLE
feat(wren-mdl): loosen manifest schema and bump layout version to 4

### DIFF
--- a/core/wren-core-base/src/mdl/manifest.rs
+++ b/core/wren-core-base/src/mdl/manifest.rs
@@ -116,7 +116,7 @@ impl PrimaryKey {
     }
 }
 
-pub const MAX_SUPPORTED_LAYOUT_VERSION: u32 = 3;
+pub const MAX_SUPPORTED_LAYOUT_VERSION: u32 = 4;
 
 impl Manifest {
     pub fn validate_layout_version(&self) -> Result<(), LayoutVersionError> {

--- a/core/wren-core-base/src/mdl/migration.rs
+++ b/core/wren-core-base/src/mdl/migration.rs
@@ -83,6 +83,7 @@ pub fn migrate_manifest(
         match version {
             1 => migrate_v1_to_v2(&mut value),
             2 => migrate_v2_to_v3(&mut value),
+            3 => migrate_v3_to_v4(&mut value),
             _ => {
                 return Err(MigrationError::UnsupportedTargetVersion {
                     target: target_version,
@@ -111,6 +112,16 @@ fn migrate_v2_to_v3(_value: &mut Value) {
     // single-column manifests deserialize correctly without changes.
 }
 
+/// v3→v4: No data transformation needed.
+/// Adds optional annotation fields (manifest-level `description` + `properties`,
+/// `model.uniqueKeys`, and `description` + `properties` on cube
+/// measure/cubeDimension/timeDimension) and widens `column.properties` value
+/// types to match model/relationship/view.
+fn migrate_v3_to_v4(_value: &mut Value) {
+    // No-op: every v4 change is an additive optional field (or a validation
+    // widening), so existing manifests deserialize and validate unchanged.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,6 +140,14 @@ mod tests {
         let result = migrate_manifest(v2_json, 3).unwrap();
         let value: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(value["layoutVersion"], 3);
+    }
+
+    #[test]
+    fn test_migrate_v3_to_v4() {
+        let v3_json = r#"{"layoutVersion":3,"catalog":"wren","schema":"public","models":[]}"#;
+        let result = migrate_manifest(v3_json, 4).unwrap();
+        let value: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(value["layoutVersion"], 4);
     }
 
     #[test]

--- a/core/wren-mdl/mdl.schema.json
+++ b/core/wren-mdl/mdl.schema.json
@@ -94,7 +94,7 @@
           "description": "the customize properties of the column",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": ["string", "number", "boolean", "object", "array", "null"]
           }
         }
       },
@@ -139,6 +139,17 @@
           "description": "the data type of the measure result",
           "type": "string",
           "minLength": 1
+        },
+        "description": {
+          "description": "human-readable description of the measure (indexed for agent comprehension)",
+          "type": "string"
+        },
+        "properties": {
+          "description": "the customize properties of the measure",
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "object", "array", "null"]
+          }
         }
       },
       "required": ["name", "expression", "type"],
@@ -162,6 +173,17 @@
           "description": "the data type of the dimension",
           "type": "string",
           "minLength": 1
+        },
+        "description": {
+          "description": "human-readable description of the dimension (indexed for agent comprehension)",
+          "type": "string"
+        },
+        "properties": {
+          "description": "the customize properties of the dimension",
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "object", "array", "null"]
+          }
         }
       },
       "required": ["name", "expression", "type"],
@@ -185,6 +207,17 @@
           "description": "the data type of the time dimension (DATE, TIMESTAMP, …)",
           "type": "string",
           "minLength": 1
+        },
+        "description": {
+          "description": "human-readable description of the time dimension (indexed for agent comprehension)",
+          "type": "string"
+        },
+        "properties": {
+          "description": "the customize properties of the time dimension",
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "object", "array", "null"]
+          }
         }
       },
       "required": ["name", "expression", "type"],
@@ -212,6 +245,17 @@
       "description": "the schema name of WrenMDL",
       "type": "string",
       "minLength": 1
+    },
+    "description": {
+      "description": "human-readable description of the manifest / semantic model",
+      "type": "string"
+    },
+    "properties": {
+      "description": "the customize properties of the manifest / semantic model",
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean", "object", "array", "null"]
+      }
     },
     "sampleDataFolder": {
       "description": "the folder path for sample data",
@@ -326,6 +370,16 @@
                 "minItems": 1
               }
             ]
+          },
+          "uniqueKeys": {
+            "description": "alternative unique identifiers; each entry is a column name or an ordered list of columns that is unique",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                { "type": "string", "minLength": 1 },
+                { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 }
+              ]
+            }
           },
           "cached": {
             "description": "(WIP) whether the model is cached or not",


### PR DESCRIPTION
## What

A new MDL layout revision (**v4**): additive, backward-compatible annotation fields on the manifest schema, plus the matching supported-layout-version bump.

### Schema (`core/wren-mdl/mdl.schema.json`)
1. **Widen `column.properties` value types** to `string | number | boolean | object | array | null`, matching `model` / `relationship` / `view` (column was string-only — an inconsistency).
2. **Add optional manifest-level `description` + `properties`**.
3. **Add `model.uniqueKeys`** (a column or list of columns, like `primaryKey`).
4. **Add optional `description` + `properties`** to cube `measure` / `cubeDimension` / `timeDimension`.

### Layout version (`core/wren-core-base`)
- Bump `MAX_SUPPORTED_LAYOUT_VERSION` 3 → 4 and add the no-op `migrate_v3_to_v4` step — matching the precedent of v2 (optional `dialect`) and v3 (composite `primaryKey`), both additive no-op migrations.

## Why

Give natively-typed homes for human/agent descriptions, business context, and uniqueness metadata — useful for knowledge annotations and semantic-layer interop — instead of forcing everything through opaque string bags.

## Compatibility

All changes are additive or validation-widenings; existing manifests stay valid and `v3→v4` is a no-op. No query-engine / semantic-logic changes: the manifest structs don't set `#[serde(deny_unknown_fields)]`, so unknown fields were already ignored — the only Rust delta is the version const + the no-op migration + tests. `wren-core-base`: 46 tests + clippy + fmt clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for descriptions on measures, cube dimensions, and time dimensions.
  * Added model-level `description` plus flexible model properties and expanded custom property value types.
  * Added `uniqueKeys` support for both single-column and composite uniqueness definitions.
* **Compatibility / Maintenance**
  * Extended manifest layout version support to version 4 and added migration handling for 3 → 4.
  * Updated tests to verify the 3 → 4 layout version migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->