### PR TITLE
fix(wren-cli): surface skipped non-mapping rows in parse/translate-types

### DIFF
--- a/core/wren/src/wren/utils_cli.py
+++ b/core/wren/src/wren/utils_cli.py
@@ -4,12 +4,63 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
 
 utils_app = typer.Typer(name="utils", help="Utility commands")
+
+# Cap on how many dropped rows we list individually; past this we still
+# report the total but stop naming each one, mirroring context_cli's
+# _WARNING_SUMMARY_THRESHOLD so large batches don't flood stderr.
+_SKIP_REPORT_LIMIT = 10
+
+
+def _skipped_rows(data: object) -> list[tuple[int, object]]:
+    """Return (index, value) for entries parse_types/translate_types will drop.
+
+    Mirrors the ``isinstance(col, Mapping)`` guard those functions apply
+    internally; recomputed here (rather than threaded back out of the pure
+    library functions) so the CLI layer can report which rows were skipped
+    and why.
+    """
+    if not isinstance(data, list):
+        return []
+    return [(i, row) for i, row in enumerate(data) if not isinstance(row, Mapping)]
+
+
+def _report_skipped(skipped: list[tuple[int, object]]) -> None:
+    """Warn about dropped rows, splitting benign padding from likely corruption.
+
+    ``None`` is treated as benign padding from dynamic schema exporters and
+    only counted. Any other non-mapping value (a bare string, number, list,
+    ...) is treated as more likely a real data problem and listed with its
+    index and value so it isn't invisible in the output.
+    """
+    if not skipped:
+        return
+    benign = [i for i, v in skipped if v is None]
+    corrupt = [(i, v) for i, v in skipped if v is not None]
+    if benign:
+        typer.echo(
+            f"Note: skipped {len(benign)} None row(s) (benign padding)", err=True
+        )
+    if corrupt:
+        typer.echo(
+            f"Warning: skipped {len(corrupt)} non-mapping row(s) with unexpected values:",
+            err=True,
+        )
+        for i, v in corrupt[:_SKIP_REPORT_LIMIT]:
+            typer.echo(f"  [{i}] {type(v).__name__}: {v!r}", err=True)
+        remaining = len(corrupt) - _SKIP_REPORT_LIMIT
+        if remaining > 0:
+            typer.echo(f"  ... and {remaining} more", err=True)
+
+
+def _has_corrupt_skips(skipped: list[tuple[int, object]]) -> bool:
+    return any(v is not None for _, v in skipped)
 
 
 @utils_app.command(name="parse-type")
@@ -37,6 +88,16 @@ def parse_types_cmd(
         Optional[str],
         typer.Option("--input", "-i", help="Input JSON file (default: stdin)"),
     ] = None,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help=(
+                "Exit 1 if any dropped row held a non-None value "
+                "(likely corruption, not benign padding)."
+            ),
+        ),
+    ] = False,
 ):
     """Batch-normalize types. Reads JSON array from stdin or file, writes JSON to stdout.
 
@@ -63,13 +124,12 @@ def parse_types_cmd(
         typer.echo(f"Error: invalid JSON input: {e}", err=True)
         raise typer.Exit(1)
 
+    skipped = _skipped_rows(data)
     results = parse_types(data, dialect, type_field=type_field)
-    if isinstance(data, list) and len(results) < len(data):
-        typer.echo(
-            f"Note: skipped {len(data) - len(results)} non-mapping row(s)",
-            err=True,
-        )
+    _report_skipped(skipped)
     typer.echo(json.dumps(results, indent=2))
+    if strict and _has_corrupt_skips(skipped):
+        raise typer.Exit(1)
 
 
 @utils_app.command(name="translate-type")
@@ -102,6 +162,16 @@ def translate_types_cmd(
         Optional[str],
         typer.Option("--input", "-i", help="Input JSON file (default: stdin)"),
     ] = None,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help=(
+                "Exit 1 if any dropped row held a non-None value "
+                "(likely corruption, not benign padding)."
+            ),
+        ),
+    ] = False,
 ):
     """Batch-translate types between dialects. Reads/writes JSON.
 
