### PR TITLE
fix(spark): apply limit via DataFrame.limit before toPandas

### DIFF
--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -22,20 +22,26 @@ class SparkConnector(ConnectorABC):
         )
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        df = self.connection.sql(strip_trailing_semicolon(sql)).toPandas()
+        # Push LIMIT into Spark SQL so the engine does not materialize the full
+        # result only for a client-side slice. Strip trailing ``;`` first so the
+        # outer subscript form stays valid.
+        cleaned = strip_trailing_semicolon(sql)
+        if limit is not None:
+            cleaned = f"SELECT * FROM ({cleaned}) AS _q LIMIT {int(limit)}"
+        df = self.connection.sql(cleaned).toPandas()
         if hasattr(df, "attrs") and df.attrs:
             df.attrs = {
                 k: v
                 for k, v in df.attrs.items()
                 if k not in ("metrics", "observed_metrics")
             }
-        arrow_table = pa.Table.from_pandas(df)
-        if limit is not None:
-            arrow_table = arrow_table.slice(0, limit)
-        return arrow_table
+        return pa.Table.from_pandas(df)
 
     def dry_run(self, sql: str) -> None:
-        self.connection.sql(strip_trailing_semicolon(sql)).limit(0).count()
+        # Prefer a LIMIT 0 subquery wrapper (like other connectors) so EXPLAIN
+        # is unnecessary and a trailing semicolon cannot break Spark SQL.
+        cleaned = strip_trailing_semicolon(sql)
+        self.connection.sql(f"SELECT * FROM ({cleaned}) AS _q LIMIT 0").count()
 
     def close(self) -> None:
         if self._closed:

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -27,7 +27,10 @@ class SparkConnector(ConnectorABC):
         # outer subscript form stays valid.
         cleaned = strip_trailing_semicolon(sql)
         if limit is not None:
