### PR TITLE
fix(profile): exclude connection_url from selectable datasources

### DIFF
--- a/core/wren/src/wren/model/field_registry.py
+++ b/core/wren/src/wren/model/field_registry.py
@@ -389,5 +389,25 @@ def get_fields(datasource: str, *, variant: str | None = None) -> list[FieldDef]
 
 
 def get_datasource_options() -> list[str]:
-    """Return sorted list of all available datasource names."""
+    """Return sorted list of every key in ``DATASOURCE_MODELS``.
+
+    Includes ``connection_url``, which is a connection *form* rather than a
+    :class:`DataSource`. Use :func:`get_selectable_datasources` for anything a
+    user picks and we then store as a profile's ``datasource``.
+    """
     return sorted(DATASOURCE_MODELS.keys())
+
+
+def get_selectable_datasources() -> list[str]:
+    """Return datasource names that are valid to store in a profile.
+
+    ``DATASOURCE_MODELS`` also carries ``connection_url`` — a cross-datasource
+    connection form, not a ``DataSource`` member — so offering it as a choice
+    yields a profile whose ``datasource`` no connector can resolve. Callers that
+    need *every* connection model (docs generation, secret masking) must keep
+    using ``DATASOURCE_MODELS`` / :func:`get_datasource_options`.
+    """
+    from wren.model.data_source import DataSource  # noqa: PLC0415
+
+    valid = {d.value for d in DataSource}
+    return sorted(k for k in DATASOURCE_MODELS if k in valid)

--- a/core/wren/src/wren/profile_cli.py
+++ b/core/wren/src/wren/profile_cli.py
@@ -397,12 +397,12 @@ def _interactive_add(default_ds: str | None) -> dict:
     import click  # noqa: PLC0415
 
     from wren.model.field_registry import (  # noqa: PLC0415
-        get_datasource_options,
         get_fields,
+        get_selectable_datasources,
         get_variants,
     )
 