@@ -128,10 +198,9 @@ def translate_types_cmd(
         typer.echo(f"Error: invalid JSON input: {e}", err=True)
         raise typer.Exit(1)
 
+    skipped = _skipped_rows(data)
     results = translate_types(data, source, target, type_field=type_field)
-    if isinstance(data, list) and len(results) < len(data):
-        typer.echo(
-            f"Note: skipped {len(data) - len(results)} non-mapping row(s)",
-            err=True,
-        )
+    _report_skipped(skipped)
     typer.echo(json.dumps(results, indent=2))
+    if strict and _has_corrupt_skips(skipped):
+        raise typer.Exit(1)

--- a/core/wren/src/wren/utils_cli.py
+++ b/core/wren/src/wren/utils_cli.py
@@ -63,6 +63,24 @@ def _has_corrupt_skips(skipped: list[tuple[int, object]]) -> bool:
     return any(v is not None for _, v in skipped)
 
 
+def _require_list(data: object) -> list:
+    """Reject a non-list top-level JSON value with a clean error, not a crash.
+
+    ``_skipped_rows`` only recognizes non-mapping *rows*; a non-list *payload*
+    (an object, string, number, ...) slips past it silently and reaches
+    parse_types/translate_types, which iterate it directly (yielding dict keys
+    or string characters instead of rows) and trip the skip-count invariant
+    below with a confusing AssertionError instead of a clean input error.
+    """
+    if not isinstance(data, list):
+        typer.echo(
+            f"Error: input must be a JSON array (got {type(data).__name__})",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return data
+
+
 @utils_app.command(name="parse-type")
 def parse_type_cmd(
     type_str: Annotated[str, typer.Option("--type", "-t", help="Raw SQL type string")],
@@ -124,6 +142,7 @@ def parse_types_cmd(
         typer.echo(f"Error: invalid JSON input: {e}", err=True)
         raise typer.Exit(1)
 
+    data = _require_list(data)
     skipped = _skipped_rows(data)
     results = parse_types(data, dialect, type_field=type_field)
     assert len(results) + len(skipped) == len(data), (
@@ -202,6 +221,7 @@ def translate_types_cmd(
         typer.echo(f"Error: invalid JSON input: {e}", err=True)
         raise typer.Exit(1)
 
+    data = _require_list(data)
     skipped = _skipped_rows(data)
     results = translate_types(data, source, target, type_field=type_field)
     assert len(results) + len(skipped) == len(data), (

--- a/core/wren/src/wren/utils_cli.py
+++ b/core/wren/src/wren/utils_cli.py
@@ -53,7 +53,7 @@ def _report_skipped(skipped: list[tuple[int, object]]) -> None:
             err=True,
         )
         for i, v in corrupt[:_SKIP_REPORT_LIMIT]:
-            typer.echo(f"  [{i}] {type(v).__name__}: {v!r}", err=True)
+            typer.echo(f"  [{i}] {type(v).__name__}: {v!r:.120}", err=True)
         remaining = len(corrupt) - _SKIP_REPORT_LIMIT
         if remaining > 0:
             typer.echo(f"  ... and {remaining} more", err=True)
@@ -126,6 +126,10 @@ def parse_types_cmd(
 
     skipped = _skipped_rows(data)
     results = parse_types(data, dialect, type_field=type_field)
+    assert len(results) + len(skipped) == len(data), (
+        "parse_types dropped a different set of rows than _skipped_rows predicted; "
+        "the mirrored Mapping guard in utils_cli.py has drifted from type_mapping.py"
+    )
     _report_skipped(skipped)
     typer.echo(json.dumps(results, indent=2))
     if strict and _has_corrupt_skips(skipped):
@@ -200,6 +204,10 @@ def translate_types_cmd(
 
     skipped = _skipped_rows(data)
     results = translate_types(data, source, target, type_field=type_field)
+    assert len(results) + len(skipped) == len(data), (
+        "translate_types dropped a different set of rows than _skipped_rows predicted; "
+        "the mirrored Mapping guard in utils_cli.py has drifted from type_mapping.py"
+    )
     _report_skipped(skipped)
     typer.echo(json.dumps(results, indent=2))
     if strict and _has_corrupt_skips(skipped):

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -378,3 +378,108 @@ def test_translate_types_accepts_non_dict_mappings() -> None:
     assert [r["column"] for r in out] == ["id", "name"]
     assert out[0]["type"] == "INT64"
     assert out[1]["type"] == "STRING"
+
+
+# ── CLI skipped-row reporting (Canner/WrenAI#2528) ─────────────────────────
+#
+# #2508 made parse_types/translate_types skip non-mapping rows instead of
+# crashing the batch, but the CLI only reported a bare count with no signal
+# of *which* rows were dropped or whether they looked like real corruption
+# (a stray string/int) versus benign None padding.
+
+
+def test_cli_parse_types_none_row_is_benign_note() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}, None]
+    result = _run_wren(
+        "utils", "parse-types", "--dialect", "postgres", stdin=json.dumps(columns)
+    )
+    _assert_success(result)
+    assert "Note: skipped 1 None row(s) (benign padding)" in result.stderr
+    assert "Warning:" not in result.stderr
+    data = json.loads(result.stdout)
+    assert len(data) == 1
+
+
+def test_cli_parse_types_non_none_row_is_warning_with_index_and_value() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}, "not-a-dict", 42]
+    result = _run_wren(
+        "utils", "parse-types", "--dialect", "postgres", stdin=json.dumps(columns)
+    )
+    # Without --strict, a corrupt-looking row is still just a warning, not a failure.
+    _assert_success(result)
+    assert "Warning: skipped 2 non-mapping row(s)" in result.stderr
+    assert "[1] str: 'not-a-dict'" in result.stderr
+    assert "[2] int: 42" in result.stderr
+
+
+def test_cli_parse_types_strict_exits_nonzero_on_corrupt_row() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}, "not-a-dict"]
+    result = _run_wren(
+        "utils",
+        "parse-types",
+        "--dialect",
+        "postgres",
+        "--strict",
+        stdin=json.dumps(columns),
+    )
+    assert result.returncode == 1
+    assert "Warning: skipped 1 non-mapping row(s)" in result.stderr
+    # Results still printed even though the command signals failure.
+    data = json.loads(result.stdout)
+    assert len(data) == 1
+
+
+def test_cli_parse_types_strict_stays_zero_on_none_only_rows() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}, None, None]
+    result = _run_wren(
+        "utils",
+        "parse-types",
+        "--dialect",
+        "postgres",
+        "--strict",
+        stdin=json.dumps(columns),
+    )
+    _assert_success(result)
+    assert "Note: skipped 2 None row(s) (benign padding)" in result.stderr
+
+
+def test_cli_parse_types_skip_report_truncates_past_limit() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}] + list(range(12))
+    result = _run_wren(
+        "utils", "parse-types", "--dialect", "postgres", stdin=json.dumps(columns)
+    )
+    _assert_success(result)
+    assert "Warning: skipped 12 non-mapping row(s)" in result.stderr
+    assert "[1] int: 0" in result.stderr
+    assert "... and 2 more" in result.stderr
+
+
+def test_cli_translate_types_strict_exits_nonzero_on_corrupt_row() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}, "not-a-dict"]
+    result = _run_wren(
+        "utils",
+        "translate-types",
+        "--source",
+        "postgres",
+        "--target",
+        "bigquery",
+        "--strict",
+        stdin=json.dumps(columns),
+    )
+    assert result.returncode == 1
+    assert "Warning: skipped 1 non-mapping row(s)" in result.stderr
+
+
+def test_cli_translate_types_none_row_is_benign_note() -> None:
+    columns = [{"column": "id", "raw_type": "int8"}, None]
+    result = _run_wren(
+        "utils",
+        "translate-types",
+        "--source",
+        "postgres",
+        "--target",
+        "bigquery",
+        stdin=json.dumps(columns),
+    )
+    _assert_success(result)
+    assert "Note: skipped 1 None row(s) (benign padding)" in result.stderr

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -495,3 +495,42 @@ def test_cli_translate_types_none_row_is_benign_note() -> None:
     )
     _assert_success(result)
     assert "Note: skipped 1 None row(s) (benign padding)" in result.stderr
