### PR TITLE
perf(ci): add fast WASM validation for pull requests

### DIFF
--- a/.github/workflows/publish-wren-core-wasm-rc.yml
+++ b/.github/workflows/publish-wren-core-wasm-rc.yml
@@ -33,6 +33,7 @@ jobs:
   build-and-publish:
     name: Build WASM + publish to npm (token-based)
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: read
     steps:
@@ -87,6 +88,10 @@ jobs:
       - name: Build dist (TypeScript + copy)
         working-directory: core/wren-core-wasm
         run: npm run build:dist
+
+      - name: WASM binary size check
+        working-directory: core/wren-core-wasm
+        run: npm run check:size
 
       - name: Run integration tests
         working-directory: core/wren-core-wasm

--- a/.github/workflows/publish-wren-core-wasm.yml
+++ b/.github/workflows/publish-wren-core-wasm.yml
@@ -24,6 +24,7 @@ jobs:
   build-and-publish:
     name: Build WASM + publish to npm
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     # Required by the npm Trusted Publisher config (Environment name: npm).
     # The 'npm' environment must exist under repo Settings → Environments.
     environment: npm
@@ -86,6 +87,10 @@ jobs:
       - name: Build dist (TypeScript + copy)
         working-directory: core/wren-core-wasm
         run: npm run build:dist
+
+      - name: WASM binary size check
+        working-directory: core/wren-core-wasm
+        run: npm run check:size
 
       - name: Run integration tests
         working-directory: core/wren-core-wasm

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: Build WASM + TypeScript SDK
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 20 || 40 }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +34,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache Cargo
+        id: cargo-cache
         uses: actions/cache@v4
         with:
           path: |
@@ -58,9 +60,28 @@ jobs:
         working-directory: core/wren-core-wasm
         run: npm install
 
-      - name: Build WASM (wasm-pack)
+      - name: Record build start
+        run: echo "WASM_BUILD_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Build WASM (PR fast path, release --no-opt)
+        if: github.event_name == 'pull_request'
+        working-directory: core/wren-core-wasm
+        run: wasm-pack build --target web --release --no-opt
+
+      - name: Build WASM (optimized)
+        if: github.event_name != 'pull_request'
         working-directory: core/wren-core-wasm
         run: wasm-pack build --target web --release
