### PR TITLE
fix(ask): guided template's recall step uses a valid CLI option

### DIFF
--- a/core/wren/src/wren/ask_templates/guided.md.tmpl
+++ b/core/wren/src/wren/ask_templates/guided.md.tmpl
@@ -3,7 +3,7 @@ Identify the task type, then follow the matching flow:
 
 TASK TYPE A — data question:
   1. wren context show [--path <project>]   # see MDL models
-  2. wren memory recall --nl "<keywords>"   # similar past queries (skip if no memory)
+  2. wren memory recall --query "<keywords>"  # similar past queries (skip if no memory)
   3. write SQL using model names (not raw tables)
   4. wren dry-plan --sql '...'              # validate non-trivial SQL
   5. wren query --sql '...'                 # execute

--- a/core/wren/src/wren/ask_templates/guided.md.tmpl
+++ b/core/wren/src/wren/ask_templates/guided.md.tmpl
@@ -3,7 +3,7 @@ Identify the task type, then follow the matching flow:
 
 TASK TYPE A — data question:
   1. wren context show [--path <project>]   # see MDL models
-  2. wren memory recall --query "<keywords>"  # similar past queries (skip if no memory)
+  2. wren memory recall -q "<keywords>"  # similar past queries (skip if no memory)
   3. write SQL using model names (not raw tables)
   4. wren dry-plan --sql '...'              # validate non-trivial SQL
   5. wren query --sql '...'                 # execute

--- a/core/wren/tests/unit/test_ask_cli.py
+++ b/core/wren/tests/unit/test_ask_cli.py
@@ -58,6 +58,24 @@ def test_render_unknown_mode_raises():
         ask_mod.render("auto", "anything")
 
 
+def test_guided_recall_step_uses_a_real_cli_option():
+    # The guided template's step 2 must emit an option `wren memory recall`
+    # actually accepts. Regression for #2503: the template said `--nl`, an
+    # option that belongs to `wren memory store`, not `recall`.
+    result = runner.invoke(app, ["ask", "x", "--guided"])
+    assert "--nl" not in result.output
+
+    recall_line = next(
+        line for line in result.output.splitlines() if "wren memory recall" in line
+    )
+    args = recall_line.split("wren memory recall", 1)[1].split("#", 1)[0].split()
+    recall_result = runner.invoke(app, ["memory", "recall", *args])
+    # A bad option is a click usage error (exit code 2, "No such option").
+    # Any other exit code means the option parsed and the command moved on
+    # to its own logic (e.g. failing later for lacking a wren project).
+    assert recall_result.exit_code != 2, recall_result.output
+
+
 def test_user_prompt_with_template_placeholder_substring_is_safe():
     # Prompt containing the literal placeholder shouldn't break rendering;
     # we only do one replacement of the bundled-template placeholder.


### PR DESCRIPTION
`guided.md.tmpl` step 2 tells the agent to run `wren memory recall --nl "<keywords>"`. `recall` only accepts `--query`/`-q` (`core/wren/src/wren/memory/cli.py`); `--nl` belongs to the unrelated `store` command. Following the guided flow as written fails at option parsing.

Reproduced against current HEAD (`f4b45edd`, `python:3.11-slim` in Docker, `uv sync`, `print(wren.__file__)` confirmed the installed package is this checkout):

```
$ wren memory recall --nl foo
Usage: wren memory recall [OPTIONS]
Try 'wren memory recall --help' for help.
Error: No such option: --nl Did you mean --help?
```

Fix: change the template's step 2 to `--query`.

Added a regression test that parses the exact `wren memory recall ...` line the guided template emits and invokes it against the real CLI, asserting it does not hit a click usage error (exit code 2). It fails on `main` (`--nl` is a usage error) and passes on this branch (`--query` reaches the command's own logic).

Ran `tests/unit/` (excluding `test_memory.py`/`test_mcp_server.py`, matching this repo's `test-unit` CI job) and `ruff format --check` / `ruff check` on `src/`: clean except a pre-existing, unrelated `NameError` in `test_redshift_semicolon.py` / `src/wren/connector/redshift.py` that also fails on unmodified `main`.

Did not add the `wren memory fetch` mention the issue also suggests; that is a template enhancement rather than the reported bug, so leaving it for a separate change if wanted.

Fixes #2503


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated guided memory recall instructions to use the correct CLI short flag for keywords.
  * Prevented guided recall workflows from failing due to an invalid CLI argument.
* **Tests**
  * Added a regression test to confirm the guided “step 2” emits a valid `wren memory recall` invocation and runs without a “no such option” error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->