+
+
+def test_cli_parse_types_rejects_non_list_object_payload() -> None:
+    # Canner/WrenAI#2570 review: a top-level JSON object used to reach
+    # parse_types() directly, which iterates a dict as its keys and trips the
+    # skip-count invariant with an AssertionError instead of a clean error.
+    result = _run_wren(
+        "utils",
+        "parse-types",
+        "--dialect",
+        "postgres",
+        stdin=json.dumps({"column": "id", "raw_type": "int8"}),
+    )
+    assert result.returncode == 1
+    assert "Error: input must be a JSON array (got dict)" in result.stderr
+    assert "AssertionError" not in result.stderr
+
+
+def test_cli_parse_types_rejects_non_list_string_payload() -> None:
+    result = _run_wren(
+        "utils", "parse-types", "--dialect", "postgres", stdin=json.dumps("not-a-list")
+    )
+    assert result.returncode == 1
+    assert "Error: input must be a JSON array (got str)" in result.stderr
+
+
+def test_cli_translate_types_rejects_non_list_object_payload() -> None:
+    result = _run_wren(
+        "utils",
+        "translate-types",
+        "--source",
+        "postgres",
+        "--target",
+        "bigquery",
+        stdin=json.dumps({"column": "id", "raw_type": "int8"}),
+    )
+    assert result.returncode == 1
+    assert "Error: input must be a JSON array (got dict)" in result.stderr
+    assert "AssertionError" not in result.stderr

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -454,6 +454,18 @@ def test_cli_parse_types_skip_report_truncates_past_limit() -> None:
     assert "... and 2 more" in result.stderr
 
 
