### PR TITLE
fix(athena): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -309,11 +309,7 @@ class AthenaConnector(ConnectorABC):
             # is terminated by the newline instead of swallowing the closing
             # `) AS _wren_sub LIMIT n`. (Single-line sibling connectors don't
             # guard this.)
-            executed = (
-                "SELECT * FROM (\n"
-                f"{stripped}\n"
-                f") AS _wren_sub LIMIT {int(limit)}"
-            )
+            executed = f"SELECT * FROM (\n{stripped}\n) AS _wren_sub LIMIT {int(limit)}"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(executed)

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -302,7 +302,8 @@ class AthenaConnector(ConnectorABC):
         # engines can stop early instead of us downloading a full result and
         # slicing in Python. Subquery-wrap + trailing-semicolon strip keeps
         # composition valid for client SQL terminated with ``;``.
-        executed = sql
+        stripped = strip_trailing_semicolon(sql)
+        executed = stripped
         if limit is not None:
             # Multiline wrap so a trailing `-- line comment` in the inner SQL
             # is terminated by the newline instead of swallowing the closing
@@ -310,7 +311,7 @@ class AthenaConnector(ConnectorABC):
             # guard this.)
             executed = (
                 "SELECT * FROM (\n"
-                f"{strip_trailing_semicolon(sql)}\n"
+                f"{stripped}\n"
                 f") AS _wren_sub LIMIT {int(limit)}"
             )
         try:

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -302,14 +302,13 @@ class AthenaConnector(ConnectorABC):
         # engines can stop early instead of us downloading a full result and
         # slicing in Python. Subquery-wrap + trailing-semicolon strip keeps
         # composition valid for client SQL terminated with ``;``.
-        stripped = strip_trailing_semicolon(sql)
-        executed = stripped
+        executed = strip_trailing_semicolon(sql)
         if limit is not None:
             # Multiline wrap so a trailing `-- line comment` in the inner SQL
             # is terminated by the newline instead of swallowing the closing
             # `) AS _wren_sub LIMIT n`. (Single-line sibling connectors don't
             # guard this.)
-            executed = f"SELECT * FROM (\n{stripped}\n) AS _wren_sub LIMIT {int(limit)}"
+            executed = f"SELECT * FROM (\n{executed}\n) AS _wren_sub LIMIT {int(limit)}"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(executed)

--- a/core/wren/tests/unit/test_athena_strip_unlimited_query.py
+++ b/core/wren/tests/unit/test_athena_strip_unlimited_query.py
@@ -25,7 +25,9 @@ def test_without_unconditional_strip_semicolon_would_reach_execute():
     def old_query(sql: str, limit: int | None = None) -> str:
         executed = sql
         if limit is not None:
-            executed = f"SELECT * FROM ({re.sub(r'[;\\s]+\\Z', '', sql)}) AS t LIMIT {limit}"
+            # Precompute strip outside f-string (Py3.11: no backslash in f-expr).
+            cleaned = re.sub(r"[;\s]+\Z", "", sql)
+            executed = f"SELECT * FROM ({cleaned}) AS t LIMIT {limit}"
         return executed
 
     assert old_query("SELECT 1;", None) == "SELECT 1;"

--- a/core/wren/tests/unit/test_athena_strip_unlimited_query.py
+++ b/core/wren/tests/unit/test_athena_strip_unlimited_query.py
@@ -1,0 +1,31 @@
+"""Athena unlimited query strips trailing semicolon like limit wrap."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_query_unlimited_path_strips_trailing_semicolon():
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren"
+        / "connector"
+        / "athena.py"
+    ).read_text(encoding="utf-8")
+    assert "stripped = strip_trailing_semicolon(sql)" in src
+    assert "executed = stripped" in src
+
+    helper = re.compile(r"[;\s]+\Z")
+    assert helper.sub("", "SELECT 1;") == "SELECT 1"
+
+
+def test_without_unconditional_strip_semicolon_would_reach_execute():
+    def old_query(sql: str, limit: int | None = None) -> str:
+        executed = sql
+        if limit is not None:
+            executed = f"SELECT * FROM ({re.sub(r'[;\\s]+\\Z', '', sql)}) AS t LIMIT {limit}"
+        return executed
+
+    assert old_query("SELECT 1;", None) == "SELECT 1;"

--- a/core/wren/tests/unit/test_athena_strip_unlimited_query.py
+++ b/core/wren/tests/unit/test_athena_strip_unlimited_query.py
@@ -1,33 +1,44 @@
-"""Athena unlimited query strips trailing semicolon like limit wrap."""
+"""Athena unlimited query strips trailing semicolon like the limit wrap."""
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wren.connector.athena import AthenaConnector
+
+pytestmark = pytest.mark.unit
+
+
+class _CM:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __enter__(self):
+        return self.obj
+
+    def __exit__(self, *a):
+        return False
+
+
+def _make_mock_connector():
+    connector = AthenaConnector.__new__(AthenaConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    cursor.close = MagicMock()
+    connector.connection.cursor.return_value = cursor
+    return connector, cursor
 
 
 def test_query_unlimited_path_strips_trailing_semicolon():
-    src = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "wren"
-        / "connector"
-        / "athena.py"
-    ).read_text(encoding="utf-8")
-    assert "stripped = strip_trailing_semicolon(sql)" in src
-    assert "executed = stripped" in src
+    connector, cursor = _make_mock_connector()
+    with (
+        patch(
+            "wren.connector.athena._build_athena_arrow_table", return_value=MagicMock()
+        ),
+        patch("wren.connector.athena.contextlib.closing", side_effect=lambda c: _CM(c)),
+    ):
+        connector.query("SELECT 1;")
 
-    helper = re.compile(r"[;\s]+\Z")
-    assert helper.sub("", "SELECT 1;") == "SELECT 1"
-
-
-def test_without_unconditional_strip_semicolon_would_reach_execute():
-    def old_query(sql: str, limit: int | None = None) -> str:
-        executed = sql
-        if limit is not None:
-            # Precompute strip outside f-string (Py3.11: no backslash in f-expr).
-            cleaned = re.sub(r"[;\s]+\Z", "", sql)
-            executed = f"SELECT * FROM ({cleaned}) AS t LIMIT {limit}"
-        return executed
-
-    assert old_query("SELECT 1;", None) == "SELECT 1;"
+    cursor.execute.assert_called_once_with("SELECT 1")


### PR DESCRIPTION
## Summary

- Athena only stripped `;` when wrapping with LIMIT.
- Unlimited path forwarded terminators to `cursor.execute`.
- Strip once; reuse stripped SQL for both branches.

## License

`core/wren/**` Apache-2.0.

## Verification

```
python3 -m pytest core/wren/tests/unit/test_athena_strip_unlimited_query.py -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Athena SQL execution by stripping any trailing semicolon before running queries.
  * Ensured the limited-query SQL wrapper isn’t affected by trailing line comments.

* **Tests**
  * Added a unit test to confirm the unlimited Athena query path removes trailing semicolons before execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->