### PR TITLE
fix(profile): mask secrets nested under kwargs and settings in profile debug

### DIFF
--- a/core/wren/src/wren/profile.py
+++ b/core/wren/src/wren/profile.py
@@ -355,7 +355,7 @@ def _registry_sensitive_keys() -> set[str]:
     return keys
 
 
-def _mask_obj(obj: Any, is_sensitive: Callable[[str], bool]) -> Any:
+def _mask_obj(obj: Any, is_sensitive: Callable[[Any], bool]) -> Any:
     """Recursively mask sensitive keys, mirroring :func:`_expand_obj`.
 
     Expansion walks nested dicts and lists, so secrets legitimately live at
@@ -407,8 +407,10 @@ def debug_profile(name: str | None = None) -> dict[str, Any]:
     }
     registry_sensitive = _registry_sensitive_keys()
 
-    def _is_sensitive(key: str) -> bool:
-        kl = key.lower()
+    def _is_sensitive(key: Any) -> bool:
+        # YAML permits non-string keys (``123:``, ``true:``); str() keeps the
+        # traversal from raising AttributeError on them.
+        kl = str(key).lower()
         return (
             kl in registry_sensitive
             or kl in _SENSITIVE

--- a/core/wren/src/wren/profile.py
+++ b/core/wren/src/wren/profile.py
@@ -12,6 +12,7 @@ import os
 import re
 import string
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -354,12 +355,30 @@ def _registry_sensitive_keys() -> set[str]:
     return keys
 
 
+def _mask_obj(obj: Any, is_sensitive: Callable[[str], bool]) -> Any:
+    """Recursively mask sensitive keys, mirroring :func:`_expand_obj`.
+
+    Expansion walks nested dicts and lists, so secrets legitimately live at
+    ``kwargs: {password: ...}``; masking must cover the same shape or it
+    under-masks exactly the values expansion supports.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: "***" if is_sensitive(k) else _mask_obj(v, is_sensitive)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_mask_obj(v, is_sensitive) for v in obj]
+    return obj
+
+
 def debug_profile(name: str | None = None) -> dict[str, Any]:
     """Return diagnostic info for a profile (or the active one).
 
     Masks fields the connection-field registry marks sensitive (``SecretStr``),
     plus a name heuristic (password, credentials, secret, token, ...) for keys
-    the registry does not know about.
+    the registry does not know about. Nested dicts and lists are walked, since
+    ``kwargs``/``settings`` may carry secrets.
     """
     if name is None:
         name = get_active_name()
@@ -387,15 +406,14 @@ def debug_profile(name: str | None = None) -> dict[str, Any]:
         "role_arn",
     }
     registry_sensitive = _registry_sensitive_keys()
-    masked = {}
-    for k, v in profile.items():
-        kl = k.lower()
-        if (
+
+    def _is_sensitive(key: str) -> bool:
+        kl = key.lower()
+        return (
             kl in registry_sensitive
             or kl in _SENSITIVE
             or any(s in kl for s in _SENSITIVE)
-        ):
-            masked[k] = "***"
-        else:
-            masked[k] = v
+        )
+
+    masked = _mask_obj(profile, _is_sensitive)
     return {"name": name, "active": data.get("active") == name, "config": masked}

--- a/core/wren/tests/unit/test_profile_env_expansion.py
+++ b/core/wren/tests/unit/test_profile_env_expansion.py
@@ -260,3 +260,30 @@ def test_debug_leaves_nested_benign_fields_intact(tmp_path, monkeypatch):
     assert cfg["kwargs"]["sslmode"] == "require"
     assert cfg["kwargs"]["connect_timeout"] == 10
     assert cfg["extras"][0]["retries"] == 3
