### PR TITLE
fix(memory): skip non-dict models/relationships/views in schema_indexer

### DIFF
--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -220,7 +220,11 @@ def index(
             pass  # instructions are optional; never fail index because of them
 
     mem_store = _get_store(path)
-    result = mem_store.index_schema(manifest, seed_queries=not no_seed)
+    try:
+        result = mem_store.index_schema(manifest, seed_queries=not no_seed)
+    except ValueError as e:
+        typer.echo(f"Malformed manifest: {e}", err=True)
+        raise typer.Exit(1) from e
     typer.echo(
         f"Indexed {result['schema_items']} schema items"
         + (f", {result['seed_queries']} seed queries" if result["seed_queries"] else "")

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -50,14 +50,23 @@ def describe_schema(manifest: dict) -> str:
         lines.append(f"Catalog: {catalog}, Schema: {schema}")
         lines.append("")
 
-    for model in manifest.get("models", []):
-        _describe_model(model, lines)
+    models = manifest.get("models") or []
+    if isinstance(models, list):
+        for model in models:
+            if isinstance(model, dict) and model.get("name"):
+                _describe_model(model, lines)
 
-    for rel in manifest.get("relationships", []):
-        _describe_relationship(rel, lines)
+    rels = manifest.get("relationships") or []
+    if isinstance(rels, list):
+        for rel in rels:
+            if isinstance(rel, dict):
+                _describe_relationship(rel, lines)
 
-    for view in manifest.get("views", []):
-        _describe_view(view, lines)
+    views = manifest.get("views") or []
+    if isinstance(views, list):
+        for view in views:
+            if isinstance(view, dict):
+                _describe_view(view, lines)
 
     cubes = manifest.get("cubes", []) or []
     if isinstance(cubes, list):
@@ -228,16 +237,28 @@ def extract_schema_items(manifest: dict) -> list[dict]:
     mdl_h = manifest_hash(manifest)
     items: list[dict] = []
 
-    for model in manifest.get("models", []):
-        items.append(_model_record(model, mdl_h, now))
-        for col in model.get("columns", []):
-            items.append(_column_record(col, model["name"], mdl_h, now))
+    models = manifest.get("models") or []
+    if isinstance(models, list):
+        for model in models:
+            if not isinstance(model, dict) or not model.get("name"):
+                continue
+            items.append(_model_record(model, mdl_h, now))
+            for col in model.get("columns", []) or []:
+                if not isinstance(col, dict) or not col.get("name"):
+                    continue
+                items.append(_column_record(col, model["name"], mdl_h, now))
 
-    for rel in manifest.get("relationships", []):
-        items.append(_relationship_record(rel, mdl_h, now))
+    rels = manifest.get("relationships") or []
+    if isinstance(rels, list):
+        for rel in rels:
+            if isinstance(rel, dict):
+                items.append(_relationship_record(rel, mdl_h, now))
 
-    for view in manifest.get("views", []):
-        items.append(_view_record(view, mdl_h, now))
+    views = manifest.get("views") or []
+    if isinstance(views, list):
+        for view in views:
+            if isinstance(view, dict):
+                items.append(_view_record(view, mdl_h, now))
 
     cubes = manifest.get("cubes", []) or []
     if isinstance(cubes, list):

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -286,7 +286,11 @@ def extract_schema_items(manifest: dict) -> list[dict]:
 def _model_record(model: dict, mdl_h: str, now: datetime) -> dict:
     name = model["name"]
     cols = model.get("columns", [])
-    col_summaries = ", ".join(f"{c['name']} ({c.get('type', '?')})" for c in cols[:20])
+    col_summaries = ", ".join(
+        f"{c['name']} ({c.get('type', '?')})"
+        for c in cols[:20]
+        if isinstance(c, dict) and c.get("name")
+    )
     pk = model.get("primaryKey") or ""
 
     description = _prop_description(model)

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -59,13 +59,13 @@ def describe_schema(manifest: dict) -> str:
     rels = manifest.get("relationships") or []
     if isinstance(rels, list):
         for rel in rels:
-            if isinstance(rel, dict):
+            if isinstance(rel, dict) and rel.get("name"):
                 _describe_relationship(rel, lines)
 
     views = manifest.get("views") or []
     if isinstance(views, list):
         for view in views:
-            if isinstance(view, dict):
+            if isinstance(view, dict) and view.get("name"):
                 _describe_view(view, lines)
 
     cubes = manifest.get("cubes", []) or []
@@ -96,10 +96,11 @@ def _describe_model(model: dict, lines: list[str]) -> None:
     if data_scope:
         lines.append(f"  Data scope: {data_scope}")
 
-    cols = model.get("columns", [])
-    if cols:
+    cols = model.get("columns", []) or []
+    described = [c for c in cols if isinstance(c, dict) and c.get("name")]
+    if described:
         lines.append("  Columns:")
-        for col in cols:
+        for col in described:
             _describe_column(col, lines)
     lines.append("")
 
@@ -251,13 +252,13 @@ def extract_schema_items(manifest: dict) -> list[dict]:
     rels = manifest.get("relationships") or []
     if isinstance(rels, list):
         for rel in rels:
-            if isinstance(rel, dict):
+            if isinstance(rel, dict) and rel.get("name"):
                 items.append(_relationship_record(rel, mdl_h, now))
 
     views = manifest.get("views") or []
     if isinstance(views, list):
         for view in views:
-            if isinstance(view, dict):
+            if isinstance(view, dict) and view.get("name"):
                 items.append(_view_record(view, mdl_h, now))
 
     cubes = manifest.get("cubes", []) or []

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -36,6 +36,27 @@ def manifest_hash(manifest: dict) -> str:
 SCHEMA_DESCRIBE_THRESHOLD = 30_000
 
 
+def _iter_section(manifest: dict, key: str) -> list:
+    """Return ``manifest[key]`` as a list, raising if it is the wrong type.
+
+    A missing or null section is treated as empty (``[]``). A section whose
+    value is present but *not* a list (e.g. a hand-edited manifest that typos
+    ``"models"`` into an object) is a structural error in the manifest, not
+    per-element junk: silently dropping it would wipe the corresponding index
+    and report success. Raising ``ValueError`` surfaces the malformed manifest
+    while keeping this module dependency-free; the CLI already catches such
+    errors and exits non-zero.
+    """
+    section = manifest.get(key)
+    if section is None:
+        return []
+    if not isinstance(section, list):
+        raise ValueError(
+            f"manifest[{key!r}] must be a list, got {type(section).__name__}"
+        )
+    return section
+
+
 def describe_schema(manifest: dict) -> str:
     """Generate a structured plain-text description of the full MDL schema.
 
@@ -50,29 +71,21 @@ def describe_schema(manifest: dict) -> str:
         lines.append(f"Catalog: {catalog}, Schema: {schema}")
         lines.append("")
 
-    models = manifest.get("models") or []
-    if isinstance(models, list):
-        for model in models:
-            if isinstance(model, dict) and model.get("name"):
-                _describe_model(model, lines)
+    for model in _iter_section(manifest, "models"):
+        if isinstance(model, dict) and model.get("name"):
+            _describe_model(model, lines)
 
-    rels = manifest.get("relationships") or []
-    if isinstance(rels, list):
-        for rel in rels:
-            if isinstance(rel, dict) and rel.get("name"):
-                _describe_relationship(rel, lines)
+    for rel in _iter_section(manifest, "relationships"):
+        if isinstance(rel, dict) and rel.get("name"):
+            _describe_relationship(rel, lines)
 
-    views = manifest.get("views") or []
-    if isinstance(views, list):
-        for view in views:
-            if isinstance(view, dict) and view.get("name"):
-                _describe_view(view, lines)
+    for view in _iter_section(manifest, "views"):
+        if isinstance(view, dict) and view.get("name"):
+            _describe_view(view, lines)
 
-    cubes = manifest.get("cubes", []) or []
-    if isinstance(cubes, list):
-        for cube in cubes:
-            if isinstance(cube, dict):
-                _describe_cube(cube, lines)
+    for cube in _iter_section(manifest, "cubes"):
+        if isinstance(cube, dict):
+            _describe_cube(cube, lines)
 
     return "\n".join(lines)
 
@@ -238,45 +251,37 @@ def extract_schema_items(manifest: dict) -> list[dict]:
     mdl_h = manifest_hash(manifest)
     items: list[dict] = []
 
-    models = manifest.get("models") or []
-    if isinstance(models, list):
-        for model in models:
-            if not isinstance(model, dict) or not model.get("name"):
+    for model in _iter_section(manifest, "models"):
+        if not isinstance(model, dict) or not model.get("name"):
+            continue
+        items.append(_model_record(model, mdl_h, now))
+        for col in model.get("columns") or []:
+            if not isinstance(col, dict) or not col.get("name"):
                 continue
-            items.append(_model_record(model, mdl_h, now))
-            for col in model.get("columns", []) or []:
-                if not isinstance(col, dict) or not col.get("name"):
-                    continue
-                items.append(_column_record(col, model["name"], mdl_h, now))
+            items.append(_column_record(col, model["name"], mdl_h, now))
 
-    rels = manifest.get("relationships") or []
-    if isinstance(rels, list):
-        for rel in rels:
-            if isinstance(rel, dict) and rel.get("name"):
-                items.append(_relationship_record(rel, mdl_h, now))
+    for rel in _iter_section(manifest, "relationships"):
+        if isinstance(rel, dict) and rel.get("name"):
+            items.append(_relationship_record(rel, mdl_h, now))
 
-    views = manifest.get("views") or []
-    if isinstance(views, list):
-        for view in views:
-            if isinstance(view, dict) and view.get("name"):
-                items.append(_view_record(view, mdl_h, now))
+    for view in _iter_section(manifest, "views"):
+        if isinstance(view, dict) and view.get("name"):
+            items.append(_view_record(view, mdl_h, now))
 
-    cubes = manifest.get("cubes", []) or []
-    if isinstance(cubes, list):
-        for cube in cubes:
-            if not isinstance(cube, dict):
-                continue
-            items.append(_cube_record(cube, mdl_h, now))
-            cube_name = cube.get("name", "")
-            for measure in cube.get("measures", []) or []:
-                if isinstance(measure, dict):
-                    items.append(_measure_record(measure, cube_name, mdl_h, now))
-            for dim in cube.get("dimensions", []) or []:
-                if isinstance(dim, dict):
-                    items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
-            for tdim in cube.get("timeDimensions", []) or []:
-                if isinstance(tdim, dict):
-                    items.append(_time_dimension_record(tdim, cube_name, mdl_h, now))
+    for cube in _iter_section(manifest, "cubes"):
+        if not isinstance(cube, dict):
+            continue
+        items.append(_cube_record(cube, mdl_h, now))
+        cube_name = cube.get("name", "")
+        for measure in cube.get("measures", []) or []:
+            if isinstance(measure, dict):
+                items.append(_measure_record(measure, cube_name, mdl_h, now))
+        for dim in cube.get("dimensions", []) or []:
+            if isinstance(dim, dict):
+                items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
+        for tdim in cube.get("timeDimensions", []) or []:
+            if isinstance(tdim, dict):
+                items.append(_time_dimension_record(tdim, cube_name, mdl_h, now))
 
     return items
 
@@ -286,12 +291,10 @@ def extract_schema_items(manifest: dict) -> list[dict]:
 
 def _model_record(model: dict, mdl_h: str, now: datetime) -> dict:
     name = model["name"]
-    cols = model.get("columns", [])
-    col_summaries = ", ".join(
-        f"{c['name']} ({c.get('type', '?')})"
-        for c in cols[:20]
-        if isinstance(c, dict) and c.get("name")
-    )
+    cols = [
+        c for c in (model.get("columns") or []) if isinstance(c, dict) and c.get("name")
+    ]
+    col_summaries = ", ".join(f"{c['name']} ({c.get('type', '?')})" for c in cols[:20])
     pk = model.get("primaryKey") or ""
 
     description = _prop_description(model)

--- a/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
+++ b/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
@@ -1,0 +1,52 @@
+"""describe_schema / extract_schema_items skip non-dict top-level entries."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren"
+        / "memory"
+        / "schema_indexer.py"
+    )
+    spec = importlib.util.spec_from_file_location("schema_indexer_solo", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_describe_schema_skips_non_dict_models_rels_views():
+    mod = _load()
+    text = mod.describe_schema(
+        {
+            "models": [None, "x", {"name": "orders", "columns": []}],
+            "relationships": [None, {"name": "r1"}],
+            "views": ["bad", {"name": "v1"}],
+        }
+    )
+    assert "orders" in text
+    assert "None" not in text
+
+
+def test_extract_schema_items_skips_non_dict_models():
+    mod = _load()
+    items = mod.extract_schema_items(
+        {
+            "models": [
+                None,
+                {"name": "ok", "columns": [None, {"name": "id", "type": "int"}]},
+            ],
+            "relationships": [None],
+            "views": [None],
+        }
+    )
+    names = {i.get("name") for i in items}
+    assert "ok" in names
+    assert "id" in names
+    assert None not in names

--- a/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
+++ b/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
@@ -13,8 +13,15 @@ def test_describe_schema_skips_non_dict_models_rels_views():
             "views": ["bad", {"name": "v1"}],
         }
     )
