### PR TITLE
fix(genbi): reject non-object Vercel API JSON

### DIFF
--- a/core/wren/src/wren/genbi/providers/vercel.py
+++ b/core/wren/src/wren/genbi/providers/vercel.py
@@ -22,7 +22,17 @@ def _request(*, method: str, url: str, headers: dict, payload: dict) -> dict:
     resp = requests.request(method, url, headers=headers, json=payload, timeout=120)
     if resp.status_code >= 400:
         raise DeployError(f"Vercel API error {resp.status_code}: {resp.text[:500]}")
-    return resp.json()
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise DeployError(
+            f"Vercel API returned non-JSON body (HTTP {resp.status_code}): {resp.text[:200]!r}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise DeployError(
+            f"Vercel API returned non-object JSON (HTTP {resp.status_code}): {type(data).__name__}"
+        )
+    return data
 
 
 def _collect_files(build_dir: Path) -> list[dict]:

--- a/core/wren/src/wren/genbi/providers/vercel.py
+++ b/core/wren/src/wren/genbi/providers/vercel.py
@@ -26,7 +26,7 @@ def _request(*, method: str, url: str, headers: dict, payload: dict) -> dict:
         data = resp.json()
     except ValueError as exc:
         raise DeployError(
-            f"Vercel API returned non-JSON body (HTTP {resp.status_code}): {resp.text[:200]!r}"
+            f"Vercel API returned non-JSON body (HTTP {resp.status_code}): {resp.text[:500]!r}"
         ) from exc
     if not isinstance(data, dict):
         raise DeployError(

--- a/core/wren/tests/unit/test_vercel_request_json.py
+++ b/core/wren/tests/unit/test_vercel_request_json.py
@@ -1,0 +1,37 @@
+"""Vercel _request must reject non-object JSON payments."""
+from types import SimpleNamespace
+
+import pytest
+
+from wren.genbi.providers.base import DeployError
+from wren.genbi.providers import vercel as vercel_mod
+
+
+def test_request_rejects_list_json(monkeypatch):
+    def fake_request(*args, **kwargs):
+        return SimpleNamespace(
+            status_code=200,
+            text="[]",
+            json=lambda: [],
+        )
+    monkeypatch.setattr(vercel_mod, "requests", SimpleNamespace(request=fake_request), raising=False)
+    # patch inside function local import - need to patch requests module
+    import sys, types
+    fake = types.ModuleType("requests")
+    fake.request = fake_request
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    with pytest.raises(DeployError, match="non-object"):
+        vercel_mod._request(method="POST", url="https://example", headers={}, payload={})
+
+
+def test_request_rejects_invalid_json(monkeypatch):
+    import sys, types
+    def fake_request(*args, **kwargs):
+        def j():
+            raise ValueError("nope")
+        return SimpleNamespace(status_code=200, text="not-json", json=j)
+    fake = types.ModuleType("requests")
+    fake.request = fake_request
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    with pytest.raises(DeployError, match="non-JSON"):
+        vercel_mod._request(method="POST", url="https://example", headers={}, payload={})

--- a/core/wren/tests/unit/test_vercel_request_json.py
+++ b/core/wren/tests/unit/test_vercel_request_json.py
@@ -1,4 +1,6 @@
-"""Vercel _request must reject non-object JSON payments."""
+"""Vercel _request must reject non-object JSON payloads."""
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
@@ -7,31 +9,39 @@ from wren.genbi.providers.base import DeployError
 from wren.genbi.providers import vercel as vercel_mod
 
 
-def test_request_rejects_list_json(monkeypatch):
-    def fake_request(*args, **kwargs):
-        return SimpleNamespace(
-            status_code=200,
-            text="[]",
-            json=lambda: [],
-        )
-    monkeypatch.setattr(vercel_mod, "requests", SimpleNamespace(request=fake_request), raising=False)
-    # patch inside function local import - need to patch requests module
-    import sys, types
+def _install_fake_requests(monkeypatch, response):
+    """Inject a stub `requests` module for the duration of one test.
+
+    `vercel._request` does a function-local `import requests`, so the only
+    patch point that actually takes effect is `sys.modules["requests"]`.
+    monkeypatch.setitem restores the real module afterwards.
+    """
     fake = types.ModuleType("requests")
-    fake.request = fake_request
+    fake.request = lambda *a, **k: response
     monkeypatch.setitem(sys.modules, "requests", fake)
+
+
+def test_request_rejects_list_json(monkeypatch):
+    resp = SimpleNamespace(status_code=200, text="[]", json=lambda: [])
+    _install_fake_requests(monkeypatch, resp)
     with pytest.raises(DeployError, match="non-object"):
         vercel_mod._request(method="POST", url="https://example", headers={}, payload={})
 
 
 def test_request_rejects_invalid_json(monkeypatch):
-    import sys, types
-    def fake_request(*args, **kwargs):
-        def j():
-            raise ValueError("nope")
-        return SimpleNamespace(status_code=200, text="not-json", json=j)
-    fake = types.ModuleType("requests")
-    fake.request = fake_request
-    monkeypatch.setitem(sys.modules, "requests", fake)
+    def _raise():
+        raise ValueError("nope")
+
+    resp = SimpleNamespace(status_code=200, text="not-json", json=_raise)
+    _install_fake_requests(monkeypatch, resp)
     with pytest.raises(DeployError, match="non-JSON"):
+        vercel_mod._request(method="POST", url="https://example", headers={}, payload={})
+
+
+def test_request_http_error_raised_before_json_branches(monkeypatch):
+    """HTTP >= 400 must raise the existing 'Vercel API error' before the
+    non-JSON / non-object guards are reached, pinning branch ordering."""
+    resp = SimpleNamespace(status_code=500, text="boom", json=lambda: [])
+    _install_fake_requests(monkeypatch, resp)
+    with pytest.raises(DeployError, match="Vercel API error 500"):
         vercel_mod._request(method="POST", url="https://example", headers={}, payload={})

--- a/core/wren/tests/unit/test_vercel_request_json.py
+++ b/core/wren/tests/unit/test_vercel_request_json.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from wren.genbi.providers.base import DeployError
 from wren.genbi.providers import vercel as vercel_mod
+from wren.genbi.providers.base import DeployError
 
 
 def _install_fake_requests(monkeypatch, response):

--- a/core/wren/tests/unit/test_vercel_request_json.py
+++ b/core/wren/tests/unit/test_vercel_request_json.py
@@ -14,11 +14,20 @@ def _install_fake_requests(monkeypatch, response):
 
     `vercel._request` does a function-local `import requests`, so the only
     patch point that actually takes effect is `sys.modules["requests"]`.
-    monkeypatch.setitem restores the real module afterwards.
+    monkeypatch.setitem restores the real module afterwards. The stub
+    records the call so tests can assert transport args (method, url,
+    headers, json, timeout) instead of silently discarding them.
     """
+    calls = []
+
+    def _fake_request(method, url, **kwargs):
+        calls.append({"method": method, "url": url, **kwargs})
+        return response
+
     fake = types.ModuleType("requests")
-    fake.request = lambda *a, **k: response
+    fake.request = _fake_request
     monkeypatch.setitem(sys.modules, "requests", fake)
+    return calls
 
 
 def test_request_rejects_list_json(monkeypatch):
@@ -45,3 +54,27 @@ def test_request_http_error_raised_before_json_branches(monkeypatch):
     _install_fake_requests(monkeypatch, resp)
     with pytest.raises(DeployError, match="Vercel API error 500"):
         vercel_mod._request(method="POST", url="https://example", headers={}, payload={})
+
+
+def test_request_returns_dict_unchanged(monkeypatch):
+    """Success path: a dict body is returned verbatim (the branch the one
+    production caller reads url/projectId/ownerId from), and the transport
+    is called with the args the caller passed — pinning that a dropped
+    timeout or json= payload would be caught."""
+    resp = SimpleNamespace(
+        status_code=200, text='{}', json=lambda: {"url": "x.vercel.app"}
+    )
+    calls = _install_fake_requests(monkeypatch, resp)
+    out = vercel_mod._request(
+        method="POST",
+        url="https://example",
+        headers={"h": "1"},
+        payload={"p": "2"},
+    )
+    assert out == {"url": "x.vercel.app"}
+    assert len(calls) == 1
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["url"] == "https://example"
+    assert calls[0]["headers"] == {"h": "1"}
+    assert calls[0]["json"] == {"p": "2"}
+    assert calls[0]["timeout"] == 120


### PR DESCRIPTION
## Summary
Vercel deploy assumed `resp.json()` is always a dict; list/invalid JSON caused AttributeError later.

## Test plan
- unit tests around `_request` with mocked requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vercel deployment response handling by safely parsing response bodies as JSON.
  * Now raises a clear error (including HTTP status and a truncated response body) when the response is non-JSON or when parsed JSON isn’t an object.

* **Tests**
  * Added unit coverage to reject JSON that parses successfully but isn’t an object.
  * Added tests to ensure HTTP error handling triggers before any JSON-content validation, plus a success-path check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->