+
+
+def test_debug_survives_non_string_keys(tmp_path, monkeypatch):
+    """Non-string YAML keys must not crash the masking walk.
+
+    ``profiles.yml`` is hand-written, and YAML admits ``123:``/``true:`` as
+    keys; recursing into ``kwargs``/``settings`` exposes the key predicate to
+    them, where a bare ``key.lower()`` raises AttributeError.
+    """
+    monkeypatch.setattr(profile_mod, "_WREN_HOME", tmp_path)
+    monkeypatch.setattr(profile_mod, "_PROFILES_FILE", tmp_path / "profiles.yml")
+
+    profile_mod.add_profile(
+        "pg",
+        {
+            "datasource": "postgres",
+            "kwargs": {123: "int-key", True: "bool-key"},
+            "settings": {"deep": {None: "none-key", "password": "NESTED"}},
+        },
+    )
+
+    cfg = profile_mod.debug_profile("pg")["config"]
+    assert cfg["kwargs"][123] == "int-key"
+    assert cfg["kwargs"][True] == "bool-key"
+    assert cfg["settings"]["deep"][None] == "none-key"
+    # Non-string siblings must not stop the walk from reaching real secrets.
+    assert cfg["settings"]["deep"]["password"] == "***"

--- a/core/wren/tests/unit/test_profile_env_expansion.py
+++ b/core/wren/tests/unit/test_profile_env_expansion.py
@@ -205,3 +205,58 @@ def test_debug_masks_registry_sensitive_fields(tmp_path, monkeypatch):
     for name, prof, key in cases:
         profile_mod.add_profile(name, prof)
         assert profile_mod.debug_profile(name)["config"][key] == "***", key
+
+
+def test_debug_masks_nested_sensitive_fields(tmp_path, monkeypatch):
+    """Secrets nested under ``kwargs``/``settings`` must be masked too.
+
+    ``expand_profile_secrets`` walks dicts and lists recursively so
+    ``kwargs: {password: ${PG_PW}}`` resolves; masking must cover the same
+    shape, or ``debug`` under-masks exactly the values expansion supports.
+    """
+    monkeypatch.setattr(profile_mod, "_WREN_HOME", tmp_path)
+    monkeypatch.setattr(profile_mod, "_PROFILES_FILE", tmp_path / "profiles.yml")
+
+    profile_mod.add_profile(
+        "pg",
+        {
+            "datasource": "postgres",
+            "host": "db.local",
+            "password": "TOP",
+            "kwargs": {"password": "NESTED", "connection_url": "postgresql://u:PW@h"},
+            "settings": {"deep": {"token": "DEEP"}},
+            "extras": [{"secret": "IN_LIST"}],
+        },
+    )
+
+    cfg = profile_mod.debug_profile("pg")["config"]
+    assert cfg["password"] == "***"
+    assert cfg["kwargs"]["password"] == "***"
+    assert cfg["kwargs"]["connection_url"] == "***"  # registry-sensitive, nested
+    assert cfg["settings"]["deep"]["token"] == "***"  # arbitrary depth
+    assert cfg["extras"][0]["secret"] == "***"  # dicts inside lists
+
+
+def test_debug_leaves_nested_benign_fields_intact(tmp_path, monkeypatch):
+    """Recursive masking must not over-mask: benign nested values survive.
+
+    Reverse anchor for ``test_debug_masks_nested_sensitive_fields`` — walking
+    nested containers must not turn every nested value into ``***``.
+    """
+    monkeypatch.setattr(profile_mod, "_WREN_HOME", tmp_path)
+    monkeypatch.setattr(profile_mod, "_PROFILES_FILE", tmp_path / "profiles.yml")
+
+    profile_mod.add_profile(
+        "pg",
+        {
+            "datasource": "postgres",
+            "host": "db.local",
+            "kwargs": {"sslmode": "require", "connect_timeout": 10},
+            "extras": [{"retries": 3}],
+        },
+    )
+
+    cfg = profile_mod.debug_profile("pg")["config"]
+    assert cfg["kwargs"]["sslmode"] == "require"
+    assert cfg["kwargs"]["connect_timeout"] == 10
+    assert cfg["extras"][0]["retries"] == 3