-            cleaned = f"SELECT * FROM ({cleaned}) AS _q LIMIT {int(limit)}"
+            coerced = int(limit)
+            if coerced < 0:
+                raise ValueError(f"limit must be non-negative, got {coerced}")
+            cleaned = f"SELECT * FROM ({cleaned}) AS _q LIMIT {coerced}"
         df = self.connection.sql(cleaned).toPandas()
         if hasattr(df, "attrs") and df.attrs:
             df.attrs = {

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -41,10 +41,11 @@ class SparkConnector(ConnectorABC):
         return pa.Table.from_pandas(df)
 
     def dry_run(self, sql: str) -> None:
-        # Prefer a LIMIT 0 subquery wrapper (like other connectors) so EXPLAIN
-        # is unnecessary and a trailing semicolon cannot break Spark SQL.
+        # Validate via the DataFrame API so statements that are not legal as a
+        # subquery (SHOW TABLES, DESCRIBE, ...) are still accepted, exactly as
+        # before. Only strip a trailing ``;`` so it cannot break Spark SQL.
         cleaned = strip_trailing_semicolon(sql)
-        self.connection.sql(f"SELECT * FROM ({cleaned}) AS _q LIMIT 0").count()
+        self.connection.sql(cleaned).limit(0).count()
 
     def close(self) -> None:
         if self._closed:

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -53,11 +53,7 @@ class SparkConnector(ConnectorABC):
             # Place the user SQL on its own line so a trailing line comment
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
             # Mirrors snowflake.py.
-            executed = (
-                "SELECT * FROM (\n"
-                f"{cleaned}\n"
-                f") AS _q LIMIT {coerced}"
-            )
+            executed = f"SELECT * FROM (\n{cleaned}\n) AS _q LIMIT {coerced}"
             df = self.connection.sql(executed).toPandas()
         else:
             # Unlimited path, or non-subqueryable statements (SHOW/DESCRIBE/…).

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -1,7 +1,29 @@
+import re
+
 import pyarrow as pa
 
 from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import SparkConnectionInfo
+
+# Statements that are not legal as a subquery on Spark. When a limit is
+# supplied for these, fall back to the DataFrame client-side slice so MCP
+# `run_sql` (which always passes a default limit) keeps working as on main.
+_NON_SUBQUERYABLE = re.compile(
+    r"^\s*(SHOW|DESCRIBE|DESC|EXPLAIN|USE|SET|RESET|CACHE|UNCACHE|CLEAR|REFRESH|"
+    r"MSCK|ANALYZE|LIST|ADD|REMOVE|GET|PUT|DFS|CREATE|DROP|ALTER|TRUNCATE|INSERT|"
+    r"UPDATE|DELETE|MERGE|LOAD|WITH\s+.*\bINSERT\b)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _coerce_limit(limit: int | None) -> int | None:
+    """Validate and coerce a user-supplied ``limit`` to a non-negative ``int``."""
+    if limit is None:
+        return None
+    coerced = int(limit)
+    if coerced < 0:
+        raise ValueError(f"limit must be non-negative, got {coerced}")
+    return coerced
 
 
 class SparkConnector(ConnectorABC):
@@ -24,14 +46,26 @@ class SparkConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         # Push LIMIT into Spark SQL so the engine does not materialize the full
         # result only for a client-side slice. Strip trailing ``;`` first so the
-        # outer subscript form stays valid.
+        # outer form stays valid.
         cleaned = strip_trailing_semicolon(sql)
-        if limit is not None:
-            coerced = int(limit)
-            if coerced < 0:
-                raise ValueError(f"limit must be non-negative, got {coerced}")
-            cleaned = f"SELECT * FROM ({cleaned}) AS _q LIMIT {coerced}"
-        df = self.connection.sql(cleaned).toPandas()
+        coerced = _coerce_limit(limit)
+        if coerced is not None and not _NON_SUBQUERYABLE.match(cleaned):
+            # Place the user SQL on its own line so a trailing line comment
+            # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
+            # Mirrors snowflake.py.
+            executed = (
+                "SELECT * FROM (\n"
+                f"{cleaned}\n"
+                f") AS _q LIMIT {coerced}"
+            )
+            df = self.connection.sql(executed).toPandas()
+        else:
+            # Unlimited path, or non-subqueryable statements (SHOW/DESCRIBE/…).
+            # Preserve main behaviour: DataFrame API + optional client slice.
+            frame = self.connection.sql(cleaned)
+            if coerced is not None:
+                frame = frame.limit(coerced)
+            df = frame.toPandas()
         if hasattr(df, "attrs") and df.attrs:
             df.attrs = {
                 k: v

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -16,9 +16,7 @@ _NON_SUBQUERYABLE = re.compile(
 )
 
 # Leading line/block comments (and whitespace) before the first keyword.
-_LEADING_SQL_NOISE = re.compile(
-    r"(?s)^(?:\s|--[^\n]*(?:\n|$)|/\*.*?\*/)+"
-)
+_LEADING_SQL_NOISE = re.compile(r"(?s)^(?:\s|--[^\n]*(?:\n|$)|/\*.*?\*/)+")
 
 
 def _strip_leading_sql_comments(sql: str) -> str:

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -9,11 +9,29 @@ from wren.model import SparkConnectionInfo
 # supplied for these, fall back to the DataFrame client-side slice so MCP
 # `run_sql` (which always passes a default limit) keeps working as on main.
 _NON_SUBQUERYABLE = re.compile(
-    r"^\s*(SHOW|DESCRIBE|DESC|EXPLAIN|USE|SET|RESET|CACHE|UNCACHE|CLEAR|REFRESH|"
+    r"^(SHOW|DESCRIBE|DESC|EXPLAIN|USE|SET|RESET|CACHE|UNCACHE|CLEAR|REFRESH|"
     r"MSCK|ANALYZE|LIST|ADD|REMOVE|GET|PUT|DFS|CREATE|DROP|ALTER|TRUNCATE|INSERT|"
     r"UPDATE|DELETE|MERGE|LOAD|WITH\s+.*\bINSERT\b)\b",
     re.IGNORECASE | re.DOTALL,
 )
+
+# Leading line/block comments (and whitespace) before the first keyword.
+_LEADING_SQL_NOISE = re.compile(
+    r"(?s)^(?:\s|--[^\n]*(?:\n|$)|/\*.*?\*/)+"
+)
+
+
+def _strip_leading_sql_comments(sql: str) -> str:
+    """Remove leading whitespace and SQL comments so keyword classification works."""
+    prev = None
+    while prev != sql:
+        prev = sql
+        sql = _LEADING_SQL_NOISE.sub("", sql, count=1)
+    return sql.lstrip()
+
+
+def _is_non_subqueryable(sql: str) -> bool:
+    return bool(_NON_SUBQUERYABLE.match(_strip_leading_sql_comments(sql)))
 
 
 def _coerce_limit(limit: int | None) -> int | None:
@@ -49,7 +67,7 @@ class SparkConnector(ConnectorABC):
         # outer form stays valid.
         cleaned = strip_trailing_semicolon(sql)
         coerced = _coerce_limit(limit)
-        if coerced is not None and not _NON_SUBQUERYABLE.match(cleaned):
+        if coerced is not None and not _is_non_subqueryable(cleaned):
             # Place the user SQL on its own line so a trailing line comment
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
             # Mirrors snowflake.py.

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -1,35 +1,7 @@
-import re
-
 import pyarrow as pa
 
 from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model import SparkConnectionInfo
-
-# Statements that are not legal as a subquery on Spark. When a limit is
-# supplied for these, fall back to the DataFrame client-side slice so MCP
-# `run_sql` (which always passes a default limit) keeps working as on main.
-_NON_SUBQUERYABLE = re.compile(
-    r"^(SHOW|DESCRIBE|DESC|EXPLAIN|USE|SET|RESET|CACHE|UNCACHE|CLEAR|REFRESH|"
-    r"MSCK|ANALYZE|LIST|ADD|REMOVE|GET|PUT|DFS|CREATE|DROP|ALTER|TRUNCATE|INSERT|"
-    r"UPDATE|DELETE|MERGE|LOAD|WITH\s+.*\bINSERT\b)\b",
-    re.IGNORECASE | re.DOTALL,
-)
-
-# Leading line/block comments (and whitespace) before the first keyword.
-_LEADING_SQL_NOISE = re.compile(r"(?s)^(?:\s|--[^\n]*(?:\n|$)|/\*.*?\*/)+")
-
-
-def _strip_leading_sql_comments(sql: str) -> str:
-    """Remove leading whitespace and SQL comments so keyword classification works."""
-    prev = None
-    while prev != sql:
-        prev = sql
-        sql = _LEADING_SQL_NOISE.sub("", sql, count=1)
-    return sql.lstrip()
-
-
-def _is_non_subqueryable(sql: str) -> bool:
-    return bool(_NON_SUBQUERYABLE.match(_strip_leading_sql_comments(sql)))
 
 
 def _coerce_limit(limit: int | None) -> int | None:
@@ -60,24 +32,15 @@ class SparkConnector(ConnectorABC):
         )
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        # Push LIMIT into Spark SQL so the engine does not materialize the full
-        # result only for a client-side slice. Strip trailing ``;`` first so the
-        # outer form stays valid.
-        cleaned = strip_trailing_semicolon(sql)
+        # Apply limit via DataFrame.limit before toPandas so Spark pushes a
+        # CollectLimit into the plan (server-side). Avoid post-Arrow slice and
+        # SQL subquery wraps — both unnecessary on the DataFrame API and the
+        # latter breaks SHOW/DESCRIBE-style statements.
         coerced = _coerce_limit(limit)
-        if coerced is not None and not _is_non_subqueryable(cleaned):
-            # Place the user SQL on its own line so a trailing line comment
-            # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
-            # Mirrors snowflake.py.
-            executed = f"SELECT * FROM (\n{cleaned}\n) AS _q LIMIT {coerced}"
-            df = self.connection.sql(executed).toPandas()
-        else:
-            # Unlimited path, or non-subqueryable statements (SHOW/DESCRIBE/…).
-            # Preserve main behaviour: DataFrame API + optional client slice.
-            frame = self.connection.sql(cleaned)
-            if coerced is not None:
-                frame = frame.limit(coerced)
-            df = frame.toPandas()
+        frame = self.connection.sql(strip_trailing_semicolon(sql))
+        if coerced is not None:
+            frame = frame.limit(coerced)
+        df = frame.toPandas()
         if hasattr(df, "attrs") and df.attrs:
             df.attrs = {
                 k: v
@@ -87,11 +50,7 @@ class SparkConnector(ConnectorABC):
         return pa.Table.from_pandas(df)
 
     def dry_run(self, sql: str) -> None:
-        # Validate via the DataFrame API so statements that are not legal as a
-        # subquery (SHOW TABLES, DESCRIBE, ...) are still accepted, exactly as
-        # before. Only strip a trailing ``;`` so it cannot break Spark SQL.
-        cleaned = strip_trailing_semicolon(sql)
-        self.connection.sql(cleaned).limit(0).count()
+        self.connection.sql(strip_trailing_semicolon(sql)).limit(0).count()
 
     def close(self) -> None:
         if self._closed:

--- a/core/wren/src/wren/connector/spark.py
+++ b/core/wren/src/wren/connector/spark.py
@@ -1,17 +1,7 @@
 import pyarrow as pa
 
-from wren.connector.base import ConnectorABC, strip_trailing_semicolon
+from wren.connector.base import ConnectorABC, coerce_limit, strip_trailing_semicolon
 from wren.model import SparkConnectionInfo
-
-
-def _coerce_limit(limit: int | None) -> int | None:
-    """Validate and coerce a user-supplied ``limit`` to a non-negative ``int``."""
-    if limit is None:
-        return None
-    coerced = int(limit)
-    if coerced < 0:
-        raise ValueError(f"limit must be non-negative, got {coerced}")
-    return coerced
 
 
 class SparkConnector(ConnectorABC):
@@ -36,7 +26,7 @@ class SparkConnector(ConnectorABC):
         # CollectLimit into the plan (server-side). Avoid post-Arrow slice and
         # SQL subquery wraps — both unnecessary on the DataFrame API and the
         # latter breaks SHOW/DESCRIBE-style statements.
-        coerced = _coerce_limit(limit)
+        coerced = coerce_limit(limit)
         frame = self.connection.sql(strip_trailing_semicolon(sql))
         if coerced is not None:
             frame = frame.limit(coerced)

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -1,6 +1,8 @@
-"""Trailing-semicolon stripping for the Spark connector (mocked session)."""
+"""Trailing-semicolon stripping + LIMIT pushdown for the Spark connector."""
 
 from unittest.mock import MagicMock
+
+import pandas as pd
 
 from wren.connector.base import strip_trailing_semicolon
 from wren.connector.spark import SparkConnector
@@ -16,19 +18,23 @@ def _make_mock_connector() -> tuple[SparkConnector, MagicMock]:
 
 def test_query_strips_trailing_semicolon_before_sql() -> None:
     connector, session = _make_mock_connector()
-    # pandas DF mock for pa.Table.from_pandas
-    import pandas as pd
-
     session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2, 3]})
