### PR TITLE
fix(genbi): treat blank provider tokens as missing

### DIFF
--- a/core/wren/src/wren/genbi/tokens.py
+++ b/core/wren/src/wren/genbi/tokens.py
@@ -11,21 +11,36 @@ import os
 from pathlib import Path
 
 
+def _as_token(value: object) -> str | None:
+    """Return a non-empty stripped token string, else None.
+
+    Blank / whitespace-only env values (`VERCEL_TOKEN=`) used to be truthy
+    enough for `if value := os.environ.get(...)` and were returned as "" or
+    spaces, so deploy sent `Authorization: Bearer ` and failed opaquely.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    return value or None
+
+
 def resolve_token(env_var: str, project_path: Path) -> str | None:
     """3-tier lookup: process env → merged .env files → project .env.
 
     Returns None when absent — the caller decides whether to prompt.
     """
     # 1. Shell-exported environment always wins.
-    if value := os.environ.get(env_var):
-        return value
+    if token := _as_token(os.environ.get(env_var)):
+        return token
 
     # 2. Standard .env discovery (cwd → cwd-walk project root → ~/.wren/.env).
     from wren.profile import _ensure_env_loaded  # noqa: PLC0415
 
     _ensure_env_loaded()
-    if value := os.environ.get(env_var):
-        return value
+    if token := _as_token(os.environ.get(env_var)):
+        return token
 
     # 3. The explicit project dir's .env — covers --path projects outside cwd.
     project_env = project_path / ".env"
@@ -33,8 +48,8 @@ def resolve_token(env_var: str, project_path: Path) -> str | None:
         try:
             from dotenv import dotenv_values  # noqa: PLC0415
 
-            if value := dotenv_values(project_env).get(env_var):
-                return value
+            if token := _as_token(dotenv_values(project_env).get(env_var)):
+                return token
         except ImportError:
             pass
 

--- a/core/wren/src/wren/genbi/tokens.py
+++ b/core/wren/src/wren/genbi/tokens.py
@@ -35,6 +35,13 @@ def resolve_token(env_var: str, project_path: Path) -> str | None:
     if token := _as_token(os.environ.get(env_var)):
         return token
 
+    # A blank/whitespace-only shell value (`VERCEL_TOKEN=`) must not block a
+    # valid token from the .env files below: `load_dotenv(override=False)`
+    # skips keys already present in ``os.environ``, so drop the blank entry
+    # first. Nonblank values returned above already took precedence.
+    if env_var in os.environ:
+        del os.environ[env_var]
+
     # 2. Standard .env discovery (cwd → cwd-walk project root → ~/.wren/.env).
     from wren.profile import _ensure_env_loaded  # noqa: PLC0415
 

--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -34,11 +34,12 @@ def generate_seed_queries(manifest: dict) -> list[dict]:
     models = [
         model
         for model in manifest.get("models", [])
-        if isinstance(model, dict) and model.get("name")
+        if isinstance(model, dict)
+        and isinstance(model.get("name"), str)
+        and model["name"].strip()
     ]
     model_layers = {
-        model["name"]: _prop_value(model, "dbtLayer", "dbt_layer")
-        for model in models
+        model["name"]: _prop_value(model, "dbtLayer", "dbt_layer") for model in models
     }
     relationship_keys = _relationship_key_columns(manifest)
 

--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -31,13 +31,18 @@ SEED_TAG = "source:seed"
 def generate_seed_queries(manifest: dict) -> list[dict]:
     """Return a list of {"nl": ..., "sql": ...} seed pairs."""
     pairs: list[dict] = []
+    models = [
+        model
+        for model in manifest.get("models", [])
+        if isinstance(model, dict) and model.get("name")
+    ]
     model_layers = {
         model["name"]: _prop_value(model, "dbtLayer", "dbt_layer")
-        for model in manifest.get("models", [])
+        for model in models
     }
     relationship_keys = _relationship_key_columns(manifest)
 
-    for model in manifest.get("models", []):
+    for model in models:
         if model_layers.get(model["name"]) == "raw":
             continue
         pairs.extend(
@@ -47,6 +52,8 @@ def generate_seed_queries(manifest: dict) -> list[dict]:
         )
 
     for rel in manifest.get("relationships", []):
+        if not isinstance(rel, dict):
+            continue
         pair = _relationship_seed(rel, model_layers)
         if pair:
             pairs.append(pair)
@@ -167,6 +174,8 @@ def _relationship_key_columns(manifest: dict) -> dict[str, frozenset[str]]:
     """
     accum: dict[str, set[str]] = {}
     for rel in manifest.get("relationships", []):
+        if not isinstance(rel, dict):
+            continue
         condition = rel.get("condition") or ""
         try:
             tree = sqlglot.parse_one(condition)

