### PR TITLE
fix(redshift): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -44,11 +44,9 @@ class RedshiftConnector(ConnectorABC):
         self.connection.autocommit = True
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {int(limit)}"
-            )
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             cols = [desc[0] for desc in cursor.description]

--- a/core/wren/tests/unit/test_redshift_strip_unlimited_query.py
+++ b/core/wren/tests/unit/test_redshift_strip_unlimited_query.py
@@ -1,0 +1,20 @@
+"""Redshift unlimited query strips trailing semicolon."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_query_unlimited_path_strips():
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren"
+        / "connector"
+        / "redshift.py"
+    ).read_text(encoding="utf-8")
+    q = src.split("def query", 1)[1].split("def dry_run", 1)[0]
+    assert "sql = strip_trailing_semicolon(sql)" in q
+    helper = re.compile(r"[;\s]+\Z")
+    assert helper.sub("", "SELECT 1;") == "SELECT 1"


### PR DESCRIPTION
## Summary

- Redshift only stripped `;` when wrapping with LIMIT.
- Unlimited path executed client terminators as-is.
- Strip unconditionally, then wrap if limited.

## License

`core/wren/**` Apache-2.0.

## Verification

```
python3 -m pytest core/wren/tests/unit/test_redshift_strip_unlimited_query.py -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Redshift query execution by consistently handling trailing semicolons, including queries without a row limit.
  - Prevented formatting-related issues when submitting SQL statements to Redshift.
  - Added coverage to verify semicolon handling for unlimited queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->