-    connector.query("SELECT 1;", limit=2)
+    connector.query("SELECT 1;")
     session.sql.assert_called_once_with("SELECT 1")
 
 
-def test_dry_run_strips_trailing_semicolon() -> None:
+def test_query_pushes_limit_into_sql_after_strip() -> None:
+    connector, session = _make_mock_connector()
+    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2]})
+    connector.query("SELECT 1 AS x;", limit=2)
+    session.sql.assert_called_once_with("SELECT * FROM (SELECT 1 AS x) AS _q LIMIT 2")
+
+
+def test_dry_run_wraps_limit_zero_after_strip() -> None:
     connector, session = _make_mock_connector()
     connector.dry_run("SELECT 1;  \n")
-    session.sql.assert_called_once_with("SELECT 1")
-    session.sql.return_value.limit.assert_called_once_with(0)
+    session.sql.assert_called_once_with("SELECT * FROM (SELECT 1) AS _q LIMIT 0")
+    session.sql.return_value.count.assert_called_once_with()
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -67,6 +67,17 @@ def test_query_show_tables_with_limit_uses_dataframe_slice() -> None:
     frame.limit.assert_called_once_with(500)
 
 
+def test_query_show_tables_with_leading_comment_uses_dataframe_slice() -> None:
+    """Leading -- / /* */ comments must not force subquery wrap on SHOW."""
+    connector, session = _make_mock_connector()
+    frame = session.sql.return_value
+    frame.limit.return_value.toPandas.return_value = pd.DataFrame({"tableName": ["t"]})
+    sql = "-- metadata\nSHOW TABLES"
+    connector.query(sql, limit=500)
+    session.sql.assert_called_once_with(sql)
+    frame.limit.assert_called_once_with(500)
+
+
 def test_dry_run_validates_via_dataframe_after_strip() -> None:
     connector, session = _make_mock_connector()
     connector.dry_run("SELECT 1;  \n")

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 
 from wren.connector.base import strip_trailing_semicolon
 from wren.connector.spark import SparkConnector
