### PR TITLE
fix(redshift): use public strip_trailing_semicolon on unlimited path

### DIFF
--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -52,7 +52,7 @@ class RedshiftConnector(ConnectorABC):
         else:
             # Unlimited path also rejects trailing ``;`` for single statements
             # depending on driver/session settings — strip for consistency.
-            sql = _strip_trailing_semicolon(sql)
+            sql = strip_trailing_semicolon(sql)
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(sql)
             cols = [desc[0] for desc in cursor.description]


### PR DESCRIPTION
## Summary
- #2482 merged with `sql = _strip_trailing_semicolon(sql)` on the unlimited query path while the import is the public `strip_trailing_semicolon` from `wren.connector.base`.
- That NameError failed ruff F821 + `test_query_without_limit_strips_trailing_semicolon`, and poisoned merge CI on open PRs (e.g. #2476).

## Test plan
- [x] Diff is one call-site rename
- [ ] Wren SDK CI lint + unit tests green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redshift query handling by removing trailing semicolons when retrieving unlimited results.
  * Preserved existing query limits and execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->