### PR TITLE
fix(snowflake): strip trailing semicolon before dry_run describe

### DIFF
--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -86,15 +86,18 @@ class SnowflakeConnector(ConnectorABC):
         return arrow_table
 
     def dry_run(self, sql: str) -> None:
+        # cursor.describe is sensitive to a trailing terminator on many
+        # client-generated statements; strip only the total-line tail.
+        cleaned = strip_trailing_semicolon(sql)
         try:
             with self.connection.cursor() as cursor:
-                cursor.describe(sql)
+                cursor.describe(cleaned)
         except _programming_error() as e:
             raise WrenError(
                 ErrorCode.INVALID_SQL,
                 str(e),
                 phase=ErrorPhase.SQL_DRY_RUN,
-                metadata={DIALECT_SQL: sql},
+                metadata={DIALECT_SQL: cleaned},
             ) from e
 
     def close(self) -> None:

--- a/core/wren/tests/unit/test_snowflake_dry_run_semicolon.py
+++ b/core/wren/tests/unit/test_snowflake_dry_run_semicolon.py
@@ -1,0 +1,33 @@
+"""dry_run must strip trailing semicolons before cursor.describe."""
+
+from unittest.mock import MagicMock
+
+from wren.connector.snowflake import SnowflakeConnector
+
+
+def _make_mock_connector() -> tuple[SnowflakeConnector, MagicMock]:
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    cursor = MagicMock()
+    # context-manager cursor
+    cm = MagicMock()
+    cm.__enter__.return_value = cursor
+    cm.__exit__.return_value = False
+    conn = MagicMock()
+    conn.cursor.return_value = cm
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_dry_run_strips_trailing_semicolon_before_describe() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;")
+    (sent,), _ = cursor.describe.call_args
+    assert sent == "SELECT 1"
+    assert not sent.endswith(";")
+
+
+def test_dry_run_strips_whitespace_after_semicolon() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1;  \n")
+    (sent,), _ = cursor.describe.call_args
+    assert sent == "SELECT 1"


### PR DESCRIPTION
## Summary

- Snowflake `dry_run` strips trailing semicolons before `cursor.describe`.

## Motivation

Limited `query()` already strips terminating `;` before subquery+LIMIT wrap. `dry_run` still passed raw SQL to `describe`, so the same client-terminated statements that execute under LIMIT validation could fail dry-run.

Apache-2.0: `core/wren/**`. Note there may be related open PR #2487; this is a focused dry_run-describe harden with intended real tests.

## Verification

- `cd core/wren && PYTHONPATH=src python -m pytest tests/unit/test_snowflake_dry_run_semicolon.py -v` — **2 passed**
- Did NOT change: query LIMIT wrap; connection setup

## Real behavior proof

```
tests/unit/test_snowflake_dry_run_semicolon.py::test_dry_run_strips_trailing_semicolon_before_describe PASSED
tests/unit/test_snowflake_dry_run_semicolon.py::test_dry_run_strips_whitespace_after_semicolon PASSED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Snowflake dry-run handling by removing trailing semicolons and surrounding whitespace before validation.
  * Error details now consistently reference the cleaned SQL statement.

* **Tests**
  * Added coverage for statements ending with semicolons, including semicolons followed by whitespace or newlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->