--- a/core/wren/tests/unit/test_resolve_token_blank.py
+++ b/core/wren/tests/unit/test_resolve_token_blank.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from wren.genbi.tokens import resolve_token
+
+
+def test_resolve_token_treats_blank_env_as_missing(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("VERCEL_TOKEN", "   ")
+    # Avoid loading real dotenv environment side effects: stub _ensure_env_loaded
+    import wren.profile as profile
+
+    monkeypatch.setattr(profile, "_ensure_env_loaded", lambda: None)
+    assert resolve_token("VERCEL_TOKEN", tmp_path) is None
+
+
+def test_resolve_token_strips(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("VERCEL_TOKEN", "  abc  ")
+    import wren.profile as profile
+
+    monkeypatch.setattr(profile, "_ensure_env_loaded", lambda: None)
+    assert resolve_token("VERCEL_TOKEN", tmp_path) == "abc"

--- a/core/wren/tests/unit/test_resolve_token_blank.py
+++ b/core/wren/tests/unit/test_resolve_token_blank.py
@@ -18,3 +18,28 @@ def test_resolve_token_strips(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr(profile, "_ensure_env_loaded", lambda: None)
     assert resolve_token("VERCEL_TOKEN", tmp_path) == "abc"
+
+
+def test_resolve_token_blank_env_falls_back_to_standard_dotenv(
+    monkeypatch, tmp_path: Path
+):
+    """A blank shell value must not shadow a valid token in $CWD/.env."""
+    monkeypatch.setenv("VERCEL_TOKEN", "   ")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("VERCEL_TOKEN=from-dotenv\n")
+
+    # Exercise the real _ensure_env_loaded discovery (reset its one-shot latch).
+    import wren.profile as profile
+
+    monkeypatch.setattr(profile, "_env_loaded", False)
+    assert resolve_token("VERCEL_TOKEN", tmp_path) == "from-dotenv"
+
+
+def test_resolve_token_blank_in_project_env_is_missing(monkeypatch, tmp_path: Path):
+    """A whitespace-only token in the explicit project .env normalizes to None."""
+    import wren.profile as profile
+
+    monkeypatch.delenv("VERCEL_TOKEN", raising=False)
+    monkeypatch.setattr(profile, "_ensure_env_loaded", lambda: None)
+    (tmp_path / ".env").write_text('VERCEL_TOKEN="   "\n')
+    assert resolve_token("VERCEL_TOKEN", tmp_path) is None

--- a/core/wren/tests/unit/test_seed_queries_nonduct_models.py
+++ b/core/wren/tests/unit/test_seed_queries_nonduct_models.py
@@ -22,6 +22,8 @@ def test_generate_seed_queries_skips_nonduct_entries() -> None:
                 ],
             },
             {"columns": [{"name": "x", "type": "int"}]},  # no name
+            {"name": "   "},  # whitespace-only name
+            {"name": 123},  # non-string name
         ],
         "relationships": [
             "bad-rel",
@@ -34,5 +36,7 @@ def test_generate_seed_queries_skips_nonduct_entries() -> None:
     pairs = generate_seed_queries(manifest)
     nls = [p["nl"] for p in pairs]
     assert any("orders" in nl for nl in nls)
-    #relationship pair may appear if both model names exist in layers
+    # relationship pair may appear if both model names exist in layers
     assert all(isinstance(p, dict) and "sql" in p for p in pairs)
+    # whitespace-only and non-string model names are dropped
+    assert not any("123" in nl for nl in nls)

--- a/core/wren/tests/unit/test_seed_queries_nonduct_models.py
+++ b/core/wren/tests/unit/test_seed_queries_nonduct_models.py
@@ -1,0 +1,38 @@
+"""generate_seed_queries must tolerate non-dict models/relationships."""
+
+from __future__ import annotations
+
+import pytest
+
+from wren.memory.seed_queries import generate_seed_queries
+
+pytestmark = pytest.mark.unit
+
+
+def test_generate_seed_queries_skips_nonduct_entries() -> None:
+    manifest = {
+        "models": [
+            "bad",
+            None,
+            {
+                "name": "orders",
+                "columns": [
+                    {"name": "status", "type": "varchar"},
+                    "nope",
+                ],
+            },
+            {"columns": [{"name": "x", "type": "int"}]},  # no name
+        ],
+        "relationships": [
+            "bad-rel",
+            {
+                "models": ["orders", "customers"],
+                "condition": "orders.customer_id = customers.id",
+            },
+        ],
+    }
+    pairs = generate_seed_queries(manifest)
+    nls = [p["nl"] for p in pairs]
+    assert any("orders" in nl for nl in nls)
+    #relationship pair may appear if both model names exist in layers
+    assert all(isinstance(p, dict) and "sql" in p for p in pairs)


### PR DESCRIPTION
## Summary
`resolve_token` returned whitespace-only env values as tokens, so deploy used `Authorization: Bearer ` and failed opaquely.

## Changes
- Strip and reject blank tokens at all 3 lookup tiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blank or whitespace-only token values are now treated as missing (including when provided via process environment), preventing invalid/blocked authorization.
  * Token values are trimmed and normalized consistently across environment and `.env` sources, so blank env entries won’t prevent valid `.env` values.
  * Seed query generation is more defensive against malformed manifest data by safely skipping unexpected non-dict entries in `models` and `relationships`.
* **Tests**
  * Added unit tests for blank/whitespace token normalization and `.env` fallback behavior.
  * Added unit tests ensuring seed query generation tolerates malformed manifest entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->