### PR TITLE
test(core-py): document and pin the physical-table visibility contract

### DIFF
--- a/core/wren-core-py/README.md
+++ b/core/wren-core-py/README.md
@@ -22,18 +22,52 @@ Linux ARM64 wheels are not yet available. To use on that platform, build from so
 ## Quick Start
 
 ```python
-from wren_core import SessionContext, to_manifest
+from wren_core import SessionContext
 
-# Load an MDL manifest from a base64-encoded JSON string
+# Create a session context from a base64-encoded MDL JSON string
 base64_mdl_json = "<your-base64-encoded-mdl-json>"
-manifest = to_manifest(base64_mdl_json)
-
-# Create a session context for query planning
-ctx = SessionContext(manifest, remote_functions=[])
+ctx = SessionContext(base64_mdl_json)
 
 # Transform a SQL query through the semantic layer
 planned_sql = ctx.transform_sql("SELECT * FROM my_model")
 ```
+
+### Registering local files (Parquet/CSV)
+
+Physical files can back MDL models via two-phase initialization — register the
+files, then load the MDL so models resolve to them:
+
+```python
+from wren_core import SessionContext
+
+base64_mdl_json = "<your-base64-encoded-mdl-json>"
+
+ctx = SessionContext()
+ctx.register_parquet("customer", "/data/customer.parquet")
+ctx.register_csv("orders", "/data/orders.csv")
+ctx.load_mdl(base64_mdl_json)  # MDL models now resolve to the files
+
+# Query by the MDL's catalog.schema.model name; returns Arrow IPC stream bytes
+ipc_bytes = ctx.query("SELECT * FROM my_catalog.my_schema.customer")
+```
+
+Visibility contract:
+
+- Tables land in the pre-existing default catalog (`datafusion`.`public`). An
+  MDL model resolves to a registered file only if its `tableReference` is
+  `{"catalog": "datafusion", "schema": "public", "table": "<registered name>"}`
+  and the columns it declares exist in the file.
+- Registering after the context was created still works: the internals of
+  pre-existing catalogs are live-shared with derived contexts, so the table is
+  visible to `query`, `dry_run`, and `list_tables`.
+- Brand-new *top-level* catalogs are the exception — they must exist before
+  MDL construction, `load_mdl`, or a transform, each of which snapshots the
+  top-level catalog list.
+- `load_mdl` must not overlap other calls on the same context; overlapping
+  calls raise `RuntimeError`.
+
+For complete runnable examples (fixture files, matching manifests, decoding
+the returned bytes), see `tests/test_physical_tables.py`.
 
 ## Developer Guide
 

--- a/core/wren-core-py/pyproject.toml
+++ b/core/wren-core-py/pyproject.toml
@@ -27,6 +27,7 @@ Issues = "https://github.com/Canner/WrenAI/issues"
 [dependency-groups]
 dev = [
   "maturin==1.9.4",
+  "pyarrow==25.0.0",
   "pytest==9.1.1",
   "ruff==0.13.1",
 ]

--- a/core/wren-core-py/src/context.rs
+++ b/core/wren-core-py/src/context.rs
@@ -418,8 +418,18 @@ impl PySessionContext {
         })
     }
 
