### PR TITLE
fix(genbi): guard non-dict models/columns in inventory format

### DIFF
--- a/core/wren/src/wren/genbi/composer.py
+++ b/core/wren/src/wren/genbi/composer.py
@@ -51,14 +51,23 @@ def _data_mode_guidance(data_mode: str) -> str:
     raise ValueError(f"unknown data-mode {data_mode!r}; expected one of {DATA_MODES}")
 
 
-def _format_model_inventory(models: list[dict]) -> str:
+def _format_model_inventory(models: list[dict] | None) -> str:
     """One markdown bullet per model with its column names."""
     if not models:
         return "- (no models found — run `wren context build` first)"
     lines = []
     for model in models:
-        cols = ", ".join(c.get("name", "?") for c in model.get("columns", []))
+        if not isinstance(model, dict):
+            continue
+        raw_cols = model.get("columns") or []
+        if not isinstance(raw_cols, list):
+            raw_cols = []
+        cols = ", ".join(
+            c.get("name", "?") for c in raw_cols if isinstance(c, dict)
+        )
         lines.append(f"- **{model.get('name', '?')}**: {cols}")
+    if not lines:
+        return "- (no models found — run `wren context build` first)"
     return "\n".join(lines)
 
 

--- a/core/wren/src/wren/genbi/composer.py
+++ b/core/wren/src/wren/genbi/composer.py
@@ -62,9 +62,7 @@ def _format_model_inventory(models: list[dict] | None) -> str:
         raw_cols = model.get("columns") or []
         if not isinstance(raw_cols, list):
             raw_cols = []
-        cols = ", ".join(
-            c.get("name", "?") for c in raw_cols if isinstance(c, dict)
-        )
+        cols = ", ".join(c.get("name", "?") for c in raw_cols if isinstance(c, dict))
         lines.append(f"- **{model.get('name', '?')}**: {cols}")
     if not lines:
         return "- (no models found — run `wren context build` first)"

--- a/core/wren/tests/unit/test_genbi_format_model_inventory.py
+++ b/core/wren/tests/unit/test_genbi_format_model_inventory.py
@@ -1,0 +1,30 @@
+from wren.genbi.composer import _format_model_inventory
+
+
+def test_formats_clean_models():
+    text = _format_model_inventory(
+        [{"name": "orders", "columns": [{"name": "id"}, {"name": "total"}]}]
+    )
+    assert "orders" in text
+    assert "id" in text
+
+
+def test_skips_non_dict_models_and_columns():
+    text = _format_model_inventory(
+        [
+            None,
+            "x",
+            {
+                "name": "t",
+                "columns": [None, {"name": "a"}, "bad"],
+            },
+        ]
+    )
+    assert "t" in text
+    assert "a" in text
+    assert "None" not in text
+
+
+def test_all_junk_falls_back_to_empty_message():
+    text = _format_model_inventory([None, "x", 1])
+    assert "no models found" in text


### PR DESCRIPTION
## Summary

- GenBI `_format_model_inventory` iterated models/columns with unconditional `.get`.
- Non-dict MDL rows crash compose_build_instruction markdown assembly.
- Skip junk models/columns; empty inventory after filtering uses the existing empty message.

## Verification

```text
$ cd core/wren && .venv/bin/python -m pytest tests/unit/test_genbi_format_model_inventory.py -q
3 passed
```

Apache-2.0 path: `core/wren/**`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model inventory formatting to be more tolerant of missing or malformed model data.
  * Invalid/non-dictionary entries and invalid column values are now ignored while preserving valid model and column names.
  * Correctly displays the “no models found” fallback when no valid models are available.
* **Tests**
  * Added unit test coverage for formatting valid inventories, mixed invalid inputs, and empty/invalid-only inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->