### PR TITLE
fix(pydantic): skip non-dict models in list_models

### DIFF
--- a/sdk/wren-pydantic/src/wren_pydantic/_tools.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_tools.py
@@ -169,11 +169,27 @@ def _run_list_models(toolkit: WrenToolkit) -> list[ModelSummary]:
         raise to_model_retry(exc) from exc
 
     models = manifest.get("models") or []
-    return [
-        ModelSummary(
-            name=m["name"],
-            column_count=len(m.get("columns") or []),
-            description=(m.get("properties") or {}).get("description"),
+    if not isinstance(models, list):
+        return []
+
+    summaries: list[ModelSummary] = []
+    for m in models:
+        if not isinstance(m, dict):
+            continue
+        name = m.get("name")
+        if not name:
+            continue
+        columns = m.get("columns") or []
+        if not isinstance(columns, list):
+            columns = []
+        props = m.get("properties") or {}
+        if not isinstance(props, dict):
+            props = {}
+        summaries.append(
+            ModelSummary(
+                name=name,
+                column_count=len(columns),
+                description=props.get("description"),
+            )
         )
-        for m in models
-    ]
+    return summaries

--- a/sdk/wren-pydantic/tests/unit/test_tools_runtime.py
+++ b/sdk/wren-pydantic/tests/unit/test_tools_runtime.py
@@ -215,6 +215,32 @@ def test_wren_list_models_empty_manifest():
     assert result == []
 
 
+def test_wren_list_models_skips_non_dict_and_nameless():
+    """Partial manifests must not AttributeError mid-comprehension."""
+    toolkit = _mock_toolkit(
+        manifest={
+            "models": [
+                "bad",
+                None,
+                {"columns": [{"name": "id"}]},  # missing name
+                {
+                    "name": "ok",
+                    "columns": "skewed",
+                    "properties": "not-a-dict",
+                },
+            ]
+        }
+    )
+    ts = build_runtime_toolset(toolkit, takes_ctx=False)
+    fn = _get_tool(ts, "wren_list_models")
+
+    result = fn()
+    assert len(result) == 1
+    assert result[0].name == "ok"
+    assert result[0].column_count == 0
+    assert result[0].description is None
+
+
 def test_wren_list_models_wraps_error_as_model_retry():
     toolkit = _mock_toolkit()
     toolkit._mdl_source.load_manifest.side_effect = WrenError(


### PR DESCRIPTION
## Summary

- _run_list_models assumed every models[] element was a dict with name/columns/properties.
- Skip non-dict rows and nameless models; coerce non-list columns and non-dict properties.

## Motivation

Malformed MDL fragments should not AttributeError wren_list_models mid-comprehension. Apache-2.0: sdk/**.

## Verification

Logic exercised with an in-process fixture reproducing non-dict/name-less rows (ok model kept with column_count 0). Full pydantic-ai env not on this host; unit test added for CI:

- tests/unit/test_tools_runtime.py::test_wren_list_models_skips_non_dict_and_nameless

## Test plan

- [x] Local behavioral proof + regression test
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model listing resilience when metadata is incomplete or malformed.
  * Invalid or unnamed models are now skipped instead of causing failures.
  * Missing or incorrectly formatted fields receive safe default values.

* **Tests**
  * Added coverage for partially invalid model metadata and expected fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->