### PR TITLE
fix(mssql): preserve outer CTEs and ORDER BY when flattening pagination wrap

### DIFF
--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -128,11 +128,12 @@ class MSSqlConnector(ConnectorABC):
 
             # Flattening keeps only the inner Select, so an outer WITH (e.g.
             # semantic-layer model CTEs) or ORDER BY would be silently dropped —
-            # producing invalid references or wrong TOP-n rows. Both are valid
-            # T-SQL next to TOP; only the bare paginate-wrap shape
-            # ``SELECT * FROM (inner) LIMIT n`` is safe to collapse.
+            # producing invalid references or wrong TOP-n rows. Only the bare
+            # paginate-wrap shape ``SELECT * FROM (inner) LIMIT n`` is safe to
+            # collapse; otherwise re-emit through the tsql dialect so a literal
+            # ``LIMIT`` still becomes TOP/FETCH while WITH and ORDER BY survive.
             if parsed.args.get("with_") or parsed.args.get("order"):
-                return sql_query
+                return parsed.sql(dialect="tsql")
 
             from_clause = parsed.find(exp.From)
             if not from_clause:

--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -126,6 +126,14 @@ class MSSqlConnector(ConnectorABC):
             if not isinstance(parsed, exp.Select) or not parsed.args.get("limit"):
                 return sql_query
 
+            # Flattening keeps only the inner Select, so an outer WITH (e.g.
+            # semantic-layer model CTEs) or ORDER BY would be silently dropped —
+            # producing invalid references or wrong TOP-n rows. Both are valid
+            # T-SQL next to TOP; only the bare paginate-wrap shape
+            # ``SELECT * FROM (inner) LIMIT n`` is safe to collapse.
+            if parsed.args.get("with_") or parsed.args.get("order"):
+                return sql_query
+
             from_clause = parsed.find(exp.From)
             if not from_clause:
                 return sql_query

--- a/core/wren/tests/connectors/test_mssql.py
+++ b/core/wren/tests/connectors/test_mssql.py
@@ -305,3 +305,39 @@ def test_url_connection(mssql_container: SqlServerContainer) -> None:
         cur.close()
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _flatten_pagination_limit unit tests (no container needed)
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_pagination_preserves_outer_cte() -> None:
+    """Flattening must not drop an outer WITH — the inner select would then
+    reference a CTE that no longer exists (e.g. semantic-layer model CTEs)."""
+    sql = (
+        "WITH m AS (SELECT a, b FROM dbo.t) "
+        "SELECT TOP 3 * FROM (SELECT a, SUM(b) AS s FROM m GROUP BY a) AS _c"
+    )
+    out = MSSqlConnector._flatten_pagination_limit(None, sql)
+    assert "WITH" in out.upper()
+    assert "FROM m" in out or "FROM [m]" in out
+
+
+def test_flatten_pagination_preserves_outer_order_by() -> None:
+    """Flattening must not drop an outer ORDER BY — TOP-n without the ordering
+    silently returns arbitrary rows."""
+    sql = (
+        "SELECT TOP 3 * FROM "
+        "(SELECT a, SUM(b) AS s FROM dbo.t GROUP BY a) AS _c ORDER BY s DESC"
+    )
+    out = MSSqlConnector._flatten_pagination_limit(None, sql)
+    assert "ORDER BY" in out.upper()
+
+
+def test_flatten_pagination_still_collapses_bare_wrap() -> None:
+    """The plain paginate-wrap shape (no WITH, no ORDER BY) keeps collapsing."""
+    sql = "SELECT * FROM (SELECT a FROM dbo.t) AS w LIMIT 5"
+    out = MSSqlConnector._flatten_pagination_limit(None, sql)
+    assert "(SELECT" not in out.upper().replace(" ", "")
+    assert "TOP 5" in out.upper() or "NEXT 5 ROWS" in out.upper()

--- a/core/wren/tests/connectors/test_mssql.py
+++ b/core/wren/tests/connectors/test_mssql.py
@@ -341,3 +341,28 @@ def test_flatten_pagination_still_collapses_bare_wrap() -> None:
     out = MSSqlConnector._flatten_pagination_limit(None, sql)
     assert "(SELECT" not in out.upper().replace(" ", "")
     assert "TOP 5" in out.upper() or "NEXT 5 ROWS" in out.upper()
+
+
+def test_flatten_pagination_limit_keyword_with_cte_becomes_tsql() -> None:
+    """A literal LIMIT on the guarded path must still be rewritten to valid
+    T-SQL (TOP/FETCH) while the outer WITH survives."""
+    sql = (
+        "WITH m AS (SELECT a, b FROM dbo.t) "
+        "SELECT * FROM (SELECT a, SUM(b) AS s FROM m GROUP BY a) AS _c LIMIT 3"
+    )
+    out = MSSqlConnector._flatten_pagination_limit(None, sql)
+    assert "WITH" in out.upper()
+    assert "LIMIT" not in out.upper()
+    assert "TOP 3" in out.upper() or "NEXT 3 ROWS" in out.upper()
+
+
+def test_flatten_pagination_limit_keyword_with_order_by_becomes_tsql() -> None:
+    """LIMIT + outer ORDER BY: ordering survives and LIMIT is rewritten."""
+    sql = (
+        "SELECT * FROM (SELECT a, SUM(b) AS s FROM dbo.t GROUP BY a) AS _c "
+        "ORDER BY s DESC LIMIT 3"
+    )
+    out = MSSqlConnector._flatten_pagination_limit(None, sql)
+    assert "ORDER BY" in out.upper()
+    assert "LIMIT" not in out.upper()
+    assert "TOP 3" in out.upper() or "NEXT 3 ROWS" in out.upper()

