### PR TITLE
fix(wren): treat non-string SQL as not exploratory

### DIFF
--- a/core/wren/src/wren/sql_classify.py
+++ b/core/wren/src/wren/sql_classify.py
@@ -4,7 +4,7 @@ import sqlglot
 from sqlglot import exp
 
 
-def is_exploratory(sql: str) -> bool:
+def is_exploratory(sql: object) -> bool:
     """Return True if *sql* looks like an exploratory peek query.
 
     Exploratory = bare SELECT with no WHERE/GROUP BY/HAVING/aggregate.

--- a/core/wren/src/wren/sql_classify.py
+++ b/core/wren/src/wren/sql_classify.py
@@ -12,6 +12,10 @@ def is_exploratory(sql: str) -> bool:
     Top-level clauses are inspected via stmt.args to avoid descending into
     subqueries (e.g. an inner LIMIT does not affect the outer query).
     """
+    # Callers (UI / store-tip) may pass null or non-string placeholders.
+    # Treat them as not exploratory rather than TypeError from sqlglot.
+    if not isinstance(sql, str) or not sql.strip():
+        return False
     try:
         parsed = sqlglot.parse(sql)
     except sqlglot.errors.ParseError:

--- a/core/wren/tests/unit/test_sql_classify.py
+++ b/core/wren/tests/unit/test_sql_classify.py
@@ -50,6 +50,6 @@ def test_empty_string_returns_false():
 
 
 def test_none_and_non_string_sql_return_false():
-    assert is_exploratory(None) is False  # type: ignore[arg-type]
-    assert is_exploratory(123) is False  # type: ignore[arg-type]
-    assert is_exploratory(b"SELECT 1") is False  # type: ignore[arg-type]
+    assert is_exploratory(None) is False
+    assert is_exploratory(123) is False
+    assert is_exploratory(b"SELECT 1") is False

--- a/core/wren/tests/unit/test_sql_classify.py
+++ b/core/wren/tests/unit/test_sql_classify.py
@@ -47,3 +47,9 @@ def test_unparseable_sql_returns_false():
 
 def test_empty_string_returns_false():
     assert is_exploratory("") is False
+
+
+def test_none_and_non_string_sql_return_false():
+    assert is_exploratory(None) is False  # type: ignore[arg-type]
+    assert is_exploratory(123) is False  # type: ignore[arg-type]
+    assert is_exploratory(b"SELECT 1") is False  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- `is_exploratory` returns `False` for non-string or blank SQL instead of TypeErroring through `sqlglot.parse`.

## Motivation

Store-tip / UI callers may pass `None` or other placeholders. `sqlglot.parse(None)` raises `TypeError: object of type 'NoneType' has no len()`, which crashes the exploratory tip path instead of just suppressing the tip (same outcome as empty/unparseable SQL).

Apache-2.0: `core/wren/**`.

## Verification

- `cd core/wren && PYTHONPATH=src python -m pytest tests/unit/test_sql_classify.py -v` — **15 passed**
- Did NOT change: classification for real SQL strings

## Real behavior proof

```
tests/unit/test_sql_classify.py::test_none_and_non_string_sql_return_false PASSED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL classification reliability by safely handling empty, whitespace-only, and non-text inputs.
  * Invalid inputs now return a consistent negative result instead of causing a parsing error.
* **Tests**
  * Added test coverage to confirm `is_exploratory` returns `False` for `None`, numeric values, and byte-string inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->