+
+      - name: Report build metrics
+        if: ${{ !cancelled() && env.WASM_BUILD_START != '' }}
+        run: |
+          {
+            echo "### WASM build"
+            echo "- Mode: ${{ github.event_name == 'pull_request' && 'release --no-opt (PR fast path)' || 'release + wasm-opt (optimized)' }}"
+            echo "- Cargo cache exact hit: ${{ steps.cargo-cache.outputs.cache-hit == 'true' }}"
+            echo "- wasm-pack phase: $(( $(date +%s) - WASM_BUILD_START ))s"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build dist (TypeScript + copy)
         working-directory: core/wren-core-wasm
@@ -70,21 +91,10 @@ jobs:
         working-directory: core/wren-core-wasm
         run: npm run typecheck
 
-      - name: WASM binary size check
+      - name: WASM binary size check (optimized artifact only)
+        if: github.event_name != 'pull_request'
         working-directory: core/wren-core-wasm
-        run: |
-          raw_size=$(stat -c%s dist/wren_core_wasm_bg.wasm)
-          gzip_size=$(gzip -c dist/wren_core_wasm_bg.wasm | wc -c)
-          raw_mb=$(echo "scale=1; $raw_size / 1048576" | bc)
-          gzip_mb=$(echo "scale=1; $gzip_size / 1048576" | bc)
-          echo "WASM binary: ${raw_mb} MB raw, ${gzip_mb} MB gzip"
-
-          # Fail if gzip > 15 MB
-          max_gzip=$((15 * 1048576))
-          if [ "$gzip_size" -gt "$max_gzip" ]; then
-            echo "::error::WASM binary gzip size (${gzip_mb} MB) exceeds 15 MB limit"
-            exit 1
-          fi
+        run: npm run check:size
 
       - name: Run integration tests
         working-directory: core/wren-core-wasm

--- a/core/wren-core-wasm/justfile
+++ b/core/wren-core-wasm/justfile
@@ -35,9 +35,9 @@ build-dist:
 
 # -- Test -----------------------------------------------------------
 
-# Run SDK integration tests (requires dist/)
+# Run the complete SDK test suite: integration + size-gate tests (requires dist/)
 test:
-    node --test sdk/tests/index.test.mjs
+    npm test
 
 # TypeScript type check only
 typecheck:

--- a/core/wren-core-wasm/package.json
+++ b/core/wren-core-wasm/package.json
@@ -21,7 +21,8 @@
     "build:dist": "node scripts/build.mjs",
     "build": "npm run build:wasm && npm run build:dist",
     "typecheck": "tsc -p sdk/tsconfig.json --noEmit",
-    "test": "node --test sdk/tests/index.test.mjs"
+    "test": "node --test sdk/tests/index.test.mjs sdk/tests/check-size.test.mjs",
+    "check:size": "node scripts/check-size.mjs"
   },
   "keywords": [
     "wasm",

--- a/core/wren-core-wasm/scripts/check-size.mjs
+++ b/core/wren-core-wasm/scripts/check-size.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Size gate for the production WASM artifact, shared by wasm-ci.yml (main
+// path) and both npm publish workflows via `npm run check:size`.
+//
+// Measures the artifact with system gzip using the file-argument form
+// (`gzip -c -- <file>`) so the filename header is included. Reports the exact
+// gzip byte count and MiB figures truncated to one decimal place.
+//
+// The gate fails closed: missing artifact, invalid limit, or gzip failure
+// all exit 1.
+//
+// Usage: node scripts/check-size.mjs [wasmPath]
+//   MAX_GZIP_MIB  override the limit in MiB (default 15); must be a finite,
+//                 non-negative number, otherwise the gate fails.
+import { statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const MIB = 1024 * 1024;
+const DEFAULT_WASM = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dist",
+  "wren_core_wasm_bg.wasm",
+);
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+// Truncate (not round) to one decimal place.
+function truncMib(bytes) {
+  return (Math.floor((bytes / MIB) * 10) / 10).toFixed(1);
+}
+
+const wasmPath = process.argv[2] ?? DEFAULT_WASM;
+
+const rawLimit = process.env.MAX_GZIP_MIB;
+const maxGzipMib =
+  rawLimit === undefined || rawLimit === "" ? 15 : Number(rawLimit);
+if (!Number.isFinite(maxGzipMib) || maxGzipMib < 0) {
+  fail(`Invalid MAX_GZIP_MIB value: ${rawLimit}`);
+}
+const maxGzipBytes = Math.round(maxGzipMib * MIB);
+
+let rawBytes;
+try {
+  rawBytes = statSync(wasmPath).size;
+} catch (err) {
+  fail(`Cannot read WASM artifact at ${wasmPath}: ${err.message}`);
+}
+
+const gzip = spawnSync("gzip", ["-c", "--", wasmPath], {
+  maxBuffer: 512 * MIB,
+});
+if (gzip.error) {
+  fail(`Failed to run system gzip: ${gzip.error.message}`);
+}
+if (gzip.status !== 0) {
+  fail(`gzip exited with status ${gzip.status}: ${gzip.stderr}`);
+}
+const gzipBytes = gzip.stdout.length;
+
+console.log(
+  `WASM binary: ${truncMib(rawBytes)} MiB raw, ${truncMib(gzipBytes)} MiB gzip ` +
+    `(${gzipBytes} bytes gzip, limit ${maxGzipMib} MiB gzip)`,
+);
+if (gzipBytes > maxGzipBytes) {
+  fail(
+    `WASM binary gzip size (${truncMib(gzipBytes)} MiB) exceeds ${maxGzipMib} MiB limit`,
+  );
+}

--- a/core/wren-core-wasm/sdk/tests/check-size.test.mjs
+++ b/core/wren-core-wasm/sdk/tests/check-size.test.mjs
@@ -1,0 +1,126 @@
+import { after, test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+  "check-size.mjs",
+);
+const MIB = 1024 * 1024;
+
+const tmpDirs = [];
+after(() => {
+  for (const dir of tmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTmpDir(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function runGate(args, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+function makeFixture(bytes) {
+  const file = path.join(makeTmpDir("check-size-"), "fixture.wasm");
+  writeFileSync(file, Buffer.alloc(bytes, 0xab));
+  return file;
+}
+
+// A fake gzip on PATH that exits with the given code, to exercise the
+// "executable runs but fails" branch.
+function makeFakeGzipDir(exitCode) {
+  const dir = makeTmpDir("fake-gzip-");
+  const fake = path.join(dir, "gzip");
+  writeFileSync(fake, `#!/bin/sh\nexit ${exitCode}\n`);
+  chmodSync(fake, 0o755);
+  return dir;
+}
+
+// The gate's own measurement: file-argument form, same file path — so the
+// at-limit/over-limit boundary tests are byte-exact against the gate.
+function gzipBytesOf(file) {
+  const out = spawnSync("gzip", ["-c", "--", file], { maxBuffer: 64 * MIB });
+  assert.equal(out.status, 0, "test helper: system gzip must be available");
+  return out.stdout.length;
+}
+
+test("passes when the artifact is below the limit", () => {
+  const file = makeFixture(1024);
+  const res = runGate([file]);
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /limit 15 MiB gzip/);
+});
+
+test("passes when the artifact is exactly at the limit", () => {
+  const file = makeFixture(256 * 1024);
+  const limitMib = gzipBytesOf(file) / MIB;
+  const res = runGate([file], { MAX_GZIP_MIB: String(limitMib) });
+  assert.equal(res.status, 0);
+});
+
+test("fails when the artifact exceeds the limit", () => {
+  const file = makeFixture(256 * 1024);
+  const limitMib = (gzipBytesOf(file) - 1) / MIB;
+  const res = runGate([file], { MAX_GZIP_MIB: String(limitMib) });
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /exceeds/);
+});
+
+test("reports the exact gzip byte count", () => {
+  const file = makeFixture(256 * 1024);
+  const res = runGate([file]);
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, new RegExp(`\\(${gzipBytesOf(file)} bytes gzip`));
+});
+
+test("fails when the artifact is missing", () => {
+  const missing = path.join(makeTmpDir("check-size-missing-"), "missing.wasm");
+  const res = runGate([missing]);
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /Cannot read WASM artifact/);
+});
+
+test("fails closed on an invalid limit", () => {
+  const file = makeFixture(1024);
+  for (const bad of ["abc", "NaN", "-1", "Infinity"]) {
+    const res = runGate([file], { MAX_GZIP_MIB: bad });
+    assert.equal(res.status, 1, `MAX_GZIP_MIB=${bad} must fail closed`);
+    assert.match(res.stderr, /Invalid MAX_GZIP_MIB/);
+  }
+});
+
+test("empty MAX_GZIP_MIB falls back to the default limit", () => {
+  const file = makeFixture(1024);
+  const res = runGate([file], { MAX_GZIP_MIB: "" });
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /limit 15 MiB gzip/);
+});
+
+test("fails when the gzip executable is unavailable", () => {
+  const file = makeFixture(1024);
+  const res = runGate([file], { PATH: "" });
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /Failed to run system gzip/);
+});
+
+test("fails when gzip exits non-zero", () => {
+  const file = makeFixture(1024);
+  const res = runGate([file], { PATH: makeFakeGzipDir(3) });
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /gzip exited with status 3/);
+});


