### PR TITLE
fix(langchain): tolerate None table in format_query_content

### DIFF
--- a/sdk/wren-langchain/src/wren_langchain/_format.py
+++ b/sdk/wren-langchain/src/wren_langchain/_format.py
@@ -19,7 +19,12 @@ def format_query_content(
     Returns ``(content, warnings)``. The content is a JSON array of row dicts
     plus an optional ``(showing N of M rows)`` footer when truncated.
     """
-    rows = table.to_pylist()
+    if table is None:
+        return "[]", ["query content empty: table is None"]
+    try:
+        rows = table.to_pylist()
+    except Exception as exc:  # pragma: no cover - defensive for non-Table mocks
+        return "[]", [f"query content empty: unable to read table ({exc})"]
     full = json.dumps(rows, default=str)
     encoded = full.encode("utf-8")
     if len(encoded) <= CONTENT_CAP_BYTES:

--- a/sdk/wren-langchain/src/wren_langchain/_format.py
+++ b/sdk/wren-langchain/src/wren_langchain/_format.py
@@ -12,7 +12,7 @@ CONTENT_CAP_BYTES = 16 * 1024
 
 
 def format_query_content(
-    table: pa.Table, total_rows: int | None = None
+    table: pa.Table | None, total_rows: int | None = None
 ) -> tuple[str, list[str]]:
     """Render query rows as JSON, truncating to fit ``CONTENT_CAP_BYTES``.
 

--- a/sdk/wren-langchain/tests/unit/test_format_query_none_table.py
+++ b/sdk/wren-langchain/tests/unit/test_format_query_none_table.py
@@ -1,8 +1,10 @@
-"""format_query_content must tolerate a None table."""
+"""format_query_content must tolerate a None or unreadable table."""
 
 from __future__ import annotations
 
 import importlib.util
+import sys
+import types
 from pathlib import Path
 
 
@@ -13,10 +15,8 @@ def _load_format():
         / "wren_langchain"
         / "_format.py"
     )
-    # Provide a lightweight pyarrow stub if missing — only to_pylist is used.
-    import sys
-    import types
-
+    # Provide a lightweight pyarrow stub if missing — only Table is referenced.
+    original = sys.modules.get("pyarrow")
     if "pyarrow" not in sys.modules:
         pa = types.ModuleType("pyarrow")
 
@@ -27,15 +27,35 @@ def _load_format():
         pa.Table = _Table
         sys.modules["pyarrow"] = pa
 
-    spec = importlib.util.spec_from_file_location("wren_langchain_format_ut", path)
-    mod = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(mod)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "wren_langchain_format_ut", path
+        )
+        mod = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(mod)
+    finally:
+        if original is not None:
+            sys.modules["pyarrow"] = original
+        else:
+            sys.modules.pop("pyarrow", None)
     return mod
 
 
 def test_format_query_content_none_table() -> None:
     fmt = _load_format()
-    content, warnings = fmt.format_query_content(None)  # type: ignore[arg-type]
+    content, warnings = fmt.format_query_content(None)
     assert content == "[]"
     assert warnings and "None" in warnings[0]
+
+
+def test_format_query_content_unreadable_table() -> None:
+    fmt = _load_format()
+
+    class _Broken:
+        def to_pylist(self):
+            raise RuntimeError("boom")
+
+    content, warnings = fmt.format_query_content(_Broken())
+    assert content == "[]"
+    assert warnings and "unable to read table" in warnings[0]

--- a/sdk/wren-langchain/tests/unit/test_format_query_none_table.py
+++ b/sdk/wren-langchain/tests/unit/test_format_query_none_table.py
@@ -9,12 +9,7 @@ from pathlib import Path
 
 
 def _load_format():
-    path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "wren_langchain"
-        / "_format.py"
-    )
+    path = Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_format.py"
     # Provide a lightweight pyarrow stub if missing — only Table is referenced.
     original = sys.modules.get("pyarrow")
     if "pyarrow" not in sys.modules:
@@ -28,9 +23,7 @@ def _load_format():
         sys.modules["pyarrow"] = pa
 
     try:
-        spec = importlib.util.spec_from_file_location(
-            "wren_langchain_format_ut", path
-        )
+        spec = importlib.util.spec_from_file_location("wren_langchain_format_ut", path)
         mod = importlib.util.module_from_spec(spec)
         assert spec.loader is not None
         spec.loader.exec_module(mod)

--- a/sdk/wren-langchain/tests/unit/test_format_query_none_table.py
+++ b/sdk/wren-langchain/tests/unit/test_format_query_none_table.py
@@ -1,0 +1,41 @@
+"""format_query_content must tolerate a None table."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_format():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren_langchain"
+        / "_format.py"
+    )
+    # Provide a lightweight pyarrow stub if missing — only to_pylist is used.
+    import sys
+    import types
+
+    if "pyarrow" not in sys.modules:
+        pa = types.ModuleType("pyarrow")
+
+        class _Table:
+            def to_pylist(self):
+                return []
+
+        pa.Table = _Table
+        sys.modules["pyarrow"] = pa
+
+    spec = importlib.util.spec_from_file_location("wren_langchain_format_ut", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_format_query_content_none_table() -> None:
+    fmt = _load_format()
+    content, warnings = fmt.format_query_content(None)  # type: ignore[arg-type]
+    assert content == "[]"
+    assert warnings and "None" in warnings[0]


### PR DESCRIPTION
## Summary
- `format_query_content` assumed a real Arrow table and crashed on `None` with AttributeError/to_pylist.
- Return empty JSON `[]` plus a warning so the tool envelope degrades cleanly.

## License
`sdk/wren-langchain/**` Apache-2.0.

## Test plan
- [x] `pytest sdk/wren-langchain/tests/unit/test_format_query_none_table.py -v` (1 passed)

## Real behavior proof
Before: AttributeError on `None.to_pylist`. After: `([], warning)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated query formatting to safely handle missing or invalid table inputs, returning empty content (`"[]"`) instead of raising errors.
  * Added warning messaging when the table is `None` or cannot be read.
* **Tests**
  * Added unit tests covering both `None` and unreadable/broken table scenarios, including resilient handling for environments without the expected table dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->