### PR TITLE
fix(type_mapping): skip non-dict rows in parse/translate_types

### DIFF
--- a/core/wren/src/wren/type_mapping.py
+++ b/core/wren/src/wren/type_mapping.py
@@ -20,6 +20,8 @@ Use as a library:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import sqlglot
 import sqlglot.errors
 from sqlglot.expressions import DataType
@@ -55,15 +57,21 @@ def parse_types(
 ) -> list[dict]:
     """Batch-normalize types for a list of column dicts.
 
-    Each dict must have a key matching *type_field* (default "raw_type").
+    Each mapping should have a key matching *type_field* (default "raw_type").
     Returns a new list with an added "type" key containing the normalized type.
-    Original dicts are not mutated.
+    Original mappings are not mutated.
+
+    Non-mapping rows (e.g. ``None`` padding or malformed entries from dynamic
+    schema exporters) are skipped, so ``len(out) <= len(columns)``. Any
+    ``collections.abc.Mapping`` is accepted, not just ``dict`` (e.g. SQLAlchemy
+    ``RowMapping`` or ``types.MappingProxyType``).
     """
     results = []
     for col in columns:
         # Callers occasionally pass sparse / non-mapping rows from dynamic
-        # schemas; skip rather than TypeError on dict(col).
-        if not isinstance(col, dict):
+        # schemas; skip rather than TypeError on dict(col). Accept any Mapping
+        # (not just dict) so mapping-likes from schema exporters survive.
+        if not isinstance(col, Mapping):
             continue
         row = dict(col)
         row["type"] = parse_type(row.get(type_field, ""), dialect)
@@ -110,13 +118,16 @@ def translate_types(
 ) -> list[dict]:
     """Batch-translate types from *source_dialect* to *target_dialect*.
 
-    Each dict must have a key matching *type_field* (default "raw_type").
+    Each mapping should have a key matching *type_field* (default "raw_type").
     Returns a new list with an added "type" key holding the translated type.
-    Original dicts are not mutated.
+    Original mappings are not mutated.
+
+    Non-mapping rows are skipped, so ``len(out) <= len(columns)``. Any
+    ``collections.abc.Mapping`` is accepted, not just ``dict``.
     """
     results = []
     for col in columns:
-        if not isinstance(col, dict):
+        if not isinstance(col, Mapping):
             continue
         row = dict(col)
         row["type"] = translate_type(

--- a/core/wren/src/wren/type_mapping.py
+++ b/core/wren/src/wren/type_mapping.py
@@ -61,6 +61,10 @@ def parse_types(
     """
     results = []
     for col in columns:
+        # Callers occasionally pass sparse / non-mapping rows from dynamic
+        # schemas; skip rather than TypeError on dict(col).
+        if not isinstance(col, dict):
+            continue
         row = dict(col)
         row["type"] = parse_type(row.get(type_field, ""), dialect)
         results.append(row)
@@ -112,6 +116,8 @@ def translate_types(
     """
     results = []
     for col in columns:
+        if not isinstance(col, dict):
+            continue
         row = dict(col)
         row["type"] = translate_type(
             row.get(type_field, ""), source_dialect, target_dialect

--- a/core/wren/src/wren/utils_cli.py
+++ b/core/wren/src/wren/utils_cli.py
@@ -64,6 +64,11 @@ def parse_types_cmd(
         raise typer.Exit(1)
 
     results = parse_types(data, dialect, type_field=type_field)
+    if isinstance(data, list) and len(results) < len(data):
+        typer.echo(
+            f"Note: skipped {len(data) - len(results)} non-mapping row(s)",
+            err=True,
+        )
     typer.echo(json.dumps(results, indent=2))
 
 
@@ -124,4 +129,9 @@ def translate_types_cmd(
         raise typer.Exit(1)
 
     results = translate_types(data, source, target, type_field=type_field)
+    if isinstance(data, list) and len(results) < len(data):
+        typer.echo(
+            f"Note: skipped {len(data) - len(results)} non-mapping row(s)",
+            err=True,
+        )
     typer.echo(json.dumps(results, indent=2))

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -326,3 +326,26 @@ def test_cli_translate_types_unreadable_file_is_clean(tmp_path) -> None:
     assert result.returncode == 1
     assert "could not read file" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_parse_types_skips_non_dict_rows() -> None:
+    columns = [
+        {"column": "id", "raw_type": "int8"},
+        "not-a-dict",
+        None,
+        {"column": "name", "raw_type": "character varying"},
+    ]
+    out = parse_types(columns, "postgres")
+    assert [r["column"] for r in out] == ["id", "name"]
+    assert out[0]["type"] == "BIGINT"
+
+
+def test_translate_types_skips_non_dict_rows() -> None:
+    columns = [
+        {"column": "id", "raw_type": "int8"},
+        42,
+        {"column": "name", "raw_type": "character varying"},
+    ]
+    out = translate_types(columns, "postgres", "bigquery")
+    assert len(out) == 2
+    assert out[0]["type"] == "INT64"

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -351,3 +351,30 @@ def test_translate_types_skips_non_dict_rows() -> None:
     assert [r["column"] for r in out] == ["id", "name"]
     assert out[0]["type"] == "INT64"
     assert out[1]["type"] == "STRING"
+
+
+def test_parse_types_accepts_non_dict_mappings() -> None:
+    from types import MappingProxyType
+
+    columns = [
+        MappingProxyType({"column": "id", "raw_type": "int8"}),
+        MappingProxyType({"column": "name", "raw_type": "character varying"}),
+    ]
+    out = parse_types(columns, "postgres")
+    assert [r["column"] for r in out] == ["id", "name"]
+    assert out[0]["type"] == "BIGINT"
+    # results are plain, mutable dicts even though inputs were read-only mappings
+    assert all(isinstance(r, dict) for r in out)
+
+
+def test_translate_types_accepts_non_dict_mappings() -> None:
+    from types import MappingProxyType
+
+    columns = [
+        MappingProxyType({"column": "id", "raw_type": "int8"}),
+        MappingProxyType({"column": "name", "raw_type": "character varying"}),
+    ]
+    out = translate_types(columns, "postgres", "bigquery")
+    assert [r["column"] for r in out] == ["id", "name"]
+    assert out[0]["type"] == "INT64"
+    assert out[1]["type"] == "STRING"

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -348,4 +348,6 @@ def test_translate_types_skips_non_dict_rows() -> None:
     ]
     out = translate_types(columns, "postgres", "bigquery")
     assert len(out) == 2
+    assert [r["column"] for r in out] == ["id", "name"]
     assert out[0]["type"] == "INT64"
+    assert out[1]["type"] == "STRING"


### PR DESCRIPTION
## Summary

- `parse_types` / `translate_types` skip non-dict column rows instead of raising TypeError on `dict(col)`.

## Motivation

Batch helpers assume list-of-dicts. Dynamic schema exporters sometimes interleave null/non-mapping entries; converting those with `dict(col)` crashed the whole batch and dropped every valid column.

Apache-2.0: `core/wren/**`.

## Verification

- `cd core/wren && PYTHONPATH=src python -m pytest tests/unit/test_type_mapping.py -k non_dict -v` — **2 passed**
- Did NOT change: normalization for well-formed column dicts; CLI contracts

## Real behavior proof

```
tests/unit/test_type_mapping.py::test_parse_types_skips_non_dict_rows PASSED
tests/unit/test_type_mapping.py::test_translate_types_skips_non_dict_rows PASSED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type parsing and translation to safely skip non-mapping entries in batch inputs instead of erroring.
  * Enhanced acceptance of mapping-like inputs (e.g., read-only mappings) while keeping output rows consistent.
  * Batch CLI commands now show a stderr note when some input rows can’t be processed.

* **Tests**
  * Added unit test coverage for batch parsing/translation behavior, including skipping invalid rows and handling mapping-like inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->