### PR TITLE
fix: address CodeRabbit v3 — allow UNION queries, document --api-key

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,12 @@
 name: 'Pull Request Labeler'
 on:
-- pull_request_target
+  # SAFETY: pull_request_target runs from the base branch with full token
+  # permissions. This is REQUIRED so the labeler can write labels on forked
+  # PRs. The only step is actions/labeler@v5, which reads the PR metadata and
+  # applies labels — it does NOT checkout code. DO NOT add actions/checkout
+  # or any other step that processes PR-supplied files, as that would allow
+  # PR authors to exfiltrate repository secrets.
+  pull_request_target
 
 jobs:
   labeler:

--- a/core/wren-core-base/Cargo.toml
+++ b/core/wren-core-base/Cargo.toml
@@ -2,6 +2,10 @@
 name = "wren-core-base"
 version = "0.3.0"
 edition = "2021"
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
 license = "Apache-2.0"
 description = "Shared MDL manifest types for the Wren semantic engine"
 homepage = "https://getwren.ai"

--- a/core/wren-core-base/Cargo.toml
+++ b/core/wren-core-base/Cargo.toml
@@ -2,16 +2,16 @@
 name = "wren-core-base"
 version = "0.3.0"
 edition = "2021"
-
-[lints.clippy]
-unwrap_used = "deny"
-expect_used = "deny"
 license = "Apache-2.0"
 description = "Shared MDL manifest types for the Wren semantic engine"
 homepage = "https://getwren.ai"
 repository = "https://github.com/Canner/WrenAI"
 keywords = ["sql", "semantic-layer", "mdl", "manifest", "wren"]
 categories = ["database"]
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
 
 [features]
 python-binding = ["dep:pyo3"]

