### PR TITLE
test(snowflake): fix the mock patch target so the suite actually runs

### DIFF
--- a/core/wren/tests/connectors/test_snowflake.py
+++ b/core/wren/tests/connectors/test_snowflake.py
@@ -89,7 +89,7 @@ class TestBuildConnectionParams:
 class TestSnowflakeConnector:
     def _make_connector(self, mock_connection: MagicMock) -> SnowflakeConnector:
         with patch(
-            "wren.connector.snowflake.snowflake.connector.connect",
+            "snowflake.connector.connect",
             return_value=mock_connection,
         ):
             return SnowflakeConnector(_password_info())
@@ -97,7 +97,7 @@ class TestSnowflakeConnector:
     def test_init_uses_password_auth(self):
         mock_conn = MagicMock()
         with patch(
-            "wren.connector.snowflake.snowflake.connector.connect",
+            "snowflake.connector.connect",
             return_value=mock_conn,
         ) as connect:
             connector = SnowflakeConnector(_password_info(warehouse="WH"))
@@ -110,7 +110,7 @@ class TestSnowflakeConnector:
     def test_init_uses_private_key_auth(self):
         mock_conn = MagicMock()
         with patch(
-            "wren.connector.snowflake.snowflake.connector.connect",
+            "snowflake.connector.connect",
             return_value=mock_conn,
         ) as connect:
             SnowflakeConnector(_private_key_info())
@@ -121,7 +121,7 @@ class TestSnowflakeConnector:
     def test_create_connector_returns_snowflake_connector(self):
         mock_conn = MagicMock()
         with patch(
-            "wren.connector.snowflake.snowflake.connector.connect",
+            "snowflake.connector.connect",
             return_value=mock_conn,
         ):
             connector = create_connector(_password_info())
@@ -146,8 +146,10 @@ class TestSnowflakeConnector:
         cursor.execute.assert_called_once_with("SELECT a FROM t")
         assert result.equals(expected)
 
-    def test_query_with_limit_slices_result(self):
-        expected = pa.table({"a": [1, 2, 3, 4, 5]})
+    def test_query_with_limit_pushes_limit_into_sql(self):
+        # LIMIT is pushed into the SQL sent to Snowflake (not sliced in
+        # Python), so the mocked cursor returns the already-limited result.
+        expected = pa.table({"a": [1, 2]})
         mock_conn = MagicMock()
         cursor = self._build_cursor(expected)
         mock_conn.cursor.return_value = cursor
@@ -155,8 +157,10 @@ class TestSnowflakeConnector:
         connector = self._make_connector(mock_conn)
         result = connector.query("SELECT a FROM t", limit=2)
 
-        assert result.num_rows == 2
-        assert result["a"].to_pylist() == [1, 2]
+        executed_sql = cursor.execute.call_args.args[0]
+        assert "SELECT a FROM t" in executed_sql
+        assert "LIMIT 2" in executed_sql
+        assert result.equals(expected)
 
     def test_query_handles_none_arrow_result(self):
         mock_conn = MagicMock()

--- a/core/wren/tests/connectors/test_snowflake.py
+++ b/core/wren/tests/connectors/test_snowflake.py
@@ -147,11 +147,13 @@ class TestSnowflakeConnector:
         assert result.equals(expected)
 
     def test_query_with_limit_pushes_limit_into_sql(self):
-        # LIMIT is pushed into the SQL sent to Snowflake (not sliced in
-        # Python), so the mocked cursor returns the already-limited result.
-        expected = pa.table({"a": [1, 2]})
+        # LIMIT is pushed into the SQL sent to Snowflake rather than applied in
+        # Python. The cursor deliberately returns more rows than the limit — a
+        # real Snowflake would honour the pushed-down LIMIT — so the last
+        # assertion fails if a client-side slice is ever reintroduced.
+        returned = pa.table({"a": [1, 2, 3, 4, 5]})
         mock_conn = MagicMock()
-        cursor = self._build_cursor(expected)
+        cursor = self._build_cursor(returned)
         mock_conn.cursor.return_value = cursor
 
         connector = self._make_connector(mock_conn)
@@ -160,7 +162,7 @@ class TestSnowflakeConnector:
         executed_sql = cursor.execute.call_args.args[0]
         assert "SELECT a FROM t" in executed_sql
         assert "LIMIT 2" in executed_sql
-        assert result.equals(expected)
+        assert result.equals(returned)
 
     def test_query_handles_none_arrow_result(self):
         mock_conn = MagicMock()


### PR DESCRIPTION
## Summary

`tests/connectors/test_snowflake.py` has been silently broken: 11 of its 16 tests fail before their bodies run. This fixes the mock patch target, and one assertion the breakage was hiding.

## What failure does this repair?

```
$ uv sync --locked --extra snowflake
$ uv run --no-sync pytest tests/connectors/test_snowflake.py -v
...
AttributeError: module 'wren.connector.snowflake' has no attribute 'snowflake'
11 failed, 5 passed
```

`src/wren/connector/snowflake.py` imports the driver **inside** the functions that use it (`import snowflake.connector`, with a `# noqa: PLC0415`), so `wren.connector.snowflake` never gains a `snowflake` attribute. The tests patch `"wren.connector.snowflake.snowflake.connector.connect"`, a path that does not exist, and `mock.patch` fails at attribute resolution before the test body executes.

The fix patches the real module path, `"snowflake.connector.connect"`. The function-local import resolves through `sys.modules` at call time, so the connector picks up the patched `connect`. The production import is deliberately function-local — it keeps an optional driver out of module import time — so it is left alone rather than hoisted to make patching convenient.

**A second, hidden failure surfaced once the tests ran.** `test_query_with_limit_slices_result` asserted that the connector fetches a full result and slices it to `limit` rows in Python. `query()` has not done that since LIMIT pushdown landed: it wraps the SQL as `SELECT * FROM (...) AS _wren_sub LIMIT n` and returns the driver's table unmodified. The assertion was stale and only survived because the whole file was inert. It is now `test_query_with_limit_pushes_limit_into_sql`, asserting the pushdown appears in the SQL handed to `cursor.execute`. The mocked cursor deliberately returns more rows than the limit — a real Snowflake would honour the pushed-down LIMIT — so the test fails if a client-side slice is ever reintroduced.

## How is it tested?

`tests/connectors/test_snowflake.py`: **11 failed / 5 passed → 16 passed**.

Note this file does not currently run in CI at all — the connector matrix covers only postgres and mysql. It needs no external service (it is fully mocked), so fixing it is a prerequisite to running it in the default jobs.

Regression check: `pytest tests/unit/ --ignore=tests/unit/test_memory.py --ignore=tests/unit/test_mcp_server.py` → 1023 passed, 2 skipped. `ruff format --check` / `ruff check` clean on `src/` and on the touched file.

## Duplicate check

No open PR touches `tests/connectors/test_snowflake.py`. #2593 and #2556 touch `src/wren/connector/snowflake.py`, which this PR does not modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Snowflake connection handling in authentication and connector creation tests.
  * Updated query limit behavior to apply limits in SQL and return complete query results without additional client-side slicing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->