### PR TITLE
fix(policy): harden resolve_model_name against non-str names

### DIFF
--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -159,10 +159,7 @@ def resolve_model_name(
     # Drop non-str names so a corrupt models collection cannot crash .lower().
     if not isinstance(name, str) or not name:
         return None
-    if isinstance(model_names, (set, frozenset)):
-        model_set = {n for n in model_names if isinstance(n, str) and n}
-    else:
-        model_set = {n for n in model_names if isinstance(n, str) and n}
+    model_set = {n for n in model_names if isinstance(n, str) and n}
     if name in model_set:
         return name
     if quoted:

--- a/core/wren/src/wren/policy.py
+++ b/core/wren/src/wren/policy.py
@@ -156,9 +156,13 @@ def resolve_model_name(
     falls back to a case-insensitive scan. Returns ``None`` if no model
     matches.
     """
-    model_set = (
-        model_names if isinstance(model_names, (set, frozenset)) else set(model_names)
-    )
+    # Drop non-str names so a corrupt models collection cannot crash .lower().
+    if not isinstance(name, str) or not name:
+        return None
+    if isinstance(model_names, (set, frozenset)):
+        model_set = {n for n in model_names if isinstance(n, str) and n}
+    else:
+        model_set = {n for n in model_names if isinstance(n, str) and n}
     if name in model_set:
         return name
     if quoted:

--- a/core/wren/tests/unit/test_resolve_model_name_nonstr.py
+++ b/core/wren/tests/unit/test_resolve_model_name_nonstr.py
@@ -1,0 +1,25 @@
+"""resolve_model_name must ignore non-str names without AttributeError."""
+
+from __future__ import annotations
+
+import pytest
+
+from wren.policy import resolve_model_name
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_filters_non_str_candidates() -> None:
+    names = {"Orders", None, 12, "", "customers"}  # type: ignore[list-item]
+    assert resolve_model_name("orders", quoted=False, model_names=names) == "Orders"
+    assert resolve_model_name("missing", quoted=False, model_names=names) is None
+
+
+def test_resolve_rejects_non_str_lookup() -> None:
+    assert resolve_model_name(None, quoted=False, model_names={"a"}) is None  # type: ignore[arg-type]
+    assert resolve_model_name(1, quoted=True, model_names={"1"}) is None  # type: ignore[arg-type]
+
+
+def test_resolve_quoted_exact() -> None:
+    assert resolve_model_name("Orders", quoted=True, model_names={"Orders"}) == "Orders"
+    assert resolve_model_name("orders", quoted=True, model_names={"Orders"}) is None


### PR DESCRIPTION
## Summary

- Filter non-str model names before exact/CI matching in `resolve_model_name`
- Return None when the lookup name is not a non-empty string

## License

Apache-2.0 (`core/**`).

## Motivation

Corrupt or partially-migrated MDL name collections could include `None`/ints. Calling `.lower()` on those raised and aborted strict-mode planning even when a usable string candidate existed.

## Verification

`cd core/wren && .venv/bin/python -m pytest tests/unit/test_resolve_model_name_nonstr.py -v` — 3 passed

## Duplicate check

- No open PR on `policy.resolve_model_name` non-str filtering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model name resolution by safely handling invalid or empty lookup inputs.
  * Candidate model names that aren’t non-empty strings are now ignored to prevent lookup errors.
  * Preserves existing exact-match behavior for quoted model names (case-sensitive).

* **Tests**
  * Added unit test coverage for non-string, empty, and quoted lookup values, including scenarios that previously could raise errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->