### PR TITLE
fix(engine): skip non-dict models/views when collecting names

### DIFF
--- a/core/wren/src/wren/engine.py
+++ b/core/wren/src/wren/engine.py
@@ -35,6 +35,7 @@ from wren.model.data_source import DataSource
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 from wren.policy import resolve_model_name, validate_sql_policy
 
+
 def _named_manifest_entries(items: object) -> set[str]:
     """Collect ``name`` values from a manifest list, skipping junk rows.
 

--- a/core/wren/src/wren/engine.py
+++ b/core/wren/src/wren/engine.py
@@ -35,6 +35,24 @@ from wren.model.data_source import DataSource
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 from wren.policy import resolve_model_name, validate_sql_policy
 
+def _named_manifest_entries(items: object) -> set[str]:
+    """Collect ``name`` values from a manifest list, skipping junk rows.
+
+    Deployed MDLs occasionally retain nulls or non-object entries after
+    manual edits or partial merges. KeyError/TypeError here would abort
+    planning before policy checks can run.
+    """
+    if not isinstance(items, list):
+        return set()
+    names: set[str] = set()
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
 
 class WrenEngine:
     """Thin facade over wren-core MDL processing and connector execution.
@@ -172,8 +190,8 @@ class WrenEngine:
             ast = parse_one(sql, dialect=dialect)
 
             manifest_json = json.loads(base64.b64decode(self.manifest_str))
-            model_names = {m["name"] for m in manifest_json.get("models", [])}
-            view_names = {v["name"] for v in manifest_json.get("views", [])}
+            model_names = _named_manifest_entries(manifest_json.get("models"))
+            view_names = _named_manifest_entries(manifest_json.get("views"))
             # Views are MDL-defined objects too. Strict mode gates access to
             # objects *outside* the manifest, so a view reference is allowed;
             # ``extract_by`` scopes the view (and the models it joins) in.

--- a/core/wren/tests/unit/test_engine_manifest_names.py
+++ b/core/wren/tests/unit/test_engine_manifest_names.py
@@ -1,0 +1,27 @@
+"""Non-dict models/views must not break queryable-name collection."""
+
+from wren.engine import _named_manifest_entries
+
+
+def test_skips_non_dict_and_nameless():
+    models = [
+        {"name": "orders"},
+        None,
+        "bad",
+        {"name": ""},
+        {"name": "customers"},
+        42,
+        {"name": 99},
+    ]
+    assert _named_manifest_entries(models) == {"orders", "customers"}
+
+
+def test_none_and_empty():
+    assert _named_manifest_entries(None) == set()
+    assert _named_manifest_entries([]) == set()
+    assert _named_manifest_entries("not-a-list") == set()
+
+
+def test_views_same_guard():
+    views = [{"name": "v1"}, [], {"name": "v2"}]
+    assert _named_manifest_entries(views) == {"v1", "v2"}


### PR DESCRIPTION
## Summary

- `WrenEngine._plan` built `model_names` / `view_names` with `m["name"]` over raw `manifest_json["models"|"views"]`.
- Non-dict or nameless entries (hand-edited/partial MDL) raised `TypeError`/`KeyError` before policy checks.
- Introduce `_named_manifest_entries` and use it for both lists.

## Motivation

Same defensive pattern as memory schema_indexer / seed_query guards already on Apache-2.0 `core/**` paths. Planning should degrade to empty name sets for junk rows, not abort the request.

## Verification

```text
$ cd core/wren && .venv/bin/python -m pytest tests/unit/test_engine_manifest_names.py -q
3 passed
```

## Real behavior proof

```text
>>> # before: m["name"] on None → TypeError
>>> models = [{"name": "orders"}, None, "x"]
>>> {m["name"] for m in models}
TypeError
>>> from wren.engine import _named_manifest_entries
>>> _named_manifest_entries(models)
{'orders'}
```

Apache-2.0 path: `core/wren/**` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of manifest model/view entries when they are missing, malformed, or contain invalid/empty names.
  * Planning and policy validation now skips bad entries instead of failing on unexpected manifest data.

* **Tests**
  * Added unit coverage to ensure invalid inputs (null, empty, non-list, non-dict, and nameless entries) are safely ignored for both models and views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->