### PR DESCRIPTION
## Summary

This draft proposes a faster validation path for WASM pull requests while
retaining fully optimized builds and size enforcement on production paths.

It is intentionally opened as a draft because this changes when optimized-size
regressions are detected. I would like maintainer feedback on that trade-off
before treating the implementation as ready to merge.

Part of #2518. This does not close the issue because the main-owned cache work
is tracked separately.

## Context

Recent `Build WASM + TypeScript SDK` runs took approximately:

| Scenario | Cargo compile | `wasm-opt` | `wasm-pack` total |
|---|---:|---:|---:|
| Warm cache | 1:09 | ~15:13 | 16:45 |
| Cold cache | 10:16 | ~18:25 | 29:04 |

The Binaryen `wasm-opt` pass therefore contributes approximately 15–18 minutes
to every pull request, independently of the Cargo cache state.

- Warm example: https://github.com/Canner/WrenAI/actions/runs/29254751463
- Cold example: https://github.com/Canner/WrenAI/actions/runs/29251947757

## Proposed behavior

| Path | Build mode | Size validation | Timeout |
|---|---|---|---:|
| Pull request | release build with `--no-opt` | skipped | 20 min |
| Push to `main` | fully optimized release build | 15 MiB gzip | 40 min |
| Stable publish | fully optimized release build | before `npm publish` | 40 min |
| RC publish | fully optimized release build | before `npm publish` | 40 min |

The timeout values are upper bounds for detecting stuck jobs; they are not
expected runtimes. The first cold-equivalent PR run completed in 11:18, including a 10:47
`wasm-pack --no-opt` phase. This meets the ≤12-minute cold target. A true warm
run has not yet been observed, so the 2–3 minute warm estimate remains
unconfirmed.

## What changed

