### PR TITLE
docs(wren): fix cube hierarchy YAML examples

### DIFF
--- a/core/wren/src/wren/skills_content/enrich-context/references/cube_proposals.md
+++ b/core/wren/src/wren/skills_content/enrich-context/references/cube_proposals.md
@@ -76,8 +76,7 @@ time_dimensions:
     expression: <ts_column>   # e.g. "created_at"
     type: TIMESTAMP           # granularity (day/week/month/…) is set at query time via --time-dimension
 hierarchies:
-  - name: time
-    levels: [year, quarter, month]   # only if multiple time grains are declared
+  time: [<td_name>]                 # map to declared dimension/time-dimension names
 properties:
   description: |
     <one-line summary from raw — e.g. "Annual Recurring Revenue, defined as MRR × 12 per the finance handbook §2.">

--- a/docs/core/guides/cubes.md
+++ b/docs/core/guides/cubes.md
@@ -48,9 +48,12 @@ time_dimensions:
     expression: order_date
     type: DATE
 hierarchies:
-  - name: time
-    levels: [year, quarter, month]
+  time: [order_date]
 ```
+
+`hierarchies` is a map from a hierarchy name to an ordered list of declared
+dimension or time-dimension names. The level names must match entries in
+`dimensions` or `time_dimensions`.
 
 See the [MDL schema reference](/oss/reference/mdl) for every cube field.
 

--- a/docs/core/reference/mdl.md
+++ b/docs/core/reference/mdl.md
@@ -272,8 +272,7 @@ time_dimensions:
     expression: order_date
     type: DATE
 hierarchies:
-  - name: time
-    levels: [year, quarter, month]
+  time: [order_date]
 ```
 
 | Field | Required | Description |
@@ -283,7 +282,7 @@ hierarchies:
 | `measures[]` | yes | Aggregated values (`expression` + `type`). |
 | `dimensions[]` | no | Categorical group-bys. |
 | `time_dimensions[]` | no | Time-based group-bys. Granularity is applied at query time via `--time-dimension name:granularity` (see [CLI reference](/oss/reference/cli#wren-cube--pre-aggregation-queries)). |
-| `hierarchies[]` | no | Ordered levels for drill-down (year → quarter → month). |
+| `hierarchies` | no | Map of hierarchy name to ordered dimension or time-dimension names for drill-down. |
 | `refresh_time` | no | Cache refresh interval. |
 | `properties` | no | Arbitrary metadata. |
 


### PR DESCRIPTION
## What

- Use the schema-compatible map format for cube `hierarchies`.
- Document that hierarchy levels must reference declared dimensions or time dimensions.
- Update the bundled `enrich-context` skill template.

## Why

The previous list-of-objects examples passed YAML validation but produced an invalid hierarchy shape, causing hierarchy metadata to be ignored.

## Verification

- Validated the examples against `mdl.schema.json`.
- Ran context and skill tests: 146 passed.
- Confirmed `wren context build` emits a hierarchy object map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cube metadata examples to use map-style hierarchy definitions.
  * Clarified that hierarchy entries map names to ordered lists of dimensions or time dimensions.
  * Documented that hierarchy levels must match declared dimension or time-dimension names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->