### PR TITLE
refactor(trino): strip trailing semicolon on unlimited query path for connector consistency

### DIFF
--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -485,10 +485,12 @@ class TrinoConnector(ConnectorABC):
         limit = coerce_limit(limit)
         trino = _import_trino()
 
+        # Strip terminating `;` for unlimited execute too — Trino's statement
+        # path is stricter than most engines about bare terminators (CLI also
+        # strips client-side). Limited path already strips inside the wrap.
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT {limit}"
-            )
+            sql = f"SELECT * FROM ({sql}) AS _sub LIMIT {limit}"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(sql)

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -485,9 +485,9 @@ class TrinoConnector(ConnectorABC):
         limit = coerce_limit(limit)
         trino = _import_trino()
 
-        # Strip terminating `;` for unlimited execute too — Trino's statement
-        # path is stricter than most engines about bare terminators (CLI also
-        # strips client-side). Limited path already strips inside the wrap.
+        # Align unlimited execute with other connectors (mysql/mssql/etc.):
+        # strip a terminating `;` before send. Limited composition still needs
+        # a clean inner SQL so `;` cannot break the subquery wrap.
         sql = strip_trailing_semicolon(sql)
         if limit is not None:
             sql = f"SELECT * FROM ({sql}) AS _sub LIMIT {limit}"

--- a/core/wren/tests/unit/test_trino_semicolon_unlimited.py
+++ b/core/wren/tests/unit/test_trino_semicolon_unlimited.py
@@ -1,0 +1,42 @@
+"""Trino unlimited query strips trailing semicolons before execute."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import pytest
+
+
+@pytest.fixture
+def connector():
+    with patch("wren.connector.trino._import_trino") as imp:
+        mod = MagicMock()
+        imp.return_value = mod
+        from wren.connector.trino import TrinoConnector
+
+        c = TrinoConnector.__new__(TrinoConnector)
+        c.connection = MagicMock()
+        c._closed = False
+        yield c, mod
+
+
+def test_query_without_limit_strips_trailing_semicolon(connector) -> None:
+    c, _mod = connector
+    cursor = MagicMock()
+    c.connection.cursor.return_value = cursor
+    # _build_trino_arrow_table path — mock fetch
+    with patch("wren.connector.trino._build_trino_arrow_table", return_value=pa.table({"x": [1]})):
+        c.query("SELECT 1;")
+    cursor.execute.assert_called_once_with("SELECT 1")
+
+
+def test_query_with_limit_strips_inside_wrap(connector) -> None:
+    c, _mod = connector
+    cursor = MagicMock()
+    c.connection.cursor.return_value = cursor
+    with patch("wren.connector.trino._build_trino_arrow_table", return_value=pa.table({"x": [1]})):
+        c.query("SELECT 1;", limit=5)
+    sent = cursor.execute.call_args[0][0]
+    assert "SELECT 1;" not in sent
+    assert "LIMIT 5" in sent


### PR DESCRIPTION
## Summary
Strip trailing `;` on Trino **unlimited** `query()` before `cursor.execute`.

## Evidence / framing
Trino's HTTP statement API and `trino.dbapi` are stricter about statement terminators than most engines; the Trino CLI also strips client-side. Limited queries already went through `strip_trailing_semicolon` inside the subquery wrap; unlimited passed SQL through raw.

I do not have a live Trino server in CI to paste a server-side error blob here. The unit test locks the **SQL we send** (mocked execute). If maintainers prefer this as `refactor(...)` consistency-only until a live error is captured, happy to retitle.

## Smaller fixes
- Comment uses trailing `;` (not a garbled `"/;"` typo).
- #2555 was the earlier same-file attempt (closed); this PR keeps the better mocked-execution test.

## Verification
```bash
cd core/wren && python -m pytest tests/unit/test_trino_semicolon_unlimited.py -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Trino query execution for SQL statements ending with semicolons.
  * Ensured limited queries apply the requested row limit correctly after normalization.

* **Tests**
  * Added coverage for unlimited and limited queries containing trailing semicolons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->