### PR TITLE
fix(memory): skip non-dict rows in describe_schema

### DIFF
--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -50,14 +50,23 @@ def describe_schema(manifest: dict) -> str:
         lines.append(f"Catalog: {catalog}, Schema: {schema}")
         lines.append("")
 
-    for model in manifest.get("models", []):
-        _describe_model(model, lines)
+    models = manifest.get("models", []) or []
+    if isinstance(models, list):
+        for model in models:
+            if isinstance(model, dict):
+                _describe_model(model, lines)
 
-    for rel in manifest.get("relationships", []):
-        _describe_relationship(rel, lines)
+    rels = manifest.get("relationships", []) or []
+    if isinstance(rels, list):
+        for rel in rels:
+            if isinstance(rel, dict):
+                _describe_relationship(rel, lines)
 
-    for view in manifest.get("views", []):
-        _describe_view(view, lines)
+    views = manifest.get("views", []) or []
+    if isinstance(views, list):
+        for view in views:
+            if isinstance(view, dict):
+                _describe_view(view, lines)
 
     cubes = manifest.get("cubes", []) or []
     if isinstance(cubes, list):
@@ -87,11 +96,12 @@ def _describe_model(model: dict, lines: list[str]) -> None:
     if data_scope:
         lines.append(f"  Data scope: {data_scope}")
 
-    cols = model.get("columns", [])
-    if cols:
+    cols = model.get("columns", []) or []
+    if isinstance(cols, list) and cols:
         lines.append("  Columns:")
         for col in cols:
-            _describe_column(col, lines)
+            if isinstance(col, dict) and col.get("name") is not None:
+                _describe_column(col, lines)
     lines.append("")
 
 

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -53,19 +53,19 @@ def describe_schema(manifest: dict) -> str:
     models = manifest.get("models", []) or []
     if isinstance(models, list):
         for model in models:
-            if isinstance(model, dict):
+            if isinstance(model, dict) and model.get("name") is not None:
                 _describe_model(model, lines)
 
     rels = manifest.get("relationships", []) or []
     if isinstance(rels, list):
         for rel in rels:
-            if isinstance(rel, dict):
+            if isinstance(rel, dict) and rel.get("name") is not None:
                 _describe_relationship(rel, lines)
 
     views = manifest.get("views", []) or []
     if isinstance(views, list):
         for view in views:
-            if isinstance(view, dict):
+            if isinstance(view, dict) and view.get("name") is not None:
                 _describe_view(view, lines)
 
     cubes = manifest.get("cubes", []) or []

--- a/core/wren/tests/unit/test_schema_describe_nonduct.py
+++ b/core/wren/tests/unit/test_schema_describe_nonduct.py
@@ -1,0 +1,18 @@
+from wren.memory.schema_indexer import describe_schema
+
+
+def test_describe_schema_skips_nonduct_entries():
+    text = describe_schema(
+        {
+            "models": [
+                {"name": "orders", "columns": [{"name": "id", "type": "int"}, "bad"]},
+                "not-a-model",
+                None,
+            ],
+            "relationships": ["x", {"name": "r1", "models": ["a", "b"], "joinType": "MANY_TO_ONE"}],
+            "views": [None, {"name": "v1", "statement": "SELECT 1"}],
+        }
+    )
+    assert "orders" in text
+    assert "not-a-model" not in text
+    assert "v1" in text


### PR DESCRIPTION
## Summary
- `describe_schema` skips non-dict models/relationships/views and non-dict columns.
- Mirrors defensive guards already used for cubes measures/dimensions.

## License
Apache-2.0 (`core/wren/...`).

## Verification
`cd core/wren && .venv/bin/python -m pytest tests/unit/test_schema_describe_nonduct.py -q`

## Test plan
- [x] unit test mixed malformed manifest
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema description generation by safely handling missing or malformed manifest entries for models, relationships, and views.
  * Made model column rendering conditional so only valid, named columns appear.
  * Omitted empty “Columns” sections from the output.

* **Tests**
  * Added a unit test to verify schema descriptions include valid items (models/views) and skip invalid non-conforming entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->