### PR TITLE
refactor(snowflake): strip trailing semicolon on unlimited query path for connector consistency

### DIFF
--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -56,18 +56,20 @@ class SnowflakeConnector(ConnectorABC):
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         limit = coerce_limit(limit)
+        # Align unlimited execute with dry_run and other connectors (mysql/
+        # bigquery/duckdb/redshift): strip a terminating `;` before send.
+        executed = strip_trailing_semicolon(sql)
         # Push LIMIT into Snowflake when requested so we do not download a
         # full result set only to slice it in Python. Wrap as a subquery so a
         # trailing semicolon in the user SQL cannot break composition, and so
         # statements that already contain an ORDER BY keep their ordering
         # under the outer LIMIT.
-        executed = sql
         if limit is not None:
             # Place the user SQL on its own line so a trailing line comment
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
             executed = (
                 "SELECT * FROM (\n"
-                f"{strip_trailing_semicolon(sql)}\n"
+                f"{executed}\n"
                 f") AS _wren_sub LIMIT {limit}"
             )
         try:

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -67,11 +67,7 @@ class SnowflakeConnector(ConnectorABC):
         if limit is not None:
             # Place the user SQL on its own line so a trailing line comment
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.
-            executed = (
-                "SELECT * FROM (\n"
-                f"{executed}\n"
-                f") AS _wren_sub LIMIT {limit}"
-            )
+            executed = f"SELECT * FROM (\n{executed}\n) AS _wren_sub LIMIT {limit}"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(executed)

--- a/core/wren/src/wren/connector/snowflake.py
+++ b/core/wren/src/wren/connector/snowflake.py
@@ -60,10 +60,9 @@ class SnowflakeConnector(ConnectorABC):
         # bigquery/duckdb/redshift): strip a terminating `;` before send.
         executed = strip_trailing_semicolon(sql)
         # Push LIMIT into Snowflake when requested so we do not download a
-        # full result set only to slice it in Python. Wrap as a subquery so a
-        # trailing semicolon in the user SQL cannot break composition, and so
+        # full result set only to slice it in Python. Wrap as a subquery so
         # statements that already contain an ORDER BY keep their ordering
-        # under the outer LIMIT.
+        # under the outer LIMIT. (Trailing `;` is already stripped above.)
         if limit is not None:
             # Place the user SQL on its own line so a trailing line comment
             # (`-- ...`) cannot swallow the closing paren, alias, or LIMIT.

--- a/core/wren/tests/unit/test_snowflake_limit_pushdown.py
+++ b/core/wren/tests/unit/test_snowflake_limit_pushdown.py
@@ -60,6 +60,18 @@ def test_query_without_limit_runs_original_sql():
     cursor.execute.assert_called_once_with("SELECT 1")
 
 
+def test_query_without_limit_strips_trailing_semicolon():
+    connector = SnowflakeConnector.__new__(SnowflakeConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    cursor.fetch_arrow_all.return_value = pa.table({})
+
+    connector.query("SELECT 1;")
+
+    cursor.execute.assert_called_once_with("SELECT 1")
+
+
 def test_dry_run_strips_trailing_semicolon_before_describe():
     connector = SnowflakeConnector.__new__(SnowflakeConnector)
     connector.connection = MagicMock()


### PR DESCRIPTION
## Summary
Strip trailing `;` on Snowflake **unlimited** `query()` so it matches `dry_run` and other connectors (see merged #2595 mysql).

## Motivation
Honest framing: this is **connector consistency**, not a proven `snowflake-connector-python` rejection of `SELECT 1;`. Limited path already stripped inside the subquery wrap; unlimited did not.

## Review follow-through (@goldmedal)
1. Restored LIMIT pushdown / subquery / ORDER BY rationale comments (kept alongside the strip).
2. Softened rationale to alignment with dry_run + other connectors; retitled `refactor(...)`.
3. Preserved `coerce_limit` from main.
4. Kept unit test for unlimited trailing-`;`.

## Verification
```bash
cd core/wren && python -m pytest tests/unit/test_snowflake_limit_pushdown.py -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Snowflake query execution by correctly handling SQL statements with trailing semicolons.
  * Ensured limited queries continue to apply limits reliably.

* **Tests**
  * Added coverage confirming semicolons are removed before executing unrestricted queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->