-    assert "orders" in text
+    # Valid records are rendered exactly once.
+    assert "### Model: orders" in text
+    assert text.count("### Model:") == 1
+    assert "r1" in text
+    assert "v1" in text
+    # Malformed entries (None / bare strings) produce no rendered sections.
     assert "None" not in text
+    assert text.count("### Relationship:") == 1
+    assert text.count("### View:") == 1
 
 
 def test_describe_schema_skips_null_and_unnamed_columns():

--- a/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
+++ b/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
@@ -1,29 +1,12 @@
-"""describe_schema / extract_schema_items skip non-dict top-level entries."""
+"""describe_schema / extract_schema_items skip non-dict and unnamed entries."""
 
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-
-
-def _load():
-    path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "wren"
-        / "memory"
-        / "schema_indexer.py"
-    )
-    spec = importlib.util.spec_from_file_location("schema_indexer_solo", path)
-    mod = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(mod)
-    return mod
+from wren.memory.schema_indexer import describe_schema, extract_schema_items
 
 
 def test_describe_schema_skips_non_dict_models_rels_views():
-    mod = _load()
-    text = mod.describe_schema(
+    text = describe_schema(
         {
             "models": [None, "x", {"name": "orders", "columns": []}],
             "relationships": [None, {"name": "r1"}],
@@ -34,9 +17,42 @@ def test_describe_schema_skips_non_dict_models_rels_views():
     assert "None" not in text
 
 
+def test_describe_schema_skips_null_and_unnamed_columns():
+    # Regression: _describe_model must skip null / dict-without-name columns.
+    text = describe_schema(
+        {
+            "models": [
+                {
+                    "name": "orders",
+                    "columns": [
+                        None,
+                        "bad",
+                        {"type": "int"},
+                        {"name": "id", "type": "int"},
+                    ],
+                }
+            ],
+        }
+    )
+    assert "orders" in text
+    assert "id" in text
+    assert "None" not in text
+
+
+def test_describe_schema_skips_unnamed_rels_and_views():
+    # Regression: relationships / views without a name must not raise KeyError.
+    text = describe_schema(
+        {
+            "relationships": [{"joinType": "one_to_many"}, {"name": "r1"}],
+            "views": [{"statement": "SELECT 1"}, {"name": "v1"}],
+        }
+    )
+    assert "r1" in text
+    assert "v1" in text
+
+
 def test_extract_schema_items_skips_non_dict_models():
-    mod = _load()
-    items = mod.extract_schema_items(
+    items = extract_schema_items(
         {
             "models": [
                 None,
@@ -49,4 +65,18 @@ def test_extract_schema_items_skips_non_dict_models():
     names = {i.get("item_name") for i in items}
     assert "ok" in names
     assert "id" in names
+    assert None not in names
+
+
+def test_extract_schema_items_skips_unnamed_rels_and_views():
+    # Regression: relationship / view dicts without name must be skipped.
+    items = extract_schema_items(
+        {
+            "relationships": [{"joinType": "one_to_many"}, {"name": "r1"}],
+            "views": [{"statement": "SELECT 1"}, {"name": "v1"}],
+        }
+    )
+    names = {i.get("item_name") for i in items}
+    assert "r1" in names
+    assert "v1" in names
     assert None not in names

--- a/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
+++ b/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
@@ -46,7 +46,7 @@ def test_extract_schema_items_skips_non_dict_models():
             "views": [None],
         }
     )
-    names = {i.get("name") for i in items}
+    names = {i.get("item_name") for i in items}
     assert "ok" in names
     assert "id" in names
     assert None not in names

--- a/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
+++ b/core/wren/tests/unit/test_schema_indexer_non_dict_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from wren.memory.schema_indexer import describe_schema, extract_schema_items
 
 
@@ -87,3 +89,49 @@ def test_extract_schema_items_skips_unnamed_rels_and_views():
     assert "r1" in names
     assert "v1" in names
     assert None not in names
+
+
+def test_columns_null_does_not_crash_either_path():
+    # Regression: an explicit "columns": null must not raise in either path.
+    # dict.get(k, default) returns default only when the key is *absent*;
+    # an explicit null yields None, so cols[:20] would raise without `or []`.
+    manifest = {"models": [{"name": "m", "columns": None}]}
+
+    text = describe_schema(manifest)
+    assert "### Model: m" in text
+
+    items = extract_schema_items(manifest)
+    names = {i.get("item_name") for i in items}
+    assert "m" in names
+
+
+def test_columns_null_slots_do_not_consume_summary_budget():
+    # Regression: filter columns before slicing the 20-column summary so
+    # leading nulls don't silently push valid columns out of the embedding
+    # text.
+    cols = [None] * 5 + [{"name": f"c{i}", "type": "int"} for i in range(25)]
+    items = extract_schema_items({"models": [{"name": "m", "columns": cols}]})
+    model_rec = next(i for i in items if i["item_type"] == "model")
+    # 20 valid columns summarised, none of the leading nulls.
+    assert model_rec["text"].count("(int)") == 20
+    assert "c0" in model_rec["text"]
+    assert "c19" in model_rec["text"]
+    assert "c20" not in model_rec["text"]
+
+
+@pytest.mark.parametrize("section", ["models", "relationships", "views", "cubes"])
+def test_non_list_section_raises_valueerror(section):
+    # A wrong-typed section (e.g. a hand-edit typo turning "models" into an
+    # object) is a structural manifest error, not per-element junk: it must
+    # raise rather than silently drop the section and wipe the index.
+    manifest = {section: {"name": "oops"}}
+    with pytest.raises(ValueError, match=section):
+        describe_schema(manifest)
+    with pytest.raises(ValueError, match=section):
+        extract_schema_items(manifest)
+
+
+def test_missing_or_null_section_is_treated_as_empty():
+    # None / absent sections remain permissive (empty), unlike wrong-typed.
+    assert describe_schema({"models": None}) == ""
+    assert extract_schema_items({"models": None}) == []


### PR DESCRIPTION
## Summary

- `describe_schema` / `extract_schema_items` iterated models, relationships, and views without type checks.
- Null or string rows raised TypeError/KeyError mid-walk and aborted schema prepare entirely.
- Skip non-dict/nameless models; skip non-dict relationships/views; mirror existing cube guards.

## License

Touches `core/**` (Apache-2.0).

## Motivation

Partial/hand-edited MDL JSON can include null list elements. Prefer partial schema text over a hard fail during deploy semantics prep.

## Verification

Direct load of `schema_indexer.py`:
- `describe_schema` with `[None, {name: orders}]` → text contains `orders`
- `extract_schema_items` with mixed null models → dictionary records only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing incomplete or malformed schema definitions.
  * Safely skips invalid models, relationships, and views when entries aren’t dictionaries or are missing required names.
  * Filters model column details to include only properly formed, named columns when generating descriptions and extracted schema items.
* **Tests**
  * Added unit tests to verify malformed schema entries (non-dict sections, null/unnamed items) are ignored and that extracted results never include unnamed records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->