### PR TITLE
fix(mcp): skip non-dict models/columns/rels in list and describe

### DIFF
--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -228,14 +228,19 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         models = load_models(ctx.project)
         result = []
         for model in models:
+            if not isinstance(model, dict):
+                continue
             description = model.get("description")
             if description is None:
                 description = (model.get("properties") or {}).get("description")
+            columns = model.get("columns") or []
+            if not isinstance(columns, list):
+                columns = []
             result.append(
                 {
                     "name": model.get("name"),
                     "description": description,
-                    "column_count": len(model.get("columns", []) or []),
+                    "column_count": len(columns),
                 }
             )
         return {"models": result}
@@ -248,25 +253,36 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         from wren.context import load_models, load_relationships  # noqa: PLC0415
 
         models = load_models(ctx.project)
-        model = next((m for m in models if m.get("name") == name), None)
+        model = next(
+            (
+                m
+                for m in models
+                if isinstance(m, dict) and m.get("name") == name
+            ),
+            None,
+        )
         if model is None:
             raise ValueError(f"Model '{name}' not found.")
 
-        columns = [
-            {
-                "name": col.get("name"),
-                "type": col.get("type"),
-                "description": col.get("description")
-                or (col.get("properties") or {}).get("description"),
-            }
-            for col in model.get("columns", []) or []
-        ]
+        columns = []
+        for col in model.get("columns") or []:
+            if not isinstance(col, dict):
+                continue
+            columns.append(
+                {
+                    "name": col.get("name"),
+                    "type": col.get("type"),
+                    "description": col.get("description")
+                    or (col.get("properties") or {}).get("description"),
+                }
+            )
 
-        relationships = [
-            rel
-            for rel in load_relationships(ctx.project)
-            if name in (rel.get("models") or [])
-        ]
+        relationships = []
+        for rel in load_relationships(ctx.project):
+            if not isinstance(rel, dict):
+                continue
+            if name in (rel.get("models") or []):
+                relationships.append(rel)
 
         return {
             "name": model.get("name"),

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -254,11 +254,7 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
 
         models = load_models(ctx.project)
         model = next(
-            (
-                m
-                for m in models
-                if isinstance(m, dict) and m.get("name") == name
-            ),
+            (m for m in models if isinstance(m, dict) and m.get("name") == name),
             None,
         )
         if model is None:

--- a/core/wren/tests/unit/test_mcp_model_guards.py
+++ b/core/wren/tests/unit/test_mcp_model_guards.py
@@ -1,0 +1,50 @@
+"""Guards for non-dict MDL rows in MCP list/describe helpers (mirrors mcp_server)."""
+
+
+def list_models_payload(models):
+    result = []
+    for model in models:
+        if not isinstance(model, dict):
+            continue
+        description = model.get("description")
+        if description is None:
+            description = (model.get("properties") or {}).get("description")
+        columns = model.get("columns") or []
+        if not isinstance(columns, list):
+            columns = []
+        result.append(
+            {
+                "name": model.get("name"),
+                "description": description,
+                "column_count": len(columns),
+            }
+        )
+    return {"models": result}
+
+
+def describe_columns(model):
+    columns = []
+    for col in model.get("columns") or []:
+        if not isinstance(col, dict):
+            continue
+        columns.append({"name": col.get("name")})
+    return columns
+
+
+def test_list_skips_junk():
+    out = list_models_payload(
+        [
+            {"name": "a", "columns": [{"name": "id"}]},
+            None,
+            "x",
+            {"name": "b", "columns": "bad"},
+        ]
+    )
+    assert out["models"][0]["column_count"] == 1
+    assert out["models"][1]["column_count"] == 0
+    assert len(out["models"]) == 2
+
+
+def test_describe_skips_non_dict_cols():
+    cols = describe_columns({"columns": [None, {"name": "id"}, "x"]})
+    assert cols == [{"name": "id"}]


### PR DESCRIPTION
## Summary

- MCP `list_models` / `describe_model` called `.get` on every model/column/relationship without type checks.
- Non-dict rows in context load output crash tool handlers with `AttributeError`.
- Skip non-dict models/columns/relationships; treat non-list `columns` as empty.

## Motivation

Defensive consistency with memory/schema_indexer guards on Apache-2.0 `core/**`. MCP tools should return partial valid inventories rather than fail closed on one corrupt row.

## Verification

```text
$ cd core/wren && .venv/bin/python -m pytest tests/unit/test_mcp_model_guards.py -q
2 passed
```

(Logic mirror of the mcp_server sequence which is nested inside factory registration.)

## Apache-2.0

Touches only `core/wren/**`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “List Models” and “Describe Model” handling for unexpected or incomplete model, column, and relationship data.
  * Non-conforming entries are now ignored instead of causing failures.
  * Column counts and column listings now remain accurate when column data is missing or malformed.
* **Tests**
  * Added unit coverage to ensure junk inputs are skipped for both model listing and model description, including malformed column entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->