### PR TITLE
chore: exclude Markdown from ruff format scope

### DIFF
--- a/core/wren-core-py/pyproject.toml
+++ b/core/wren-core-py/pyproject.toml
@@ -46,6 +46,8 @@ build-backend = "maturin"
 line-length = 88
 target-version = "py311"
 exclude = ["tools/"]
+# ruff 0.16+ formats Markdown code blocks by default; docs are hand-formatted.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = [

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -89,6 +89,8 @@ artifacts = [
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+# ruff 0.16+ formats Markdown code blocks by default; docs are hand-formatted.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "PLC"]

--- a/sdk/wren-langchain/pyproject.toml
+++ b/sdk/wren-langchain/pyproject.toml
@@ -99,6 +99,8 @@ packages = ["src/wren_langchain"]
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+# ruff 0.16+ formats Markdown code blocks by default; docs are hand-formatted.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "PLC"]

--- a/sdk/wren-pydantic/pyproject.toml
+++ b/sdk/wren-pydantic/pyproject.toml
@@ -95,6 +95,8 @@ packages = ["src/wren_pydantic"]
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+# ruff 0.16+ formats Markdown code blocks by default; docs are hand-formatted.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "PLC"]


### PR DESCRIPTION
## Root cause

ruff 0.16.0 (2026-07-23) ships a breaking change:

> Ruff can now format Python code blocks in Markdown files and will do this by
> default.

Our lint jobs declare `ruff>=0.4` with no upper bound, so CI adopted 0.16.0 on
its own and `.md` files entered `ruff format`'s scope for the first time.
`wren-langchain CI` has been red on `main` since 2026-07-24.

Bisect in `sdk/wren-langchain` — the file count alone shows it:

| ruff | files scanned | result |
|------|---------------|--------|
| ≤ 0.15.0 | 38 (= exactly the `.py` count) | pass |
| 0.16.0 | 40 (38 `.py` + 2 `.md`) | **fail** |

All 38 `.py` files are clean under 0.16.0. The failure comes entirely from
Markdown.

## Why exclude rather than reformat

- **Formatting Markdown buys no correctness.** ruff silently skips code blocks
  it cannot parse — a `.md` holding syntactically invalid Python still reports
  `1 file already formatted` and exits 0. The check is cosmetic only.
- **Coverage is incoherent.** `docs/core/sdk/langchain.md` and
  `docs/core/sdk/pydantic.md` share snippets with the SDK READMEs but sit under
  no ruff config, so the same example is enforced in one file and unmanaged in
  the other.
- **It recurs.** With no upper bound on ruff and docs in scope, any future
  release can turn CI red on documentation again.
- **The docs are hand-formatted on purpose.** These READMEs align inline
  comments across a column of API-to-description pairs. ruff has declined to
  preserve alignment (astral-sh/ruff#7684, open since 2023; astral-sh/ruff#23578
  closed unmerged) — a fair call for code, a poor fit for a hand-tuned doc table.

`extend-exclude = ["*.md"]` is the opt-out Astral documents for this.

## What

Added to every package carrying a ruff config:

- `sdk/wren-langchain` — fixes the red CI
- `sdk/wren-pydantic` — latent; its CI has not run since before the release
- `core/wren` — passing, but its lint runs `uvx ruff` (always newest)
- `core/wren-core-py` — no-op while pinned at 0.13.1

No documentation content is changed.

## Test plan

Each package's own CI commands under ruff 0.16.0, plus 0.15.0 to confirm the
setting is inert on older versions — all pass: `wren-langchain` 38 files,
`wren-pydantic` 34, `core/wren` 69 (`src/`), `wren-core-py` 3.

Pre-existing and untouched: `core/wren-core-py` has an `I001` in
`tests/test_cube.py` on `main`, identical with and without this change.

---

Separately: pinning ruff would not help `core/wren` — its lint calls `uvx ruff`,
which resolves independently of the project's dev dependencies. Happy to open an
issue if worth pursuing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality tooling configuration to exclude Markdown files from automated Ruff processing.
  * Added documentation clarifying Markdown formatting behavior in newer Ruff versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->