### PR TITLE
ci(workflows): delete PR-scoped caches when a pull request closes

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,62 @@
+name: Cleanup PR Caches
+
+# Deletes GitHub Actions caches scoped to a pull request's merge ref once the
+# PR closes. PR-scoped caches (including those created by fork PRs) are stored
+# in this repository under refs/pull/<number>/merge and can only be restored
+# by re-runs of that same PR, so after close they only consume repository
+# cache capacity and crowd out reusable main-branch caches.
+#
+# Security: pull_request_target is used solely to obtain a base-repository
+# token with actions: write for fork-initiated closures. The job never checks
+# out or executes PR-controlled code — the only value consumed from the event
+# is the PR number.
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Closed PR number whose merge-ref caches should be deleted"
+        required: true
+        type: number
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Delete merge-ref caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Delete caches for the PR merge ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          # Only ever delete caches for a PR that is no longer open. The closed
+          # event normally guarantees this; the explicit check also stops a
+          # mistyped manual dispatch from evicting an active PR's warm cache,
+          # and skips a PR reopened in the brief window before this job runs.
+          state=$(gh pr view "$PR_NUMBER" --json state --jq .state)
+          if [ "$state" = "OPEN" ]; then
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "::error::PR #${PR_NUMBER} is open; refusing manual cache deletion."
+              exit 1
+            fi
+            echo "PR #${PR_NUMBER} was reopened before cleanup ran; skipping." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # --all deletes every cache for the ref in a single call: a genuine
+          # deletion, permission, or API error fails the job (so the ref is not
+          # silently left populated), while an empty ref is a successful no-op.
+          ref="refs/pull/${PR_NUMBER}/merge"
+          gh cache delete --all --ref "$ref" --succeed-on-no-caches
+          echo "Cleaned caches for ${ref} (PR state=${state})" \
+            | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

PR-scoped GitHub Actions caches are stored under `refs/pull/<n>/merge` and are
available only to runs of that same PR. After the PR closes, they no longer
support active PR feedback but continue occupying repository cache capacity.
This can crowd out reusable `main`-branch caches and increase cold-compile cache
misses in unrelated workflows.

Snapshot on 2026-07-16: 23 caches using approximately 11.8 GiB. `main` owns only
one reusable seed of approximately 350 MiB; all remaining entries are
PR-scoped, with several PRs retaining approximately 1–2 GiB each.

This is the first of a small, incremental series tracked in #2518 .

## What

- Add `cleanup-pr-caches.yml`, triggered by `pull_request_target: closed`, to
  delete every cache for the closing PR's merge ref:

  ```bash
  gh cache delete --all \
    --ref refs/pull/<n>/merge \
    --succeed-on-no-caches
  ```

- Use `pull_request_target` only to obtain a base-repository token with
  `actions: write`, including for fork PR closures. The job does not check out
  or execute PR-controlled code; the only PR-derived value it consumes is the
  server-assigned PR number.
- Provide a guarded `workflow_dispatch` entry point that refuses to delete
  caches for an open PR.
- Default to `permissions: {}` and grant only job-level `actions: write` and
  `pull-requests: read`, the latter being required by the open-state guard.
- Treat an empty merge ref as a successful no-op while allowing deletion,
  permission, and API failures to fail the job visibly.

## Verification

- `actionlint .github/workflows/cleanup-pr-caches.yml`
- This workflow runs from the base branch, so functional verification is
  available only after it merges to `main`.
- After another PR closes or merges, compare the workflow summary with:

  ```bash
  gh cache list \
    --repo Canner/WrenAI \
    --ref refs/pull/<n>/merge
  ```

- The manual workflow may also be tested with an already-closed PR number. It
  should succeed when the ref is empty and refuse an open PR number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated cleanup of GitHub Actions caches when pull requests are closed.
  * Added a manual option to clean caches for a specified pull request.
  * Added safeguards to prevent cache removal while a pull request remains open.
  * Reports cleanup results, including when no matching caches are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->