### PR TITLE
chore(wren): fix ruff format in dlt-connector skill docs

### DIFF
--- a/core/wren/src/wren/skills_content/dlt-connector/SKILL.md
+++ b/core/wren/src/wren/skills_content/dlt-connector/SKILL.md
@@ -112,6 +112,7 @@ After the run, confirm:
 
 ```python
 import duckdb
+
 con = duckdb.connect("<pipeline_name>.duckdb", read_only=True)
 for row in con.execute("""
     SELECT table_schema, table_name,
@@ -179,7 +180,9 @@ wren_home = Path.home() / ".wren"
 wren_home.mkdir(exist_ok=True)
 profiles_file = wren_home / "profiles.yml"
 
-existing = (yaml.safe_load(profiles_file.read_text()) or {}) if profiles_file.exists() else {}
+existing = (
+    (yaml.safe_load(profiles_file.read_text()) or {}) if profiles_file.exists() else {}
+)
 existing.setdefault("profiles", {})
 
 profile_name = "<source>_dlt"

--- a/core/wren/src/wren/skills_content/dlt-connector/references/dlt_sources.md
+++ b/core/wren/src/wren/skills_content/dlt-connector/references/dlt_sources.md
@@ -37,6 +37,7 @@ pipeline = dlt.pipeline(
 
 # With the verified source:
 from hubspot import hubspot_source
+
 source = hubspot_source(api_key=dlt.secrets.value)
 info = pipeline.run(source)
 print(info)


### PR DESCRIPTION
## Problem

The `lint` job runs `uvx ruff format --check src/` under `core/wren`. Two dlt-connector skill docs contain Python code blocks that fail the check, so lint is red on `main` and on any PR that touches `core/wren`:

- `src/wren/skills_content/dlt-connector/SKILL.md`
- `src/wren/skills_content/dlt-connector/references/dlt_sources.md`

```
2 files would be reformatted, 78 files already formatted
```

## Fix

Ran `uvx ruff format src/` on the two files. Formatting-only, no behavior change:

- add the missing blank line after an `import` inside a code block
- wrap an over-length `existing = (...)` assignment

After the fix both lint steps pass locally:

```
80 files already formatted
All checks passed!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and readability of dlt-connector documentation code examples.
  * Added spacing to clarify Python imports and source initialization steps.
  * Reformatted a profile configuration example without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->