@@ -27,7 +28,43 @@ def test_query_pushes_limit_into_sql_after_strip() -> None:
     connector, session = _make_mock_connector()
     session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2]})
     connector.query("SELECT 1 AS x;", limit=2)
-    session.sql.assert_called_once_with("SELECT * FROM (SELECT 1 AS x) AS _q LIMIT 2")
+    session.sql.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 AS x\n) AS _q LIMIT 2"
+    )
+
+
+def test_query_trailing_line_comment_does_not_swallow_wrap() -> None:
+    connector, session = _make_mock_connector()
+    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1]})
+    connector.query("SELECT 1 -- note", limit=10)
+    session.sql.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 -- note\n) AS _q LIMIT 10"
+    )
+
+
+def test_query_limit_zero_pushes_limit_zero() -> None:
+    connector, session = _make_mock_connector()
+    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": []})
+    connector.query("SELECT 1 AS x", limit=0)
+    session.sql.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 AS x\n) AS _q LIMIT 0"
+    )
+
+
+def test_query_negative_limit_raises() -> None:
+    connector, _session = _make_mock_connector()
+    with pytest.raises(ValueError, match="non-negative"):
+        connector.query("SELECT 1", limit=-1)
+
+
+def test_query_show_tables_with_limit_uses_dataframe_slice() -> None:
+    """Non-subqueryable statements keep DataFrame path (MCP always passes limit)."""
+    connector, session = _make_mock_connector()
+    frame = session.sql.return_value
+    frame.limit.return_value.toPandas.return_value = pd.DataFrame({"tableName": ["t"]})
+    connector.query("SHOW TABLES", limit=500)
+    session.sql.assert_called_once_with("SHOW TABLES")
+    frame.limit.assert_called_once_with(500)
 
 
 def test_dry_run_validates_via_dataframe_after_strip() -> None:

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -1,4 +1,4 @@
-"""Trailing-semicolon stripping + LIMIT pushdown for the Spark connector."""
+"""Trailing-semicolon stripping + DataFrame limit for the Spark connector."""
 
 from unittest.mock import MagicMock
 