### PR DESCRIPTION
## Summary
- `wren profile debug` masks only **top-level** keys. Secrets nested under `kwargs` / `settings` — a shape this module explicitly supports — are printed **in plaintext**, while the top-level `password` right next to them shows `***`.
- Fix: walk nested dicts and lists when masking, mirroring `_expand_obj`, which already walks them.

## Motivation

`expand_profile_secrets` documents nested secrets as a supported shape:

> *"Only string values are substituted; integers, booleans, lists, and nested dicts are preserved (lists and dicts are walked recursively so `kwargs: {password: ${PG_PW}}` works)."*

Expansion honours that — `_expand_obj` recurses through dicts and lists. Masking does not:

```python
for k, v in profile.items():        # top level only
    masked[k] = "***" if sensitive(k) else v   # nested dict passes through whole
```

So the two halves of the same feature disagree: **expansion recurses, masking doesn't.**

The declared contract says these must be masked:
- `_registry_sensitive_keys` docstring — *"over-masking a benign key in a diagnostic dump is harmless, **under-masking a secret is not**."*
- CLI help (`wren profile debug`) — *"Show resolved profile config (sensitive fields masked)."*

Reachability: `debug` is what the CLI points users to after a connection failure, and its output is what gets pasted into bug reports. With `kwargs: {password: ...}` — the exact form the docstring advertises — that paste contains the password:

```
"password": "***"                                  ← top-level, masked
"kwargs":   { "password": "NESTED_SECRET" }        ← nested, plaintext
"settings": { "token": "NESTED_TOKEN" }            ← nested, plaintext
```

This is the sibling site my own #2492 missed: that PR fixed *which keys* count as sensitive and I scoped it to the predicate, never asking whether the guard's **shape** matched the function's **semantics**. The predicate was right; the traversal depth was not.

## Fix

Add `_mask_obj`, mirroring the existing `_expand_obj` shape (dict / list / scalar) rather than inventing a new structure. The sensitivity predicate itself is unchanged — only traversal depth is. Nothing that was masked before becomes unmasked.

Scope: I grepped every surface that prints profile fields and **drove each one**. `wren profile list` prints only name + datasource (no leak). `debug` is the only leaking exit. (`wren profile show`, listed in `.claude/CLAUDE.md`, does not actually exist as a command — out of scope here.)

## Verification

- New regression tests in `tests/unit/test_profile_env_expansion.py` (covered by the CI unit job):
  - `test_debug_masks_nested_sensitive_fields` — nested `password`, registry-sensitive `connection_url`, arbitrary depth (`settings.deep.token`), and dicts inside lists.
    - Without the change: `assert 'NESTED' == '***'` — **RED**. With it: **PASS**.
  - `test_debug_leaves_nested_benign_fields_intact` — reverse anchor: `kwargs.sslmode` / `connect_timeout` must survive.
    - Verified load-bearing: replacing the fix with a blanket `k: "***"` reds it.
- Existing tests not hollowed out: neutralising the sensitivity predicate reds `test_debug_profile_returns_literal_placeholder`, `test_debug_masks_registry_sensitive_fields` and `tests/test_profile.py::test_debug_masks_sensitive` — they still guard top-level masking.
- Full unit suite vs clean `main`, verbatim: **967 → 969 passed, 2 skipped** (+2 = exactly the new tests; **0 new failures**). Lint clean (`just lint`).
- End-to-end via the real CLI: `wren profile debug pg` masks `kwargs.password` and `settings.token` to `***` while `kwargs.sslmode` stays `require`; plaintext-secret occurrences in the output: **0**. The same profile on unpatched `main` prints the secret.

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — this contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile diagnostics to recursively mask sensitive values across nested configuration, including deeply nested `kwargs`/`settings` and values inside lists.
  * Updated masking logic to correctly identify sensitive fields while leaving non-sensitive details unchanged.

* **Tests**
  * Expanded coverage to verify recursive masking at multiple depths, ensure safe fields aren’t over-masked, and confirm robustness when profile/YAML keys aren’t strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->