### PR TITLE
fix(context): reject non-dict models/views in MDL conversion

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -197,7 +197,11 @@ def convert_mdl_to_project(mdl_json: dict) -> list[ProjectFile]:
     )
 
     # ── Models ────────────────────────────────────────────────
-    for i, model in enumerate(mdl_json.get("models", [])):
+    for i, model in enumerate(mdl_json.get("models", []) or []):
+        if not isinstance(model, dict):
+            raise ValueError(
+                f"Model at index {i} must be an object, got {type(model).__name__}"
+            )
         model_snake = _convert_keys_to_snake(model)
         if "name" not in model_snake:
             raise ValueError(f"Model at index {i} is missing required 'name' field")
@@ -226,7 +230,11 @@ def convert_mdl_to_project(mdl_json: dict) -> list[ProjectFile]:
         )
 
     # ── Views ─────────────────────────────────────────────────
-    for i, view in enumerate(mdl_json.get("views", [])):
+    for i, view in enumerate(mdl_json.get("views", []) or []):
+        if not isinstance(view, dict):
+            raise ValueError(
+                f"View at index {i} must be an object, got {type(view).__name__}"
+            )
         view_snake = _convert_keys_to_snake(view)
         if "name" not in view_snake:
             raise ValueError(f"View at index {i} is missing required 'name' field")
@@ -941,6 +949,15 @@ def validate_project(project_path: Path) -> list[ValidationError]:
 
     # Check models
     for i, model in enumerate(models):
+        if not isinstance(model, dict):
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"models[{i}]",
+                    f"model entry must be an object, got {type(model).__name__}",
+                )
+            )
+            continue
         src = model.get("_source_dir", f"models[{i}]")
         src_path = f"models/{src}/metadata.yml"
         name = model.get("name")
@@ -1098,6 +1115,15 @@ def validate_project(project_path: Path) -> list[ValidationError]:
 
     # Check views
     for i, view in enumerate(views):
+        if not isinstance(view, dict):
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"views[{i}]",
+                    f"view entry must be an object, got {type(view).__name__}",
+                )
+            )
+            continue
         src_dir = view.get("_source_dir", f"views[{i}]")
         name = view.get("name")
         if not name:

--- a/core/wren/tests/unit/test_convert_mdl.py
+++ b/core/wren/tests/unit/test_convert_mdl.py
@@ -383,3 +383,13 @@ def test_cli_init_from_mdl_force(tmp_path: Path, sample_mdl_file: Path):
     assert "Imported MDL" in result.output
     project = yaml.safe_load((tmp_path / "wren_project.yml").read_text())
     assert project["schema_version"] == 2
+
+
+def test_convert_mdl_rejects_non_dict_model():
+    with pytest.raises(ValueError, match="must be an object"):
+        convert_mdl_to_project({"models": ["not-a-dict"], "views": []})
+
+
+def test_convert_mdl_rejects_non_dict_view():
+    with pytest.raises(ValueError, match="View at index 0 must be an object"):
+        convert_mdl_to_project({"models": [], "views": [None]})


### PR DESCRIPTION
## Summary
- `convert_mdl_to_project` assumed every `models`/`views` entry was a dict; list litter crashed during snake_case convert.
- Raise a clear `ValueError` naming the index and actual type.
- `validate_project` records a `ValidationError` for non-dict loaded entries instead of `AttributeError`.

## License
`core/wren/**` Apache-2.0.

## Test plan
- [x] `pytest tests/unit/test_convert_mdl.py -k non_dict -v` (2 passed)

## Real behavior proof
Non-dict model raised TypeError-ish path inside convert; now ValueError with index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when importing project definitions.
  * Clear errors are now reported when model or view entries have an invalid format, including the affected item’s position.
  * Missing or empty model and view lists are handled safely.

* **Tests**
  * Added coverage for invalid model and view entries during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->