### PR TITLE
fix(sql_classify): treat non-string SQL as not exploratory

### DIFF
--- a/core/wren/src/wren/sql_classify.py
+++ b/core/wren/src/wren/sql_classify.py
@@ -12,6 +12,12 @@ def is_exploratory(sql: str) -> bool:
     Top-level clauses are inspected via stmt.args to avoid descending into
     subqueries (e.g. an inner LIMIT does not affect the outer query).
     """
+    # Call sites may pass None / non-text placeholders. Treat them as
+    # non-exploratory (same tip-not-suppressed outcome as unparseable SQL)
+    # rather than letting sqlglot TypeError through.
+    if not isinstance(sql, str) or not sql.strip():
+        return False
+
     try:
         parsed = sqlglot.parse(sql)
     except sqlglot.errors.ParseError:

--- a/core/wren/tests/unit/test_sql_classify.py
+++ b/core/wren/tests/unit/test_sql_classify.py
@@ -47,3 +47,10 @@ def test_unparseable_sql_returns_false():
 
 def test_empty_string_returns_false():
     assert is_exploratory("") is False
+
+
+def test_none_and_non_string_sql_return_false():
+    assert is_exploratory(None) is False  # type: ignore[arg-type]
+    assert is_exploratory(123) is False  # type: ignore[arg-type]
+    assert is_exploratory(b"SELECT 1") is False  # type: ignore[arg-type]
+    assert is_exploratory("   ") is False


### PR DESCRIPTION
## Summary

- `is_exploratory` returns False for None / non-string / blank SQL instead of TypeErroring through sqlglot.parse.
- Apache-2.0: `core/wren/**`.

## Motivation

Store-tip / UI callers may pass None or placeholders. Crashing the tip path is worse than simply not suppressing the tip.

## Verification

- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_sql_classify.py -v` — **15 passed**

## Real behavior proof

`test_none_and_non_string_sql_return_false` PASSED.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL classification handling for blank, whitespace-only, and invalid input values.
  * Prevented errors when classification receives unexpected input types.
  * Ensured unsupported or unparseable inputs are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->