-    /// Register a Parquet file as a named table.
-    /// Tables registered on base_ctx are visible to exec_ctx via shared catalog.
+    /// Register a Parquet file as a named table on the base context.
+    ///
+    /// The table lands in the pre-existing default catalog
+    /// (`datafusion`.`public`), whose internals are live-shared with derived
+    /// contexts — so it is visible to `query`/`dry_run`/`list_tables` even
+    /// when the session context was created before this call. Only
+    /// pre-existing catalogs get this guarantee: derived contexts and each
+    /// `transform_sql` call snapshot *top-level* catalog membership, so new
+    /// top-level catalogs must exist before MDL construction, `load_mdl`,
+    /// or a transform. See `clone_catalog_list` in wren-core's
+    /// `mdl::context` for the exact contract. Call `load_mdl` afterward if
+    /// MDL models should resolve to this table (two-phase init).
     #[pyo3(signature = (name, path))]
     pub fn register_parquet(
         &self,
@@ -441,8 +451,11 @@ impl PySessionContext {
         Ok(())
     }
 
-    /// Register a CSV file as a named table.
-    /// Tables registered on base_ctx are visible to exec_ctx via shared catalog.
+    /// Register a CSV file as a named table on the base context.
+    ///
+    /// Same visibility contract as `register_parquet`: lands in the
+    /// pre-existing default catalog (`datafusion`.`public`), visible to
+    /// derived contexts even when they were created before this call.
     #[pyo3(signature = (name, path))]
     pub fn register_csv(&self, py: Python<'_>, name: &str, path: &str) -> PyResult<()> {
         let (name, path) = (name.to_owned(), path.to_owned());
@@ -502,6 +515,12 @@ impl PySessionContext {
 
     /// Load MDL and apply semantic layer rules (two-phase init).
     /// Call this after registering physical tables to enable the semantic layer.
+    ///
+    /// Concurrency: this method takes `&mut self`, so PyO3's exclusive
+    /// borrow rejects any overlapping call on the same SessionContext with a
+    /// `RuntimeError`. Finish `register_parquet`/`register_csv` calls before
+    /// `load_mdl`, and finish `load_mdl` before issuing queries that depend
+    /// on the new MDL.
     #[pyo3(signature = (mdl_base64))]
     pub fn load_mdl(&mut self, py: Python<'_>, mdl_base64: &str) -> PyResult<()> {
         let manifest = to_manifest(mdl_base64)?;

--- a/core/wren-core-py/tests/test_physical_tables.py
+++ b/core/wren-core-py/tests/test_physical_tables.py
@@ -1,0 +1,134 @@
+"""Physical-table visibility through the execution context.
+
+These tests pin the consumer-facing contract of ``register_parquet`` /
+``register_csv``: tables land in the pre-existing default catalog
+(``datafusion``.``public``), whose internals are live-shared with derived
+execution contexts, so registration is visible through ``query`` /
+``dry_run`` / ``list_tables`` regardless of whether it happened before or
+after the derived execution context was created.
+
+Deliberately NOT tested: creating a brand-new *top-level* catalog after a
+derived context exists. Top-level catalog membership is snapshotted when a
+derived context is created and later additions are outside the visibility
+contract (see ``clone_catalog_list`` in wren-core's ``mdl::context``).
+"""
+
+import base64
+import io
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pyarrow import ipc
+from wren_core import SessionContext
+
+# int32 keys so the fixture's Arrow types agree with the MDL-declared
+# `integer` columns on the semantic query path.
+CUSTOMER_KEYS = [1, 2, 3]
+CUSTOMER_TABLE = pa.table(
+    {
+        "c_custkey": pa.array(CUSTOMER_KEYS, type=pa.int32()),
+        "c_name": ["a", "b", "c"],
+    }
+)
+
+
+def _ipc_to_pydict(ipc_bytes):
+    return ipc.open_stream(io.BytesIO(bytes(ipc_bytes))).read_all().to_pydict()
+
+
+def _customer_manifest_b64():
+    # The three-part tableReference must match the default catalog/schema the
+    # register APIs write into, so load_mdl's provider extraction
+    # ("{catalog}.{schema}.{table}") resolves the model to the physical file.
+    manifest = {
+        "catalog": "my_catalog",
+        "schema": "my_schema",
+        "dataSource": "datafusion",
+        "models": [
+            {
+                "name": "customer",
+                "tableReference": {
+                    "catalog": "datafusion",
+                    "schema": "public",
+                    "table": "customer",
+                },
+                "columns": [
+                    {"name": "c_custkey", "type": "integer"},
+                    {"name": "c_name", "type": "varchar"},
+                ],
+                "primaryKey": "c_custkey",
+            }
+        ],
+    }
+    return base64.b64encode(json.dumps(manifest).encode("utf-8")).decode("utf-8")
+
+
+def _write_customer_parquet(tmp_path):
+    path = tmp_path / "customer.parquet"
+    pq.write_table(CUSTOMER_TABLE, path)
+    return str(path)
+
+
+def test_register_before_load_mdl_queryable_via_semantic_layer(tmp_path):
+    """Two-phase init: register the file, then load MDL to resolve the model.
+
+    The DataFusionConnector consumer never calls load_mdl; the
+    register-then-query path it relies on is pinned by
+    test_register_after_exec_ctx_visible_without_reload.
+    """
+    path = _write_customer_parquet(tmp_path)
+
+    ctx = SessionContext()
+    ctx.register_parquet("customer", path)
+    ctx.load_mdl(_customer_manifest_b64())
+
+    assert "customer" in ctx.list_tables()
+
+    sql = "SELECT c_custkey FROM my_catalog.my_schema.customer ORDER BY c_custkey"
+    assert _ipc_to_pydict(ctx.query(sql)) == {"c_custkey": CUSTOMER_KEYS}
+    assert ctx.dry_run(sql)
+
+
+def test_register_after_exec_ctx_visible_without_reload(tmp_path):
+    """Registration after context creation is visible without any reload.
+
+    The default catalog pre-exists, and pre-existing catalog internals are
+    live-shared with the derived execution context. Python twin of the Rust
+    test
+    table_added_to_pre_existing_catalog_after_apply_is_visible_from_derived_ctx.
+    """
+    # Constructing WITH an MDL is what forces real derived contexts (a bare
+    # SessionContext aliases base/exec to one context and would test
+    # nothing); the customer model itself is unused here.
+    ctx = SessionContext(_customer_manifest_b64(), None)
+
+    path = tmp_path / "late_orders.csv"
+    path.write_text("o_orderkey\n10\n20\n")
+    ctx.register_csv("late_orders", str(path))
+
+    assert "late_orders" in ctx.list_tables()
+
+    sql = "SELECT o_orderkey FROM datafusion.public.late_orders ORDER BY o_orderkey"
+    assert _ipc_to_pydict(ctx.query(sql)) == {"o_orderkey": [10, 20]}
+    assert ctx.dry_run(sql)
+
+
+def test_register_after_exec_ctx_then_load_mdl_resolves_model(tmp_path):
+    """A late-registered table still backs a model loaded afterwards.
+
+    load_mdl's provider extraction walks the base context at call time, so
+    it picks up tables registered after the context was constructed.
+    """
+    ctx = SessionContext(_customer_manifest_b64(), None)
+
+    path = _write_customer_parquet(tmp_path)
+    ctx.register_parquet("customer", path)
+    ctx.load_mdl(_customer_manifest_b64())
+
+    sql = "SELECT c_custkey FROM my_catalog.my_schema.customer ORDER BY c_custkey"
+    assert _ipc_to_pydict(ctx.query(sql)) == {"c_custkey": CUSTOMER_KEYS}
+    assert (
+        ctx.transform_sql("SELECT c_custkey FROM my_catalog.my_schema.customer")
+        is not None
+    )

--- a/core/wren-core-py/tests/test_physical_tables.py
+++ b/core/wren-core-py/tests/test_physical_tables.py
@@ -73,8 +73,8 @@ def _write_customer_parquet(tmp_path):
 def test_register_before_load_mdl_queryable_via_semantic_layer(tmp_path):
     """Two-phase init: register the file, then load MDL to resolve the model.
 
-    The DataFusionConnector consumer never calls load_mdl; the
-    register-then-query path it relies on is pinned by
+    DataFusionConnector uses the same register-then-query APIs on a bare
+    context. The derived-context visibility contract is covered by
     test_register_after_exec_ctx_visible_without_reload.
     """
     path = _write_customer_parquet(tmp_path)
@@ -82,8 +82,6 @@ def test_register_before_load_mdl_queryable_via_semantic_layer(tmp_path):
     ctx = SessionContext()
     ctx.register_parquet("customer", path)
     ctx.load_mdl(_customer_manifest_b64())
-
-    assert "customer" in ctx.list_tables()
 
     sql = "SELECT c_custkey FROM my_catalog.my_schema.customer ORDER BY c_custkey"
     assert _ipc_to_pydict(ctx.query(sql)) == {"c_custkey": CUSTOMER_KEYS}
@@ -128,7 +126,5 @@ def test_register_after_exec_ctx_then_load_mdl_resolves_model(tmp_path):
 
     sql = "SELECT c_custkey FROM my_catalog.my_schema.customer ORDER BY c_custkey"
     assert _ipc_to_pydict(ctx.query(sql)) == {"c_custkey": CUSTOMER_KEYS}
-    assert (
-        ctx.transform_sql("SELECT c_custkey FROM my_catalog.my_schema.customer")
-        is not None
-    )
+    planned = ctx.transform_sql("SELECT c_custkey FROM my_catalog.my_schema.customer")
+    assert 'datafusion."public".customer' in planned

--- a/core/wren-core-py/uv.lock
+++ b/core/wren-core-py/uv.lock
@@ -60,6 +60,49 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/98/ae2b5acf9876dbeffa6f320776242c52caab062df55c8ac5501ed2679e74/pyarrow-25.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2e3b6544e26e393fe2cd530f523e36c1c8d3c345bbbb60cca3fd866be8322517", size = 35939080, upload-time = "2026-07-10T08:26:04.53Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/3de2a968edbd496c86cb8b932cdbee2d4b08c4a28e9884a15e5c705a646b/pyarrow-25.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:b724d127783b4c19f088fcdfc844cbc318809246a30307bcabd5ed02045e890e", size = 37633420, upload-time = "2026-07-10T08:26:10.354Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/8399243a4ce080426ec37db18d5e29148b7ec960a8a8c7f9059a7bf6ef0a/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:244f98a595f70fa4fd35faa7508c4ae67e14a173397a4b3b49d2b3c360fb0062", size = 46861050, upload-time = "2026-07-10T08:26:16.397Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/72d704b02bc5fc6d06954d76a0208c1e79cad3ab370f6d6a91ffe5078870/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0222f0071d13313962a88d21bf28b80d355ac39d81bfa6ff3fe00eeaf748e4be", size = 50056458, upload-time = "2026-07-10T08:26:23.271Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5d/3c31a60b6403d63cad2e0f829096f5fc5763a129ead4207a5d4690b96448/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b58726f118c079f9d4ed7e904975d4f15fd69d0741ba511a4e2dcaa4ef16354f", size = 49957793, upload-time = "2026-07-10T08:26:30.232Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/8f8a019061f9863a831915329264372a87ed25eaf9109ce56eb0e84012c5/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38a2c887cb3883e241b70201688db34133b6dfadd04f03c8f9213df53770c18e", size = 53100544, upload-time = "2026-07-10T08:26:36.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e2/738071e95c5ddad7b3dfc12f569ffa992db89d7d7b4a95258fd184191249/pyarrow-25.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:161649d60a7a46c613a19fd795763ea8a88c36ba997dd99d9bc66e6794ee36e8", size = 27848311, upload-time = "2026-07-10T08:26:41.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -118,6 +161,7 @@ source = { editable = "." }
 [package.dev-dependencies]
 dev = [
     { name = "maturin" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -127,6 +171,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "maturin", specifier = "==1.9.4" },
+    { name = "pyarrow", specifier = "==25.0.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "ruff", specifier = "==0.13.1" },
 ]


### PR DESCRIPTION
## Why

#2495 made `apply_wren_on_ctx` snapshot top-level catalog membership per
derivation. `register_parquet`/`register_csv` write into the pre-existing
default catalog (`datafusion`.`public`), whose internals are live-shared
with derived contexts — so tables registered *after* a session context was
created are still visible through `query`/`dry_run`/`list_tables`. The
`DataFusionConnector` consumer relies on exactly this, but until now the
behavior was implicit: no documentation stated it and no test guarded it.
#2504 asks for both.

## What

- Document the visibility contract on `register_parquet`/`register_csv`
  (where tables land, why late registration is visible, and that brand-new
  *top-level* catalogs must exist before MDL construction, `load_mdl`, or a
  transform), plus `load_mdl`'s concurrency contract (its exclusive borrow
  rejects overlapping calls with `RuntimeError`).
- Add a README section for registering local files, including the
  `tableReference` ↔ registered-name mapping requirement, and fix the Quick
  Start sample (it passed a manifest object and a non-existent
  `remote_functions` kwarg to the constructor).
- Add `tests/test_physical_tables.py`: register-before-`load_mdl`,
  register-after-derivation-without-reload (Python twin of the wren-core
  `catalog_race` visibility test), and register-then-reload. `pyarrow`
  joins the dev group to write Parquet fixtures and decode the Arrow IPC
  bytes `query()` returns, enabling row-level assertions.

No production code changes; no release bump expected.

Note: fixtures declare/store `c_custkey` as int32 on purpose — writing the
IPC stream with the logical plan's schema corrupts results when MDL types
differ from physical file types. That serialization issue was found by
these tests and is fixed separately in a follow-up `fix(core-py)` PR.

## Test Plan

- `just test-py`: 38 passed (35 existing + 3 new), on this branch without
  any production change.
- `just test-rs`: 37 passed.
- `ruff check` / `ruff format --check`: clean on the new test file.

Part of #2504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registered Parquet and CSV tables are now consistently discoverable in table listings and usable by queries, previews, and semantic model resolution, including across derived contexts.
  * Late registrations behave predictably for existing sessions without requiring manual reloads.

* **Documentation**
  * Updated quick-start/example code to use the current session construction approach.
  * Added clearer guidance on registration/load ordering, visibility expectations, and concurrency limitations for model loading.

* **Tests**
  * Added pinned coverage for physical-table registration visibility and semantic-resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->