- Use `wasm-pack build --target web --release --no-opt` only for pull requests.
- Keep the existing fully optimized build on `main`.
- Skip the production size gate for the non-optimized PR artifact.
- Add one tested `npm run check:size` implementation shared by:
  - the optimized `main` build;
  - stable npm publishing;
  - RC npm publishing.
- Preserve the existing 15 MiB gzip limit and historical system-gzip
  measurement.
- Block `npm publish` when an optimized artifact exceeds the limit.
- Report the selected build mode, Cargo exact-cache hit, and `wasm-pack`
  duration in the Actions job summary.
- Add 20-minute and 40-minute job timeout ceilings.
- Keep cache ownership, save/restore policy, and cache-key redesign out of this
  PR.

The 15 MiB limit is not newly introduced here. The current optimized artifact
is approximately 13.8 MiB gzip; this PR centralizes the existing check and also
applies it directly to both publish paths.

## Trade-off and feedback requested

The main trade-off is that an optimized-size regression would be detected on
the first `main` build after merge rather than during the pull request.

The current `main` ruleset does not require status checks, so the optimized PR
size result is advisory today rather than an enforced merge gate. Nevertheless,
pre-merge visibility may still be valuable to maintainers, and I do not want to
assume that shorter PR feedback is necessarily more important than running the
full optimizer on every PR.

I would especially appreciate feedback on:

1. Is moving optimized-size detection from PR time to `main` acceptable?
2. Would maintainers prefer to keep the full 17–29 minute optimized PR build,
   even though it is not currently an enforced merge gate?
3. Are the 20-minute PR and 40-minute optimized-build timeout ceilings useful,
   or would different values/no timeout be preferable?
4. Should stable and RC publish workflows directly enforce the existing size
   limit before `npm publish`, as proposed here?

If pre-merge optimized validation is preferred, I am happy to retain the
current full PR build. Another future option would be enforcing the optimized
gate through a merge queue using `merge_group`.

## CI measurement

Two PR runs have completed successfully:

| Run | Cache observation | `wasm-pack` | Job total |
|---|---|---:|---:|
| Initial PR run | exact-key restore, but compiler-stale/full rebuild | 10:47 | 11:18 |
| After rebasing onto `main` | same exact key and another near-full rebuild | 10:51 | 11:26 |

Runs:

- https://github.com/Canner/WrenAI/actions/runs/29556999300/job/87811153626
- https://github.com/Canner/WrenAI/actions/runs/29558380493/job/87815362921

In both runs, the PR fast path, typecheck, and all 43 tests passed. The optimized
build and production size gate were correctly skipped.

Although `actions/cache` reported an exact-key restore, neither run was a usable
warm build. Both restored the same main cache, which was created on July 15,
while `rust-toolchain@stable` resolved to Rust 1.97.1 after the July 16 stable
update. Because the current key does not include compiler identity, Cargo
invalidated the restored fingerprints and performed a near-full rebuild.

The second run naturally reproduces this behavior after rebasing onto `main`;
the unchanged exact key was restored again and could not be refreshed.

These runs should therefore be treated as cold-equivalent rather than warm:

- previous cold `wasm-pack`: 29:04
- PR fast-path `wasm-pack`: 10:47–10:51
- saving: 18:13–18:17, approximately 63%
- total PR job: 11:18–11:26, within the ≤12-minute cold target in both runs

A true warm-path measurement is still pending. I will not force one by deleting
or manipulating caches. The repeated stale exact-hit behavior also provides
concrete evidence for the compiler-aware cache-key work tracked in the
follow-up cache PR.

## Validation

Completed locally:

- `just test`: 43/43 passed
- `npm test`: 43/43 passed
- `npm run typecheck`: passed
- `actionlint` for all three modified workflows: passed
- `git diff --check`: passed
- Real optimized artifact:
  - shared checker: 14,547,440 gzip bytes / 13.8 MiB
  - direct `gzip -c <file> | wc -c`: 14,547,440 bytes

After opening the draft, I will record the actual warm/cold PR timings and
confirm that the post-merge optimized path retains the existing size result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a production WASM size gate using `npm run check:size`, with configurable gzip-size limits and clearer reporting.
  * Publishing workflows now run the size check before integration tests and npm publish.
* **Bug Fixes**
  * Improved CI reliability with explicit job timeouts and clearer build-time metrics.
* **Tests**
  * Expanded WASM SDK tests to include size-gate coverage (including boundary and failure scenarios).
  * Pull-request CI uses faster unoptimized builds, while size checks apply to optimized artifacts only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->