### PR TITLE
fix(langchain): coerce None in format_store_content

### DIFF
--- a/sdk/wren-langchain/src/wren_langchain/_format.py
+++ b/sdk/wren-langchain/src/wren_langchain/_format.py
@@ -119,11 +119,15 @@ def format_recall_content(rows: list[dict[str, Any]]) -> str:
 
 def format_store_content(nl: str, sql: str, tags: list[str] | None) -> str:
     """One-liner ``Stored: "<nl>" → <sql preview> (N tags)``."""
-    sql_preview = sql.strip().split("\n")[0]
+    # Memory/tool callers may pass None for sql/nl before validation; bare
+    # ``sql.strip()`` raised AttributeError and aborted the store envelope.
+    nl_text = "" if nl is None else str(nl)
+    sql_text = "" if sql is None else str(sql)
+    sql_preview = sql_text.strip().split("\n")[0]
     if len(sql_preview) > 80:
         sql_preview = sql_preview[:77] + "..."
     tag_count = len(tags) if tags else 0
-    return f'Stored: "{nl}" → {sql_preview} ({tag_count} tags)'
+    return f'Stored: "{nl_text}" → {sql_preview} ({tag_count} tags)'
 
 
 def format_list_models_content(manifest: dict[str, Any]) -> str:

--- a/sdk/wren-langchain/tests/unit/test_format_store_content_none.py
+++ b/sdk/wren-langchain/tests/unit/test_format_store_content_none.py
@@ -1,17 +1,15 @@
 """format_store_content must tolerate None nl/sql."""
+
 import importlib.util
 from pathlib import Path
 
-_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "wren_langchain"
-    / "_format.py"
-)
+_PATH = Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_format.py"
 # file is under tests/unit → parents[2] is wren-langchain package root
 _PATH = Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_format.py"
 if not _PATH.exists():
-    _PATH = Path(__file__).resolve().parents[3] / "src" / "wren_langchain" / "_format.py"
+    _PATH = (
+        Path(__file__).resolve().parents[3] / "src" / "wren_langchain" / "_format.py"
+    )
 
 # Direct load: path is sdk/wren-langchain/tests/unit/... so parents:
 # 0=unit 1=tests 2=wren-langchain

--- a/sdk/wren-langchain/tests/unit/test_format_store_content_none.py
+++ b/sdk/wren-langchain/tests/unit/test_format_store_content_none.py
@@ -1,0 +1,40 @@
+"""format_store_content must tolerate None nl/sql."""
+import importlib.util
+from pathlib import Path
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "wren_langchain"
+    / "_format.py"
+)
+# file is under tests/unit → parents[2] is wren-langchain package root
+_PATH = Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_format.py"
+if not _PATH.exists():
+    _PATH = Path(__file__).resolve().parents[3] / "src" / "wren_langchain" / "_format.py"
+
+# Direct load: path is sdk/wren-langchain/tests/unit/... so parents:
+# 0=unit 1=tests 2=wren-langchain
+_ROOT = Path(__file__).resolve().parents[2]
+_PATH = _ROOT / "src" / "wren_langchain" / "_format.py"
+_spec = importlib.util.spec_from_file_location("_fmt", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_none_sql():
+    out = _mod.format_store_content("q", None, None)
+    assert "Stored:" in out
+    assert "q" in out
+
+
+def test_none_nl_and_tags():
+    out = _mod.format_store_content(None, "SELECT 1", None)
+    assert "SELECT 1" in out
+
+
+def test_long_sql_truncated():
+    sql = "SELECT " + ("x" * 200)
+    out = _mod.format_store_content("n", sql, ["a", "b"])
+    assert "..." in out
+    assert "(2 tags)" in out


### PR DESCRIPTION
## Summary

Coerce `None` nl/sql in `format_store_content` so store envelopes do not AttributeError on `.strip()`.

## Motivation

Tool callers can emit store confirmations before fields are fully populated.

## Real behavior proof

```
$ python3 -m pytest sdk/wren-langchain/tests/unit/test_format_store_content_none.py -v
3 passed
```

## License

Touches `sdk/wren-langchain/**` (Apache-2.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stored-content formatting to gracefully handle cases where SQL and/or natural-language descriptions are missing.
  * Prevented formatting failures when optional fields aren’t provided.
  * Kept existing SQL preview behavior, truncation, and tag-count display consistent.

* **Tests**
  * Added unit tests covering missing SQL, missing natural-language descriptions, and long SQL truncation with tag-count verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->