@@ -24,41 +24,35 @@ def test_query_strips_trailing_semicolon_before_sql() -> None:
     session.sql.assert_called_once_with("SELECT 1")
 
 
-def test_query_pushes_limit_into_sql_after_strip() -> None:
+def test_query_limit_uses_dataframe_limit_before_to_pandas() -> None:
     connector, session = _make_mock_connector()
-    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2]})
+    frame = session.sql.return_value
+    frame.limit.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2]})
     connector.query("SELECT 1 AS x;", limit=2)
-    session.sql.assert_called_once_with(
-        "SELECT * FROM (\nSELECT 1 AS x\n) AS _q LIMIT 2"
-    )
+    session.sql.assert_called_once_with("SELECT 1 AS x")
+    frame.limit.assert_called_once_with(2)
+    frame.limit.return_value.toPandas.assert_called_once_with()
+    # Must not call toPandas on the unlimited frame.
+    frame.toPandas.assert_not_called()
 
 
-def test_query_trailing_line_comment_does_not_swallow_wrap() -> None:
+def test_query_limit_zero_uses_dataframe_limit_zero() -> None:
     connector, session = _make_mock_connector()
-    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1]})
-    connector.query("SELECT 1 -- note", limit=10)
-    session.sql.assert_called_once_with(
-        "SELECT * FROM (\nSELECT 1 -- note\n) AS _q LIMIT 10"
-    )
-
-
-def test_query_limit_zero_pushes_limit_zero() -> None:
-    connector, session = _make_mock_connector()
-    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": []})
+    frame = session.sql.return_value
+    frame.limit.return_value.toPandas.return_value = pd.DataFrame({"x": []})
     connector.query("SELECT 1 AS x", limit=0)
