### PR TITLE
fix(connector): use public strip_trailing_semicolon in dry_run paths

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -43,7 +43,7 @@ class DataFusionConnector(ConnectorABC):
         # break the LIMIT subquery wrap (``SELECT 1;`` is a multi-statement batch
         # the planner rejects). Strip only the terminating run so ';' inside
         # string literals stays intact — same helper already used by ``query``.
-        self.ctx.dry_run(_strip_trailing_semicolon(sql))
+        self.ctx.dry_run(strip_trailing_semicolon(sql))
 
     def close(self) -> None:
         pass

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -88,7 +88,7 @@ class SnowflakeConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         # ``describe`` still fails when the statement is terminated with ``;``
         # (ProgrammingError: unexpected ';'). Strip only the trailing run.
-        cleaned = _strip_trailing_semicolon(sql)
+        cleaned = strip_trailing_semicolon(sql)
         try:
             with self.connection.cursor() as cursor:
                 cursor.describe(cleaned)


### PR DESCRIPTION
## Summary
- `main` currently imports `strip_trailing_semicolon` but still calls `_strip_trailing_semicolon` in `DataFusionConnector.dry_run` and `SnowflakeConnector.dry_run`.
- That yields ruff F821 + unit `NameError` on every fresh PR merge queue check (seen on #2546–#2549).
- One-line rename at both call sites to the already-imported public helper.

## Test plan
- [x] Wren SDK CI lint + unit on this PR
- [ ] Confirm #2546–#2549 go green after rebase/recheck once this lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL dry-run validation for DataFusion and Snowflake connections.
  * Trailing semicolons are now handled consistently, helping prevent unnecessary validation failures when previewing or checking SQL statements.
  * Existing dry-run error handling and query metadata remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->