### PR TITLE
fix(mcp): apply default row cap in list_stored_queries markdown fallback

### DIFF
--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -462,8 +462,7 @@ def _register_knowledge_tools(mcp: FastMCP, ctx: ServeContext) -> None:
             pairs = load_query_pairs(ctx.project)
             if source:
                 pairs = [p for p in pairs if p.get("source", "user") == source]
-            if limit is not None:
-                pairs = pairs[:limit]
+            pairs = pairs[: limit if limit is not None else MAX_ROW_LIMIT]
             queries = [
                 {
                     "nl_query": p["nl"],

--- a/core/wren/tests/unit/test_mcp_server.py
+++ b/core/wren/tests/unit/test_mcp_server.py
@@ -126,6 +126,61 @@ def test_list_stored_queries_uses_ctx_project(tmp_path, monkeypatch):
     assert captured["path"] != str(proj_a / ".wren" / "memory")
 
 
+def test_list_stored_queries_fallback_applies_default_cap(tmp_path, monkeypatch):
+    """The markdown fallback must apply the same default cap as the LanceDB path.
+
+    ``store.list_queries`` is called with ``limit=MAX_ROW_LIMIT`` when the caller
+    omits ``limit``; the fallback (taken on *any* MemoryStore error, not just a
+    missing extra) must not return the whole corpus uncapped.
+    """
+    import wren.mcp_server as mcp_mod
+
+    ctx = _make_ctx(tmp_path)
+    mcp = build_server(ctx)
+    list_stored_queries = _get_tool(mcp, "list_stored_queries")
+
+    class BrokenStore:
+        def __init__(self, path):
+            raise RuntimeError("memory extra unavailable")
+
+    monkeypatch.setattr("wren.memory.store.MemoryStore", BrokenStore)
+    monkeypatch.setattr(mcp_mod, "MAX_ROW_LIMIT", 3)
+    monkeypatch.setattr(
+        "wren.memory.markdown.load_query_pairs",
+        lambda project: [{"nl": f"q{i}", "sql": f"SELECT {i}"} for i in range(10)],
+    )
+
+    result = list_stored_queries()
+
+    assert len(result["queries"]) == 3
+
+
+def test_list_stored_queries_fallback_honours_explicit_limit(tmp_path, monkeypatch):
+    """Reverse anchor: an explicit limit below the cap must still win.
+
+    Guards against "fix" that hard-caps the fallback at MAX_ROW_LIMIT and
+    ignores the caller's smaller limit.
+    """
+    import wren.mcp_server as mcp_mod
+
+    ctx = _make_ctx(tmp_path)
+    mcp = build_server(ctx)
+    list_stored_queries = _get_tool(mcp, "list_stored_queries")
+
+    class BrokenStore:
+        def __init__(self, path):
+            raise RuntimeError("memory extra unavailable")
+
+    monkeypatch.setattr("wren.memory.store.MemoryStore", BrokenStore)
+    monkeypatch.setattr(mcp_mod, "MAX_ROW_LIMIT", 3)
+    monkeypatch.setattr(
+        "wren.memory.markdown.load_query_pairs",
+        lambda project: [{"nl": f"q{i}", "sql": f"SELECT {i}"} for i in range(10)],
+    )
+
+    assert len(list_stored_queries(limit=2)["queries"]) == 2
+
+
 def test_store_query_uses_ctx_project(tmp_path, monkeypatch):
     proj_a = tmp_path / "projA"
     proj_b = tmp_path / "projB"


### PR DESCRIPTION
## Summary
- `list_stored_queries`'s markdown fallback applies **no default row cap**, while the LanceDB path ten lines above defaults to `MAX_ROW_LIMIT`. With `limit` omitted, the fallback returns the entire `knowledge/sql` corpus.
- Fix: apply the same default in the fallback — a one-line change.

## Motivation

Both paths live in the same handler and disagree:

```python
try:
    rows, _total = store.list_queries(
        source=source,
        limit=limit if limit is not None else MAX_ROW_LIMIT,   # default cap
    )
except Exception:
    pairs = load_query_pairs(ctx.project)
    if limit is not None:
        pairs = pairs[:limit]                                  # no default cap
```

Every other `MAX_ROW_LIMIT` site guards:

| site | guard |
|---|---|
| `_query_with_limit_probe` | `min(effective_limit, MAX_ROW_LIMIT)` |
| `_query_cube_with_limit_probe` | `min(effective_limit, MAX_ROW_LIMIT)` |
| `list_stored_queries` (LanceDB) | `limit if limit is not None else MAX_ROW_LIMIT` |
| `list_stored_queries` (fallback) | — none |

Three of four obey the cap; the fourth doesn't.

Reachability is wider than "user didn't install the `memory` extra": the `except Exception` catches **any** `MemoryStore` error, so an installed-and-working setup that hits one transient failure silently switches from capped to uncapped and returns the whole corpus to the MCP client.

## Fix

```python
pairs = pairs[: limit if limit is not None else MAX_ROW_LIMIT]
```

This mirrors the sibling path's semantics exactly (default when omitted, honour an explicit `limit`). I deliberately did **not** also align the *other* asymmetry — the probe helpers hard-cap with `min(...)` while `list_stored_queries` treats `MAX_ROW_LIMIT` as a default an explicit larger `limit` can exceed. Reconciling those two is a behaviour change to an existing API, not a bug fix, so it is out of scope here.

## Verification

- New regression tests in `tests/unit/test_mcp_server.py` (covered by the dedicated CI `mcp tests` job):
  - `test_list_stored_queries_fallback_applies_default_cap` — forces the fallback via a raising store, `MAX_ROW_LIMIT` monkeypatched to 3, 10 pairs available.
    - Without the change: `assert 10 == 3` — **RED**. With it: **PASS**.
  - `test_list_stored_queries_fallback_honours_explicit_limit` — reverse anchor: an explicit `limit=2` below the cap must still win.
    - Verified load-bearing: replacing the fix with a blanket `pairs[:MAX_ROW_LIMIT]` reds it.
- Full `mcp tests` job vs clean `main`, verbatim: **14 → 16 passed** (+2 = exactly the new tests; **0 new failures**). Lint clean (`just lint`).

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — this contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited stored query results to the default maximum when no limit is specified.
  * Ensured explicitly requested result limits are consistently honored, including fallback scenarios.

* **Tests**
  * Added coverage for default and custom result limits when the primary query storage service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->