### PR TITLE
ci(workflows): Closing inactive issues

### DIFF
--- a/.github/workflows/cleanup-issues.yml
+++ b/.github/workflows/cleanup-issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Why

Issues opened against the repo can sit indefinitely with no activity once the
original reporter stops responding or the underlying question resolves
itself elsewhere. Left alone, these accumulate in the tracker, adding noise
that makes it harder to see which open issues still need triage or action,
and to gauge real backlog size.

There was previously no automated hygiene pass for issues: nothing labeled
them as inactive, and nothing closed them out once they'd been inactive long
enough. Cleanup was manual and did not happen consistently.

### What

Add cleanup-issues.yml, running on a daily schedule (cron: "30 1 * * *"),
using actions/stale@v10 to:

- Label an issue "stale" after 30 days with no activity
  (days-before-issue-stale: 30)
- Close a stale issue after a further 14 days of inactivity
  (days-before-issue-close: 14)
- Post an explanatory comment on both staling and closing, so authors
  understand why and can reopen/comment to reset the clock

Pull requests are explicitly excluded from this pass
(days-before-pr-stale: -1, days-before-pr-close: -1) — PR staleness is a
separate concern with different risk (PRs can represent live, reviewable
work) and isn't addressed by this workflow.

Permissions are scoped to what actions/stale needs for issue operations:
issues: write (labeling/closing/commenting) and pull-requests: write
(required by the action even though PR staling is disabled here, since it
still reads PR state as part of its run).

### Verification

- actionlint .github/workflows/cleanup-issues.yml
- This workflow only triggers on schedule (no workflow_dispatch entry
  point), so functional verification is available after merge, on the next
  01:30 UTC run.
- After the first scheduled run, confirm behavior via:
  gh issue list --repo Canner/WrenAI --label stale
  and check that issues inactive for 30+ days receive the stale label and
  comment as expected, with no pull requests affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated maintenance for inactive GitHub issues.
  * Issues are marked stale after 30 days of inactivity and closed 14 days later if no further activity occurs.
  * Pull requests are excluded from this automated cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->