### PR TITLE
deps(core): bump pyo3 to 0.29 and serde_with to 3.21 for security advisories

### DIFF
--- a/core/wren-core-base/Cargo.toml
+++ b/core/wren-core-base/Cargo.toml
@@ -14,7 +14,7 @@ python-binding = ["dep:pyo3"]
 default = []
 
 [dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.29.0", features = ["extension-module"], optional = true }
 serde = { version = "1.0.201", features = ["derive", "rc"] }
 wren-manifest-macro = { path = "manifest-macro", version = "0.2.0" }
 serde_json = { version = "1.0.117" }

--- a/core/wren-core-py/Cargo.lock
+++ b/core/wren-core-py/Cargo.lock
@@ -465,6 +465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,15 +1865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,15 +2063,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2375,55 +2366,42 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.26.0",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
-dependencies = [
- "target-lexicon 0.13.5",
+ "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
- "pyo3-build-config 0.26.0",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2433,13 +2411,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config 0.26.0",
  "quote",
  "syn",
 ]
@@ -2738,11 +2715,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2757,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2918,12 +2896,6 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
@@ -3021,6 +2993,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3165,12 +3152,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"
@@ -3615,7 +3596,7 @@ dependencies = [
  "env_logger",
  "log",
  "pyo3",
- "pyo3-build-config 0.23.5",
+ "pyo3-build-config",
  "rstest",
  "serde",
  "serde_json",

--- a/core/wren-core-py/Cargo.toml
+++ b/core/wren-core-py/Cargo.toml
@@ -12,7 +12,7 @@ name = "wren_core_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = "0.29.0", features = ["extension-module", "abi3-py311"] }
 wren-core = { path = "../wren-core/core", package = "wren-semantic-core" }
 wren-core-base = { path = "../wren-core-base", features = ["python-binding"] }
 datafusion-common = "53.0.0"
@@ -29,7 +29,7 @@ tokio = "1.46.0"
 rstest = "0.23.0"
 
 [build-dependencies]
-pyo3-build-config = "0.23.3"
+pyo3-build-config = "0.29.0"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/core/wren-core-py/src/context.rs
+++ b/core/wren-core-py/src/context.rs
@@ -162,10 +162,10 @@ impl PySessionContext {
                 if obj.is_none(py) {
                     HashMap::new()
                 } else {
-                    let frozenset = obj.downcast_bound::<PyFrozenSet>(py)?;
+                    let frozenset = obj.cast_bound::<PyFrozenSet>(py)?;
                     let mut map = HashMap::new();
                     for item in frozenset.iter() {
-                        match item.as_any().clone().downcast_into::<PyTuple>() {
+                        match item.as_any().clone().cast_into::<PyTuple>() {
                             Ok(tuple) => {
                                 if tuple.len()? != 2 {
                                     return Err(CoreError::new(

--- a/core/wren-core-wasm/Cargo.lock
+++ b/core/wren-core-wasm/Cargo.lock
@@ -421,6 +421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,11 +2960,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2970,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
## What

Bump Rust dependencies in the `core` crates to clear open security advisories.

| Package | From | To | Crates | Severity |
| --- | --- | --- | --- | --- |
| pyo3 | 0.26.0 | 0.29.0 | wren-core-base, wren-core-py | HIGH + MED |
| serde_with | 3.18.0 | 3.21.0 | wren-core-py, wren-core-wasm | MED |

**pyo3** — 0.26 is affected by an out-of-bounds read in the `nth`/`nth_back` iterators for `PyList`/`PyTuple` (HIGH) and a missing `Sync` bound on `PyCFunction::new_closure` closures (MED), both fixed in 0.29.

**serde_with** — versions < 3.21 panic when serializing empty `KeyValueMap` sequence/map entries. Transitive in both crates, so only the lockfiles change.

## Code change

pyo3 0.29 renamed the fallible cast family (`downcast_bound` → `cast_bound`, `downcast_into` → `cast_into`). The two call sites in `context.rs` are updated; `pyo3-build-config` is bumped to match pyo3.

pyo3 also now warns that the auto-`FromPyObject` derive for `#[pyclass]` types implementing `Clone` is becoming opt-in. That is a behavioral change orthogonal to these advisories (the derive still works in 0.29) and is left for a dedicated follow-up, since opting in correctly requires making the manifest derive-macro emit the attribute only for `Clone` types.

## Verification

- `cargo test --no-default-features` (wren-core-py): 37 passed
- `maturin develop` builds the abi3-py311 extension cleanly under pyo3 0.29
- `pytest` (wren-core-py): 34 passed
- `cargo check` (wren-core-wasm) passes with serde_with 3.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python integration compatibility when creating session contexts from property collections.
  * Preserved validation for property entries, including clear handling of incorrectly formatted pairs.

* **Chores**
  * Updated Python binding components to newer versions for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->