### PR TITLE
fix(langchain): skip non-dict models in format_list_models_content

### DIFF
--- a/sdk/wren-langchain/src/wren_langchain/_format.py
+++ b/sdk/wren-langchain/src/wren_langchain/_format.py
@@ -137,11 +137,21 @@ def format_list_models_content(manifest: dict[str, Any]) -> str:
 
     lines = ["| model | cols | description |", "|---|---|---|"]
     for m in models:
-        name = m.get("name", "")
-        col_count = len(m.get("columns", []) or [])
-        desc = (
-            (m.get("properties") or {}).get("description") or m.get("description") or ""
-        )
+        # MDL loaders / LLM-shaped manifests may include None rows, bare
+        # strings, or mixed types. Non-dicts previously AttributeError'd
+        # on ``.get`` and aborted the whole list_models content path.
+        if not isinstance(m, dict):
+            continue
+        name = m.get("name", "") or ""
+        columns = m.get("columns", []) or []
+        if not isinstance(columns, list):
+            columns = []
+        col_count = len(columns)
+        props = m.get("properties") or {}
+        if not isinstance(props, dict):
+            props = {}
+        desc = props.get("description") or m.get("description") or ""
+        desc = str(desc)
         # Trim long descriptions to keep table compact.
         if len(desc) > 80:
             desc = desc[:77] + "..."

--- a/sdk/wren-langchain/tests/unit/test_format_list_models_guard.py
+++ b/sdk/wren-langchain/tests/unit/test_format_list_models_guard.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_PATH = _ROOT / "src" / "wren_langchain" / "_format.py"
+_spec = importlib.util.spec_from_file_location("_fmt", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_skips_non_dict_and_bad_nested():
+    out = _mod.format_list_models_content(
+        {
+            "models": [
+                None,
+                "x",
+                {"name": "ok", "columns": None, "properties": "bad", "description": "d"},
+                {"name": "wide", "columns": [1, 2], "properties": {"description": "y" * 100}},
+            ]
+        }
+    )
+    assert "| ok |" in out
+    assert "| wide |" in out
+    assert "None" not in out.split("\n")[2]
+    assert "..." in out

--- a/sdk/wren-langchain/tests/unit/test_format_list_models_guard.py
+++ b/sdk/wren-langchain/tests/unit/test_format_list_models_guard.py
@@ -14,8 +14,17 @@ def test_skips_non_dict_and_bad_nested():
             "models": [
                 None,
                 "x",
-                {"name": "ok", "columns": None, "properties": "bad", "description": "d"},
-                {"name": "wide", "columns": [1, 2], "properties": {"description": "y" * 100}},
+                {
+                    "name": "ok",
+                    "columns": None,
+                    "properties": "bad",
+                    "description": "d",
+                },
+                {
+                    "name": "wide",
+                    "columns": [1, 2],
+                    "properties": {"description": "y" * 100},
+                },
             ]
         }
     )


### PR DESCRIPTION
## Summary

Skip non-dict model rows and coerce nested `columns`/`properties` in `format_list_models_content`.

## Real behavior proof

```
$ python3 -m pytest sdk/wren-langchain/tests/unit/test_format_list_models_guard.py -v
1 passed
```

## License

`sdk/wren-langchain/**` Apache-2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model list rendering when manifest entries contain invalid or unexpected data.
  * Safely skips malformed/non-standard entries so the full model list doesn’t fail to display.
  * More robust handling of nested fields and descriptions, including consistent text formatting and safer truncation.

* **Tests**
  * Added unit test coverage for mixed invalid models, malformed nested fields, and truncated output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->