### PR TITLE
fix(connector): coerce non-string SQL in strip_trailing_semicolon

### DIFF
--- a/core/wren/src/wren/connector/base.py
+++ b/core/wren/src/wren/connector/base.py
@@ -16,7 +16,15 @@ def strip_trailing_semicolon(sql: str) -> str:
     or ``EXPLAIN SELECT 1;``). Only the *terminating* run of semicolons and
     whitespace is removed, so semicolons inside string literals
     (``SELECT 'a;b'``) are preserved.
+
+    Non-string values are coerced with ``str(...)`` so accidental ``None``/
+    numeric SQL arguments degrade instead of raising ``TypeError`` inside
+    the regex. Empty input becomes ``""``.
     """
+    if sql is None:
+        return ""
+    if not isinstance(sql, str):
+        sql = str(sql)
     return _TRAILING_SEMICOLONS_RE.sub("", sql)
 
 

--- a/core/wren/tests/unit/test_strip_trailing_semicolon_coerce.py
+++ b/core/wren/tests/unit/test_strip_trailing_semicolon_coerce.py
@@ -1,0 +1,14 @@
+from wren.connector.base import strip_trailing_semicolon
+
+
+def test_strips_string():
+    assert strip_trailing_semicolon("SELECT 1;") == "SELECT 1"
+    assert strip_trailing_semicolon("SELECT 1 ; \n") == "SELECT 1"
+
+
+def test_none_becomes_empty():
+    assert strip_trailing_semicolon(None) == ""
+
+
+def test_non_string_coerced():
+    assert strip_trailing_semicolon(42) == "42"


### PR DESCRIPTION
## Summary
- Coerce non-string `sql` arguments in `strip_trailing_semicolon` (`None` → `""`, other values via `str(...)`).
- Prevents `TypeError` inside the trailing-semicolon regex when callers pass accidental non-strings.

## Motivation
Every connector funnels user/limit/EXOLAIN composition through this helper. A `None` or int SQL argument currently raises `TypeError: expected string or bytes-like object` deep in `re.sub`, masking the real caller bug with a generic regex crash.

## License
Apache-2.0 path: `core/wren/src/wren/connector/base.py` (+ unit test).

## Verification
`cd core/wren && .venv/bin/python -m pytest tests/unit/test_strip_trailing_semicolon_coerce.py -q` → 3 passed

## Test plan
- [x] unit tests for string / None / int
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL statement handling when input is empty, null, or not provided as text.
  * Non-text values are now safely converted to text before trailing semicolons and whitespace are removed.

* **Tests**
  * Added coverage for standard strings, null values, and non-text inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->