### PR TITLE
fix(clickhouse): catch SqlglotError in type string parsing

### DIFF
--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -55,7 +55,10 @@ def _parse_clickhouse_type(type_str: str | None) -> pa.DataType:
         return pa.string()
     try:
         parsed = sqlglot.parse_one(type_str, into=DataType, dialect="clickhouse")
-    except sqlglot.errors.ParseError:
+    except (sqlglot.errors.SqlglotError, ValueError):
+        # SqlglotError covers ParseError *and* TokenError (unterminated quotes /
+        # stray control chars). Match wren.type_mapping: fall back to string
+        # rather than failing the entire query result conversion.
         logger.warning(f"Failed to parse ClickHouse type string: {type_str}")
         return pa.string()
     if parsed is None:

--- a/core/wren/tests/unit/test_clickhouse_helpers.py
+++ b/core/wren/tests/unit/test_clickhouse_helpers.py
@@ -228,6 +228,19 @@ def test_parse_clickhouse_type_nullable(
     assert _parse_clickhouse_type(type_str) == expected
 
 
+@pytest.mark.parametrize(
+    "type_str",
+    [
+        # TokenError (not ParseError) — must fall back to string, not raise.
+        '"unterminated',
+        "VARC\x00HAR",
+    ],
+)
+def test_parse_clickhouse_type_falls_back_on_sqlglot_error(type_str: str) -> None:
+    """TokenError is a SqlglotError but not a ParseError; never hatch out."""
+    assert _parse_clickhouse_type(type_str) == pa.string()
+
+
 def test_clickhouse_arrow_table_nullable_columns_preserve_none_values() -> None:
     """Nullable columns must round-trip None through _build_clickhouse_arrow_table.
 


### PR DESCRIPTION
## Summary

- _parse_clickhouse_type only caught ParseError.
- Catch SqlglotError + ValueError (same as type_mapping) so TokenError from unterminated quotes / control chars falls back to pa.string() instead of crashing query result conversion.

## Motivation

Regression pattern already fixed in type_mapping and the trino parser: TokenError is a SqlglotError but not a ParseError. ClickHouse result conversion should match.

## License

core/** Apache-2.0

## Verification

```
cd core/wren && .venv/bin/python -m pytest tests/unit/test_clickhouse_helpers.py -k 'parse_clickhouse or sqlglot' -v
# 17 passed (incl. untested TokenError cases)
```

## Test plan

- [x] Local unit tests
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or unsupported ClickHouse type definitions.
  * Prevented schema conversion errors by safely falling back to a string type when parsing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->