### PR TITLE
fix(connector): coerce non-string SQL in strip_trailing_semicolon

### DIFF
--- a/core/wren/src/wren/connector/base.py
+++ b/core/wren/src/wren/connector/base.py
@@ -16,7 +16,12 @@ def strip_trailing_semicolon(sql: str) -> str:
     or ``EXPLAIN SELECT 1;``). Only the *terminating* run of semicolons and
     whitespace is removed, so semicolons inside string literals
     (``SELECT 'a;b'``) are preserved.
+
+    Non-string inputs (None/bytes) coerce to ``""`` so call sites that pass
+    placeholders do not raise TypeError inside the re engine.
     """
+    if not isinstance(sql, str):
+        return ""
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 

--- a/core/wren/tests/unit/test_strip_trailing_semicolon_non_string.py
+++ b/core/wren/tests/unit/test_strip_trailing_semicolon_non_string.py
@@ -1,0 +1,15 @@
+"""strip_trailing_semicolon must not TypeError on non-string SQL."""
+
+from wren.connector.base import strip_trailing_semicolon
+
+
+def test_none_returns_empty():
+    assert strip_trailing_semicolon(None) == ""  # type: ignore[arg-type]
+
+
+def test_bytes_returns_empty():
+    assert strip_trailing_semicolon(b"SELECT 1;") == ""  # type: ignore[arg-type]
+
+
+def test_string_still_strips():
+    assert strip_trailing_semicolon("SELECT 1;") == "SELECT 1"


### PR DESCRIPTION
## Summary

- `strip_trailing_semicolon` returns `""` for non-string inputs instead of raising TypeError in the re engine.
- Apache-2.0: `core/wren/**`.

## Motivation

Call sites and connector wrappers occasionally pass None placeholders before SQL is fully formed. Shared strip helper should be safe for all connectors that fork through base.

## Verification

- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_strip_trailing_semicolon_non_string.py -v` — **3 passed**

## Real behavior proof

none/bytes → empty; string strip still works PASSED.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL input handling to safely process non-text values without raising errors.
  * Continued removing trailing semicolons and whitespace from valid SQL text.

* **Tests**
  * Added coverage for `None`, byte values, and standard SQL strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->