-    session.sql.assert_called_once_with(
-        "SELECT * FROM (\nSELECT 1 AS x\n) AS _q LIMIT 0"
-    )
+    session.sql.assert_called_once_with("SELECT 1 AS x")
+    frame.limit.assert_called_once_with(0)
 
 
 def test_query_negative_limit_raises() -> None:
-    connector, _session = _make_mock_connector()
+    connector, session = _make_mock_connector()
     with pytest.raises(ValueError, match="non-negative"):
         connector.query("SELECT 1", limit=-1)
+    session.sql.assert_not_called()
 
 
-def test_query_show_tables_with_limit_uses_dataframe_slice() -> None:
-    """Non-subqueryable statements keep DataFrame path (MCP always passes limit)."""
+def test_query_show_tables_with_limit_uses_dataframe_limit() -> None:
     connector, session = _make_mock_connector()
     frame = session.sql.return_value
     frame.limit.return_value.toPandas.return_value = pd.DataFrame({"tableName": ["t"]})
@@ -67,22 +61,9 @@ def test_query_show_tables_with_limit_uses_dataframe_slice() -> None:
     frame.limit.assert_called_once_with(500)
 
 
-def test_query_show_tables_with_leading_comment_uses_dataframe_slice() -> None:
-    """Leading -- / /* */ comments must not force subquery wrap on SHOW."""
-    connector, session = _make_mock_connector()
-    frame = session.sql.return_value
-    frame.limit.return_value.toPandas.return_value = pd.DataFrame({"tableName": ["t"]})
-    sql = "-- metadata\nSHOW TABLES"
-    connector.query(sql, limit=500)
-    session.sql.assert_called_once_with(sql)
-    frame.limit.assert_called_once_with(500)
-
-
 def test_dry_run_validates_via_dataframe_after_strip() -> None:
     connector, session = _make_mock_connector()
     connector.dry_run("SELECT 1;  \n")
-    # Validation stays on the DataFrame API so non-subquery statements
-    # (SHOW TABLES, DESCRIBE, ...) remain valid; only the trailing ; is stripped.
     session.sql.assert_called_once_with("SELECT 1")
     session.sql.return_value.limit.assert_called_once_with(0)
     session.sql.return_value.limit.return_value.count.assert_called_once_with()

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -19,9 +19,11 @@ def _make_mock_connector() -> tuple[SparkConnector, MagicMock]:
 
 def test_query_strips_trailing_semicolon_before_sql() -> None:
     connector, session = _make_mock_connector()
