### PR TITLE
fix(sdk): coerce non-str tool descriptions in system prompts

### DIFF
--- a/sdk/wren-langchain/src/wren_langchain/_prompt.py
+++ b/sdk/wren-langchain/src/wren_langchain/_prompt.py
@@ -209,7 +209,9 @@ def _tool_name(tool) -> str:
     when the ``name`` attribute is missing or not a non-empty string."""
     name = getattr(tool, "name", None)
     if not isinstance(name, str) or not name:
-        name = getattr(tool, "__name__", "tool")
+        name = getattr(tool, "__name__", None)
+    if not isinstance(name, str) or not name:
+        name = "tool"
     return name
 
 

--- a/sdk/wren-langchain/src/wren_langchain/_prompt.py
+++ b/sdk/wren-langchain/src/wren_langchain/_prompt.py
@@ -209,8 +209,14 @@ def _build_tools_section(tool_list: list) -> str:
         return ""
     lines = ["## Available tools"]
     for tool in tool_list:
-        description = (tool.description or "").strip().split("\n")[0]
-        lines.append(f"- `{tool.name}`: {description}")
+        raw_desc = getattr(tool, "description", None)
+        if not isinstance(raw_desc, str):
+            raw_desc = "" if raw_desc is None else str(raw_desc)
+        description = raw_desc.strip().split("\n")[0]
+        name = getattr(tool, "name", None)
+        if not isinstance(name, str) or not name:
+            name = getattr(tool, "__name__", "tool")
+        lines.append(f"- `{name}`: {description}")
     return "\n".join(lines)
 
 

--- a/sdk/wren-langchain/src/wren_langchain/_prompt.py
+++ b/sdk/wren-langchain/src/wren_langchain/_prompt.py
@@ -181,7 +181,7 @@ def build_system_prompt(toolkit: WrenToolkit, *, tools: Iterable | None = None) 
     ``wren_store_query``, the workflow's persistence step is dropped too.
     """
     tool_list = list(tools) if tools is not None else list(toolkit.get_tools())
-    tool_names = {t.name for t in tool_list}
+    tool_names = {_tool_name(t) for t in tool_list}
 
     sections: list[str] = [_INTRO]
     sections.append(_build_workflow_section(tool_names))
@@ -204,6 +204,15 @@ def build_system_prompt(toolkit: WrenToolkit, *, tools: Iterable | None = None) 
     return "\n\n".join(sections)
 
 
+def _tool_name(tool) -> str:
+    """Return a validated tool name, falling back to ``__name__`` or ``"tool"``
+    when the ``name`` attribute is missing or not a non-empty string."""
+    name = getattr(tool, "name", None)
+    if not isinstance(name, str) or not name:
+        name = getattr(tool, "__name__", "tool")
+    return name
+
+
 def _build_tools_section(tool_list: list) -> str:
     if not tool_list:
         return ""
@@ -213,10 +222,7 @@ def _build_tools_section(tool_list: list) -> str:
         if not isinstance(raw_desc, str):
             raw_desc = "" if raw_desc is None else str(raw_desc)
         description = raw_desc.strip().split("\n")[0]
-        name = getattr(tool, "name", None)
-        if not isinstance(name, str) or not name:
-            name = getattr(tool, "__name__", "tool")
-        lines.append(f"- `{name}`: {description}")
+        lines.append(f"- `{_tool_name(tool)}`: {description}")
     return "\n".join(lines)
 
 

--- a/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
+++ b/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
@@ -1,4 +1,4 @@
-"""_build_tools_section must tolerate non-str tool.description."""
+"""_build_tools_section must tolerate non-str tool.description and bad names."""
 
 from __future__ import annotations
 
@@ -10,12 +10,13 @@ from types import SimpleNamespace
 def _load_build_tools_section():
     path = Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_prompt.py"
     tree = ast.parse(path.read_text())
-    fn_node = next(
+    wanted = {"_tool_name", "_build_tools_section"}
+    nodes = [
         n
         for n in tree.body
-        if isinstance(n, ast.FunctionDef) and n.name == "_build_tools_section"
-    )
-    mod = ast.Module(body=[fn_node], type_ignores=[])
+        if isinstance(n, ast.FunctionDef) and n.name in wanted
+    ]
+    mod = ast.Module(body=nodes, type_ignores=[])
     ast.fix_missing_locations(mod)
     ns: dict = {}
     exec(compile(mod, str(path), "exec"), ns)
@@ -34,3 +35,25 @@ def test_build_tools_section_non_str_description():
     assert "`wren_store`: 42" in out
     assert "`wren_ok`: line1" in out
     assert "line2" not in out
+
+
+def test_build_tools_section_name_fallbacks():
+    fn = _load_build_tools_section()
+
+    class NoName:
+        description = "no name attr"
+        __name__ = "dunder_name"
+
+    tools = [
+        SimpleNamespace(name=None, description="null name"),
+        SimpleNamespace(name="", description="empty name"),
+        SimpleNamespace(name=123, description="numeric name"),
+        NoName(),
+    ]
+    out = fn(tools)
+    # None / empty / non-str names with no __name__ fall back to "tool"
+    assert "`tool`: null name" in out
+    assert "`tool`: empty name" in out
+    assert "`tool`: numeric name" in out
+    # missing name attr falls back to __name__
+    assert "`dunder_name`: no name attr" in out

