### PR TITLE
fix(langchain): coerce None in format_store_content

### DIFF
--- a/sdk/wren-langchain/src/wren_langchain/_format.py
+++ b/sdk/wren-langchain/src/wren_langchain/_format.py
@@ -128,10 +128,7 @@ def format_store_content(nl: str, sql: str, tags: list[str] | None) -> str:
     sql_preview = sql.strip().split("\n")[0]
     if len(sql_preview) > 80:
         sql_preview = sql_preview[:77] + "..."
-    if tags is None or not isinstance(tags, list):
-        tag_count = 0
-    else:
-        tag_count = len(tags)
+    tag_count = len(tags) if isinstance(tags, list) else 0
     return f'Stored: "{nl}" → {sql_preview} ({tag_count} tags)'
 
 

--- a/sdk/wren-langchain/src/wren_langchain/_format.py
+++ b/sdk/wren-langchain/src/wren_langchain/_format.py
@@ -119,10 +119,19 @@ def format_recall_content(rows: list[dict[str, Any]]) -> str:
 
 def format_store_content(nl: str, sql: str, tags: list[str] | None) -> str:
     """One-liner ``Stored: "<nl>" → <sql preview> (N tags)``."""
+    # Store tool paths occasionally surface None/placeholders before validation.
+    # Coerce so format helpers never TypeError on .strip().
+    if not isinstance(nl, str):
+        nl = "" if nl is None else str(nl)
+    if not isinstance(sql, str):
+        sql = "" if sql is None else str(sql)
     sql_preview = sql.strip().split("\n")[0]
     if len(sql_preview) > 80:
         sql_preview = sql_preview[:77] + "..."
-    tag_count = len(tags) if tags else 0
+    if tags is None or not isinstance(tags, list):
+        tag_count = 0
+    else:
+        tag_count = len(tags)
     return f'Stored: "{nl}" → {sql_preview} ({tag_count} tags)'
 
 

--- a/sdk/wren-langchain/tests/unit/test_format_store_content.py
+++ b/sdk/wren-langchain/tests/unit/test_format_store_content.py
@@ -2,33 +2,28 @@
 
 from __future__ import annotations
 
-import importlib.util
-import pathlib
-
-_PATH = (
-    pathlib.Path(__file__).resolve().parents[2]
-    / "src"
-    / "wren_langchain"
-    / "_format.py"
-)
-_spec = importlib.util.spec_from_file_location("wren_langchain_format_store_ut", _PATH)
-_fmt = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_fmt)
+from wren_langchain._format import format_store_content
 
 
 def test_format_store_content_happy_path() -> None:
-    out = _fmt.format_store_content("List orders", "SELECT 1\nFROM t", ["a", "b"])
+    out = format_store_content("List orders", "SELECT 1\nFROM t", ["a", "b"])
     assert 'Stored: "List orders"' in out
     assert "SELECT 1" in out
     assert "(2 tags)" in out
 
 
 def test_format_store_content_none_sql_and_nl() -> None:
-    out = _fmt.format_store_content(None, None, None)  # type: ignore[arg-type]
+    out = format_store_content(None, None, None)  # type: ignore[arg-type]
     assert 'Stored: ""' in out
     assert "(0 tags)" in out
 
 
+def test_format_store_content_non_string_text() -> None:
+    out = format_store_content(123, 456, [])  # type: ignore[arg-type]
+    assert 'Stored: "123"' in out
+    assert "456" in out
+
+
 def test_format_store_content_non_list_tags() -> None:
-    out = _fmt.format_store_content("q", "SELECT 1", "tags")  # type: ignore[arg-type]
+    out = format_store_content("q", "SELECT 1", "tags")  # type: ignore[arg-type]
     assert "(0 tags)" in out

--- a/sdk/wren-langchain/tests/unit/test_format_store_content.py
+++ b/sdk/wren-langchain/tests/unit/test_format_store_content.py
@@ -1,0 +1,34 @@
+"""format_store_content must tolerate None/non-str nl/sql and bad tags."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "src"
+    / "wren_langchain"
+    / "_format.py"
+)
+_spec = importlib.util.spec_from_file_location("wren_langchain_format_store_ut", _PATH)
+_fmt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fmt)
+
+
+def test_format_store_content_happy_path() -> None:
+    out = _fmt.format_store_content("List orders", "SELECT 1\nFROM t", ["a", "b"])
+    assert 'Stored: "List orders"' in out
+    assert "SELECT 1" in out
+    assert "(2 tags)" in out
+
+
+def test_format_store_content_none_sql_and_nl() -> None:
+    out = _fmt.format_store_content(None, None, None)  # type: ignore[arg-type]
+    assert 'Stored: ""' in out
+    assert "(0 tags)" in out
+
+
+def test_format_store_content_non_list_tags() -> None:
+    out = _fmt.format_store_content("q", "SELECT 1", "tags")  # type: ignore[arg-type]
+    assert "(0 tags)" in out


### PR DESCRIPTION
## Summary

- format_store_content called .strip() on sql/nl without guarding None.
- Coerce non-str nl/sql; treat non-list tags as zero tags.

## Motivation

Store-tool confirmation paths can pass placeholders. formatting must not TypeError after a successful store.

## License

sdk/** Apache-2.0

## Verification

```
cd sdk/wren-langchain && python3 -m pytest tests/unit/test_format_store_content.py -v
# 3 passed
```

## Test plan

- [x] Local unit tests
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stored content with unexpected input types.
  * Prevented formatting failures when SQL and natural-language text are missing or not strings.
  * Hardened tag reporting by only counting tags when they are provided as a list.
* **Tests**
  * Added unit tests covering normal formatting, missing values, non-string title/SQL/natural-language inputs, and non-list tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->