### PR TITLE
fix(mysql): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/mysql.py
+++ b/core/wren/src/wren/connector/mysql.py
@@ -90,6 +90,9 @@ class MySqlConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         limit = _coerce_limit(limit)
+        # Always strip terminator so unlimited execute matches dry_run EXPLAIN
+        # and LIMIT rewrite composition for client-pasted ``SELECT 1;``.
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
             sql = _apply_limit(sql, limit)
         with closing(self.connection.cursor()) as cursor:

--- a/core/wren/tests/unit/test_mysql_unlimited_semicolon.py
+++ b/core/wren/tests/unit/test_mysql_unlimited_semicolon.py
@@ -1,0 +1,16 @@
+"""MySQL unlimited query strips trailing semis (source pin)."""
+
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "wren" / "connector" / "mysql.py"
+
+
+def test_query_always_strips_before_limit():
+    text = SRC.read_text(encoding="utf-8")
+    start = text.index("def query(self, sql: str, limit: int | None = None)")
+    end = text.index("def dry_run(self, sql: str)", start)
+    body = text[start:end]
+    assert "sql = strip_trailing_semicolon(sql)" in body
+    assert body.index("sql = strip_trailing_semicolon(sql)") < body.index(
+        "if limit is not None:"
+    )


### PR DESCRIPTION
## Summary

MySQL Connector.query always strips before LIMIT so unlimited SEL CET matches dry_run (core/wren Apache-2.0).

pytest core/wren/tests/unit/test_mysql_unlimited_semicolon.py — 1 passed

Author Bartok9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL query execution by consistently removing trailing semicolons, including queries without a row limit.

* **Tests**
  * Added coverage to verify semicolon handling occurs before limit processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->