### PR TITLE
fix(genbi): harden non-dict apps.yml entries in list/get/register

### DIFF
--- a/core/wren/src/wren/genbi/cli.py
+++ b/core/wren/src/wren/genbi/cli.py
@@ -364,7 +364,7 @@ def deploy(
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
-    deploy_state = {
+    deploy_record = {
         "provider": adapter.name,
         "project_id": deployment.project_id,
         "org_id": deployment.org_id,
@@ -373,5 +373,5 @@ def deploy(
         "last_deployed_at": date.today().isoformat(),
         "environment": deployment.environment,
     }
-    update_app(project_path, name, status="deployed", deploy=deploy_state)
+    update_app(project_path, name, status="deployed", deploy=deploy_record)
     typer.echo(f"Deployed {name} ({deployment.environment}): {deployment.url}")

--- a/core/wren/src/wren/genbi/cli.py
+++ b/core/wren/src/wren/genbi/cli.py
@@ -195,7 +195,7 @@ def register(
 @genbi_app.command(name="list")
 def list_apps(path: ProjectPathOpt = None) -> None:
     """List registered apps with data mode, status, and deploy state."""
-    from wren.genbi.index import load_index  # noqa: PLC0415
+    from wren.genbi.index import deploy_state, load_index  # noqa: PLC0415
 
     project_path = _discover(path)
     apps = load_index(project_path)["apps"]
@@ -207,10 +207,7 @@ def list_apps(path: ProjectPathOpt = None) -> None:
         if not isinstance(entry, dict):
             typer.echo(f"{name}  [invalid entry: {type(entry).__name__}]", err=True)
             continue
-        deploy = entry.get("deploy") or {}
-        if not isinstance(deploy, dict):
-            deploy = {}
-        last_url = deploy.get("last_url")
+        last_url = deploy_state(entry).get("last_url")
         suffix = f" → {last_url}" if last_url else ""
         typer.echo(
             f"{name}  [{entry.get('data_mode', '?')}, {entry.get('status', '?')}]"
@@ -317,7 +314,7 @@ def deploy(
     """Verify, then ship a registered app to the user's provider account."""
     from datetime import date  # noqa: PLC0415
 
-    from wren.genbi.index import update_app  # noqa: PLC0415
+    from wren.genbi.index import deploy_state, update_app  # noqa: PLC0415
     from wren.genbi.providers import get_provider  # noqa: PLC0415
     from wren.genbi.providers.base import DeployError  # noqa: PLC0415
     from wren.genbi.tokens import resolve_token  # noqa: PLC0415
@@ -361,7 +358,7 @@ def deploy(
             app_name=name,
             token=token,
             prod=prod,
-            link=entry.get("deploy"),
+            link=deploy_state(entry) or None,
         )
     except DeployError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/core/wren/src/wren/genbi/cli.py
+++ b/core/wren/src/wren/genbi/cli.py
@@ -204,8 +204,14 @@ def list_apps(path: ProjectPathOpt = None) -> None:
         return
 
     for name, entry in apps.items():
+        if not isinstance(entry, dict):
+            typer.echo(f"{name}  [invalid entry: {type(entry).__name__}]", err=True)
+            continue
         deploy = entry.get("deploy") or {}
-        suffix = f" → {deploy['last_url']}" if deploy.get("last_url") else ""
+        if not isinstance(deploy, dict):
+            deploy = {}
+        last_url = deploy.get("last_url")
+        suffix = f" → {last_url}" if last_url else ""
         typer.echo(
             f"{name}  [{entry.get('data_mode', '?')}, {entry.get('status', '?')}]"
             f"{suffix}"

--- a/core/wren/src/wren/genbi/index.py
+++ b/core/wren/src/wren/genbi/index.py
@@ -117,6 +117,12 @@ def get_app(project_path: Path, name: str) -> dict | None:
     return entry
 
 
+def deploy_state(entry: dict) -> dict:
+    """The entry's deploy block, or {} when hand-edited to a non-mapping."""
+    d = entry.get("deploy")
+    return d if isinstance(d, dict) else {}
+
+
 def update_app(project_path: Path, name: str, **fields) -> dict:
     """Merge ``fields`` into the entry for ``name`` and persist.
 

--- a/core/wren/src/wren/genbi/index.py
+++ b/core/wren/src/wren/genbi/index.py
@@ -80,11 +80,17 @@ def save_index(project_path: Path, index: dict) -> None:
 def register_app(project_path: Path, name: str, *, data_mode: str) -> dict:
     """Create or update the entry for ``name``. Returns the entry."""
     index = load_index(project_path)
-    entry = index["apps"].get(name) or {
-        "source": f"apps/{name}",
-        "status": "scaffolded",
-        "created_at": date.today().isoformat(),
-    }
+    existing = index["apps"].get(name)
+    # Hand-edited truthy non-dicts (e.g. a string) must not fall through the
+    # ``or`` default — assignment would raise TypeError. Treat like missing.
+    if not isinstance(existing, dict):
+        entry = {
+            "source": f"apps/{name}",
+            "status": "scaffolded",
+            "created_at": date.today().isoformat(),
+        }
+    else:
+        entry = existing
     entry["data_mode"] = data_mode
     index["apps"][name] = entry
     save_index(project_path, index)
@@ -103,13 +109,25 @@ def remove_app(project_path: Path, name: str) -> bool:
 
 def get_app(project_path: Path, name: str) -> dict | None:
     """Return the entry for ``name`` or None if not registered."""
-    return load_index(project_path)["apps"].get(name)
+    entry = load_index(project_path)["apps"].get(name)
+    # Hand-edited apps.yml may put a scalar/list under an app key; treat as
+    # unregistered rather than letting callers AttributeError on mapping ops.
+    if entry is not None and not isinstance(entry, dict):
+        return None
+    return entry
 
 
 def update_app(project_path: Path, name: str, **fields) -> dict:
-    """Merge ``fields`` into the entry for ``name`` and persist."""
+    """Merge ``fields`` into the entry for ``name`` and persist.
+
+    Raises ``KeyError`` when the name is missing or the stored entry is not a
+    mapping (hand-edited scalar/list). Callers that need a friendlier message
+    should go through ``get_app`` / ``_require_registered`` first.
+    """
     index = load_index(project_path)
-    entry = index["apps"][name]
+    entry = index["apps"].get(name)
+    if not isinstance(entry, dict):
+        raise KeyError(name)
     entry.update(fields)
     save_index(project_path, index)
     return entry

--- a/core/wren/tests/unit/test_genbi_deploy.py
+++ b/core/wren/tests/unit/test_genbi_deploy.py
@@ -98,6 +98,8 @@ def test_deploy_tolerates_scalar_deploy_block(tmp_path: Path, monkeypatch) -> No
     goldmedal mutation-check: reverting link=deploy_state(entry) or None back to
     entry.get("deploy") must fail this test.
     """
+    import wren.genbi.providers as providers  # noqa: PLC0415
+
     project = _make_deployable_project(tmp_path)
     apps_yml = project / ".wren" / "apps.yml"
     index = yaml.safe_load(apps_yml.read_text())
@@ -110,15 +112,30 @@ def test_deploy_tolerates_scalar_deploy_block(tmp_path: Path, monkeypatch) -> No
     )
     monkeypatch.setattr(vercel, "_request", fake)
 
+    link_args: list[object] = []
+    real_get_provider = providers.get_provider
+
+    def _spy_get_provider(name: str):
+        adapter = real_get_provider(name)
+        real_deploy = adapter.deploy
+
+        def _deploy(*args, **kwargs):
+            link_args.append(kwargs.get("link", args[3] if len(args) > 3 else None))
+            return real_deploy(*args, **kwargs)
+
+        adapter.deploy = _deploy  # type: ignore[method-assign]
+        return adapter
+
+    monkeypatch.setattr(providers, "get_provider", _spy_get_provider)
+
     result = runner.invoke(
         app, ["genbi", "deploy", "myapp", "--provider", "vercel", "-p", str(project)]
     )
 
     assert not isinstance(result.exception, AttributeError), result.exception
     assert result.exit_code == 0, (result.exception, result.output)
-    # provider must have been called with link=None (normalized), not a str
     assert fake.calls, "provider was not invoked"
-    # _request path does not include link; success without AttributeError is the guard.
+    assert link_args == [None], f"provider link must be None for scalar deploy, got {link_args!r}"
     index_after = yaml.safe_load(apps_yml.read_text())
     assert isinstance(index_after["apps"]["myapp"]["deploy"], dict)
 

--- a/core/wren/tests/unit/test_genbi_deploy.py
+++ b/core/wren/tests/unit/test_genbi_deploy.py
@@ -92,6 +92,37 @@ class _FakeTransport:
         return self.response
 
 
+def test_deploy_tolerates_scalar_deploy_block(tmp_path: Path, monkeypatch) -> None:
+    """Regression: non-dict entry['deploy'] must not AttributeError in providers.
+
+    goldmedal mutation-check: reverting link=deploy_state(entry) or None back to
+    entry.get("deploy") must fail this test.
+    """
+    project = _make_deployable_project(tmp_path)
+    apps_yml = project / ".wren" / "apps.yml"
+    index = yaml.safe_load(apps_yml.read_text())
+    index["apps"]["myapp"]["deploy"] = "https://x"
+    apps_yml.write_text(yaml.safe_dump(index))
+
+    monkeypatch.setenv("VERCEL_TOKEN", "tok-123")
+    fake = _FakeTransport(
+        {"id": "dpl_1", "url": "myapp-abc.vercel.app", "projectId": "prj_9"}
+    )
+    monkeypatch.setattr(vercel, "_request", fake)
+
+    result = runner.invoke(
+        app, ["genbi", "deploy", "myapp", "--provider", "vercel", "-p", str(project)]
+    )
+
+    assert not isinstance(result.exception, AttributeError), result.exception
+    assert result.exit_code == 0, (result.exception, result.output)
+    # provider must have been called with link=None (normalized), not a str
+    assert fake.calls, "provider was not invoked"
+    # _request path does not include link; success without AttributeError is the guard.
+    index_after = yaml.safe_load(apps_yml.read_text())
+    assert isinstance(index_after["apps"]["myapp"]["deploy"], dict)
+
+
 def test_deploy_vercel_uploads_and_persists_state(tmp_path: Path, monkeypatch) -> None:
     project = _make_deployable_project(tmp_path)
     monkeypatch.setenv("VERCEL_TOKEN", "tok-123")

--- a/core/wren/tests/unit/test_genbi_index.py
+++ b/core/wren/tests/unit/test_genbi_index.py
@@ -224,3 +224,14 @@ def test_update_app_rejects_non_dict_entry(tmp_path: Path) -> None:
     save_index(tmp_path, {"schema_version": 1, "apps": {"bad": "not-a-map"}})
     with pytest.raises(KeyError):
         update_app(tmp_path, "bad", status="deployed")
+
+
+def test_deploy_state_normalizes_non_dict() -> None:
+    from wren.genbi.index import deploy_state
+
+    assert deploy_state({"deploy": "https://x"}) == {}
+    assert deploy_state({"deploy": {"last_url": "https://ok"}}) == {
+        "last_url": "https://ok"
+    }
+    assert deploy_state({}) == {}
+

--- a/core/wren/tests/unit/test_genbi_index.py
+++ b/core/wren/tests/unit/test_genbi_index.py
@@ -192,3 +192,35 @@ def test_load_index_preserves_falsy_schema_version(tmp_path: Path) -> None:
 
     data = load_index(tmp_path)
     assert data["schema_version"] == 0
+
+
+def test_get_app_skips_non_dict_entry(tmp_path: Path) -> None:
+    from wren.genbi.index import get_app, save_index
+
+    save_index(
+        tmp_path,
+        {"schema_version": 1, "apps": {"bad": "not-a-map", "good": {"source": "apps/good"}}},
+    )
+    assert get_app(tmp_path, "bad") is None
+    assert get_app(tmp_path, "good") == {"source": "apps/good"}
+    assert get_app(tmp_path, "missing") is None
+
+
+def test_register_app_replaces_non_dict_entry(tmp_path: Path) -> None:
+    from wren.genbi.index import load_index, register_app, save_index
+
+    save_index(tmp_path, {"schema_version": 1, "apps": {"bad": "not-a-map"}})
+    entry = register_app(tmp_path, "bad", data_mode="snapshot")
+    assert isinstance(entry, dict)
+    assert entry["data_mode"] == "snapshot"
+    assert entry["source"] == "apps/bad"
+    assert isinstance(load_index(tmp_path)["apps"]["bad"], dict)
+
+
+def test_update_app_rejects_non_dict_entry(tmp_path: Path) -> None:
+    from wren.genbi.index import save_index, update_app
+    import pytest
+
+    save_index(tmp_path, {"schema_version": 1, "apps": {"bad": "not-a-map"}})
+    with pytest.raises(KeyError):
+        update_app(tmp_path, "bad", status="deployed")

--- a/core/wren/tests/unit/test_genbi_list_nondict.py
+++ b/core/wren/tests/unit/test_genbi_list_nondict.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from wren.genbi.cli import genbi_app
-from wren.genbi.index import save_index
+from wren.genbi.index import deploy_state, save_index
 
 
 def test_list_reports_non_dict_entry(tmp_path: Path) -> None:
@@ -23,7 +23,8 @@ def test_list_reports_non_dict_entry(tmp_path: Path) -> None:
     result = CliRunner().invoke(genbi_app, ["list", "--path", str(tmp_path)])
     assert result.exit_code == 0
     assert "good" in result.stdout
-    assert "invalid entry" in (result.stdout + result.stderr)
+    assert "invalid entry" in result.stderr
+    assert "invalid entry" not in result.stdout
 
 
 def test_list_tolerates_non_dict_deploy_block(tmp_path: Path) -> None:
@@ -45,3 +46,11 @@ def test_list_tolerates_non_dict_deploy_block(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.exception
     assert "good" in result.stdout
     assert "https://x" not in result.stdout
+
+
+def test_deploy_state_normalizes_non_dict() -> None:
+    assert deploy_state({"deploy": "https://x"}) == {}
+    assert deploy_state({"deploy": {"last_url": "https://ok"}}) == {
+        "last_url": "https://ok"
+    }
+    assert deploy_state({}) == {}

--- a/core/wren/tests/unit/test_genbi_list_nondict.py
+++ b/core/wren/tests/unit/test_genbi_list_nondict.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from wren.genbi.cli import genbi_app
-from wren.genbi.index import deploy_state, save_index
+from wren.genbi.index import save_index
 
 
 def test_list_reports_non_dict_entry(tmp_path: Path) -> None:
@@ -47,10 +47,3 @@ def test_list_tolerates_non_dict_deploy_block(tmp_path: Path) -> None:
     assert "good" in result.stdout
     assert "https://x" not in result.stdout
 
-
-def test_deploy_state_normalizes_non_dict() -> None:
-    assert deploy_state({"deploy": "https://x"}) == {}
-    assert deploy_state({"deploy": {"last_url": "https://ok"}}) == {
-        "last_url": "https://ok"
-    }
-    assert deploy_state({}) == {}

--- a/core/wren/tests/unit/test_genbi_list_nonduct.py
+++ b/core/wren/tests/unit/test_genbi_list_nonduct.py
@@ -44,3 +44,4 @@ def test_list_tolerates_non_dict_deploy_block(tmp_path: Path) -> None:
     result = CliRunner().invoke(genbi_app, ["list", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.exception
     assert "good" in result.stdout
+    assert "https://x" not in result.stdout

--- a/core/wren/tests/unit/test_genbi_list_nonduct.py
+++ b/core/wren/tests/unit/test_genbi_list_nonduct.py
@@ -1,0 +1,46 @@
+"""genbi list must tolerate non-dict apps.yml entries and non-dict deploy blocks."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from wren.genbi.cli import genbi_app
+from wren.genbi.index import save_index
+
+
+def test_list_reports_non_dict_entry(tmp_path: Path) -> None:
+    (tmp_path / "wren_project.yml").write_text("name: t\n")
+    save_index(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "apps": {
+                "good": {"data_mode": "snapshot", "status": "ready"},
+                "bad": "not-a-mapping",
+            },
+        },
+    )
+    result = CliRunner().invoke(genbi_app, ["list", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "good" in result.stdout
+    assert "invalid entry" in (result.stdout + result.stderr)
+
+
+def test_list_tolerates_non_dict_deploy_block(tmp_path: Path) -> None:
+    (tmp_path / "wren_project.yml").write_text("name: t\n")
+    save_index(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "apps": {
+                "good": {
+                    "source": "apps/good",
+                    "status": "deployed",
+                    "deploy": "https://x",
+                }
+            },
+        },
+    )
+    result = CliRunner().invoke(genbi_app, ["list", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.exception
+    assert "good" in result.stdout


### PR DESCRIPTION
## Summary
Single PR for hand-edited `apps.yml` non-dict entries (folds #2583 list/index hardening):

| Path | Behavior |
|------|----------|
| `list` | prints invalid entry on stderr, continues; non-dict `deploy` via `deploy_state` |
| `get_app` | non-dict → `None` (CLI "not registered") |
| `register_app` | replaces truthy non-dict instead of `TypeError` on item assignment |
| `update_app` | `KeyError` when missing/non-dict |
| `deploy` | `link=deploy_state(entry) or None` so providers never `.get` on a scalar |

## Reproduction (base / before)
```text
apps: {bad: "not-a-map"}
register_app → TypeError: 'str' object does not support item assignment
list with deploy: "https://x" on a valid entry → AttributeError: 'str' object has no attribute 'get'
deploy with deploy: "https://x" → same AttributeError inside provider
```

## Verification
```bash
cd core/wren && python -m pytest tests/unit/test_genbi_index.py tests/unit/test_genbi_list_nondict.py -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app listing reliability when deployment records are incomplete or malformed.
  * Invalid app entries are now reported safely instead of causing failures.
  * Deployment links are handled safely when sharing existing deployment information.
  * Invalid app records can be replaced with valid registrations, while unsupported updates are rejected clearly.
  * Deployment metadata is normalized to ensure deployments complete successfully.

* **Tests**
  * Added coverage for malformed app entries, deployment data, and deployment regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->