### PR TITLE
fix(datafusion): strip trailing semicolon on unlimited query path

### DIFF
--- a/core/wren/src/wren/connector/datafusion.py
+++ b/core/wren/src/wren/connector/datafusion.py
@@ -29,11 +29,11 @@ class DataFusionConnector(ConnectorABC):
         self._register_tables()
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        # Unlimited path must strip trailing terminators too — DataFusion's
+        # SQL parser rejects ``SELECT 1;`` the same way subquery-wrap does.
+        sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {int(limit)}"
-            )
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
         ipc_bytes = self.ctx.query(sql)
         reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))
         return reader.read_all()

--- a/core/wren/tests/unit/test_datafusion_semicolon.py
+++ b/core/wren/tests/unit/test_datafusion_semicolon.py
@@ -49,8 +49,8 @@ def test_query_without_limit_is_unwrapped() -> None:
     connector, ctx = _make_mock_connector()
     connector.query("SELECT 1;")
     (sent,), _ = ctx.query.call_args
-    # No limit -> no subquery wrapping; passed through verbatim.
-    assert sent == "SELECT 1;"
+    # No limit -> no subquery wrapping; terminator still stripped.
+    assert sent == "SELECT 1"
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:


### PR DESCRIPTION
## Summary
Strip trailing semicolons on DataFusion unlimited queries.

## Motivation
Limited/dry_run already stripped; unlimited left `SELECT 1;` intact and DataFusion rejects it.

## Verification
```
.venv/bin/python -m pytest tests/unit/test_datafusion_semicolon.py -q
7 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query handling by removing trailing semicolons consistently.
  * Fixed queries without a row limit that could fail due to semicolon-related parsing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->