-    session.sql.return_value.toPandas.return_value = pd.DataFrame({"x": [1, 2, 3]})
+    frame = session.sql.return_value
+    frame.toPandas.return_value = pd.DataFrame({"x": [1, 2, 3]})
     connector.query("SELECT 1;")
     session.sql.assert_called_once_with("SELECT 1")
+    frame.limit.assert_not_called()
 
 
 def test_query_limit_uses_dataframe_limit_before_to_pandas() -> None:

--- a/core/wren/tests/unit/test_spark_semicolon.py
+++ b/core/wren/tests/unit/test_spark_semicolon.py
@@ -30,11 +30,14 @@ def test_query_pushes_limit_into_sql_after_strip() -> None:
     session.sql.assert_called_once_with("SELECT * FROM (SELECT 1 AS x) AS _q LIMIT 2")
 
 
-def test_dry_run_wraps_limit_zero_after_strip() -> None:
+def test_dry_run_validates_via_dataframe_after_strip() -> None:
     connector, session = _make_mock_connector()
     connector.dry_run("SELECT 1;  \n")
-    session.sql.assert_called_once_with("SELECT * FROM (SELECT 1) AS _q LIMIT 0")
-    session.sql.return_value.count.assert_called_once_with()
+    # Validation stays on the DataFrame API so non-subquery statements
+    # (SHOW TABLES, DESCRIBE, ...) remain valid; only the trailing ; is stripped.
+    session.sql.assert_called_once_with("SELECT 1")
+    session.sql.return_value.limit.assert_called_once_with(0)
+    session.sql.return_value.limit.return_value.count.assert_called_once_with()
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:


### PR DESCRIPTION
## Summary

- Apply `limit` with Spark `DataFrame.limit(n)` **before** `toPandas()`, so the engine gets a server-side `CollectLimit` instead of materializing the full result and slicing the Arrow table on the client
- Drop SQL subquery wrapping and the non-subqueryable classifier — unnecessary on Spark’s DataFrame API (same physical plan as wrap; works for `SHOW`/`DESCRIBE`/SELECT alike)
- Use shared `coerce_limit` from `connector/base.py` (#2624) so Spark matches the other connectors (rejects negatives, bools, and non-integral values — on `main`, `limit=-1` silently returned an empty table via `pa.Table.slice(0, -1)`)
- `dry_run` unchanged vs `main` (trailing `;` strip + `.limit(0).count()`)

## License

Apache-2.0 (`core/**`).

## Motivation

On `main`, Spark applied `limit` only after `toPandas()` via Arrow `slice`, so bounded asks still fully materialized. Maintainer measurements on PySpark 4.1.1 show `DataFrame.limit()` is already plan-level pushdown:

```
spark.sql("SELECT * FROM t").limit(3).explain()
== Physical Plan ==
CollectLimit 3
+- *(1) Range (0, 1000, step=1, splits=1)

spark.sql("SELECT * FROM (\nSELECT * FROM t\n) AS _q LIMIT 3").explain()
== Physical Plan ==
CollectLimit 3
+- *(1) Range (0, 1000, step=1, splits=1)
```

Identical plans — string-wrapping LIMIT is the right tool for DBAPI connectors, not Spark.

## What failure does this repair?

Bounded Spark queries (MCP always passes a default limit) fully materialize the result set, then client-slice with Arrow. Negative limits on `main` did not error: `pa.Table.slice(0, -1)` returned zero rows silently.

## Verification

`cd core/wren && .venv/bin/python -m pytest tests/unit/test_spark_semicolon.py -v` — 8 passed

## Duplicate check

- No open PR for Spark DataFrame limit-before-toPandas