### PR TITLE
fix(memory): coerce non-str text in slugify

### DIFF
--- a/core/wren/src/wren/memory/markdown.py
+++ b/core/wren/src/wren/memory/markdown.py
@@ -31,6 +31,12 @@ _MAX_SLUG_LEN = 60
 
 def slugify(text: str) -> str:
     """Normalize NL text into a filesystem-safe, deterministic slug."""
+    # Callers (CLI / memory store) may pass None or non-str NL text from
+    # partially-filled frontmatter; coerce rather than AttributeError.
+    if text is None:
+        return "query"
+    if not isinstance(text, str):
+        text = str(text)
     text = re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
     if len(text) > _MAX_SLUG_LEN:
         text = text[:_MAX_SLUG_LEN].rstrip("-")

--- a/core/wren/tests/unit/test_slugify_guard.py
+++ b/core/wren/tests/unit/test_slugify_guard.py
@@ -1,0 +1,14 @@
+"""slugify must tolerate None/non-str NL text."""
+from wren.memory.markdown import slugify
+
+
+def test_slugify_none():
+    assert slugify(None) == "query"
+
+
+def test_slugify_non_str():
+    assert slugify(123) == "123"
+
+
+def test_slugify_normal():
+    assert slugify("Hello World!") == "hello-world"


### PR DESCRIPTION
## Summary
`slugify` called `.strip()` on NL text; None/non-str frontmatter crashed filesystem path generation.

## Changes
- Coerce None/non-str to a safe slug
- Unit tests

## Test plan
- isolated import of `wren.memory.markdown.slugify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty, missing, and non-text values during slug generation.
  * Prevented errors when processing unexpected input types.

* **Tests**
  * Added coverage for missing values, numeric inputs, and standard text slug generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->