### PR TITLE
fix(dbt): skip unusable models/columns in seed payloads

### DIFF
--- a/core/wren/src/wren/dbt.py
+++ b/core/wren/src/wren/dbt.py
@@ -1251,8 +1251,16 @@ def _build_dbt_query_pairs(
     from wren.memory.seed_queries import generate_seed_queries  # noqa: PLC0415
 
     manifest = {
-        "models": [_seed_model_payload(model) for model in imported_models],
-        "relationships": [_seed_relationship_payload(rel) for rel in relationships],
+        "models": [
+            payload
+            for model in imported_models
+            if (payload := _seed_model_payload(model)) is not None
+        ],
+        "relationships": [
+            payload
+            for rel in relationships
+            if (payload := _seed_relationship_payload(rel)) is not None
+        ],
     }
 
     pairs = generate_seed_queries(manifest)
@@ -1267,24 +1275,39 @@ def _build_dbt_query_pairs(
     ]
 
 
-def _seed_model_payload(model: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "name": model["name"],
-        "primaryKey": model.get("primary_key"),
-        "properties": _camelize_props(model.get("properties", {})),
-        "columns": [
+def _seed_model_payload(model: dict[str, Any]) -> dict[str, Any] | None:
+    """Build seed payload for one imported model, or None if unusable."""
+    if not isinstance(model, dict) or not model.get("name"):
+        return None
+    props = model.get("properties") or {}
+    if not isinstance(props, dict):
+        props = {}
+    columns_out: list[dict[str, Any]] = []
+    for column in model.get("columns") or []:
+        if not isinstance(column, dict) or not column.get("name"):
+            continue
+        col_props = column.get("properties") or {}
+        if not isinstance(col_props, dict):
+            col_props = {}
+        columns_out.append(
             {
                 "name": column["name"],
                 "type": column.get("type"),
                 "isCalculated": column.get("is_calculated", False),
-                "properties": _camelize_props(column.get("properties", {})),
+                "properties": _camelize_props(col_props),
             }
-            for column in model.get("columns", [])
-        ],
+        )
+    return {
+        "name": model["name"],
+        "primaryKey": model.get("primary_key"),
+        "properties": _camelize_props(props),
+        "columns": columns_out,
     }
 
 
-def _seed_relationship_payload(relationship: dict[str, Any]) -> dict[str, Any]:
+def _seed_relationship_payload(relationship: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(relationship, dict):
+        return None
     return {
         "name": relationship.get("name"),
         "models": relationship.get("models", []),
@@ -1293,7 +1316,9 @@ def _seed_relationship_payload(relationship: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _camelize_props(properties: dict[str, Any]) -> dict[str, Any]:
+def _camelize_props(properties: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(properties, dict):
+        return {}
     mapping = {
         "accepted_values": "acceptedValues",
         "data_scope": "dataScope",

--- a/core/wren/tests/unit/test_dbt_seed_payload_guards.py
+++ b/core/wren/tests/unit/test_dbt_seed_payload_guards.py
@@ -1,0 +1,57 @@
+from wren.dbt import (
+    _build_dbt_query_pairs,
+    _camelize_props,
+    _seed_model_payload,
+    _seed_relationship_payload,
+)
+
+
+def test_seed_model_skips_junk_columns():
+    payload = _seed_model_payload(
+        {
+            "name": "orders",
+            "columns": [None, {"name": "id"}, "x", {"properties": {}}],
+        }
+    )
+    assert payload is not None
+    assert [c["name"] for c in payload["columns"]] == ["id"]
+
+
+def test_seed_model_rejects_non_dict():
+    assert _seed_model_payload(None) is None  # type: ignore[arg-type]
+    assert _seed_model_payload({"columns": []}) is None
+
+
+def test_seed_relationship_rejects_non_dict():
+    assert _seed_relationship_payload("x") is None  # type: ignore[arg-type]
+
+
+def test_camelize_props_tolerates_none():
+    assert _camelize_props(None) == {}
+    assert _camelize_props("x") == {}  # type: ignore[arg-type]
+
+
+def test_build_pairs_skips_junk_models(monkeypatch):
+    def fake_seed(manifest):
+        assert manifest["models"] == [
+            {
+                "name": "ok",
+                "primaryKey": None,
+                "properties": {},
+                "columns": [],
+            }
+        ]
+        return [{"nl": "q", "sql": "select 1"}]
+
+    monkeypatch.setattr(
+        "wren.memory.seed_queries.generate_seed_queries",
+        fake_seed,
+    )
+    pairs = _build_dbt_query_pairs(
+        [None, {"name": "ok", "columns": []}, "bad"],
+        [None, {"name": "r1"}],
+        datasource="postgres",
+    )
+    assert pairs == [
+        {"nl": "q", "sql": "select 1", "source": "dbt", "datasource": "postgres"}
+    ]


### PR DESCRIPTION
## Summary

- `_seed_model_payload` / `_build_dbt_query_pairs` assumed dict models and named columns.
- Partial dbt imports with junk rows raised `TypeError`/`KeyError` during seed pair generation.
- Return `None` for unusable models/relationships, skip bad columns, harden `_camelize_props`.

## Verification

```text
$ cd core/wren && .venv/bin/python -m pytest tests/unit/test_dbt_seed_payload_guards.py -q
5 passed
```

Apache-2.0: `core/wren/**` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dbt seed-query generation by safely handling missing or malformed model, relationship, column, and property data.
  * Invalid model/relationship inputs are now skipped, preventing crashes during manifest construction.
  * Ensures only valid entries contribute to generated seed queries, while preserving correct source and data source annotations.
* **Tests**
  * Added unit tests covering defensive payload guards and tolerance behaviors for malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->