### PR TITLE
chore(databricks): add the test for stripping trailing semicolon before query execute

### DIFF
--- a/core/wren/tests/unit/test_databricks_strip_query_semicolon.py
+++ b/core/wren/tests/unit/test_databricks_strip_query_semicolon.py
@@ -1,0 +1,23 @@
+"""Databricks query path strips trailing semicolons before execute."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_query_strips_trailing_semicolon():
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren"
+        / "connector"
+        / "databricks.py"
+    ).read_text(encoding="utf-8")
+    assert "sql = strip_trailing_semicolon(sql)" in src
+    # appears in query, not only dry_run
+    q = src.split("def query", 1)[1].split("def dry_run", 1)[0]
+    assert "strip_trailing_semicolon" in q
+
+    helper = re.compile(r"[;\s]+\Z")
+    assert helper.sub("", "SELECT 1;") == "SELECT 1"


### PR DESCRIPTION
## Summary

- Databricks `query()` executed raw SQL including trailing `;`.
- `dry_run` already stripped for subquery wrap.
- Strip once before execute so both limited-fetch and full-fetch paths are consistent.

## License

`core/wren/**` Apache-2.0.

## Verification

```
python3 -m pytest core/wren/tests/unit/test_databricks_strip_query_semicolon.py -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that trailing semicolons are removed from Databricks queries before execution.
  * Confirmed the behavior handles trailing whitespace alongside the semicolon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->