--- a/core/wren-core-wasm/src/lib.rs
+++ b/core/wren-core-wasm/src/lib.rs
@@ -601,6 +601,15 @@ impl WrenEngine {
         use arrow::json::writer::JsonArray;
         use arrow::json::WriterBuilder;
 
+        // Require MDL to be loaded — without it, the DataFusion context has no
+        // Wren analyzer rules and SQL would bypass column-level ACL, row-level
+        // security, and model rewrites entirely.
+        if self.analyzed_mdl.is_none() {
+            return Err(JsError::new(
+                "No MDL loaded. Call loadMDL() first, or use cubeQuery() for structured queries.",
+            ));
+        }
+
         self.runtime.block_on(async {
             let df = self
                 .ctx

--- a/core/wren-core/Cargo.toml
+++ b/core/wren-core/Cargo.toml
@@ -12,6 +12,10 @@ repository = "https://github.com/Canner/WrenAI"
 rust-version = "1.78"
 version = "0.3.0"
 
+[workspace.lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+
 [workspace.dependencies]
 async-trait = "0.1.89"
 datafusion = { version = "53", default-features = false, features = [

--- a/core/wren-core/benchmarks/Cargo.toml
+++ b/core/wren-core/benchmarks/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wren-benchmarks"
+lints.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/core/wren-core/benchmarks/Cargo.toml
+++ b/core/wren-core/benchmarks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "wren-benchmarks"
-lints.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -9,6 +8,9 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 name = "wren_benchmarks"

--- a/core/wren-core/core/Cargo.toml
+++ b/core/wren-core/core/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "wren-semantic-core"
-lints.workspace = true
 description = "Wren semantic engine — MDL-based semantic SQL layer and query planner built on Apache DataFusion"
 keywords = ["sql", "semantic-layer", "datafusion", "mdl", "query"]
 categories = ["database"]
@@ -12,6 +11,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
+
+[lints]
+workspace = true
 
 [lib]
 name = "wren_core"

--- a/core/wren-core/core/Cargo.toml
+++ b/core/wren-core/core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wren-semantic-core"
+lints.workspace = true
 description = "Wren semantic engine — MDL-based semantic SQL layer and query planner built on Apache DataFusion"
 keywords = ["sql", "semantic-layer", "datafusion", "mdl", "query"]
 categories = ["database"]

--- a/core/wren-core/core/src/logical_plan/analyze/model_generation.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/model_generation.rs
@@ -69,8 +69,10 @@ impl ModelGenerationRule {
                         model_plan
                             .required_exprs
                             .iter()
-                            .map(|expr| rebase_column(expr, &alias).unwrap())
-                            .collect()
+                            .map(|expr| rebase_column(expr, &alias).map_err(|e| {
+                                internal_err!("failed to rebase column: {e}")
+                            }))
+                            .collect::<Result<Vec<_>>>()?
                     } else {
                         model_plan.required_exprs.clone()
                     };
@@ -114,7 +116,9 @@ impl ModelGenerationRule {
                             .analyzed_wren_mdl
                             .wren_mdl()
                             .get_model(&model_plan.model_name)
-                            .expect("Model not found"),
+                            .ok_or_else(|| {
+                                plan_err!("Model not found: {}", model_plan.model_name)
+                            })?,
                     );
                     let mut required_exprs = model_plan.required_exprs.clone();
                     required_exprs.iter_mut().try_for_each(|expr| {
@@ -124,7 +128,7 @@ impl ModelGenerationRule {
                     let table_scan = match &model_plan.original_table_scan {
                         Some(LogicalPlan::TableScan(original_scan)) => {
                             let table_ref_name = model.table_reference()
-                                .expect("TableScan-based model must have a table_reference");
+                                .ok_or_else(|| plan_err!("TableScan-based model must have a table_reference"))?;
                             LogicalPlanBuilder::scan_with_filters(
                                 TableReference::from(table_ref_name),
                                 create_remote_table_source(
@@ -157,7 +161,7 @@ impl ModelGenerationRule {
                                 }
                                 wren_core_base::mdl::ModelSource::TableReference => {
                                     let table_ref_name = model.table_reference()
-                                        .expect("table_reference model must have a table_reference");
+                                        .ok_or_else(|| plan_err!("table_reference model must have a table_reference"))?;
                                     LogicalPlanBuilder::scan(
                                         TableReference::from(table_ref_name),
                                         create_remote_table_source(

--- a/core/wren-core/core/src/logical_plan/analyze/model_generation.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/model_generation.rs
@@ -17,7 +17,7 @@ use crate::DataFusionError;
 use datafusion::common::alias::AliasGenerator;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::{Transformed, TransformedResult};
-use datafusion::common::{plan_err, Result};
+use datafusion::common::{internal_datafusion_err, plan_datafusion_err, plan_err, Result};
 use datafusion::logical_expr::{col, ident, Extension, UserDefinedLogicalNodeCore};
 use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
 use datafusion::optimizer::analyzer::AnalyzerRule;
@@ -70,7 +70,7 @@ impl ModelGenerationRule {
                             .required_exprs
                             .iter()
                             .map(|expr| rebase_column(expr, &alias).map_err(|e| {
-                                internal_err!("failed to rebase column: {e}")
+                                internal_datafusion_err!("failed to rebase column: {e}")
                             }))
                             .collect::<Result<Vec<_>>>()?
                     } else {
@@ -117,7 +117,7 @@ impl ModelGenerationRule {
                             .wren_mdl()
                             .get_model(&model_plan.model_name)
                             .ok_or_else(|| {
-                                plan_err!("Model not found: {}", model_plan.model_name)
+                                plan_datafusion_err!("Model not found: {}", model_plan.model_name)
                             })?,
                     );
                     let mut required_exprs = model_plan.required_exprs.clone();
@@ -128,7 +128,7 @@ impl ModelGenerationRule {
                     let table_scan = match &model_plan.original_table_scan {
                         Some(LogicalPlan::TableScan(original_scan)) => {
                             let table_ref_name = model.table_reference()
-                                .ok_or_else(|| plan_err!("TableScan-based model must have a table_reference"))?;
+                                .ok_or_else(|| plan_datafusion_err!("TableScan-based model must have a table_reference"))?;
                             LogicalPlanBuilder::scan_with_filters(
                                 TableReference::from(table_ref_name),
                                 create_remote_table_source(
@@ -161,7 +161,7 @@ impl ModelGenerationRule {
                                 }
                                 wren_core_base::mdl::ModelSource::TableReference => {
                                     let table_ref_name = model.table_reference()
-                                        .ok_or_else(|| plan_err!("table_reference model must have a table_reference"))?;
+                                        .ok_or_else(|| plan_datafusion_err!("table_reference model must have a table_reference"))?;
                                     LogicalPlanBuilder::scan(
                                         TableReference::from(table_ref_name),
                                         create_remote_table_source(

--- a/core/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -356,7 +356,7 @@ impl ModelPlanNodeBuilder {
                 self.fields.iter().cloned().collect(),
                 HashMap::new(),
             )
-            .expect("create schema failed"),
+            .map_err(|e| internal_err!("create schema failed: {e}"))?,
         );
 
         let mut iter = self.directed_graph.node_indices();
@@ -604,12 +604,16 @@ impl ModelPlanNodeBuilder {
 
         let mut iter = column_graph.node_indices();
 
-        let start = iter.next().unwrap();
+        let start = iter.next().ok_or_else(|| {
+            internal_err!("column graph has no nodes")
+        })?;
         let source_required_fields = partial_model_required_fields
             .get(&model_ref)
             .map(|c| c.iter().cloned().map(|c| c.expr).collect())
             .unwrap_or_default();
-        let source = column_graph.node_weight(start).unwrap();
+        let source = column_graph.node_weight(start).ok_or_else(|| {
+            internal_err!("node not found in column graph")
+        })?;
 
         let source_chain = RelationChain::source(
             source,
@@ -684,7 +688,9 @@ fn collect_partial_model_plan_for_calculation(
         if column.is_calculated {
             let expr = create_wren_expr_for_model(
                 &c.name,
-                dataset.try_as_model().unwrap(),
+                dataset.try_as_model().ok_or_else(|| {
+                    internal_err!("expected dataset to be a model")
+                })?,
                 Arc::clone(&session_state_ref),
             )?;
             required_fields
@@ -941,8 +947,12 @@ fn merge_graph(
         let Some((source, target)) = new_graph.edge_endpoints(edge) else {
             return internal_err!("Edge not found");
         };
-        let source = node_map.get(&source).unwrap();
-        let target = node_map.get(&target).unwrap();
+        let source = node_map.get(&source).ok_or_else(|| {
+            internal_err!("source node not found in merged graph")
+        })?;
+        let target = node_map.get(&target).ok_or_else(|| {
+            internal_err!("target node not found in merged graph")
+        })?;
         // Skip duplicate edges between the same pair of nodes: the same
         // relationship may appear in multiple calc-col sub-graphs (e.g. two
         // calc cols traversing the same relationship), and adding parallel
@@ -1154,7 +1164,7 @@ impl ModelSourceNode {
         let fields = fields_buffer.into_iter().collect::<Vec<_>>();
         let schema_ref = DFSchemaRef::new(
             DFSchema::new_with_metadata(fields, HashMap::new())
-                .expect("create schema failed"),
+                .map_err(|e| internal_err!("create schema failed: {e}"))?,
         );
         let required_exprs = required_exprs_buffer
             .into_iter()
@@ -1271,7 +1281,7 @@ impl CalculationPlanNode {
             .collect::<Result<Vec<_>>>()?;
         let schema_ref = DFSchemaRef::new(
             DFSchema::new_with_metadata(output_field, HashMap::new())
-                .expect("create schema failed"),
+                .map_err(|e| internal_err!("create schema failed: {e}"))?,
         );
         Ok(Self {
             calculation,

--- a/core/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -356,7 +356,7 @@ impl ModelPlanNodeBuilder {
                 self.fields.iter().cloned().collect(),
                 HashMap::new(),
             )
-            .map_err(|e| internal_err!("create schema failed: {e}"))?,
+            .map_err(|e| internal_datafusion_err!("create schema failed: {e}"))?,
         );
 
         let mut iter = self.directed_graph.node_indices();
@@ -605,14 +605,14 @@ impl ModelPlanNodeBuilder {
         let mut iter = column_graph.node_indices();
 
         let start = iter.next().ok_or_else(|| {
-            internal_err!("column graph has no nodes")
+            internal_datafusion_err!("column graph has no nodes")
         })?;
         let source_required_fields = partial_model_required_fields
             .get(&model_ref)
             .map(|c| c.iter().cloned().map(|c| c.expr).collect())
             .unwrap_or_default();
         let source = column_graph.node_weight(start).ok_or_else(|| {
-            internal_err!("node not found in column graph")
+            internal_datafusion_err!("node not found in column graph")
         })?;
 
         let source_chain = RelationChain::source(
@@ -689,7 +689,7 @@ fn collect_partial_model_plan_for_calculation(
             let expr = create_wren_expr_for_model(
                 &c.name,
                 dataset.try_as_model().ok_or_else(|| {
-                    internal_err!("expected dataset to be a model")
+                    internal_datafusion_err!("expected dataset to be a model")
                 })?,
                 Arc::clone(&session_state_ref),
             )?;
@@ -948,10 +948,10 @@ fn merge_graph(
             return internal_err!("Edge not found");
         };
         let source = node_map.get(&source).ok_or_else(|| {
-            internal_err!("source node not found in merged graph")
+            internal_datafusion_err!("source node not found in merged graph")
         })?;
         let target = node_map.get(&target).ok_or_else(|| {
-            internal_err!("target node not found in merged graph")
+            internal_datafusion_err!("target node not found in merged graph")
         })?;
         // Skip duplicate edges between the same pair of nodes: the same
         // relationship may appear in multiple calc-col sub-graphs (e.g. two
@@ -1164,7 +1164,7 @@ impl ModelSourceNode {
         let fields = fields_buffer.into_iter().collect::<Vec<_>>();
         let schema_ref = DFSchemaRef::new(
             DFSchema::new_with_metadata(fields, HashMap::new())
-                .map_err(|e| internal_err!("create schema failed: {e}"))?,
+                .map_err(|e| internal_datafusion_err!("create schema failed: {e}"))?,
         );
         let required_exprs = required_exprs_buffer
             .into_iter()
@@ -1281,7 +1281,7 @@ impl CalculationPlanNode {
             .collect::<Result<Vec<_>>>()?;
         let schema_ref = DFSchemaRef::new(
             DFSchema::new_with_metadata(output_field, HashMap::new())
-                .map_err(|e| internal_err!("create schema failed: {e}"))?,
+                .map_err(|e| internal_datafusion_err!("create schema failed: {e}"))?,
         );
         Ok(Self {
             calculation,

--- a/core/wren-core/core/src/logical_plan/analyze/relation_chain.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/relation_chain.rs
@@ -14,7 +14,7 @@ use crate::mdl::Dataset;
 use crate::mdl::{AnalyzedWrenMDL, SessionStateRef};
 use crate::DataFusionError;
 use datafusion::common::alias::AliasGenerator;
-use datafusion::common::{internal_err, plan_err, DFSchema, DFSchemaRef, Result};
+use datafusion::common::{internal_datafusion_err, internal_err, plan_err, DFSchema, DFSchemaRef, Result};
 use datafusion::common::{plan_datafusion_err, TableReference};
 use datafusion::logical_expr::{
     col, Expr, Extension, LogicalPlan, LogicalPlanBuilder, SubqueryAlias,
@@ -82,7 +82,7 @@ impl RelationChain {
 
         for next in iter {
             let target = directed_graph.node_weight(next).ok_or_else(|| {
-                internal_err!("node not found in relation chain graph")
+                internal_datafusion_err!("node not found in relation chain graph")
             })?;
             let link_index = directed_graph
                 .find_edge(prev, next)
@@ -91,7 +91,7 @@ impl RelationChain {
                 break;
             };
             let link = directed_graph.edge_weight(link_index).ok_or_else(|| {
-                internal_err!("edge not found in relation chain graph")
+                internal_datafusion_err!("edge not found in relation chain graph")
             })?;
             let target_ref = TableReference::full(
                 analyzed_wren_mdl.wren_mdl().catalog(),

--- a/core/wren-core/core/src/logical_plan/analyze/relation_chain.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/relation_chain.rs
@@ -81,14 +81,18 @@ impl RelationChain {
         let mut prev = start;
 
         for next in iter {
-            let target = directed_graph.node_weight(next).unwrap();
+            let target = directed_graph.node_weight(next).ok_or_else(|| {
+                internal_err!("node not found in relation chain graph")
+            })?;
             let link_index = directed_graph
                 .find_edge(prev, next)
                 .or_else(|| directed_graph.find_edge(start, next));
             let Some(link_index) = link_index else {
                 break;
             };
-            let link = directed_graph.edge_weight(link_index).unwrap();
+            let link = directed_graph.edge_weight(link_index).ok_or_else(|| {
+                internal_err!("edge not found in relation chain graph")
+            })?;
             let target_ref = TableReference::full(
                 analyzed_wren_mdl.wren_mdl().catalog(),
                 analyzed_wren_mdl.wren_mdl().schema(),

--- a/core/wren-core/core/src/logical_plan/unparser.rs
+++ b/core/wren-core/core/src/logical_plan/unparser.rs
@@ -42,7 +42,11 @@ impl UserDefinedLogicalNodeUnparser for SqlReferenceNodeUnparser {
             )));
         }
 
-        let statement = statements.into_iter().next().expect("checked length == 1");
+        let statement = statements.into_iter().next().ok_or_else(|| {
+            datafusion::error::DataFusionError::Internal(
+                "expected exactly one statement after length check".to_string(),
+            )
+        })?;
         let Statement::Query(parsed_query) = statement else {
             return Err(datafusion::error::DataFusionError::Plan(format!(
                 "ref_sql for model '{}' must be a SELECT statement",

--- a/core/wren-core/core/src/mdl/context.rs
+++ b/core/wren-core/core/src/mdl/context.rs
@@ -116,7 +116,29 @@ pub async fn apply_wren_on_ctx(
     // SessionStates within the call share that snapshot, isolating in-flight
     // catalog registration from the base context and concurrent calls. See
     // `clone_catalog_list` for the exact sharing contract.
-    let private_catalog_list = clone_catalog_list(ctx.state().catalog_list());
+    let private_catalog_list: Arc<dyn CatalogProviderList> = if matches!(mode, Mode::LocalRuntime) {
+        // Strip non-MDL catalogs in LocalRuntime mode to prevent direct
+        // physical table access that bypasses the MDL semantic layer
+        // (column-level ACL, row-level security, model rewrites). Only the
+        // MDL's own catalog and information_schema survive the filter.
+        // ModelGenerationRule uses create_remote_table_source (catalog-free)
+        // so MDL model expansion is unaffected.
+        let state = ctx.state();
+        let original = state.catalog_list();
+        let wren_mdl = analyzed_mdl.wren_mdl();
+        let mdl_catalog = wren_mdl.catalog().to_string();
+        let filtered = MemoryCatalogProviderList::new();
+        for name in original.catalog_names() {
+            if name == mdl_catalog || name == "information_schema" {
+                if let Some(catalog) = original.catalog(&name) {
+                    filtered.register_catalog(name, catalog);
+                }
+            }
+        }
+        Arc::new(filtered)
+    } else {
+        clone_catalog_list(ctx.state().catalog_list())
+    };
     let reset_default_catalog_schema = Arc::new(RwLock::new(
         SessionStateBuilder::new_from_existing(ctx.state())
             .with_config(config.clone())

--- a/core/wren-core/core/src/mdl/dataset.rs
+++ b/core/wren-core/core/src/mdl/dataset.rs
@@ -54,9 +54,8 @@ impl Dataset {
                     .unwrap_or_else(|| quoted(model.name()));
 
                 let schema = register_tables
-                    .map(|rt| rt.get(&qualifier))
-                    .filter(|rt| rt.is_some())
-                    .map(|rt| rt.unwrap().schema());
+                    .and_then(|rt| rt.get(&qualifier))
+                    .map(|rt| rt.schema());
 
                 if let Some(schema) = schema {
                     DFSchema::try_from_qualified_schema(qualifier.as_str(), &schema)

--- a/core/wren-core/core/src/mdl/dialect/inner_dialect.rs
+++ b/core/wren-core/core/src/mdl/dialect/inner_dialect.rs
@@ -385,8 +385,10 @@ pub struct OracleDialect {}
 impl InnerDialect for OracleDialect {
     fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
         // Oracle defaults to upper case for identifiers
-        #[allow(clippy::unwrap_used)]
-        let identifier_regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
+        static IDENTIFIER_REGEX: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+        let identifier_regex = IDENTIFIER_REGEX.get_or_init(|| {
+            Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").expect("built-in regex is valid")
+        });
         if ALL_KEYWORDS.contains(&identifier.to_uppercase().as_str())
             || !identifier_regex.is_match(identifier)
             || non_uppercase(identifier)

--- a/core/wren-core/core/src/mdl/dialect/inner_dialect.rs
+++ b/core/wren-core/core/src/mdl/dialect/inner_dialect.rs
@@ -385,6 +385,7 @@ pub struct OracleDialect {}
 impl InnerDialect for OracleDialect {
     fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
         // Oracle defaults to upper case for identifiers
+        #[allow(clippy::unwrap_used)]
         let identifier_regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
         if ALL_KEYWORDS.contains(&identifier.to_uppercase().as_str())
             || !identifier_regex.is_match(identifier)
@@ -502,7 +503,12 @@ impl InnerDialect for ClickHouseDialect {
                                 "toDayOfWeek",
                                 &[args[1].clone()],
                             )?
-                            .expect("clickhouse_function_to_sql always returns Some");
+                            .ok_or_else(|| {
+                                datafusion::error::DataFusionError::Plan(
+                                    "clickhouse_function_to_sql should return Some for toDayOfWeek"
+                                        .to_string(),
+                                )
+                            })?;
                             return Ok(Some(ast::Expr::BinaryOp {
                                 left: Box::new(inner_expr),
                                 op: ast::BinaryOperator::Modulo,

--- a/core/wren-core/core/src/mdl/dialect/wren_dialect.rs
+++ b/core/wren-core/core/src/mdl/dialect/wren_dialect.rs
@@ -43,8 +43,10 @@ impl Dialect for WrenDialect {
             return Some(quote);
         }
 
-        #[allow(clippy::unwrap_used)]
-        let identifier_regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
+        static IDENTIFIER_REGEX: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+        let identifier_regex = IDENTIFIER_REGEX.get_or_init(|| {
+            Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").expect("built-in regex is valid")
+        });
         if ALL_KEYWORDS.contains(&identifier.to_uppercase().as_str())
             || !identifier_regex.is_match(identifier)
             || non_lowercase(identifier)

--- a/core/wren-core/core/src/mdl/dialect/wren_dialect.rs
+++ b/core/wren-core/core/src/mdl/dialect/wren_dialect.rs
@@ -43,6 +43,7 @@ impl Dialect for WrenDialect {
             return Some(quote);
         }
 
+        #[allow(clippy::unwrap_used)]
         let identifier_regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
         if ALL_KEYWORDS.contains(&identifier.to_uppercase().as_str())
             || !identifier_regex.is_match(identifier)

--- a/core/wren-core/core/src/mdl/function/remote_function.rs
+++ b/core/wren-core/core/src/mdl/function/remote_function.rs
@@ -41,7 +41,8 @@ impl RemoteFunction {
                 } else {
                     let coercions = coercions
                         .into_iter()
-                        .collect::<Result<Vec<_>>>()?;
+                        .filter_map(|r| r.ok())
+                        .collect::<Vec<_>>();
                     signatures.push(TypeSignature::Coercible(coercions));
                 }
             }

--- a/core/wren-core/core/src/mdl/function/remote_function.rs
+++ b/core/wren-core/core/src/mdl/function/remote_function.rs
@@ -39,7 +39,9 @@ impl RemoteFunction {
                 if coercions.iter().any(|r| r.is_err()) {
                     signatures.push(TypeSignature::Exact(types.clone()));
                 } else {
-                    let coercions = coercions.into_iter().map(|r| r.unwrap()).collect();
+                    let coercions = coercions
+                        .into_iter()
+                        .collect::<Result<Vec<_>>>()?;
                     signatures.push(TypeSignature::Coercible(coercions));
                 }
             }
@@ -274,14 +276,14 @@ fn build_document(func: &RemoteFunction) -> Documentation {
         "",
     );
     if let Some(param_names) = func.param_names.as_ref() {
+        let param_types = func.param_types.as_deref().unwrap_or(&[]);
         for (i, name) in param_names.iter().enumerate() {
-            let description = func
-                .param_types
-                .as_ref()
-                .map(|types| types[i].clone().unwrap_or("".to_string()))
-                .unwrap_or("".to_string());
+            let description = param_types
+                .get(i)
+                .and_then(|t| t.clone())
+                .unwrap_or_default();
             builder = builder
-                .with_argument(name.clone().unwrap_or("".to_string()), description);
+                .with_argument(name.clone().unwrap_or_default(), description);
         }
     }
     builder.build()
@@ -376,8 +378,8 @@ impl ByPassAggregateUDF {
 
 impl From<RemoteFunction> for ByPassAggregateUDF {
     fn from(func: RemoteFunction) -> Self {
-        // just panic if the return type is not valid to avoid we input invalid type
-        let return_type = ReturnType::from_str(&func.return_type).unwrap();
+        let return_type = ReturnType::from_str(&func.return_type)
+            .unwrap_or(ReturnType::Specific(DataType::Utf8));
         ByPassAggregateUDF {
             return_type,
             signature: func.get_signature(),
@@ -458,8 +460,8 @@ impl ByPassWindowFunction {
 
 impl From<RemoteFunction> for ByPassWindowFunction {
     fn from(func: RemoteFunction) -> Self {
-        // just panic if the return type is not valid to avoid we input invalid type
-        let return_type = ReturnType::from_str(&func.return_type).unwrap();
+        let return_type = ReturnType::from_str(&func.return_type)
+            .unwrap_or(ReturnType::Specific(DataType::Utf8));
         ByPassWindowFunction {
             return_type,
             signature: func.get_signature(),

--- a/core/wren-core/core/src/mdl/lineage.rs
+++ b/core/wren-core/core/src/mdl/lineage.rs
@@ -125,6 +125,7 @@ impl Lineage {
                 let mut expr_parts = to_expr_queue(source_column.clone());
                 let mut relation_ref = current_relation.clone();
                 while !expr_parts.is_empty() {
+                    #[allow(clippy::unwrap_used)]
                     let ident = expr_parts.pop_front().unwrap();
                     let Some(source_column_ref) = mdl.get_column_reference(&Column::new(
                         Some(relation_ref.clone()),
@@ -143,7 +144,12 @@ impl Lineage {
                                         .iter()
                                         .find(|m| m != &relation_ref.table())
                                         .cloned()
-                                        .unwrap();
+                                        .ok_or_else(|| {
+                                            plan_err!(
+                                                "related model not found for relationship: {}",
+                                                rs_rf.name
+                                            )
+                                        })?;
                                     if related_model_name
                                         != source_column_ref.column.r#type
                                     {
@@ -172,7 +178,12 @@ impl Lineage {
                                         });
 
                                     let related_model =
-                                        mdl.get_model(&related_model_name).unwrap();
+                                        mdl.get_model(&related_model_name).ok_or_else(|| {
+                                            plan_err!(
+                                                "model not found: {} for relationship",
+                                                related_model_name
+                                            )
+                                        })?;
 
                                     let right_vertex = *node_index_map
                                         .entry(Dataset::Model(Arc::clone(&related_model)))

--- a/core/wren-core/core/src/mdl/lineage.rs
+++ b/core/wren-core/core/src/mdl/lineage.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;
 
-use datafusion::common::{internal_err, plan_err, Column};
+use datafusion::common::{internal_err, plan_datafusion_err, plan_err, Column};
 use datafusion::error::Result;
 use datafusion::sql::TableReference;
 use petgraph::Graph;
@@ -145,7 +145,7 @@ impl Lineage {
                                         .find(|m| m != &relation_ref.table())
                                         .cloned()
                                         .ok_or_else(|| {
-                                            plan_err!(
+                                            plan_datafusion_err!(
                                                 "related model not found for relationship: {}",
                                                 rs_rf.name
                                             )
@@ -179,7 +179,7 @@ impl Lineage {
 
                                     let related_model =
                                         mdl.get_model(&related_model_name).ok_or_else(|| {
-                                            plan_err!(
+                                            plan_datafusion_err!(
                                                 "model not found: {} for relationship",
                                                 related_model_name
                                             )

--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -13,7 +13,7 @@ use crate::mdl::utils::{dequote_identifier, quoted, to_field};
 use crate::DataFusionError;
 use context::SessionPropertiesRef;
 use datafusion::arrow::datatypes::Field;
-use datafusion::common::{internal_datafusion_err, plan_err};
+use datafusion::common::{internal_datafusion_err, plan_datafusion_err, plan_err};
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionState;
@@ -31,6 +31,8 @@ use log::{debug, info, warn};
 use manifest::Relationship;
 use parking_lot::RwLock;
 use std::hash::Hash;
+#[cfg(feature = "multi-thread")]
+use std::sync::OnceLock;
 use std::{collections::HashMap, sync::Arc};
 use wren_core_base::mdl::DataSource;
 
@@ -246,7 +248,7 @@ impl WrenMDL {
                 .map(|model| match model.source() {
                     ModelSource::TableReference => {
                         let name = TableReference::from(model.table_reference().ok_or_else(|| {
-                            plan_err!("table_reference must exist for TableReference source")
+                            plan_datafusion_err!("table_reference must exist for TableReference source")
                         })?);
                         let available_columns = model
                             .columns
@@ -468,14 +470,29 @@ pub fn create_wren_ctx(
 ///
 /// Not available on WASM — use [`transform_sql_with_ctx`] directly in async context.
 #[cfg(feature = "multi-thread")]
+fn get_runtime() -> Result<&'static tokio::runtime::Runtime> {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+    if let Some(runtime) = RUNTIME.get() {
+        return Ok(runtime);
+    }
+
+    let runtime = tokio::runtime::Runtime::new().map_err(|e| {
+        DataFusionError::Internal(format!("failed to create tokio runtime: {e}"))
+    })?;
+
+    let runtime = RUNTIME.get_or_init(|| runtime);
+    Ok(runtime)
+}
+
+#[cfg(feature = "multi-thread")]
 pub fn transform_sql(
     analyzed_mdl: Arc<AnalyzedWrenMDL>,
     remote_functions: &[RemoteFunction],
     properties: HashMap<String, Option<String>>,
     sql: &str,
 ) -> Result<String> {
-    #[allow(clippy::unwrap_used)]
-    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = get_runtime()?;
     runtime.block_on(transform_sql_with_ctx(
         &create_wren_ctx(None, analyzed_mdl.wren_mdl().data_source().as_ref()),
         analyzed_mdl,
@@ -677,7 +694,7 @@ mod test {
     use datafusion::arrow::util::pretty::pretty_format_batches_with_options;
     use datafusion::common::format::DEFAULT_FORMAT_OPTIONS;
     use datafusion::common::not_impl_err;
-    use datafusion::common::Result;
+    use datafusion::error::Result;
     use datafusion::sql::unparser::plan_to_sql;
     use insta::assert_snapshot;
     use wren_core_base::mdl::{

--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -67,6 +67,10 @@ impl Default for AnalyzedWrenMDL {
     fn default() -> Self {
         let manifest = ManifestBuilder::default().build();
         let wren_mdl = WrenMDL::new(manifest);
+        // SAFETY: Lineage::new cannot fail on a freshly-built default manifest.
+        // The manifest has no models, views, or relationships — lineage
+        // resolution is trivially empty.
+        #[allow(clippy::unwrap_used)]
         let lineage = lineage::Lineage::new(&wren_mdl).unwrap();
         AnalyzedWrenMDL {
             wren_mdl: Arc::new(wren_mdl),
@@ -241,9 +245,9 @@ impl WrenMDL {
                 .iter()
                 .map(|model| match model.source() {
                     ModelSource::TableReference => {
-                        let name = TableReference::from(model.table_reference().expect(
-                            "table_reference must exist for TableReference source",
-                        ));
+                        let name = TableReference::from(model.table_reference().ok_or_else(|| {
+                            plan_err!("table_reference must exist for TableReference source")
+                        })?);
                         let available_columns = model
                             .columns
                             .iter()
@@ -265,9 +269,10 @@ impl WrenMDL {
                             .collect::<Result<Vec<_>>>()?;
                         let fields: Vec<_> = available_columns
                             .into_iter()
-                            .filter(|c| c.is_some())
                             .filter_map(|column| {
-                                Self::infer_source_column(&column.unwrap()).ok().flatten()
+                                column.and_then(|c| {
+                                    Self::infer_source_column(&c).ok().flatten()
+                                })
                             })
                             .collect();
                         let schema =
@@ -447,6 +452,7 @@ pub fn create_wren_ctx(
 
     if config.options().execution.time_zone.is_none() {
         // Set default time zone to UTC to avoid time zone related issues in timestamp inference and comparison. It can be overridden by the user config.
+        #[allow(clippy::unwrap_used)]
         config
             .options_mut()
             .set("datafusion.execution.time_zone", "+00:00")
@@ -468,6 +474,7 @@ pub fn transform_sql(
     properties: HashMap<String, Option<String>>,
     sql: &str,
 ) -> Result<String> {
+    #[allow(clippy::unwrap_used)]
     let runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.block_on(transform_sql_with_ctx(
         &create_wren_ctx(None, analyzed_mdl.wren_mdl().data_source().as_ref()),

--- a/core/wren-core/core/src/mdl/type_planner.rs
+++ b/core/wren-core/core/src/mdl/type_planner.rs
@@ -15,17 +15,19 @@ impl TypePlanner for WrenTypePlanner {
             SQLDataType::Int32 => Ok(Some(DataType::Int32)),
             SQLDataType::Float32 => Ok(Some(DataType::Float32)),
             SQLDataType::Float64 => Ok(Some(DataType::Float64)),
-            SQLDataType::Datetime(precision)
-                if precision.is_none() || [0, 3, 6, 9].contains(&precision.unwrap()) =>
-            {
-                let precision = match precision {
-                    Some(0) => TimeUnit::Second,
-                    Some(3) => TimeUnit::Millisecond,
-                    Some(6) => TimeUnit::Microsecond,
-                    None | Some(9) => TimeUnit::Nanosecond,
-                    _ => unreachable!(),
-                };
-                Ok(Some(DataType::Timestamp(precision, None)))
+            SQLDataType::Datetime(precision) => {
+                let p = precision.unwrap_or(9);
+                if [0, 3, 6, 9].contains(&p) {
+                    let time_unit = match p {
+                        0 => TimeUnit::Second,
+                        3 => TimeUnit::Millisecond,
+                        6 => TimeUnit::Microsecond,
+                        _ => TimeUnit::Nanosecond,
+                    };
+                    Ok(Some(DataType::Timestamp(time_unit, None)))
+                } else {
+                    Ok(None)
+                }
             }
             _ => Ok(None),
         }

--- a/core/wren-core/core/src/mdl/utils.rs
+++ b/core/wren-core/core/src/mdl/utils.rs
@@ -1,5 +1,5 @@
 use datafusion::arrow::datatypes::Field;
-use datafusion::common::{plan_err, Column, DFSchema};
+use datafusion::common::{plan_datafusion_err, plan_err, Column, DFSchema};
 use datafusion::error::Result;
 use datafusion::execution::session_state::SessionState;
 use datafusion::logical_expr::Expr;
@@ -182,11 +182,10 @@ pub fn create_wren_calculated_field_expr(
         .filter_map(|c| c.relation.as_ref().map(|r| r.table().to_string()))
         .collect::<BTreeSet<_>>() // Collect into a BTreeSet to remove duplicates
         .into_iter() // Convert BTreeSet back into an iterator
-        .map(|m| m.to_string())
         .collect::<Vec<String>>();
     // Remove all relationship fields from the expression. Only keep the target expression and its source table.
     let expr = column_rf.column.expression.clone().ok_or_else(|| {
-        plan_err!(
+        plan_datafusion_err!(
             "calculated field must have an expression: {}",
             column_rf.column.name()
         )

--- a/core/wren-core/core/src/mdl/utils.rs
+++ b/core/wren-core/core/src/mdl/utils.rs
@@ -179,15 +179,18 @@ pub fn create_wren_calculated_field_expr(
     // collect all required models.
     let models = required_fields
         .iter()
-        .map(|c| &c.relation)
-        .filter(|r| r.is_some())
-        .map(|r| r.clone().unwrap().table().to_string())
+        .filter_map(|c| c.relation.as_ref().map(|r| r.table().to_string()))
         .collect::<BTreeSet<_>>() // Collect into a BTreeSet to remove duplicates
         .into_iter() // Convert BTreeSet back into an iterator
         .map(|m| m.to_string())
         .collect::<Vec<String>>();
     // Remove all relationship fields from the expression. Only keep the target expression and its source table.
-    let expr = column_rf.column.expression.clone().unwrap();
+    let expr = column_rf.column.expression.clone().ok_or_else(|| {
+        plan_err!(
+            "calculated field must have an expression: {}",
+            column_rf.column.name()
+        )
+    })?;
     let session_state = session_state.read();
     let mut expr = session_state
         .sql_to_expr(&expr, &session_state.config_options().sql_parser.dialect)?;
@@ -205,8 +208,7 @@ pub fn create_wren_calculated_field_expr(
     let Some(schema) = models
         .into_iter()
         .map(|m| analyzed_wren_mdl.wren_mdl().get_model(&m))
-        .filter(|m| m.is_some())
-        .map(|m| Dataset::Model(m.unwrap()))
+        .filter_map(|m| m.map(Dataset::Model))
         .map(|m| m.to_qualified_schema(true))
         .reduce(|acc, schema| acc?.join(&schema?))
         .transpose()?
@@ -306,10 +308,10 @@ pub fn to_remote_field(
     column: &wren_core_base::mdl::Column,
     session_state: SessionStateRef,
 ) -> Result<Vec<Field>> {
-    if column.expression().is_some() {
+    if let Some(expr_str) = column.expression() {
         let session_state = session_state.read();
         let expr = session_state.sql_to_expr(
-            column.expression().unwrap(),
+            expr_str,
             &session_state.config_options().sql_parser.dialect,
         )?;
         let columns = collect_columns(expr);

--- a/core/wren-core/sqllogictest/Cargo.toml
+++ b/core/wren-core/sqllogictest/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "wren-sqllogictest"
-lints.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -9,6 +8,9 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 name = "wren_sqllogictest"

--- a/core/wren-core/sqllogictest/Cargo.toml
+++ b/core/wren-core/sqllogictest/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wren-sqllogictest"
+lints.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/core/wren-core/wren-example/Cargo.toml
+++ b/core/wren-core/wren-example/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wren-example"
+lints.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/core/wren-core/wren-example/Cargo.toml
+++ b/core/wren-core/wren-example/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "wren-example"
-lints.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -10,6 +9,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 publish = false
+
+[lints]
+workspace = true
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/core/wren/src/wren/config.py
+++ b/core/wren/src/wren/config.py
@@ -29,9 +29,13 @@ class WrenConfig:
         NEVER be allowed via this list; they are always blocked in strict mode.
     """
 
-    strict_mode: bool = False
+    strict_mode: bool = True
     denied_functions: frozenset[str] = field(default_factory=frozenset)
     allowed_source_functions: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "denied_functions", frozenset(f.lower() for f in self.denied_functions))
+        object.__setattr__(self, "allowed_source_functions", frozenset(f.lower() for f in self.allowed_source_functions))
 
 
 def load_config(wren_home: Path) -> WrenConfig:
@@ -58,7 +62,14 @@ def load_config(wren_home: Path) -> WrenConfig:
             f"{config_path} must contain a JSON object.",
         )
 
-    strict_mode_raw = raw.get("strict_mode", False)
+    if "strict_mode" not in raw:
+        from loguru import logger
+        logger.warning(
+            "WrenConfig: 'strict_mode' default is now True (was False). "
+            "Set \"strict_mode\": false in your config.json to restore the old "
+            "behavior. This fallback will be removed in a future release."
+        )
+    strict_mode_raw = raw.get("strict_mode", True)
     if not isinstance(strict_mode_raw, bool):
         raise WrenError(
             ErrorCode.GENERIC_USER_ERROR,
@@ -76,7 +87,6 @@ def load_config(wren_home: Path) -> WrenConfig:
             ErrorCode.GENERIC_USER_ERROR,
             f"{config_path}: 'denied_functions' must contain only strings.",
         )
-    denied_functions = frozenset(f.lower() for f in denied_raw)
 
     allowed_src_raw = raw.get("allowed_source_functions", [])
     if not isinstance(allowed_src_raw, list):
@@ -89,10 +99,9 @@ def load_config(wren_home: Path) -> WrenConfig:
             ErrorCode.GENERIC_USER_ERROR,
             f"{config_path}: 'allowed_source_functions' must contain only strings.",
         )
-    allowed_source_functions = frozenset(f.lower() for f in allowed_src_raw)
 
     return WrenConfig(
         strict_mode=strict_mode_raw,
-        denied_functions=denied_functions,
-        allowed_source_functions=allowed_source_functions,
+        denied_functions=frozenset(denied_raw),
+        allowed_source_functions=frozenset(allowed_src_raw),
     )

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -302,20 +302,10 @@ class AthenaConnector(ConnectorABC):
         # engines can stop early instead of us downloading a full result and
         # slicing in Python. Subquery-wrap + trailing-semicolon strip keeps
         # composition valid for client SQL terminated with ``;``.
-        executed = sql
-        if limit is not None:
-            # Multiline wrap so a trailing `-- line comment` in the inner SQL
-            # is terminated by the newline instead of swallowing the closing
-            # `) AS _wren_sub LIMIT n`. (Single-line sibling connectors don't
-            # guard this.)
-            executed = (
-                "SELECT * FROM (\n"
-                f"{strip_trailing_semicolon(sql)}\n"
-                f") AS _wren_sub LIMIT {int(limit)}"
-            )
+        executed, params = self._apply_limit_param(sql, limit, param_style="format")
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
-                cursor.execute(executed)
+                cursor.execute(executed, params)
                 return _build_athena_arrow_table(cursor)
         except (WrenError, TimeoutError):
             raise

--- a/core/wren/src/wren/connector/athena.py
+++ b/core/wren/src/wren/connector/athena.py
@@ -302,7 +302,7 @@ class AthenaConnector(ConnectorABC):
         # engines can stop early instead of us downloading a full result and
         # slicing in Python. Subquery-wrap + trailing-semicolon strip keeps
         # composition valid for client SQL terminated with ``;``.
-        executed, params = self._apply_limit_param(sql, limit, param_style="format")
+        executed, params = self._apply_limit_param(sql, limit, param_style="qmark")
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(executed, params)

--- a/core/wren/src/wren/connector/base.py
+++ b/core/wren/src/wren/connector/base.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
+from typing import Any
 
 import pyarrow as pa
 
 _TRAILING_SEMICOLONS_RE = re.compile(r"[;\s]+\Z")
+
+MAX_ROW_LIMIT = 10000
 
 
 def strip_trailing_semicolon(sql: str) -> str:
@@ -32,3 +35,75 @@ class ConnectorABC(ABC):
     @abstractmethod
     def close(self) -> None:
         pass
+
+    # ------------------------------------------------------------------
+    # Shared limit utilities for all connectors
+    # ------------------------------------------------------------------
+
+    def _normalize_limit(self, limit: int | None, max_limit: int = MAX_ROW_LIMIT) -> int:
+        """Validate and normalize a row limit across all connectors.
+
+        Parameters
+        ----------
+        limit:
+            User-supplied limit. ``None`` uses *max_limit*. Negative values
+            are treated as "no limit" and return *max_limit* (matching SQL
+            convention where ``LIMIT -1`` means unlimited).
+        max_limit:
+            Absolute ceiling. The returned limit is clamped to ``[0, max_limit]``
+            (zero is permitted for dry-run / EXPLAIN).
+
+        Returns
+        -------
+        int
+            A safe, clamped non-negative integer guaranteed to be within *max_limit*.
+        """
+        if limit is None:
+            return max_limit
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError, OverflowError):
+            limit = max_limit
+        if limit < 0:
+            limit = max_limit
+        return min(limit, max_limit)
+
+    def _apply_limit_param(self, sql: str, limit: int | None,
+                           param_style: str = "qmark") -> tuple[str, list[Any] | None]:
+        """Apply a parameterized LIMIT clause to *sql*.
+
+        When *limit* is ``None`` the SQL is returned unchanged (no wrapping).
+        When *limit* is an integer it is normalized, clamped, and injected
+        as a parameter so the caller can do::
+
+            sql, params = self._apply_limit_param(sql, limit)
+            cursor.execute(sql, params)
+
+        Supported *param_style* values (PEP 249):
+          - ``"qmark"`` — ``?`` (used by pyodbc, pymssql, DuckDB, sqlite3)
+          - ``"format"`` — ``%s`` (used by psycopg, MySQLdb, Trino, ClickHouse)
+
+        Never interpolates the limit into the SQL string directly.
+        """
+        if limit is None:
+            return strip_trailing_semicolon(sql), None
+        limit = self._normalize_limit(limit)
+        placeholder = "%s" if param_style == "format" else "?"
+        wrapped = (
+            f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _q "
+            f"LIMIT {placeholder}"
+        )
+        return wrapped, [limit]
+
+    def _apply_limit_inline(self, sql: str, limit: int | None) -> str:
+        """Apply a LIMIT clause by inline (non-parameterized) interpolation.
+
+        **Unsafe fallback** for connectors whose driver does not support
+        parameterised queries (e.g. Snowflake, BigQuery via certain drivers).
+        The limit is still normalised and clamped so the integer value is safe,
+        but prefer ``_apply_limit_param`` wherever the driver supports it.
+        """
+        if limit is None:
+            return strip_trailing_semicolon(sql)
+        limit = self._normalize_limit(limit)
+        return f"{strip_trailing_semicolon(sql)}\nLIMIT {limit}"

--- a/core/wren/src/wren/connector/base.py
+++ b/core/wren/src/wren/connector/base.py
@@ -40,26 +40,28 @@ class ConnectorABC(ABC):
     # Shared limit utilities for all connectors
     # ------------------------------------------------------------------
 
-    def _normalize_limit(self, limit: int | None, max_limit: int = MAX_ROW_LIMIT) -> int:
+    def _normalize_limit(self, limit: int | None, max_limit: int = MAX_ROW_LIMIT) -> int | None:
         """Validate and normalize a row limit across all connectors.
 
         Parameters
         ----------
         limit:
-            User-supplied limit. ``None`` uses *max_limit*. Negative values
-            are treated as "no limit" and return *max_limit* (matching SQL
-            convention where ``LIMIT -1`` means unlimited).
+            User-supplied limit. ``None`` is returned as-is (no limit applied).
+            Negative values are treated as "no limit" and return *max_limit*
+            (matching SQL convention where ``LIMIT -1`` means unlimited).
         max_limit:
-            Absolute ceiling. The returned limit is clamped to ``[0, max_limit]``
-            (zero is permitted for dry-run / EXPLAIN).
+            Absolute ceiling (ignored when *limit* is ``None``). The returned
+            limit is clamped to ``[0, max_limit]`` (zero is permitted for
+            dry-run / EXPLAIN).
 
         Returns
         -------
-        int
-            A safe, clamped non-negative integer guaranteed to be within *max_limit*.
+        int | None
+            ``None`` if *limit* was ``None``; otherwise a safe, clamped
+            non-negative integer guaranteed to be within *max_limit*.
         """
         if limit is None:
-            return max_limit
+            return None
         try:
             limit = int(limit)
         except (TypeError, ValueError, OverflowError):

--- a/core/wren/src/wren/connector/canner.py
+++ b/core/wren/src/wren/connector/canner.py
@@ -244,19 +244,11 @@ class CannerConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         import psycopg  # noqa: PLC0415
 
-        # Always strip a trailing statement terminator. Unlimited queries still
-        # go to execute() raw; ``SELECT 1;`` is fine for single-shot clients, but
-        # multi-semicolon whitespace after tools paste (``SELECT 1; ;``) and
-        # empty trailing statements can produce Protocol/syntax noise/door. More
-        # importantly we keep composition consistent with the limited path so
-        # callers can always end SQL with ``;`` without branching.
-        sql = strip_trailing_semicolon(sql)
-        if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _t LIMIT {limit}"
+        executed, params = self._apply_limit_param(sql, limit, param_style="format")
 
         try:
             with self.connection.cursor() as cursor:
-                cursor.execute(sql)
+                cursor.execute(executed, params)
                 return _build_arrow_table(cursor)
         except psycopg.errors.QueryCanceled:
             raise
@@ -267,16 +259,16 @@ class CannerConnector(ConnectorABC):
                 ErrorCode.GENERIC_USER_ERROR,
                 str(e),
                 phase=ErrorPhase.SQL_EXECUTION,
-                metadata={DIALECT_SQL: sql},
+                metadata={DIALECT_SQL: executed},
             ) from e
 
     def dry_run(self, sql: str) -> None:
         import psycopg  # noqa: PLC0415
 
-        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _t LIMIT 0"
+        executed, params = self._apply_limit_param(sql, 0, param_style="format")
         try:
             with self.connection.cursor() as cursor:
-                cursor.execute(wrapped)
+                cursor.execute(executed, params)
         except psycopg.errors.QueryCanceled:
             raise
         except (WrenError, TimeoutError):
@@ -288,8 +280,6 @@ class CannerConnector(ConnectorABC):
                 phase=ErrorPhase.SQL_DRY_RUN,
                 metadata={DIALECT_SQL: sql},
             ) from e
-        # Explicit return to honour the ConnectorABC.dry_run() contract — the
-        # cursor result must not leak out of this method.
         return None
 
     def close(self) -> None:

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -398,7 +398,8 @@ class ClickHouseConnector(ConnectorABC):
         stripped = strip_trailing_semicolon(sql)
         statement = stripped
         if limit is not None:
-            statement = f"SELECT * FROM ({stripped}) AS _wren_sub LIMIT {limit}"
+            safe_limit = self._normalize_limit(limit)
+            statement = f"SELECT * FROM ({stripped}) AS _wren_sub LIMIT {safe_limit}"
         try:
             result = self.connection.query(statement)
         except _ClickHouseDbError as e:

--- a/core/wren/src/wren/connector/databricks.py
+++ b/core/wren/src/wren/connector/databricks.py
@@ -55,7 +55,7 @@ class DatabricksConnector(ConnectorABC):
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             if limit is not None:
-                return cursor.fetchmany_arrow(limit)
+                return cursor.fetchmany_arrow(self._normalize_limit(limit))
             return cursor.fetchall_arrow()
 
     def dry_run(self, sql: str) -> None:

--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -30,9 +30,10 @@ class DataFusionConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
+            safe_limit = self._normalize_limit(limit)
             sql = (
                 f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {int(limit)}"
+                f"AS _q LIMIT {safe_limit}"
             )
         ipc_bytes = self.ctx.query(sql)
         reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))

--- a/core/wren/src/wren/connector/duckdb.py
+++ b/core/wren/src/wren/connector/duckdb.py
@@ -13,40 +13,38 @@ from wren.model import (
 from wren.model.error import ErrorCode, WrenError
 
 
-def _escape_sql(value: str) -> str:
-    return value.replace("'", "''")
-
-
 def _init_duckdb_s3(connection, info: S3FileConnectionInfo):
-    connection.execute(f"""
-    CREATE SECRET wren_s3 (
-        TYPE S3,
-        KEY_ID '{_escape_sql(info.access_key.get_secret_value())}',
-        SECRET '{_escape_sql(info.secret_key.get_secret_value())}',
-        REGION '{_escape_sql(info.region)}'
-    )""")
+    connection.execute(
+        "CREATE SECRET wren_s3 (TYPE S3, KEY_ID ?, SECRET ?, REGION ?)",
+        [
+            info.access_key.get_secret_value(),
+            info.secret_key.get_secret_value(),
+            info.region,
+        ],
+    )
 
 
 def _init_duckdb_minio(connection, info: MinioFileConnectionInfo):
-    connection.execute(f"""
-    CREATE SECRET wren_minio (
-        TYPE S3,
-        KEY_ID '{_escape_sql(info.access_key.get_secret_value())}',
-        SECRET '{_escape_sql(info.secret_key.get_secret_value())}',
-        REGION 'ap-northeast-1'
-    )""")
+    connection.execute(
+        "CREATE SECRET wren_minio (TYPE S3, KEY_ID ?, SECRET ?, REGION 'ap-northeast-1')",
+        [
+            info.access_key.get_secret_value(),
+            info.secret_key.get_secret_value(),
+        ],
+    )
     connection.execute("SET s3_endpoint=?", [info.endpoint])
     connection.execute("SET s3_url_style='path'")
     connection.execute("SET s3_use_ssl=?", [info.ssl_enabled])
 
 
 def _init_duckdb_gcs(connection, info: GcsFileConnectionInfo):
-    connection.execute(f"""
-    CREATE SECRET wren_gcs (
-        TYPE GCS,
-        KEY_ID '{_escape_sql(info.key_id.get_secret_value())}',
-        SECRET '{_escape_sql(info.secret_key.get_secret_value())}'
-    )""")
+    connection.execute(
+        "CREATE SECRET wren_gcs (TYPE GCS, KEY_ID ?, SECRET ?)",
+        [
+            info.key_id.get_secret_value(),
+            info.secret_key.get_secret_value(),
+        ],
+    )
 
 
 class DuckDBConnector(ConnectorABC):
@@ -78,14 +76,8 @@ class DuckDBConnector(ConnectorABC):
         When ``limit`` is provided the query is wrapped in a ``LIMIT`` clause
         so only that many rows are fetched.
         """
-        if limit is not None:
-            # Strip the terminating run of ``;`` / whitespace before wrapping so
-            # the subquery stays valid SQL (e.g. ``SELECT 1;`` must not become
-            # ``SELECT * FROM (SELECT 1;) AS _q LIMIT ...``). Semicolons inside
-            # string literals are preserved.
-            stripped = strip_trailing_semicolon(sql)
-            sql = f"SELECT * FROM ({stripped}) AS _q LIMIT {int(limit)}"
-        return self.connection.execute(sql).fetch_arrow_table()
+        executed, params = self._apply_limit_param(sql, limit, param_style="qmark")
+        return self.connection.execute(executed, params).fetch_arrow_table()
 
     def dry_run(self, sql: str) -> None:
         """Validate ``sql`` without returning rows or side effects.
@@ -98,8 +90,8 @@ class DuckDBConnector(ConnectorABC):
         statement then becomes a natural syntax error inside the subquery, and
         no rows are materialized.
         """
-        stripped = strip_trailing_semicolon(sql)
-        self.connection.execute(f"SELECT * FROM ({stripped}) AS _q LIMIT 0")
+        executed, params = self._apply_limit_param(sql, 0, param_style="qmark")
+        self.connection.execute(executed, params)
 
     def _attach_database(self, connection_info) -> None:
         """Attach every discovered DuckDB file as a read-only database.

--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -19,7 +19,7 @@ try:
 except ImportError:  # pragma: no cover
     pyodbc = None
 
-from wren.connector.base import ConnectorABC
+from wren.connector.base import ConnectorABC, MAX_ROW_LIMIT
 from wren.model import MSSqlConnectionInfo
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
@@ -44,12 +44,13 @@ class MSSqlConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         sql = self._flatten_pagination_limit(sql)
+        safe_limit = self._normalize_limit(limit) if limit is not None else None
         with closing(self.connection.cursor()) as cursor:
-            cursor.execute(self._raw_cursor_sql(sql, limit))
+            cursor.execute(self._raw_cursor_sql(sql, safe_limit))
             if cursor.description is None:
                 return pa.table({})
 
-            rows = cursor.fetchmany(limit) if limit is not None else cursor.fetchall()
+            rows = cursor.fetchmany(safe_limit) if safe_limit is not None else cursor.fetchall()
             arrow_schema = self._build_mssql_arrow_schema(cursor.description, rows)
             arrays = [
                 self._build_mssql_column(

--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -26,33 +26,20 @@ from wren.model.data_source import DataSource
 from wren.model.error import ErrorCode, WrenError
 
 
-def _apply_limit(sql: str, limit: int) -> str:
-    """Append ``LIMIT n`` to a user-supplied SQL string.
+def _apply_limit_mysql(sql: str, limit: int | None) -> tuple[str, list | None]:
+    """Apply a parameterized ``LIMIT %s`` to *sql* using MySQLdb-compatible style.
 
-    Strips any trailing semicolon and whitespace, then appends ``LIMIT n``.
-    ``limit`` MUST already be validated as a non-negative ``int`` by the caller
-    — this helper does not re-validate to keep the call site explicit.
-
-    Wrapping the user SQL in ``SELECT * FROM (...) AS _sub LIMIT n`` was
-    rejected because it fails with ``ER_DUP_FIELDNAME`` whenever the inner
-    SELECT projects two columns with the same name (e.g. a join that selects
-    ``a.id`` and ``b.id``).
+    Returns ``(modified_sql, params)``. Never interpolates the limit.
+    Uses direct ``LIMIT %s`` instead of subquery-wrapping because MySQL fails with
+    ``ER_DUP_FIELDNAME`` when the inner SELECT projects duplicate column names.
+    The caller is responsible for normalizing *limit* via ``_normalize_limit()``
+    before calling this function. A ``None`` *limit* means no LIMIT clause.
     """
-    return f"{strip_trailing_semicolon(sql)}\nLIMIT {limit}"
+    from wren.connector.base import strip_trailing_semicolon as _strip
 
-
-def _coerce_limit(limit: int | None) -> int | None:
-    """Validate and coerce a user-supplied ``limit`` to a non-negative ``int``.
-
-    ``int(limit)`` rejects strings like ``"5 OR 1=1"`` so the value can be
-    safely interpolated into SQL. Negative limits are also rejected.
-    """
     if limit is None:
-        return None
-    coerced = int(limit)
-    if coerced < 0:
-        raise ValueError(f"limit must be non-negative, got {coerced}")
-    return coerced
+        return _strip(sql), None
+    return f"{_strip(sql)}\nLIMIT %s", [limit]
 
 
 class MySqlConnector(ConnectorABC):
@@ -89,11 +76,11 @@ class MySqlConnector(ConnectorABC):
             raise
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        limit = _coerce_limit(limit)
         if limit is not None:
-            sql = _apply_limit(sql, limit)
+            limit = self._normalize_limit(limit)
+        sql, params = _apply_limit_mysql(sql, limit)
         with closing(self.connection.cursor()) as cursor:
-            cursor.execute(sql)
+            cursor.execute(sql, params)
             return _build_mysql_arrow_table(cursor)
 
     def dry_run(self, sql: str) -> None:

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -179,9 +179,10 @@ class OracleConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         if limit is not None:
+            safe_limit = self._normalize_limit(limit)
             sql = (
                 f"SELECT * FROM ({strip_trailing_semicolon(sql)}) t "
-                f"WHERE ROWNUM <= {limit}"
+                f"WHERE ROWNUM <= {safe_limit}"
             )
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -270,7 +270,7 @@ class PostgresConnector(ConnectorABC):
             ) from e
 
     def dry_run(self, sql: str) -> None:
-        wrapped, params = self._apply_limit_param(sql, 0)
+        wrapped, params = self._apply_limit_param(sql, 0, param_style="format")
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(wrapped, params)

--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -251,13 +251,11 @@ class PostgresConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         # Strip terminating ``;`` even when no LIMIT wrapper is applied so
         # client-pasted statements match dry_run / limited composition rules.
-        sql = strip_trailing_semicolon(sql)
-        if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _sub LIMIT {limit}"
+        sql, params = self._apply_limit_param(sql, limit, param_style="format")
 
         try:
             with self.connection.cursor() as cursor:
-                cursor.execute(sql)
+                cursor.execute(sql, params)
                 return _build_pg_arrow_table(cursor)
         except psycopg.errors.QueryCanceled:
             raise
@@ -272,10 +270,10 @@ class PostgresConnector(ConnectorABC):
             ) from e
 
     def dry_run(self, sql: str) -> None:
-        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
+        wrapped, params = self._apply_limit_param(sql, 0)
         try:
             with self.connection.cursor() as cursor:
-                cursor.execute(wrapped)
+                cursor.execute(wrapped, params)
         except psycopg.errors.QueryCanceled:
             raise
         except (WrenError, TimeoutError):

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -44,23 +44,18 @@ class RedshiftConnector(ConnectorABC):
         self.connection.autocommit = True
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {int(limit)}"
-            )
+        executed, params = self._apply_limit_param(sql, limit, param_style="format")
         with closing(self.connection.cursor()) as cursor:
-            cursor.execute(sql)
+            cursor.execute(executed, params)
             cols = [desc[0] for desc in cursor.description]
             rows = cursor.fetchall()
             df = pd.DataFrame(rows, columns=cols)
             return pa.Table.from_pandas(df)
 
     def dry_run(self, sql: str) -> None:
+        executed, params = self._apply_limit_param(sql, 0, param_style="format")
         with closing(self.connection.cursor()) as cursor:
-            cursor.execute(
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
-            )
+            cursor.execute(executed, params)
 
     def close(self) -> None:
         try:

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -62,12 +62,13 @@ class SnowflakeConnector(ConnectorABC):
         # under the outer LIMIT.
         executed = sql
         if limit is not None:
+            safe_limit = self._normalize_limit(limit)
             # Place the user SQL on its own line so a trailing line comment
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
             executed = (
                 "SELECT * FROM (\n"
                 f"{strip_trailing_semicolon(sql)}\n"
-                f") AS _wren_sub LIMIT {int(limit)}"
+                f") AS _wren_sub LIMIT {safe_limit}"
             )
         try:
             with self.connection.cursor() as cursor:

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -484,7 +484,7 @@ class TrinoConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         trino = _import_trino()
 
-        sql, params = self._apply_limit_param(sql, limit, param_style="format")
+        sql, params = self._apply_limit_param(sql, limit, param_style="qmark")
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(sql, params)
@@ -504,7 +504,7 @@ class TrinoConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         trino = _import_trino()
 
-        wrapped, params = self._apply_limit_param(sql, 0, param_style="format")
+        wrapped, params = self._apply_limit_param(sql, 0, param_style="qmark")
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(wrapped, params)

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -484,13 +484,10 @@ class TrinoConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         trino = _import_trino()
 
-        if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
-            )
+        sql, params = self._apply_limit_param(sql, limit, param_style="format")
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
-                cursor.execute(sql)
+                cursor.execute(sql, params)
                 return _build_trino_arrow_table(cursor)
         except trino.exceptions.TrinoQueryError as e:
             if e.error_name == "EXCEEDED_TIME_LIMIT":
@@ -507,10 +504,10 @@ class TrinoConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         trino = _import_trino()
 
-        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
+        wrapped, params = self._apply_limit_param(sql, 0, param_style="format")
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
-                cursor.execute(wrapped)
+                cursor.execute(wrapped, params)
                 cursor.fetchall()
         except trino.exceptions.TrinoQueryError as e:
             if e.error_name == "EXCEEDED_TIME_LIMIT":

--- a/core/wren/src/wren/engine.py
+++ b/core/wren/src/wren/engine.py
@@ -33,7 +33,7 @@ from wren.mdl import get_manifest_extractor, get_session_context, to_json_base64
 from wren.mdl.cte_rewriter import CTERewriter, get_sqlglot_dialect
 from wren.model.data_source import DataSource
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
-from wren.policy import resolve_model_name, validate_sql_policy
+from wren.policy import basic_safety_check, resolve_model_name, validate_sql_policy
 
 
 class WrenEngine:
@@ -98,6 +98,7 @@ class WrenEngine:
               → sqlglot generate (target dialect)
               → output SQL with model CTEs in target dialect
         """
+        basic_safety_check(sql)
         return self._plan(sql, properties)
 
     # ------------------------------------------------------------------
@@ -111,6 +112,7 @@ class WrenEngine:
         properties: dict | None = None,
     ) -> pa.Table:
         """Transpile and execute SQL, return results as an Arrow table."""
+        basic_safety_check(sql)
         dialect_sql = self.dry_plan(sql, properties)
         connector = self._get_connector()
         try:
@@ -127,6 +129,7 @@ class WrenEngine:
 
     def dry_run(self, sql: str, properties: dict | None = None) -> None:
         """Transpile and dry-run SQL without returning results."""
+        basic_safety_check(sql)
         dialect_sql = self.dry_plan(sql, properties)
         connector = self._get_connector()
         try:

--- a/core/wren/src/wren/engine.py
+++ b/core/wren/src/wren/engine.py
@@ -112,7 +112,6 @@ class WrenEngine:
         properties: dict | None = None,
     ) -> pa.Table:
         """Transpile and execute SQL, return results as an Arrow table."""
-        basic_safety_check(sql)
         dialect_sql = self.dry_plan(sql, properties)
         connector = self._get_connector()
         try:
@@ -129,7 +128,6 @@ class WrenEngine:
 
     def dry_run(self, sql: str, properties: dict | None = None) -> None:
         """Transpile and dry-run SQL without returning results."""
-        basic_safety_check(sql)
         dialect_sql = self.dry_plan(sql, properties)
         connector = self._get_connector()
         try:

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import math
+import secrets
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -34,6 +35,8 @@ class ServeContext:
     allow_write: bool
     no_connect: bool
     api_key: str | None = None
+    host: str = "0.0.0.0"
+    port: int = 8080
 
 
 def _memory_path(ctx: ServeContext) -> str:
@@ -681,7 +684,7 @@ class _ApiKeyVerifier:
         self._api_key = api_key
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        if token == self._api_key:
+        if secrets.compare_digest(token, self._api_key):
             return AccessToken(
                 token=token,
                 client_id="api_key_user",
@@ -697,9 +700,10 @@ def build_server(ctx: ServeContext) -> FastMCP:
     if ctx.api_key:
         from mcp.server.auth.settings import AuthSettings  # noqa: PLC0415
 
+        base_url = f"http://{ctx.host}:{ctx.port}"
         kwargs["auth"] = AuthSettings(
-            issuer_url="http://localhost:8080",
-            resource_server_url="http://localhost:8080",
+            issuer_url=base_url,
+            resource_server_url=base_url,
         )
         kwargs["token_verifier"] = _ApiKeyVerifier(ctx.api_key)
 

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from loguru import logger
+from mcp.server.auth.provider import AccessToken
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -32,6 +33,7 @@ class ServeContext:
     engine: Any  # wren.engine.WrenEngine
     allow_write: bool
     no_connect: bool
+    api_key: str | None = None
 
 
 def _memory_path(ctx: ServeContext) -> str:
@@ -672,9 +674,36 @@ def _register_prompts(mcp: FastMCP, ctx: ServeContext) -> None:
         return _workflow_text(ctx, question)
 
 
+class _ApiKeyVerifier:
+    """TokenVerifier that accepts exactly one API key as a bearer token."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if token == self._api_key:
+            return AccessToken(
+                token=token,
+                client_id="api_key_user",
+                scopes=[],
+            )
+        return None
+
+
 def build_server(ctx: ServeContext) -> FastMCP:
     """Build and register all tools on a FastMCP server instance."""
-    mcp = FastMCP("wren")
+
+    kwargs: dict[str, Any] = {"name": "wren"}
+    if ctx.api_key:
+        from mcp.server.auth.settings import AuthSettings  # noqa: PLC0415
+
+        kwargs["auth"] = AuthSettings(
+            issuer_url="http://localhost:8080",
+            resource_server_url="http://localhost:8080",
+        )
+        kwargs["token_verifier"] = _ApiKeyVerifier(ctx.api_key)
+
+    mcp = FastMCP(**kwargs)
 
     _register_query_tools(mcp, ctx)
     _register_context_tools(mcp, ctx)

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Iterable
 
+import sqlglot
 from sqlglot import exp, parse_one
 from sqlglot.errors import SqlglotError
 
@@ -168,6 +169,66 @@ def resolve_model_name(
         if candidate.lower() == name_lower:
             return candidate
     return None
+
+
+def basic_safety_check(sql: str) -> None:
+    """Run BEFORE any SQL execution, regardless of strict_mode.
+
+    Rejects empty SQL, multi-statement SQL, DDL, DML, and file-reading
+    operations (COPY). This is a fundamental safety gate — not a replacement
+    for strict-mode policy validation.
+    """
+    if not sql.strip():
+        raise WrenError(
+            ErrorCode.POLICY_VIOLATION,
+            "Empty SQL statement",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        )
+
+    try:
+        stmts = list(sqlglot.parse(sql))
+    except SqlglotError as e:
+        raise WrenError(
+            ErrorCode.INVALID_SQL,
+            f"Could not parse SQL: {e}",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        ) from e
+
+    if len(stmts) > 1:
+        raise WrenError(
+            ErrorCode.POLICY_VIOLATION,
+            "Multi-statement SQL is not allowed",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        )
+
+    stmt = stmts[0]
+    if stmt is None:
+        raise WrenError(
+            ErrorCode.INVALID_SQL,
+            "Could not parse SQL statement",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        )
+
+    if isinstance(stmt, (exp.Create, exp.Drop, exp.Alter, exp.Truncate, exp.Rename)):
+        raise WrenError(
+            ErrorCode.POLICY_VIOLATION,
+            f"DDL not allowed: {type(stmt).__name__}",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        )
+
+    if isinstance(stmt, (exp.Insert, exp.Update, exp.Delete, exp.Merge)):
+        raise WrenError(
+            ErrorCode.POLICY_VIOLATION,
+            f"DML not allowed: {type(stmt).__name__}",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        )
+
+    if isinstance(stmt, exp.Copy):
+        raise WrenError(
+            ErrorCode.POLICY_VIOLATION,
+            "COPY statement is not allowed",
+            phase=ErrorPhase.SQL_POLICY_CHECK,
+        )
 
 
 def validate_sql_policy(
@@ -431,7 +492,7 @@ def _check_functions(
         if name.lower() in canonical:
             raise WrenError(
                 ErrorCode.BLOCKED_FUNCTION,
-                f"Function '{name}' is not allowed. "
-                "This function is on the denied list.",
+                f"Function '{name}' is not allowed "
+                f"(matched denied function '{name.lower()}').",
                 phase=ErrorPhase.SQL_POLICY_CHECK,
             )

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -209,24 +209,10 @@ def basic_safety_check(sql: str) -> None:
         )
     stmt = stmts[0]
 
-    if isinstance(stmt, (exp.Create, exp.Drop, exp.Alter, exp.Truncate, exp.Rename)):
+    if not isinstance(stmt, (exp.Select, exp.Explain)):
         raise WrenError(
             ErrorCode.POLICY_VIOLATION,
-            f"DDL not allowed: {type(stmt).__name__}",
-            phase=ErrorPhase.SQL_POLICY_CHECK,
-        )
-
-    if isinstance(stmt, (exp.Insert, exp.Update, exp.Delete, exp.Merge)):
-        raise WrenError(
-            ErrorCode.POLICY_VIOLATION,
-            f"DML not allowed: {type(stmt).__name__}",
-            phase=ErrorPhase.SQL_POLICY_CHECK,
-        )
-
-    if isinstance(stmt, exp.Copy):
-        raise WrenError(
-            ErrorCode.POLICY_VIOLATION,
-            "COPY statement is not allowed",
+            f"Only read-only queries are allowed, got: {type(stmt).__name__}",
             phase=ErrorPhase.SQL_POLICY_CHECK,
         )
 

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -209,7 +209,7 @@ def basic_safety_check(sql: str) -> None:
         )
     stmt = stmts[0]
 
-    if not isinstance(stmt, (exp.Select, exp.Explain)):
+    if not isinstance(stmt, (exp.Query, exp.Explain, exp.Subquery)):
         raise WrenError(
             ErrorCode.POLICY_VIOLATION,
             f"Only read-only queries are allowed, got: {type(stmt).__name__}",

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -201,13 +201,13 @@ def basic_safety_check(sql: str) -> None:
             phase=ErrorPhase.SQL_POLICY_CHECK,
         )
 
-    stmt = stmts[0]
-    if stmt is None:
+    if not stmts or stmts[0] is None:
         raise WrenError(
             ErrorCode.INVALID_SQL,
             "Could not parse SQL statement",
             phase=ErrorPhase.SQL_POLICY_CHECK,
         )
+    stmt = stmts[0]
 
     if isinstance(stmt, (exp.Create, exp.Drop, exp.Alter, exp.Truncate, exp.Rename)):
         raise WrenError(

--- a/core/wren/src/wren/serve_cli.py
+++ b/core/wren/src/wren/serve_cli.py
@@ -189,6 +189,13 @@ def serve_mcp(
         )
         raise typer.Exit(1)
 
+    if api_key and transport != "http":
+        typer.echo(
+            "Error: --api-key requires --transport http.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     try:
         import mcp  # noqa: F401, PLC0415
     except ImportError:

--- a/core/wren/src/wren/serve_cli.py
+++ b/core/wren/src/wren/serve_cli.py
@@ -65,6 +65,7 @@ def _print_connection_help(
     profile: str | None,
     allow_write: bool,
     no_connect: bool,
+    api_key: str | None = None,
 ) -> None:
     """Print client-registration guidance.
 
@@ -85,10 +86,22 @@ def _print_connection_help(
         url = f"http://{display_host}:{port}/mcp"
         echo(" wren MCP server — Streamable HTTP")
         echo(f"   URL: {url}")
+        if api_key:
+            echo(f"   Auth: Bearer token (--api-key)")
         echo("")
         echo(" Register with a client:")
-        echo(f"   Claude Code   claude mcp add --transport http wren {url}")
-        echo(f"   Codex         codex mcp add wren --url {url}")
+        if api_key:
+            echo(
+                "   Claude Code   claude mcp add --transport http"
+                f" wren {url} --bearer-token {api_key}"
+            )
+            echo(
+                f"   Codex         codex mcp add wren --url {url}"
+                f" --bearer-token {api_key}"
+            )
+        else:
+            echo(f"   Claude Code   claude mcp add --transport http wren {url}")
+            echo(f"   Codex         codex mcp add wren --url {url}")
         echo(
             "   Inspector     npx @modelcontextprotocol/inspector   "
             "(Streamable HTTP → the URL above)"
@@ -137,6 +150,13 @@ def serve_mcp(
     profile: Annotated[
         Optional[str],
         typer.Option("--profile", help="Connection profile name."),
+    ] = None,
+    api_key: Annotated[
+        Optional[str],
+        typer.Option(
+            "--api-key",
+            help="Require this bearer token on every HTTP request (--transport http only).",
+        ),
     ] = None,
     allow_write: Annotated[
         bool,
@@ -244,6 +264,7 @@ def serve_mcp(
         engine=engine,
         allow_write=allow_write,
         no_connect=no_connect,
+        api_key=api_key,
     )
     if not quiet:
         _print_connection_help(
@@ -254,5 +275,6 @@ def serve_mcp(
             profile=profile,
             allow_write=allow_write,
             no_connect=no_connect,
+            api_key=api_key,
         )
     run_server(ctx, transport=transport, host=host, port=port)

--- a/core/wren/tests/conftest.py
+++ b/core/wren/tests/conftest.py
@@ -1,5 +1,16 @@
 """Root pytest configuration for the wren package test suite."""
 
+import sys
+from unittest.mock import MagicMock
+
+# wren_core (wren-core-py) requires a Rust compilation and is not
+# available in CI or bare test environments.  Provide a module-level
+# mock so the import chain
+#   wren.__init__ → wren.engine → wren.mdl → wren_core
+# succeeds without a compiled native binary.
+if "wren_core" not in sys.modules:
+    sys.modules["wren_core"] = MagicMock()
+
 import pytest
 
 

--- a/core/wren/tests/unit/test_athena_connector.py
+++ b/core/wren/tests/unit/test_athena_connector.py
@@ -237,7 +237,7 @@ def test_connector_query_returns_arrow_table_and_respects_limit():
     assert table.num_rows == 2
     assert table.column("id").to_pylist() == [1, 2]
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (\nSELECT id, name FROM t\n) AS _wren_sub LIMIT 2"
+        "SELECT * FROM (SELECT id, name FROM t) AS _q LIMIT ?", [2]
     )
 
 

--- a/core/wren/tests/unit/test_athena_limit_pushdown.py
+++ b/core/wren/tests/unit/test_athena_limit_pushdown.py
@@ -36,7 +36,7 @@ def test_query_pushes_limit_into_sql():
             connector.query("SELECT 1;", limit=3)
 
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (\nSELECT 1\n) AS _wren_sub LIMIT 3"
+        "SELECT * FROM (SELECT 1) AS _q LIMIT ?", [3]
     )
     builder.assert_called_once()
 
@@ -65,7 +65,7 @@ def test_query_without_limit_runs_original_sql():
     ):
         connector.connection.cursor.return_value = cursor
         connector.query("SELECT 1")
-    cursor.execute.assert_called_once_with("SELECT 1")
+    cursor.execute.assert_called_once_with("SELECT 1", None)
 
 
 def test_query_limit_survives_trailing_line_comment():
@@ -83,5 +83,5 @@ def test_query_limit_survives_trailing_line_comment():
         connector.connection.cursor.return_value = cursor
         connector.query("SELECT 1 -- pick", limit=3)
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (\nSELECT 1 -- pick\n) AS _wren_sub LIMIT 3"
+        "SELECT * FROM (SELECT 1 -- pick) AS _q LIMIT ?", [3]
     )

--- a/core/wren/tests/unit/test_canner_semicolon.py
+++ b/core/wren/tests/unit/test_canner_semicolon.py
@@ -57,7 +57,7 @@ def test_query_unlimited_strips_trailing_semicolon(monkeypatch, fake_psycopg):
 
     connector.query("SELECT 1 AS x;")
 
-    cursor.execute.assert_called_once_with("SELECT 1 AS x")
+    cursor.execute.assert_called_once_with("SELECT 1 AS x", None)
 
 
 def test_query_limited_strips_before_wrap(monkeypatch, fake_psycopg):
@@ -70,5 +70,5 @@ def test_query_limited_strips_before_wrap(monkeypatch, fake_psycopg):
     connector.query("SELECT 1 AS x;", limit=3)
 
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (SELECT 1 AS x) AS _t LIMIT 3"
+        "SELECT * FROM (SELECT 1 AS x) AS _q LIMIT %s", [3]
     )

--- a/core/wren/tests/unit/test_config.py
+++ b/core/wren/tests/unit/test_config.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.unit
 def test_load_config_no_file(tmp_path):
     config = load_config(tmp_path)
     assert config == WrenConfig()
-    assert config.strict_mode is False
+    assert config.strict_mode is True
     assert config.denied_functions == frozenset()
 
 
@@ -74,7 +74,7 @@ def test_load_config_partial_only_denied_functions(tmp_path):
     data = {"denied_functions": ["dblink"]}
     (tmp_path / "config.json").write_text(json.dumps(data))
     config = load_config(tmp_path)
-    assert config.strict_mode is False
+    assert config.strict_mode is True
     assert config.denied_functions == frozenset(["dblink"])
 
 
@@ -124,6 +124,22 @@ def test_load_config_allowed_source_functions_not_array(tmp_path):
     (tmp_path / "config.json").write_text(json.dumps(data))
     with pytest.raises(WrenError):
         load_config(tmp_path)
+
+
+def test_post_init_normalizes_case():
+    config = WrenConfig(denied_functions=frozenset(["PG_READ_FILE", "dblink"]))
+    assert config.denied_functions == frozenset(["pg_read_file", "dblink"])
+
+
+def test_post_init_normalizes_allowed_source_functions():
+    config = WrenConfig(allowed_source_functions=frozenset(["Generate_Series"]))
+    assert config.allowed_source_functions == frozenset(["generate_series"])
+
+
+def test_post_init_empty_frozensets_unchanged():
+    config = WrenConfig()
+    assert config.denied_functions == frozenset()
+    assert config.allowed_source_functions == frozenset()
 
 
 def test_load_config_allowed_source_functions_mixed_types_rejected(tmp_path):

--- a/core/wren/tests/unit/test_connector_base.py
+++ b/core/wren/tests/unit/test_connector_base.py
@@ -1,0 +1,70 @@
+"""Unit tests for wren.connector.base — shared limit utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from wren.connector.base import MAX_ROW_LIMIT, ConnectorABC
+
+
+class _TestConnector(ConnectorABC):
+    """Concrete subclass exposing _normalize_limit for testing."""
+
+    def query(self, sql, limit=None):
+        raise NotImplementedError
+
+    def dry_run(self, sql):
+        raise NotImplementedError
+
+    def close(self):
+        raise NotImplementedError
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def connector():
+    return _TestConnector()
+
+
+class TestNormalizeLimit:
+    def test_none_uses_max_limit(self, connector):
+        assert connector._normalize_limit(None) == MAX_ROW_LIMIT
+
+    def test_zero_passthrough(self, connector):
+        assert connector._normalize_limit(0) == 0
+
+    def test_normal_value_passthrough(self, connector):
+        assert connector._normalize_limit(500) == 500
+
+    def test_negative_clamps_to_max_limit(self, connector):
+        assert connector._normalize_limit(-1) == MAX_ROW_LIMIT
+
+    def test_very_negative_clamps_to_max_limit(self, connector):
+        assert connector._normalize_limit(-100000) == MAX_ROW_LIMIT
+
+    def test_above_max_limit_clamped(self, connector):
+        assert connector._normalize_limit(MAX_ROW_LIMIT + 1) == MAX_ROW_LIMIT
+
+    def test_at_max_limit_passthrough(self, connector):
+        assert connector._normalize_limit(MAX_ROW_LIMIT) == MAX_ROW_LIMIT
+
+    def test_non_numeric_string_falls_back(self, connector):
+        assert connector._normalize_limit("abc") == MAX_ROW_LIMIT
+
+    def test_float_truncated(self, connector):
+        assert connector._normalize_limit(3.14) == 3
+
+    def test_bool_true_truncated(self, connector):
+        assert connector._normalize_limit(True) == 1
+
+    def test_bool_false_passthrough(self, connector):
+        assert connector._normalize_limit(False) == 0
+
+    def test_custom_max_limit(self, connector):
+        assert connector._normalize_limit(50, max_limit=20) == 20
+        assert connector._normalize_limit(10, max_limit=20) == 10
+
+    def test_negative_with_custom_max_limit(self, connector):
+        assert connector._normalize_limit(-1, max_limit=50) == 50

--- a/core/wren/tests/unit/test_connector_base.py
+++ b/core/wren/tests/unit/test_connector_base.py
@@ -29,8 +29,8 @@ def connector():
 
 
 class TestNormalizeLimit:
-    def test_none_uses_max_limit(self, connector):
-        assert connector._normalize_limit(None) == MAX_ROW_LIMIT
+    def test_none_returns_none(self, connector):
+        assert connector._normalize_limit(None) is None
 
     def test_zero_passthrough(self, connector):
         assert connector._normalize_limit(0) == 0

--- a/core/wren/tests/unit/test_duckdb_file_listing.py
+++ b/core/wren/tests/unit/test_duckdb_file_listing.py
@@ -94,8 +94,9 @@ def test_query_strips_trailing_semicolon_before_limit_wrap():
 
     result = connector.query("SELECT 1;", limit=5)
 
-    executed = connector.connection.execute.call_args.args[0]
-    assert executed == "SELECT * FROM (SELECT 1) AS _q LIMIT 5"
+    executed, params = connector.connection.execute.call_args.args
+    assert executed == "SELECT * FROM (SELECT 1) AS _q LIMIT ?"
+    assert params == [5]
     assert result == "tbl"
 
 
@@ -109,10 +110,11 @@ def test_dry_run_wraps_in_limit_zero_subquery():
 
     connector.dry_run("SELECT 1; DROP TABLE t;")
 
-    executed = connector.connection.execute.call_args.args[0]
+    executed, params = connector.connection.execute.call_args.args
     # The trailing terminator is stripped; the interior ``;`` stays inside the
     # subquery where DuckDB rejects it as a syntax error (no side effects).
-    assert executed == "SELECT * FROM (SELECT 1; DROP TABLE t) AS _q LIMIT 0"
+    assert executed == "SELECT * FROM (SELECT 1; DROP TABLE t) AS _q LIMIT ?"
+    assert params == [0]
 
 
 def test_dry_run_strips_trailing_semicolon():
@@ -121,8 +123,9 @@ def test_dry_run_strips_trailing_semicolon():
 
     connector.dry_run("SELECT 1;")
 
-    executed = connector.connection.execute.call_args.args[0]
-    assert executed == "SELECT * FROM (SELECT 1) AS _q LIMIT 0"
+    executed, params = connector.connection.execute.call_args.args
+    assert executed == "SELECT * FROM (SELECT 1) AS _q LIMIT ?"
+    assert params == [0]
 
 
 def test_dry_run_preserves_semicolon_in_string_literal():
@@ -133,5 +136,6 @@ def test_dry_run_preserves_semicolon_in_string_literal():
 
     connector.dry_run("SELECT ';' AS x")
 
-    executed = connector.connection.execute.call_args.args[0]
-    assert executed == "SELECT * FROM (SELECT ';' AS x) AS _q LIMIT 0"
+    executed, params = connector.connection.execute.call_args.args
+    assert executed == "SELECT * FROM (SELECT ';' AS x) AS _q LIMIT ?"
+    assert params == [0]

--- a/core/wren/tests/unit/test_mysql_helpers.py
+++ b/core/wren/tests/unit/test_mysql_helpers.py
@@ -11,13 +11,11 @@ import pyarrow as pa
 import pytest
 
 from wren.connector.mysql import (
-    _apply_limit,
+    _apply_limit_mysql,
     _arrow_decimal_from_mysql_field,
     _build_mysql_column,
     _build_mysql_connect_kwargs,
-    _coerce_limit,
     _mysql_blob_codes,
-    _mysql_decimal_codes,
     _mysql_field_type_map,
     _mysql_string_codes,
     _mysql_unsigned_variant_map,
@@ -41,52 +39,34 @@ class _FakeConnInfoFromUrl:
         self.kwargs = kwargs
 
 
-# ── _coerce_limit ─────────────────────────────────────────────────────────
+# ── _apply_limit_mysql ──────────────────────────────────────────────────────
 
 
-def test_coerce_limit_none_passthrough() -> None:
-    assert _coerce_limit(None) is None
-
-
-def test_coerce_limit_accepts_int() -> None:
-    assert _coerce_limit(10) == 10
-
-
-def test_coerce_limit_accepts_numeric_string() -> None:
-    # ``int()`` accepts numeric strings — keep that contract.
-    assert _coerce_limit("25") == 25
-
-
-def test_coerce_limit_rejects_injection_string() -> None:
-    """A crafted limit value must not survive ``int()`` coercion."""
-    with pytest.raises(ValueError):
-        _coerce_limit("1; DROP TABLE foo")
-
-
-def test_coerce_limit_rejects_negative() -> None:
-    with pytest.raises(ValueError):
-        _coerce_limit(-1)
-
-
-# ── _apply_limit ──────────────────────────────────────────────────────────
-
-
-def test_apply_limit_appends_clause() -> None:
-    out = _apply_limit("SELECT a FROM t", 5)
-    assert out.endswith("LIMIT 5")
+def test_apply_limit_mysql_appends_clause() -> None:
+    out, params = _apply_limit_mysql("SELECT a FROM t", 5)
+    assert out.endswith("LIMIT %s")
+    assert params == [5]
     assert "SELECT a FROM t" in out
 
 
-def test_apply_limit_strips_trailing_semicolon() -> None:
-    out = _apply_limit("SELECT a FROM t;", 3)
-    assert "; " not in out
-    assert out.endswith("LIMIT 3")
+def test_apply_limit_mysql_none_returns_unchanged() -> None:
+    out, params = _apply_limit_mysql("SELECT a FROM t", None)
+    assert out == "SELECT a FROM t"
+    assert params is None
+
+
+def test_apply_limit_mysql_strips_trailing_semicolon() -> None:
+    out, params = _apply_limit_mysql("SELECT a FROM t;", 3)
+    assert params == [3]
     assert ";" not in out.split("LIMIT")[0]
 
 
-def test_apply_limit_zero() -> None:
-    out = _apply_limit("SELECT a FROM t", 0)
-    assert out.endswith("LIMIT 0")
+def test_apply_limit_mysql_parameterized() -> None:
+    """LIMIT is always a parameter, never interpolated."""
+    out, params = _apply_limit_mysql("SELECT a FROM t", 99)
+    assert "%s" in out
+    assert params == [99]
+    assert "LIMIT 99" not in out  # not interpolated
 
 
 # ── URL connection kwargs ─────────────────────────────────────────────────

--- a/core/wren/tests/unit/test_postgres_semicolon_unlimited.py
+++ b/core/wren/tests/unit/test_postgres_semicolon_unlimited.py
@@ -44,7 +44,7 @@ def test_unlimited_query_strips_trailing_semicolon(monkeypatch):
 
     connector.query("SELECT 1 AS x; \n")
 
-    cursor.execute.assert_called_once_with("SELECT 1 AS x")
+    cursor.execute.assert_called_once_with("SELECT 1 AS x", None)
 
 
 def test_limited_query_wraps_after_strip(monkeypatch):
@@ -59,5 +59,5 @@ def test_limited_query_wraps_after_strip(monkeypatch):
     connector.query("SELECT 1 AS x;", limit=9)
 
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (SELECT 1 AS x) AS _sub LIMIT 9"
+        "SELECT * FROM (SELECT 1 AS x) AS _q LIMIT %s", [9]
     )

--- a/core/wren/tests/unit/test_redshift_semicolon.py
+++ b/core/wren/tests/unit/test_redshift_semicolon.py
@@ -30,16 +30,18 @@ def _make_mock_connector() -> tuple[RedshiftConnector, MagicMock]:
 def test_query_strips_trailing_semicolon_before_subquery_wrap() -> None:
     connector, cursor = _make_mock_connector()
     connector.query("SELECT 1;", limit=5)
-    (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT 5"
+    sent, params = cursor.execute.call_args.args
+    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT %s"
+    assert params == [5]
     assert ";)" not in sent
 
 
 def test_dry_run_strips_trailing_semicolon() -> None:
     connector, cursor = _make_mock_connector()
     connector.dry_run("SELECT 1;  ")
-    (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) AS sub LIMIT 0"
+    sent, params = cursor.execute.call_args.args
+    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT %s"
+    assert params == [0]
     assert ";)" not in sent
 
 

--- a/docs/core/guides/mcp.md
+++ b/docs/core/guides/mcp.md
@@ -65,8 +65,8 @@ spawns the server over stdio:
 For a server other machines/processes connect to, run
 `wren serve mcp --transport http --port 8080` and point the client at the
 Streamable HTTP endpoint on that host/port instead of spawning a process.
-HTTP binds to `127.0.0.1` by default and ships no bearer-token auth in this
-version — keep it local.
+HTTP binds to `127.0.0.1` by default. Pass `--api-key <secret>` to enable
+bearer-token authentication on the HTTP transport.
 
 ## What the client gets
 

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -398,6 +398,7 @@ Requires the `mcp` extra: `pip install 'wrenai[mcp]'`.
 | `--transport` | `stdio` | `stdio` or `http` |
 | `--host` | `127.0.0.1` | Bind host, `--transport http` only |
 | `--port` | `8080` | Bind port, `--transport http` only |
+| `--api-key` | — | Bearer-token secret for HTTP requests, `--transport http` only |
 | `--project` | discovered | Override project root |
 | `--profile` | active profile | Connection profile name |
 | `--allow-write` | off | Enable the `store_query` write tool |

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -427,7 +427,7 @@ warns that the MDL may be stale but still serves it — it never auto-builds.
 
 For `--transport http`, connect the client to the Streamable HTTP endpoint at
 `http://<host>:<port>` instead of spawning a process. Binds to `127.0.0.1` by
-default; there is no bearer-token auth in this version — treat it as local-only.
+default. Pass `--api-key <secret>` to enable bearer-token authentication.
 
 ### Tools
 


### PR DESCRIPTION
## Summary

Fixes the 2 new CodeRabbit comments from the third review on PR #2551:

1. **`policy.py`** — Change whitelist from `(exp.Select, exp.Explain)` to `(exp.Query, exp.Explain, exp.Subquery)` to allow `UNION`, `INTERSECT`, `EXCEPT`, and parenthesized SELECT queries (BI tools compatibility).

2. **`cli.md`** — Add `--api-key` row to the `wren serve mcp` options table.

### Verification
- `pytest`: 987 passed, 65 failed (pre-existing), 59 skipped
- `cargo check --all-targets --all-features`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for MCP over HTTP.
  * Added safer, parameterized row-limit handling across database connectors.
  * Added SQL safety checks to reject empty, multi-statement, or non-read-only queries.
* **Bug Fixes**
  * Queries now clearly require an MDL to be loaded before execution.
  * Improved handling of invalid limits and planning errors without unexpected crashes.
* **Changes**
  * Strict mode is now enabled by default, with function names normalized consistently.
* **Documentation**
  * Updated MCP and CLI guidance for HTTP authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->