### PR TITLE
fix(langchain): coerce non-str nl/sql in format_recall_content

### DIFF
--- a/sdk/wren-langchain/README.md
+++ b/sdk/wren-langchain/README.md
@@ -86,9 +86,9 @@ pip install wren-langchain
   - `wren_store_query` — persist a confirmed NL→SQL pair for future recall
 - **Direct Python API**:
   ```python
-  toolkit.query("SELECT ...")             # → pyarrow.Table
-  toolkit.dry_plan("SELECT ...")           # → str (target-dialect SQL)
-  toolkit.dry_run("SELECT ...")            # → None (validation only)
+  toolkit.query("SELECT ...")  # → pyarrow.Table
+  toolkit.dry_plan("SELECT ...")  # → str (target-dialect SQL)
+  toolkit.dry_run("SELECT ...")  # → None (validation only)
   toolkit.memory.fetch("revenue trends")
   toolkit.memory.recall("top customers")
   toolkit.memory.store(nl="...", sql="...", tags=["..."])
@@ -99,13 +99,13 @@ pip install wren-langchain
 
 ```python
 WrenToolkit.from_project(
-    path,                # required — path to your prepared Wren project
-    profile="prod",      # optional — picks a named profile (default: active)
+    path,  # required — path to your prepared Wren project
+    profile="prod",  # optional — picks a named profile (default: active)
 )
 
 toolkit.get_tools(
-    include_memory_write=True,   # set False to keep memory read-only
-    raise_on_error=False,        # set True to surface exceptions to LangChain retry
+    include_memory_write=True,  # set False to keep memory read-only
+    raise_on_error=False,  # set True to surface exceptions to LangChain retry
 )
 ```
 

--- a/sdk/wren-langchain/tests/unit/test_format_malformed.py
+++ b/sdk/wren-langchain/tests/unit/test_format_malformed.py
@@ -121,3 +121,8 @@ def test_format_list_models_normalizes_non_dict_properties() -> None:
         }
     )
     assert "| customers | 1 | fallback desc |" in out
+
+
+def test_format_recall_coerces_non_str_nl_sql() -> None:
+    out = format_recall_content([{"nl": 123, "sql": None}])
+    assert '1. "123"' in out


### PR DESCRIPTION
## Summary

- Coerce non-str `nl`/`sql` values in `format_recall_content` so recall formatting never embeds `TypeError` risk when memory rows hold non-strings.

## Verification

- Direct module load proof: `format_recall_content([{"nl": 123, "sql": None}])` → `1. "123"` with empty SQL fence.

## License

`sdk/**` Apache-2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recall content formatting when recall rows are malformed, such as non-text values and missing SQL.
  * Ensured single-item recall results display with the expected row numbering.

* **Tests**
  * Added unit coverage for malformed recall inputs to prevent future formatting regressions.

* **Documentation**
  * Reformatted README code examples for consistent indentation and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->