--- a/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
+++ b/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
@@ -1,0 +1,38 @@
+"""_build_tools_section must tolerate non-str tool.description."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_build_tools_section():
+    path = (
+        Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_prompt.py"
+    )
+    tree = ast.parse(path.read_text())
+    fn_node = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_build_tools_section"
+    )
+    mod = ast.Module(body=[fn_node], type_ignores=[])
+    ast.fix_missing_locations(mod)
+    ns: dict = {}
+    exec(compile(mod, str(path), "exec"), ns)
+    return ns["_build_tools_section"]
+
+
+def test_build_tools_section_non_str_description():
+    fn = _load_build_tools_section()
+    tools = [
+        SimpleNamespace(name="wren_query", description=None),
+        SimpleNamespace(name="wren_store", description=42),
+        SimpleNamespace(name="wren_ok", description="line1\nline2"),
+    ]
+    out = fn(tools)
+    assert "`wren_query`:" in out
+    assert "`wren_store`: 42" in out
+    assert "`wren_ok`: line1" in out
+    assert "line2" not in out

--- a/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
+++ b/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
@@ -8,9 +8,7 @@ from types import SimpleNamespace
 
 
 def _load_build_tools_section():
-    path = (
-        Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_prompt.py"
-    )
+    path = Path(__file__).resolve().parents[2] / "src" / "wren_langchain" / "_prompt.py"
     tree = ast.parse(path.read_text())
     fn_node = next(
         n

--- a/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
+++ b/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
@@ -12,9 +12,7 @@ def _load_build_tools_section():
     tree = ast.parse(path.read_text())
     wanted = {"_tool_name", "_build_tools_section"}
     nodes = [
-        n
-        for n in tree.body
-        if isinstance(n, ast.FunctionDef) and n.name in wanted
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in wanted
     ]
     mod = ast.Module(body=nodes, type_ignores=[])
     ast.fix_missing_locations(mod)

--- a/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
+++ b/sdk/wren-langchain/tests/unit/test_prompt_tool_description.py
@@ -29,7 +29,7 @@ def test_build_tools_section_non_str_description():
         SimpleNamespace(name="wren_ok", description="line1\nline2"),
     ]
     out = fn(tools)
-    assert "`wren_query`:" in out
+    assert "- `wren_query`: " in out.splitlines()
     assert "`wren_store`: 42" in out
     assert "`wren_ok`: line1" in out
     assert "line2" not in out

--- a/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
@@ -184,7 +184,7 @@ def build_instructions(toolkit: WrenToolkit, *, toolset: object | None = None) -
     if toolset is None:
         toolset = toolkit.toolset()
     tool_list = _extract_tool_list(toolset)
-    tool_names = {t.name for t in tool_list}
+    tool_names = {_tool_name(t) for t in tool_list}
 
     sections: list[str] = [_INTRO]
     sections.append(_build_workflow_section(tool_names))
@@ -223,6 +223,15 @@ def _extract_tool_list(toolset: object) -> list:
     return list(tools_attr)
 
 
+def _tool_name(tool) -> str:
+    """Return a validated tool name, falling back to ``__name__`` or ``"tool"``
+    when the ``name`` attribute is missing or not a non-empty string."""
+    name = getattr(tool, "name", None)
+    if not isinstance(name, str) or not name:
+        name = getattr(tool, "__name__", "tool")
+    return name
+
+
 def _build_tools_section(tool_list: list) -> str:
     if not tool_list:
         return ""
@@ -232,10 +241,7 @@ def _build_tools_section(tool_list: list) -> str:
         if not isinstance(raw_desc, str):
             raw_desc = "" if raw_desc is None else str(raw_desc)
         description = raw_desc.strip().split("\n")[0]
-        name = getattr(tool, "name", None)
-        if not isinstance(name, str) or not name:
-            name = getattr(tool, "__name__", "tool")
-        lines.append(f"- `{name}`: {description}")
+        lines.append(f"- `{_tool_name(tool)}`: {description}")
     return "\n".join(lines)
 
 

--- a/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
@@ -228,8 +228,14 @@ def _build_tools_section(tool_list: list) -> str:
         return ""
     lines = ["## Available tools"]
     for tool in tool_list:
-        description = (tool.description or "").strip().split("\n")[0]
-        lines.append(f"- `{tool.name}`: {description}")
+        raw_desc = getattr(tool, "description", None)
+        if not isinstance(raw_desc, str):
+            raw_desc = "" if raw_desc is None else str(raw_desc)
+        description = raw_desc.strip().split("\n")[0]
+        name = getattr(tool, "name", None)
+        if not isinstance(name, str) or not name:
+            name = getattr(tool, "__name__", "tool")
+        lines.append(f"- `{name}`: {description}")
     return "\n".join(lines)
 
 

--- a/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_instructions.py
@@ -228,7 +228,9 @@ def _tool_name(tool) -> str:
     when the ``name`` attribute is missing or not a non-empty string."""
     name = getattr(tool, "name", None)
     if not isinstance(name, str) or not name:
-        name = getattr(tool, "__name__", "tool")
+        name = getattr(tool, "__name__", None)
+    if not isinstance(name, str) or not name:
+        name = "tool"
     return name
 
 

--- a/sdk/wren-pydantic/tests/unit/test_instructions_tool_description.py
+++ b/sdk/wren-pydantic/tests/unit/test_instructions_tool_description.py
@@ -1,4 +1,4 @@
-"""_build_tools_section must tolerate non-str tool.description."""
+"""_build_tools_section must tolerate non-str tool.description and bad names."""
 
 from __future__ import annotations
 
@@ -15,12 +15,13 @@ def _load_build_tools_section():
         / "_instructions.py"
     )
     tree = ast.parse(path.read_text())
-    fn_node = next(
+    wanted = {"_tool_name", "_build_tools_section"}
+    nodes = [
         n
         for n in tree.body
-        if isinstance(n, ast.FunctionDef) and n.name == "_build_tools_section"
-    )
-    mod = ast.Module(body=[fn_node], type_ignores=[])
+        if isinstance(n, ast.FunctionDef) and n.name in wanted
+    ]
+    mod = ast.Module(body=nodes, type_ignores=[])
     ast.fix_missing_locations(mod)
     ns: dict = {}
     exec(compile(mod, str(path), "exec"), ns)
@@ -32,7 +33,30 @@ def test_build_tools_section_non_str_description():
     tools = [
         SimpleNamespace(name="wren_query", description=None),
         SimpleNamespace(name="wren_store", description=42),
+        SimpleNamespace(name="wren_ok", description="line1\nline2"),
     ]
     out = fn(tools)
     assert "`wren_query`:" in out
     assert "`wren_store`: 42" in out
+    assert "`wren_ok`: line1" in out
+    assert "line2" not in out
+
+
+def test_build_tools_section_name_fallbacks():
+    fn = _load_build_tools_section()
+
+    class NoName:
+        description = "no name attr"
+        __name__ = "dunder_name"
+
+    tools = [
+        SimpleNamespace(name=None, description="null name"),
+        SimpleNamespace(name="", description="empty name"),
+        SimpleNamespace(name=123, description="numeric name"),
+        NoName(),
+    ]
+    out = fn(tools)
+    assert "`tool`: null name" in out
+    assert "`tool`: empty name" in out
+    assert "`tool`: numeric name" in out
+    assert "`dunder_name`: no name attr" in out

--- a/sdk/wren-pydantic/tests/unit/test_instructions_tool_description.py
+++ b/sdk/wren-pydantic/tests/unit/test_instructions_tool_description.py
@@ -17,9 +17,7 @@ def _load_build_tools_section():
     tree = ast.parse(path.read_text())
     wanted = {"_tool_name", "_build_tools_section"}
     nodes = [
-        n
-        for n in tree.body
-        if isinstance(n, ast.FunctionDef) and n.name in wanted
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in wanted
     ]
     mod = ast.Module(body=nodes, type_ignores=[])
     ast.fix_missing_locations(mod)

--- a/sdk/wren-pydantic/tests/unit/test_instructions_tool_description.py
+++ b/sdk/wren-pydantic/tests/unit/test_instructions_tool_description.py
@@ -1,0 +1,38 @@
+"""_build_tools_section must tolerate non-str tool.description."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_build_tools_section():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "wren_pydantic"
+        / "_instructions.py"
+    )
+    tree = ast.parse(path.read_text())
+    fn_node = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_build_tools_section"
+    )
+    mod = ast.Module(body=[fn_node], type_ignores=[])
+    ast.fix_missing_locations(mod)
+    ns: dict = {}
+    exec(compile(mod, str(path), "exec"), ns)
+    return ns["_build_tools_section"]
+
+
+def test_build_tools_section_non_str_description():
+    fn = _load_build_tools_section()
+    tools = [
+        SimpleNamespace(name="wren_query", description=None),
+        SimpleNamespace(name="wren_store", description=42),
+    ]
+    out = fn(tools)
+    assert "`wren_query`:" in out
+    assert "`wren_store`: 42" in out


### PR DESCRIPTION
## Summary
- Shared `_build_tools_section` in langchain + pydantic assumed `tool.description` is \'`str|None`\'.
- Non-str descriptions raised `AttributeError` on `.strip()`.
- Coerce description (and missing name) before rendering markdown bullets.

## License
`sdk/**` Apache-2.0.

## Test plan
- [x] langchain: `test_prompt_tool_description.py` (1 passed)
- [x] pydantic: `test_instructions_tool_description.py` (1 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Available tools” rendering to tolerate missing/invalid tool names and non-text descriptions, ensuring consistent bullet labels and safer description formatting (including first-line truncation).

* **Tests**
  * Expanded prompt/instruction unit test coverage for tool-name fallback behavior (missing/empty/invalid `name`, using `__name__`) and for non-string/multiline `description` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->