### PR TITLE
fix(trino): fall back on Sqlglot TokenError for type strings

### DIFF
--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -40,8 +40,12 @@ def _parse_trino_data_type(type_str: str | None) -> pa.DataType:
         return pa.string()
     try:
         parsed = sqlglot.parse_one(type_str, into=DataType, dialect="trino")
-    except sqlglot.errors.ParseError:
-        logger.warning(f"Failed to parse trino type string: {type_str}")
+    except (sqlglot.errors.SqlglotError, ValueError):
+        # SqlglotError covers ParseError *and* TokenError (tokenizer failures
+        # on stray control chars / unterminated quotes are NOT subclasses of
+        # ParseError). Mirror wren.type_mapping.parse_type's fallback contract
+        # so a bad cursor.description type cannot abort an otherwise-valid query.
+        logger.warning(f"Failed to parse trino type string: {type_str!r}")
         return pa.string()
     if parsed is None:
         return pa.string()

--- a/core/wren/tests/unit/test_trino_parser.py
+++ b/core/wren/tests/unit/test_trino_parser.py
@@ -115,6 +115,17 @@ def test_parse_trino_data_type_unparseable_falls_back() -> None:
     assert _parse_trino_data_type("not a real type {{") == pa.string()
 
 
+def test_parse_trino_data_type_tokenizer_error_falls_back() -> None:
+    """TokenError is a SqlglotError but not a ParseError — must not bubble.
+
+    Mirrors the type_mapping TokenError regression: unterminated quotes and
+    control characters trip the tokenizer. Columns with bad description types
+    should degrade to string Arrow, not abort the result table build.
+    """
+    assert _parse_trino_data_type('"unterminated') == pa.string()
+    assert _parse_trino_data_type("VARC\x00HAR") == pa.string()
+
+
 def test_build_trino_column_map_dict_to_pairs() -> None:
     # Trino driver returns Python dicts; PyArrow map_ wants (k, v) pairs.
     arrow_type = pa.map_(pa.string(), pa.int64())


### PR DESCRIPTION
## Summary

- `_parse_trino_data_type` now catches `sqlglot.errors.SqlglotError` (and `ValueError`), not only `ParseError`.
- Tokenizer failures (TokenError on bad `cursor.description` type strings) degrade to `pa.string()` instead of aborting result materialization.

## Motivation

`type_mapping.parse_type` already documents and tests that TokenError is a SqlglotError but **not** a ParseError, so catching only ParseError lets tokenizer crashes escape. Trino's type parser had the same bug: a single column with a corrupt/unterminated type string could fail the whole Arrow table build for an otherwise valid query.

Apache-2.0 path: `core/wren/**`.

## Verification

- `cd core/wren && PYTHONPATH=src python -m pytest tests/unit/test_trino_parser.py -k 'tokenizer_error or unparseable or handles_none' -v` — **3 passed**
- New regression: token-error inputs (`"unterminated`, control character) return `pa.string()`
- Did NOT change: Arrow mappings for well-formed Trino types; strip_trailing_semicolon / connect paths

## Real behavior proof

```
tests/unit/test_trino_parser.py::test_parse_trino_data_type_handles_none PASSED
tests/unit/test_trino_parser.py::test_parse_trino_data_type_unparseable_falls_back PASSED
tests/unit/test_trino_parser.py::test_parse_trino_data_type_tokenizer_error_falls_back PASSED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unsupported Trino data types during query processing.
  * Prevented tokenizer and parsing errors from interrupting processing by safely falling back to a string type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->