-    ds_choices = get_datasource_options()
+    ds_choices = get_selectable_datasources()
     ds = typer.prompt(
         "Data source",
         default=default_ds,

--- a/core/wren/src/wren/profile_web.py
+++ b/core/wren/src/wren/profile_web.py
@@ -27,7 +27,11 @@ from starlette.responses import HTMLResponse
 from starlette.routing import Route
 from starlette.templating import Jinja2Templates
 
-from wren.model.field_registry import get_datasource_options, get_fields, get_variants
+from wren.model.field_registry import (
+    get_fields,
+    get_selectable_datasources,
+    get_variants,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +61,7 @@ def create_app(
             "profile_form.html",
             {
                 "profile_name": profile_name,
-                "datasource_options": get_datasource_options(),
+                "datasource_options": get_selectable_datasources(),
             },
         )
 

--- a/core/wren/tests/test_field_registry.py
+++ b/core/wren/tests/test_field_registry.py
@@ -9,6 +9,7 @@ from wren.model.field_registry import (
     FieldDef,
     get_datasource_options,
     get_fields,
+    get_selectable_datasources,
     get_variants,
 )
 
@@ -27,6 +28,38 @@ def test_all_datasources_covered():
 
 def test_get_datasource_options_sorted():
     opts = get_datasource_options()
+    assert opts == sorted(opts)
+
+
+def test_selectable_datasources_excludes_non_datasource_entries():
+    """Every selectable option must be a real DataSource.
+
+    ``connection_url`` is a registry entry but not a DataSource enum value, so a
+    profile saved with ``datasource: connection_url`` can never be resolved by a
+    connector.
+    """
+    from wren.model.data_source import DataSource  # noqa: PLC0415
+
+    ds_names = {e.value for e in DataSource}
+    selectable = get_selectable_datasources()
+
+    assert "connection_url" not in selectable
+    assert not set(selectable) - ds_names
+
+
+def test_selectable_datasources_keeps_every_real_datasource():
+    """Reverse anchor: filtering must not drop any genuine DataSource."""
+    from wren.model.data_source import DataSource  # noqa: PLC0415
+
+    ds_names = {e.value for e in DataSource}
+    selectable = set(get_selectable_datasources())
+
+    assert not ds_names - selectable
+    assert selectable == set(get_datasource_options()) - {"connection_url"}
+
+
+def test_selectable_datasources_sorted():
+    opts = get_selectable_datasources()
     assert opts == sorted(opts)
     assert "postgres" in opts
     assert "bigquery" in opts

--- a/core/wren/tests/test_profile_cli.py
+++ b/core/wren/tests/test_profile_cli.py
@@ -608,3 +608,28 @@ def test_validate_unknown_datasource(monkeypatch):
     output = buf.getvalue()
     assert "Cannot validate" in output
     assert "unknown datasource" in output
+
+
+def test_interactive_add_does_not_offer_connection_url(monkeypatch):
+    """The interactive "Data source" prompt must not offer ``connection_url``.
+
+    It is a field-registry entry but not a DataSource, so picking it saves a
+    profile whose datasource no connector can resolve.
+    """
+    import wren.profile_cli as cli_mod
+
+    captured = {}
+
+    def fake_prompt(text, **kwargs):
+        captured["choices"] = list(kwargs["type"].choices)
+        raise RuntimeError("stop after the datasource prompt")
+
+    monkeypatch.setattr(cli_mod.typer, "prompt", fake_prompt)
+
+    with pytest.raises(RuntimeError):
+        cli_mod._interactive_add(None)
+
+    assert "connection_url" not in captured["choices"]
+    # Reverse anchor: real datasources must still be offered.
+    assert "postgres" in captured["choices"]
+    assert "bigquery" in captured["choices"]

--- a/core/wren/tests/test_profile_web.py
+++ b/core/wren/tests/test_profile_web.py
@@ -46,6 +46,17 @@ def test_form_contains_datasource_options(client):
     assert resp.status_code == 200
     assert "postgres" in resp.text
     assert "bigquery" in resp.text
+
+
+def test_form_omits_connection_url_datasource(client):
+    """The dropdown must not offer ``connection_url``.
+
+    It is a registry entry but not a DataSource, so saving it produces a profile
+    no connector can resolve.
+    """
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert '<option value="connection_url"' not in resp.text
     assert "duckdb" in resp.text
 
 


### PR DESCRIPTION
## Summary
- `wren profile add --interactive` and `--ui` both offer `connection_url` as a datasource choice, but it is not a `DataSource` — picking it saves a profile that no connector can ever resolve (`ValueError: 'connection_url' is not a valid DataSource`).
- Fix: add `get_selectable_datasources()` for the two user-facing pickers. `get_datasource_options()` is left untouched, deliberately — see below.

## Motivation

`get_datasource_options()` returns every key of `DATASOURCE_MODELS`, and that dict carries one entry which is a connection *form*, not a datasource. The repo says so itself, in `tests/test_field_registry.py`:

> `# (connection_url is extra — not a DataSource enum value but valid.)`

That list is fed straight to the pickers:

- `profile_cli.py` → `click.Choice(ds_choices, case_sensitive=False)` for the `Data source` prompt
- `profile_web.py` → `datasource_options` → `<option value="connection_url">` in the form

So a user can pick it, and the saved profile is unusable:

```
>>> DataSource('connection_url')
ValueError: 'connection_url' is not a valid DataSource
```

## Fix

The obvious fix — dropping `connection_url` from `get_datasource_options()` — **would introduce a secret leak**, so I did not do it.

`profile.py::_registry_sensitive_keys` iterates `get_datasource_options()` to collect every `SecretStr` field, and `ConnectionUrl.connection_url` *is* a `SecretStr`. Removing the entry drops `connection_url` out of the mask set, and `wren profile debug` would start printing full database URLs (`user:password@host`) in plaintext. The function's docstring states exactly why it spans everything:

> *"The set spans all datasources because a profile may carry a cross-datasource secret (e.g. `connection_url`); over-masking a benign key in a diagnostic dump is harmless, under-masking a secret is not."*

Change set, measured rather than reasoned about: `set(get_selectable_datasources()) == set(get_datasource_options()) - {"connection_url"}`, and no `DataSource` enum member is dropped.

So the two consumers need two different semantics, and this PR gives them exactly that:

| consumer | needs | this PR |
|---|---|---|
| `profile_cli` prompt, `profile_web` form | real datasources | → `get_selectable_datasources()` |
| `_registry_sensitive_keys` (masking) | *all* connection models | unchanged |
| `docs.py` | uses `DATASOURCE_MODELS` directly | unchanged (docs *should* cover `connection_url`) |

## Verification

- New tests:
  - `tests/test_field_registry.py::test_selectable_datasources_excludes_non_datasource_entries` — every option is a real `DataSource`.
  - `tests/test_field_registry.py::test_selectable_datasources_keeps_every_real_datasource` — reverse anchor: filtering drops nothing genuine; the delta is exactly `{connection_url}`.
  - `tests/test_profile_web.py::test_form_omits_connection_url_datasource` — the rendered form has no `<option value="connection_url">`.
  - `tests/test_profile_cli.py::test_interactive_add_does_not_offer_connection_url` — the prompt's `click.Choice` list excludes it, and still offers `postgres`/`bigquery`.
- Red checks were run **per call site**, reverting only the call site (reverting the whole change would raise `ImportError` on the new function — that is not a red check):
  - web site reverted → `assert '<option value="connection_url"' not in resp.text` — **RED**
  - CLI site reverted → `assert 'connection_url' not in [... 'connection_url' ...]` — **RED**
  - The existing `test_form_contains_datasource_options` stays green under both, so it was not hollowed out.
- Suites vs clean `main`, verbatim: UI job **55 → 59 passed**, `tests/test_profile_cli.py`+`tests/test_profile.py` **63 → 64 passed** (+5 = exactly the new tests; **0 new failures**). Lint clean (`just lint`).
- Coverage note, in the interest of accuracy: `tests/test_profile_cli.py` is not run by any CI job (CI runs `tests/unit/`, `tests/connectors/*`, `tests/test_profile_web.py`+`tests/test_field_registry.py`, and the memory/mcp files). The registry and web regressions above **are** covered by the `ui tests` job; the CLI one is local-only.

## License
`core/**` is Apache-2.0 per the repo LICENSE path map — this contribution is within an Apache-2.0 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile creation now displays only valid datasource choices.
  * Removed the non-selectable `connection_url` option from interactive and web-based profile forms.

* **Tests**
  * Added coverage to verify valid datasource options remain available and are presented in sorted order.
  * Added checks confirming `connection_url` is excluded from both profile creation interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->