### PR TITLE
fix(context): filter non-mapping entries in _load_views_v1

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -599,7 +599,8 @@ def _load_views_v1(project_path: Path) -> list[dict]:
     if not views_file.exists():
         return []
     data = yaml.safe_load(views_file.read_text(encoding="utf-8")) or {}
-    return data.get("views", []) if isinstance(data, dict) else []
+    views = data.get("views", []) if isinstance(data, dict) else []
+    return [v for v in views if isinstance(v, dict)]
 
 
 def _load_views_v2(project_path: Path) -> list[dict]:
@@ -1095,6 +1096,25 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                         f"unknown dialect '{model_dialect}'",
                     )
                 )
+
+    # v1 legacy views.yml may contain non-mapping entries (e.g. `- null`).
+    # load_views() silently drops those (matching the other loaders), but
+    # validate_project's job is to tell the user about hand-edited mistakes
+    # rather than let them vanish quietly, so re-check the raw entries here.
+    if sv == 1:
+        views_file = project_path / "views.yml"
+        if views_file.exists():
+            raw = yaml.safe_load(views_file.read_text(encoding="utf-8")) or {}
+            raw_views = raw.get("views", []) if isinstance(raw, dict) else []
+            for i, v in enumerate(raw_views):
+                if not isinstance(v, dict):
+                    errors.append(
+                        ValidationError(
+                            "error",
+                            f"views.yml > views[{i}]",
+                            f"view entry must be a mapping, got {type(v).__name__}",
+                        )
+                    )
 
     # Check views
     for i, view in enumerate(views):

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -599,7 +599,12 @@ def _load_views_v1(project_path: Path) -> list[dict]:
     if not views_file.exists():
         return []
     data = yaml.safe_load(views_file.read_text(encoding="utf-8")) or {}
-    views = data.get("views", []) if isinstance(data, dict) else []
+    views = data.get("views") if isinstance(data, dict) else None
+    # A bare ``views:`` parses to None and means "no views", same as a missing
+    # key. Any other non-list value is malformed; return nothing here and let
+    # ``validate_project`` be the one to report it.
+    if not isinstance(views, list):
+        return []
     return [v for v in views if isinstance(v, dict)]
 
 
@@ -1105,8 +1110,18 @@ def validate_project(project_path: Path) -> list[ValidationError]:
         views_file = project_path / "views.yml"
         if views_file.exists():
             raw = yaml.safe_load(views_file.read_text(encoding="utf-8")) or {}