+def test_cli_parse_types_corrupt_value_repr_is_bounded() -> None:
+    # A few large corrupt values must not flood stderr just because there are
+    # fewer of them than _SKIP_REPORT_LIMIT.
+    columns = [{"column": "id", "raw_type": "int8"}, "x" * 5000]
+    result = _run_wren(
+        "utils", "parse-types", "--dialect", "postgres", stdin=json.dumps(columns)
+    )
+    _assert_success(result)
+    line = next(ln for ln in result.stderr.splitlines() if ln.startswith("  [1]"))
+    assert len(line) < 200
+
+
 def test_cli_translate_types_strict_exits_nonzero_on_corrupt_row() -> None:
     columns = [{"column": "id", "raw_type": "int8"}, "not-a-dict"]
     result = _run_wren(


### PR DESCRIPTION
`parse_types()`/`translate_types()` (`core/wren/src/wren/type_mapping.py`, fixed in #2508) skip any row that isn't a `Mapping` instead of crashing the batch. The CLI commands built on top of them only reported a bare `skipped N` count, so a caller had no way to tell whether the dropped rows were benign padding or something worth investigating, and no way to see which rows were dropped.

Per the issue's proposal, the library functions stay pure (`list -> list`, no signature change). The CLI layer in `utils_cli.py` now recomputes which input rows are non-`Mapping` (the same check `parse_types`/`translate_types` apply internally) before calling them, then reports on that list:

- `None` rows are counted and logged once as benign padding (dynamic schema exporters routinely interleave `None`), never treated as an error.
- Any other non-mapping value (a bare string, number, list, ...) is logged individually with its index and value, since it more plausibly signals real corruption. The list is capped at 10 named entries with an `... and N more` tail so a large batch can't flood stderr.
- Both `parse-types` and `translate-types` gain `--strict`, which exits 1 only when at least one non-`None` row was dropped. A batch that only drops `None` padding still exits 0 under `--strict`, matching the benign/error split above.

Verified in Docker (`python:3.11-slim`, `uv sync`, `print(wren.__file__)` confirmed the installed package resolves to this checkout): added 7 named regression tests (`--strict` exit code on a corrupt row vs. a `None`-only batch, the note/warning wording, index+value reporting, and the 10-row truncation), each fails on unmodified `main` and passes on this branch. Ran the full `tests/unit/` tree (excluding `test_memory.py`/`test_mcp_server.py`, matching this repo's `test-unit` CI job: 1009 passed, 2 skipped) and `ruff format --check` / `ruff check` on `src/`: clean.

Did not touch the `Mapping` guard itself or the docstrings (`#2508` already covers both) and did not add a `--verbose`/grouped-summary mode like `context_cli.py`'s warning printer; the batches this CLI handles are schema-sized, not log-sized, so the flat 10-row cap seemed like the right amount of ceremony for this file.

Fixes #2528


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced batch type-processing feedback by identifying skipped non-mapping input rows, reporting their indices/values with truncation for large batches.
  * Added a `--strict` mode to `parse-types` and `translate-types` that exits non-zero when corruption-like rows are detected while still printing valid results.
  * Improved input validation by rejecting non-array top-level JSON payloads with a clear error.
* **Bug Fixes**
  * Clarified reporting so skipped `None` rows are treated as benign padding (note) and separated from corruption warnings.
* **Tests**
  * Expanded CLI integration tests for strict/benign behavior, warning truncation limits, and non-array payload rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->