### PR TITLE
fix(oracle): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -178,11 +178,12 @@ class OracleConnector(ConnectorABC):
         self.connection = _make_oracle_connection(connection_info)
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Always strip terminating `;` even on the unlimited path: a bare
+        # trailing semicolon is rejected by some Oracle clients/drivers even
+        # though engines accept multi-statement scripts elsewhere.
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) t "
-                f"WHERE ROWNUM <= {limit}"
-            )
+            sql = f"SELECT * FROM ({sql}) t WHERE ROWNUM <= {limit}"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)

--- a/core/wren/tests/unit/test_oracle_strip_unlimited_query.py
+++ b/core/wren/tests/unit/test_oracle_strip_unlimited_query.py
@@ -1,0 +1,37 @@
+"""Oracle Connector.query strips trailing semicolons when limit is None."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_query_unlimited_path_strips_trailing_semicolon():
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren"
+        / "connector"
+        / "oracle.py"
+    ).read_text(encoding="utf-8")
+    # Unlimited branch used to pass `sql` through unchanged after the
+    # limited branch. Require an unconditional strip for both paths.
+    assert "sql = strip_trailing_semicolon(sql)" in src
+
+    # Helper behaviour (same regex as production):
+    helper = re.compile(r"[;\s]+\Z")
+    assert helper.sub("", "SELECT 1;") == "SELECT 1"
+    assert helper.sub("", "SELECT 'a;b'") == "SELECT 'a;b'"
+
+
+def test_without_unconditional_strip_semicolon_would_reach_execute():
+    """Document pre-fix behaviour: only the limit branch stripped."""
+    # Simulated old code path for regression documentation.
+    def old_query(sql: str, limit: int | None = None) -> str:
+        if limit is not None:
+            sql = re.sub(r"[;\s]+\Z", "", sql)
+            sql = f"SELECT * FROM ({sql}) t WHERE ROWNUM <= {limit}"
+        return sql
+
+    assert old_query("SELECT 1;", None) == "SELECT 1;"
+    assert old_query("SELECT 1;", 10).startswith("SELECT * FROM (SELECT 1)")


### PR DESCRIPTION
## Summary

- Oracle `query()` only stripped trailing `;` when wrapping with `ROWNUM` limits.
- Unlimited executes forwarded client-pasted terminators and could fail.
- Strip unconditionally; wrap the already-stripped SQL when limit is set.

## License

Touches `core/wren/**` (Apache-2.0).

## Verification

```
python3 -m pytest core/wren/tests/unit/test_oracle_strip_unlimited_query.py -q
# 2 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Oracle queries now consistently remove trailing semicolons before execution, including queries without a row limit.
  - Improved compatibility for unlimited Oracle query execution.

- **Tests**
  - Added coverage verifying semicolon removal for unlimited queries.
  - Added regression coverage for the previous execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->