### PR TITLE
fix(types): coerce non-str inputs in parse_type

### DIFF
--- a/core/wren/src/wren/type_mapping.py
+++ b/core/wren/src/wren/type_mapping.py
@@ -38,11 +38,19 @@ def parse_type(type_str: str, dialect: str) -> str:
         Canonical type string (e.g. "VARCHAR(255)", "BIGINT").
         Falls back to original string if parsing fails.
     """
+    # Dynamic exporters occasionally send None / ints; coerce before truthiness
+    # checks and sqlglot so callers never see TypeError from parse_one.
+    if type_str is None:
+        return ""
+    if not isinstance(type_str, str):
+        type_str = str(type_str)
+    if not isinstance(dialect, str) or not dialect:
+        dialect = ""
     if not type_str:
         return type_str
     try:
         return sqlglot.parse_one(type_str, into=DataType, dialect=dialect).sql()
-    except (sqlglot.errors.SqlglotError, ValueError):
+    except (sqlglot.errors.SqlglotError, ValueError, TypeError):
         # SqlglotError covers both ParseError and TokenError (the tokenizer
         # raises TokenError on unterminated quotes / stray control chars, and
         # it is NOT a subclass of ParseError). Fall back to the raw string.

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -378,3 +378,17 @@ def test_translate_types_accepts_non_dict_mappings() -> None:
     assert [r["column"] for r in out] == ["id", "name"]
     assert out[0]["type"] == "INT64"
     assert out[1]["type"] == "STRING"
+
+
+def test_parse_type_none_and_non_str():
+    assert parse_type(None, "postgres") == ""  # type: ignore[arg-type]
+    assert parse_type(38, "postgres")  # type: ignore[arg-type]
+    # int falls back to stringified form when not a parseable type name
+    out = parse_type(38, "postgres")  # type: ignore[arg-type]
+    assert isinstance(out, str)
+
+
+def test_parse_types_none_type_field():
+    out = parse_types([{"column": "a", "raw_type": None}], dialect="postgres")
+    assert len(out) == 1
+    assert out[0]["type"] == ""

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -382,10 +382,9 @@ def test_translate_types_accepts_non_dict_mappings() -> None:
 
 def test_parse_type_none_and_non_str():
     assert parse_type(None, "postgres") == ""  # type: ignore[arg-type]
-    assert parse_type(38, "postgres")  # type: ignore[arg-type]
     # int falls back to stringified form when not a parseable type name
     out = parse_type(38, "postgres")  # type: ignore[arg-type]
-    assert isinstance(out, str)
+    assert out == "38"
 
 
 def test_parse_types_none_type_field():


### PR DESCRIPTION
## Summary

- Coerce `None` → empty string and non-str raw types via `str(...)` in `parse_type`
- Also tolerate bad dialect values; catch `TypeError` from sqlglot

## License

Apache-2.0 (`core/**`).

## Motivation

Dynamic schema exporters sometimes emit `null`/numeric type placeholders. `parse_type` assumed a string and crashed start-up mapping paths.

## Verification

`cd core/wren && .venv/bin/python -m pytest tests/unit/test_type_mapping.py::test_parse_type_none_and_non_str tests/unit/test_type_mapping.py::test_parse_types_none_type_field -v` — 2 passed

## Duplicate check

- No open PR on `type_mapping.parse_type` non-str coercion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type parsing to handle missing and non-text inputs more safely.
  * Added defensive handling for invalid or empty dialect values during parsing.
  * Expanded failure handling to prevent unexpected crashes and keep a usable fallback value.

* **Tests**
  * Added unit tests covering `None` and non-string inputs for type parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->