-            raw_views = raw.get("views", []) if isinstance(raw, dict) else []
-            for i, v in enumerate(raw_views):
+            raw_views = raw.get("views") if isinstance(raw, dict) else None
+            if raw_views is not None and not isinstance(raw_views, list):
+                # A bare ``views:`` (None) legitimately means "no views"; a
+                # scalar or mapping there does not.
+                errors.append(
+                    ValidationError(
+                        "error",
+                        "views.yml > views",
+                        f"'views' must be a list, got {type(raw_views).__name__}",
+                    )
+                )
+            for i, v in enumerate(raw_views if isinstance(raw_views, list) else []):
                 if not isinstance(v, dict):
                     errors.append(
                         ValidationError(

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1418,18 +1418,35 @@ def test_validate_project_accepts_empty_v1_views_key(tmp_path):
     assert not [e for e in validate_project(tmp_path) if "views" in e.path]
 
 
-def test_validate_project_reports_non_list_v1_views_container(tmp_path):
-    """A scalar under ``views:`` is malformed — report it, don't crash."""
+@pytest.mark.parametrize(
+    ("views_yml", "expected_type"),
+    [
+        ("views: junk\n", "str"),
+        ("views: 3\n", "int"),
+        ("views:\n  a: 1\n", "dict"),
+    ],
+)
+def test_validate_project_reports_non_list_v1_views_container(
+    tmp_path, views_yml, expected_type
+):
+    """A non-list under ``views:`` is malformed — report it once, don't crash."""
     _make_v1_project(tmp_path)
-    (tmp_path / "views.yml").write_text("views: junk\n")
+    (tmp_path / "views.yml").write_text(views_yml)
+
     hard = [e for e in validate_project(tmp_path) if e.level == "error"]
     container = [e for e in hard if e.path == "views.yml > views"]
     assert len(container) == 1
-    assert "must be a list" in container[0].message
-    # Not additionally reported once per character of the scalar.
+    assert f"must be a list, got {expected_type}" in container[0].message
+    # Not additionally reported once per character/key of the container.
     assert not [e for e in hard if "must be a mapping" in e.message]
-    # And the build path degrades to no views rather than raising.
+
+    # Every consumer degrades to "no views" rather than raising.
     assert build_manifest(tmp_path)["views"] == []
+    assert build_json(tmp_path)["views"] == []
+    plan = plan_upgrade(tmp_path, target_version=2)
+    assert not [f for f in plan.files_created if f.startswith("views/")]
+    apply_upgrade(tmp_path, plan)
+    assert not (tmp_path / "views").exists()
 
 
 def test_build_manifest_drops_v1_views_yml_non_mapping_entries(tmp_path):

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1398,9 +1398,38 @@ def test_validate_project_reports_v1_views_yml_non_mapping_entries(tmp_path):
     _corrupt_v1_views_yml(tmp_path)
     errors = validate_project(tmp_path)
     hard = [e for e in errors if e.level == "error"]
-    assert any("must be a mapping" in e.message for e in hard)
+    # Both malformed entries are reported, each at its own index.
+    entry_errors = [e for e in hard if "must be a mapping" in e.message]
+    assert {e.path for e in entry_errors} == {
+        "views.yml > views[0]",
+        "views.yml > views[1]",
+    }
+    assert any("NoneType" in e.message for e in entry_errors)
+    assert any("str" in e.message for e in entry_errors)
     # The well-formed sibling entry is unaffected.
     assert not any("summary" in e.message for e in errors)
+
+
+def test_validate_project_accepts_empty_v1_views_key(tmp_path):
+    """A bare ``views:`` means "no views" and must not be reported."""
+    _make_v1_project(tmp_path)
+    (tmp_path / "views.yml").write_text("views:\n")
+    assert build_manifest(tmp_path)["views"] == []
+    assert not [e for e in validate_project(tmp_path) if "views" in e.path]
+
+
+def test_validate_project_reports_non_list_v1_views_container(tmp_path):
+    """A scalar under ``views:`` is malformed — report it, don't crash."""
+    _make_v1_project(tmp_path)
+    (tmp_path / "views.yml").write_text("views: junk\n")
+    hard = [e for e in validate_project(tmp_path) if e.level == "error"]
+    container = [e for e in hard if e.path == "views.yml > views"]
+    assert len(container) == 1
+    assert "must be a list" in container[0].message
+    # Not additionally reported once per character of the scalar.
+    assert not [e for e in hard if "must be a mapping" in e.message]
+    # And the build path degrades to no views rather than raising.
+    assert build_manifest(tmp_path)["views"] == []
 
 
 def test_build_manifest_drops_v1_views_yml_non_mapping_entries(tmp_path):
@@ -1421,7 +1450,8 @@ def test_plan_upgrade_v1_to_v2_does_not_crash_on_non_mapping_view(tmp_path):
     _make_v1_project(tmp_path)
     _corrupt_v1_views_yml(tmp_path)
     result = plan_upgrade(tmp_path, target_version=2)
-    assert any("views/summary/metadata.yml" in f for f in result.files_created)
+    view_files = [f for f in result.files_created if f.startswith("views/")]
+    assert view_files == ["views/summary/metadata.yml"]
 
 
 def test_apply_upgrade_v1_to_v2_does_not_crash_on_non_mapping_view(tmp_path):
@@ -1431,6 +1461,8 @@ def test_apply_upgrade_v1_to_v2_does_not_crash_on_non_mapping_view(tmp_path):
     apply_upgrade(tmp_path, result)
     assert (tmp_path / "views" / "summary" / "metadata.yml").exists()
     assert not (tmp_path / "views.yml").exists()
+    # Only the well-formed view became a directory — no junk siblings.
+    assert [d.name for d in (tmp_path / "views").iterdir()] == ["summary"]
 
 
 def test_apply_upgrade_v2_to_v3(tmp_path):

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1377,6 +1377,62 @@ def test_apply_upgrade_v1_to_v2(tmp_path):
     assert cubes[0]["name"] == "order_metrics"
 
 
+# ── Regression: v1 views.yml with non-mapping entries (issue #2597) ────────
+#
+# A hand-edited legacy views.yml can contain a non-mapping list entry (e.g.
+# `- null`). _load_views_v1 must drop it, matching the other v1/v2 loaders,
+# so every consumer below still works instead of crashing with a bare
+# AttributeError — and validate_project must additionally report it rather
+# than silently ignore it.
+
+
+def _corrupt_v1_views_yml(tmp_path: Path) -> None:
+    """Overwrite views.yml with a non-mapping entry alongside a valid one."""
+    (tmp_path / "views.yml").write_text(
+        'views:\n  - null\n  - "junk"\n  - name: summary\n    statement: SELECT 1\n'
+    )
+
+
+def test_validate_project_reports_v1_views_yml_non_mapping_entries(tmp_path):
+    _make_v1_project(tmp_path)
+    _corrupt_v1_views_yml(tmp_path)
+    errors = validate_project(tmp_path)
+    hard = [e for e in errors if e.level == "error"]
+    assert any("must be a mapping" in e.message for e in hard)
+    # The well-formed sibling entry is unaffected.
+    assert not any("summary" in e.message for e in errors)
+
+
+def test_build_manifest_drops_v1_views_yml_non_mapping_entries(tmp_path):
+    _make_v1_project(tmp_path)
+    _corrupt_v1_views_yml(tmp_path)
+    manifest = build_manifest(tmp_path)
+    assert [v["name"] for v in manifest["views"]] == ["summary"]
+
+
+def test_build_json_does_not_crash_on_v1_views_yml_non_mapping_entries(tmp_path):
+    _make_v1_project(tmp_path)
+    _corrupt_v1_views_yml(tmp_path)
+    manifest = build_json(tmp_path)
+    assert [v["name"] for v in manifest["views"]] == ["summary"]
+
+
+def test_plan_upgrade_v1_to_v2_does_not_crash_on_non_mapping_view(tmp_path):
+    _make_v1_project(tmp_path)
+    _corrupt_v1_views_yml(tmp_path)
+    result = plan_upgrade(tmp_path, target_version=2)
+    assert any("views/summary/metadata.yml" in f for f in result.files_created)
+
+
+def test_apply_upgrade_v1_to_v2_does_not_crash_on_non_mapping_view(tmp_path):
+    _make_v1_project(tmp_path)
+    _corrupt_v1_views_yml(tmp_path)
+    result = plan_upgrade(tmp_path, target_version=2)
+    apply_upgrade(tmp_path, result)
+    assert (tmp_path / "views" / "summary" / "metadata.yml").exists()
+    assert not (tmp_path / "views.yml").exists()
+
+
 def test_apply_upgrade_v2_to_v3(tmp_path):
     _make_v2_project(tmp_path)
     result = plan_upgrade(tmp_path, target_version=3)


### PR DESCRIPTION
## Summary

Fixes #2597. `_load_views_v1` was the only project loader that did not filter non-mapping entries out of the list it returns, while its return annotation promises `list[dict]` and all four of its consumers call `.get()` / `.pop()` on the entries.

## What failure does this repair?

A legacy (`schema_version: 1`) project whose hand-written `views.yml` contains a non-mapping list entry:

```yaml
views:
  - null
  - "junk"
```

Every consumer crashes with a bare `AttributeError`:

| consumer | failure |
| --- | --- |
| `validate_project` | `'NoneType' object has no attribute 'get'` |
| `build_manifest` / `build_json` | `'NoneType' object has no attribute 'pop'` (the `_source_dir` strip) |
| `_plan_v1_to_v2` | `'NoneType' object has no attribute 'get'` |
| `_apply_v1_to_v2` | same — but **after** the models loop has written the new `models/<name>/` directories and `unlink()`ed the old flat files |

The last one is the worst: the migration leaves the project half-converted — models restructured, `views.yml` untouched, no `views/` directory — and reports it as an unhandled `AttributeError`. The first is the most incongruous: `validate_project` exists to tell users what is wrong with a hand-edited project, and instead it crashes on one.

The sibling loaders `_load_models_v1`, `_load_models_v2` and `_load_views_v2` all guard their items already; this one did not.

## The fix

One filter at the loader, covering all four consumers:

```python
views = data.get("views", []) if isinstance(data, dict) else []
return [v for v in views if isinstance(v, dict)]
```

**`validate_project` additionally reports the bad entries rather than letting them vanish.** The issue raised drop-vs-report as an open question; reporting is what the surrounding code already does — both the model-columns loop and the relationships loop `isinstance`-check each item and append a `ValidationError` instead of relying on silent filtering. Swallowing a hand-edit mistake would be inconsistent with the function's own conventions and its purpose. The addition is gated behind `sv == 1` and an existence check, so it is a no-op for v2+ projects and adds no errors for well-formed v1 ones. Build and migration keep the loader's silent-drop behaviour, matching their siblings.

## How is it tested?

Five regression tests in `tests/unit/test_context.py`, each driving a real consumer on a `tmp_path` v1 fixture rather than testing the loader helper in isolation — `validate_project`, `build_manifest`, `build_json`, `_plan_v1_to_v2`, `_apply_v1_to_v2`. They live under `tests/unit/` so the default `unit tests` job executes them; files under `tests/connectors/` are gated behind optional extras or containers and would not run.

`pytest tests/unit/ --ignore=tests/unit/test_memory.py --ignore=tests/unit/test_mcp_server.py` → 1028 passed, 2 skipped. `ruff format --check src/` and `ruff check src/` clean.

## Duplicate check

No open PR touches `_load_views_v1` or the v1 loaders. #2567 patches `validate_project` for a related non-dict concern but at the consumer rather than the loader, and does not cover `build_manifest` or either migration path.

## Noted, deliberately not fixed here

`context.validate_manifest` has the same shape — it decodes a base64 manifest and iterates `manifest.get("views", [])` with `.get()` calls before `WrenEngine` is constructed, and construction does not deserialize. It is **not reachable with malformed input today**: its only caller rebuilds the manifest through `build_json()`, so it always receives loader-sanitized data and never a hand-edited `target/mdl.json`. Left alone to keep this change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of legacy schema v1 view settings (`views.yml`), including clear errors when `views` isn’t a list and when list entries aren’t valid mappings.
  * Prevents malformed view entries from being silently ignored while preserving valid views.
  * Strengthens manifest generation and upgrade behavior so corrupted legacy configurations don’t break upgrades.
* **Tests**
  * Added regression tests covering corrupted `views.yml` scenarios and v1→v2 upgrade resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->