### PR TITLE
fix(datafusion): strip trailing semicolon in dry_run

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -39,7 +39,10 @@ class DataFusionConnector(ConnectorABC):
         return reader.read_all()
 
     def dry_run(self, sql: str) -> None:
-        self.ctx.dry_run(sql)
+        # Same subquery composition hazard as query(limit=...): a trailing
+        # semicolon makes many DataFusion parsers reject the statement when
+        # it is validated through dry_run paths that wrap/EXPLAIN SQL.
+        self.ctx.dry_run(strip_trailing_semicolon(sql))
 
     def close(self) -> None:
         pass

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -60,3 +60,11 @@ def test_helper_preserves_semicolon_inside_string_literal() -> None:
 
 def test_helper_no_trailing_semicolon_unchanged() -> None:
     assert _strip_trailing_semicolon("SELECT 1") == "SELECT 1"
+
+
+def test_dry_run_strips_trailing_semicolon() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.dry_run("SELECT 1;")
+    (sent,), _ = ctx.dry_run.call_args
+    assert sent == "SELECT 1"
+    assert not sent.endswith(";")


### PR DESCRIPTION
## Summary

- DataFusion `dry_run` now runs `strip_trailing_semicolon(sql)` before `ctx.dry_run`, matching the limited-`query` subquery path.

## Motivation

Limited `query()` already strips terminating semicolons before subquery wrap. `dry_run` still forwarded raw SQL, so the same client-terminated inputs that succeed under LIMIT verification could fail dry-run validation.

Apache-2.0: `core/wren/**`.

## Verification

- `cd core/wren && PYTHONPATH=src python -m pytest tests/unit/test_datafusion_semicolon.py -v` — **5 passed**
- New: `test_dry_run_strips_trailing_semicolon` asserts `SELECT 1;` → `SELECT 1`
- Did NOT change: unlimited query passthrough; format registration

## Real behavior proof

```
tests/unit/test_datafusion_semicolon.py::test_dry_run_strips_trailing_semicolon PASSED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL dry-run validation by handling queries with trailing semicolons correctly.
  * Prevented parser errors when validating semicolon-terminated SQL statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->