--- a/core/wren/tests/connectors/test_mssql.py
+++ b/core/wren/tests/connectors/test_mssql.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import datetime as dtlib
+import re
 from decimal import Decimal as PyDecimal
 
 import duckdb
@@ -312,6 +313,17 @@ def test_url_connection(mssql_container: SqlServerContainer) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _has_exact_limit(sql: str, n: int) -> bool:
+    """True if the rendered SQL limits to exactly ``n`` rows (TOP or FETCH form).
+
+    Token-boundary aware so ``TOP 3`` does not match ``TOP 30``.
+    """
+    return bool(
+        re.search(rf"\bTOP {n}\b", sql, re.IGNORECASE)
+        or re.search(rf"\bNEXT {n} ROWS\b", sql, re.IGNORECASE)
+    )
+
+
 def test_flatten_pagination_preserves_outer_cte() -> None:
     """Flattening must not drop an outer WITH — the inner select would then
     reference a CTE that no longer exists (e.g. semantic-layer model CTEs)."""
@@ -340,7 +352,7 @@ def test_flatten_pagination_still_collapses_bare_wrap() -> None:
     sql = "SELECT * FROM (SELECT a FROM dbo.t) AS w LIMIT 5"
     out = MSSqlConnector._flatten_pagination_limit(None, sql)
     assert "(SELECT" not in out.upper().replace(" ", "")
-    assert "TOP 5" in out.upper() or "NEXT 5 ROWS" in out.upper()
+    assert _has_exact_limit(out, 5)
 
 
 def test_flatten_pagination_limit_keyword_with_cte_becomes_tsql() -> None:
@@ -353,7 +365,7 @@ def test_flatten_pagination_limit_keyword_with_cte_becomes_tsql() -> None:
     out = MSSqlConnector._flatten_pagination_limit(None, sql)
     assert "WITH" in out.upper()
     assert "LIMIT" not in out.upper()
-    assert "TOP 3" in out.upper() or "NEXT 3 ROWS" in out.upper()
+    assert _has_exact_limit(out, 3)
 
 
 def test_flatten_pagination_limit_keyword_with_order_by_becomes_tsql() -> None:
@@ -365,4 +377,4 @@ def test_flatten_pagination_limit_keyword_with_order_by_becomes_tsql() -> None:
     out = MSSqlConnector._flatten_pagination_limit(None, sql)
     assert "ORDER BY" in out.upper()
     assert "LIMIT" not in out.upper()
-    assert "TOP 3" in out.upper() or "NEXT 3 ROWS" in out.upper()
+    assert _has_exact_limit(out, 3)


### PR DESCRIPTION
## Problem

`MSSqlConnector._flatten_pagination_limit` collapses the v4 paginate-wrap shape `SELECT * FROM (inner) LIMIT n` into the inner select, but it returns **only the inner node**. Two outer clauses are silently dropped:

- an outer `WITH` (e.g. semantic-layer model CTEs emitted by `dry_plan`) — the flattened query then references CTEs that no longer exist and fails with *Invalid object name*;
- an outer `ORDER BY` — `TOP n` then returns **arbitrary rows** instead of the requested top-n, a silent correctness bug.

Repro (both shapes are produced by wrapping a cube/aggregate query for ordering + limit):

```sql
WITH m AS (SELECT a, b FROM dbo.t)
SELECT TOP 3 * FROM (SELECT a, SUM(b) AS s FROM m GROUP BY a) AS _c ORDER BY s DESC
```

flattens to `SELECT TOP 3 a, SUM(b) AS s FROM m GROUP BY a` → `Invalid object name 'm'`; without the CTE the ORDER BY loss makes TOP 3 nondeterministic.

## Fix

Bail out of flattening when the outer select carries `WITH` or `ORDER BY` — both are valid T-SQL next to `TOP`, so the original query runs correctly as-is. The bare paginate-wrap shape still collapses as before.

## Tests

Three container-free unit tests in `tests/connectors/test_mssql.py`: CTE preserved, ORDER BY preserved, bare wrap still collapses. Verified end-to-end against SQL Server 2022 (real data): before the fix the CTE shape errors and the ORDER BY shape returns wrong rows; after the fix both return correct results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL Server pagination rewriting to preserve top-level `WITH` (CTEs) and `ORDER BY` when present.
  * Prevented outer pagination transformations from breaking query structure or result determinism.
  * Ensured `LIMIT` is correctly rewritten into valid T-SQL while keeping supported outer clauses intact.
* **Tests**
  * Expanded unit-test coverage for pagination flattening, including outer `WITH` and outer `ORDER BY` scenarios, plus standard limit rewriting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->