### PR TITLE
fix(memory): skip non-dict columns in seed query generation

### DIFF
--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -85,7 +85,9 @@ def _model_seeds(
         is_pk = norm_name in primary_keys
         # Identifiers are numeric by storage but not measures: summing a join
         # key (e.g. SUM(customer_id)) is semantically meaningless.
-        is_identifier = is_pk or norm_name in relationship_keys or _is_id_like(str(col_name))
+        is_identifier = (
+            is_pk or norm_name in relationship_keys or _is_id_like(str(col_name))
+        )
 
         if (
             col_type in _NUMERIC_TYPES

--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -58,7 +58,11 @@ def _model_seeds(
     model: dict, relationship_keys: frozenset[str] = frozenset()
 ) -> list[dict]:
     name = model["name"]
-    columns = model.get("columns", [])
+    columns = [
+        c
+        for c in (model.get("columns") or [])
+        if isinstance(c, dict) and c.get("name")
+    ]
     primary_keys = _primary_key_columns(model)
     pairs = []
 
@@ -74,11 +78,7 @@ def _model_seeds(
     numeric_col = None
     group_col = None
     for col in columns:
-        if not isinstance(col, dict):
-            continue
         col_name = col.get("name")
-        if not col_name:
-            continue
         norm_name = _norm_ident(str(col_name))
         col_type = (col.get("type") or "").split("(")[0].lower().strip()
         is_calc = col.get("isCalculated", False)
@@ -123,11 +123,7 @@ def _model_seeds(
         )
 
     for col in columns:
-        if not isinstance(col, dict):
-            continue
         col_name = col.get("name")
-        if not col_name:
-            continue
         accepted_values = _prop_raw(col, "acceptedValues", "accepted_values")
         first_value = _first_accepted_value(accepted_values)
         if not first_value:

--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -59,9 +59,7 @@ def _model_seeds(
 ) -> list[dict]:
     name = model["name"]
     columns = [
-        c
-        for c in (model.get("columns") or [])
-        if isinstance(c, dict) and c.get("name")
+        c for c in (model.get("columns") or []) if isinstance(c, dict) and c.get("name")
     ]
     primary_keys = _primary_key_columns(model)
     pairs = []

--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -74,14 +74,18 @@ def _model_seeds(
     numeric_col = None
     group_col = None
     for col in columns:
-        col_name = col["name"]
-        norm_name = _norm_ident(col_name)
+        if not isinstance(col, dict):
+            continue
+        col_name = col.get("name")
+        if not col_name:
+            continue
+        norm_name = _norm_ident(str(col_name))
         col_type = (col.get("type") or "").split("(")[0].lower().strip()
         is_calc = col.get("isCalculated", False)
         is_pk = norm_name in primary_keys
         # Identifiers are numeric by storage but not measures: summing a join
         # key (e.g. SUM(customer_id)) is semantically meaningless.
-        is_identifier = is_pk or norm_name in relationship_keys or _is_id_like(col_name)
+        is_identifier = is_pk or norm_name in relationship_keys or _is_id_like(str(col_name))
 
         if (
             col_type in _NUMERIC_TYPES
@@ -117,6 +121,11 @@ def _model_seeds(
         )
 
     for col in columns:
+        if not isinstance(col, dict):
+            continue
+        col_name = col.get("name")
+        if not col_name:
+            continue
         accepted_values = _prop_raw(col, "acceptedValues", "accepted_values")
         first_value = _first_accepted_value(accepted_values)
         if not first_value:
@@ -124,8 +133,8 @@ def _model_seeds(
         quoted = first_value.replace("'", "''")
         pairs.append(
             {
-                "nl": f"Show {name} where {col['name']} is {first_value}",
-                "sql": f"SELECT * FROM {name} WHERE {col['name']} = '{quoted}' LIMIT 100",
+                "nl": f"Show {name} where {col_name} is {first_value}",
+                "sql": f"SELECT * FROM {name} WHERE {col_name} = '{quoted}' LIMIT 100",
             }
         )
 

--- a/core/wren/tests/unit/test_seed_queries.py
+++ b/core/wren/tests/unit/test_seed_queries.py
@@ -792,3 +792,25 @@ class TestIdentifierExclusion:
         sqls = [p["sql"] for p in generate_seed_queries(manifest)]
         assert not any("SUM(CreatedBy)" in s for s in sqls)
         assert "SELECT SUM(word_count) FROM documents" in sqls
+
+
+def test_skips_non_dict_columns():
+    """Partial MDL column arrays must not TypeError the seed generator."""
+    manifest = {
+        "models": [
+            {
+                "name": "orders",
+                "primaryKey": "id",
+                "columns": [
+                    None,
+                    "bad",
+                    {"name": "amount", "type": "int"},
+                    {"type": "varchar"},  # missing name
+                ],
+            }
+        ]
+    }
+    pairs = generate_seed_queries(manifest)
+    sqls = [p["sql"] for p in pairs]
+    assert "SELECT * FROM orders LIMIT 100" in sqls
+    assert "SELECT SUM(amount) FROM orders" in sqls


### PR DESCRIPTION
## Summary

- `_model_seeds` skips non-dict or nameless column entries instead of TypeErroring on `col["name"]`.
- Apache-2.0 path: `core/wren/**`.

## Motivation

Partial/hand-edited MDL column arrays can include nulls or unshaped rows. Seed generation is pure and runs during indexing; a single bad column listed should not kill the model.

## Verification

- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_seed_queries.py -v` — **39 passed**

## Real behavior proof

`test_skips_non_dict_columns` PASSED (null/string/missing-name columns ignored; SUM(amount) still generated).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing incomplete or malformed model column metadata.
  * Seed query generation now safely ignores invalid column entries while continuing to generate listings and aggregations for valid columns.
* **Tests**
  * Added unit coverage to ensure seed queries are produced correctly even when a model’s columns list contains non-dictionary or unnamed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->