### PR TITLE
fix(datafusion): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -29,11 +29,14 @@ class DataFusionConnector(ConnectorABC):
         self._register_tables()
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Always strip terminating ``;`` / whitespace. Limited path needs it
+        # for the subquery wrap; unlimited ``ctx.query`` also rejects a trailing
+        # statement terminator on single-statement LocalRuntime execution.
+        cleaned = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {int(limit)}"
-            )
+            sql = f"SELECT * FROM ({cleaned}) AS _q LIMIT {int(limit)}"
+        else:
+            sql = cleaned
         ipc_bytes = self.ctx.query(sql)
         reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))
         return reader.read_all()

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -45,12 +45,21 @@ def test_query_strips_trailing_semicolon_before_subquery_wrap() -> None:
     assert ";)" not in sent
 
 
-def test_query_without_limit_is_unwrapped() -> None:
+def test_query_without_limit_strips_trailing_semicolon() -> None:
     connector, ctx = _make_mock_connector()
     connector.query("SELECT 1;")
     (sent,), _ = ctx.query.call_args
-    # No limit -> no subquery wrapping; passed through verbatim.
-    assert sent == "SELECT 1;"
+    # No limit -> no subquery wrapping, but terminating ``;`` is still stripped
+    # so LocalRuntime single-statement execution accepts client SQL.
+    assert sent == "SELECT 1"
+    assert not sent.endswith(";")
+
+
+def test_query_without_limit_strips_semicolon_and_whitespace() -> None:
+    connector, ctx = _make_mock_connector()
+    connector.query("SELECT 1;  \n")
+    (sent,), _ = ctx.query.call_args
+    assert sent == "SELECT 1"
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:


### PR DESCRIPTION
## Summary

- Strip terminating semicolon/whitespace on DataFusion unlimited `query()` before `ctx.query`.
- Keep limited-path subquery wrap behavior; add regression tests.

## Motivation

Limited queries already stripped before wrap. Unlimited still forwarded raw `SELECT 1;`, which LocalRuntime rejects for single-statement execution.

## Verification

- `core/wren/.venv/bin/python -m pytest tests/unit/test_datafusion_semicolon.py -q` — 8 passed

## Duplicate check

- Prior unlimited strip PRs #2483/#2506 closed/stale against older tips; main still lacked unlimited strip (test asserted pass-through).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query handling by consistently removing trailing semicolons, including those followed by whitespace or newlines.
  * Ensured queries with row limits are executed reliably when wrapped as subqueries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->