### PR TITLE
fix(memory): reject non-list relationship models in schema_indexer

### DIFF
--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -162,9 +162,26 @@ def _describe_column(col: dict, lines: list[str]) -> None:
     lines.append("".join(parts))
 
 
+def _relationship_models(rel: dict) -> list:
+    """Return relationship endpoint models; raise on wrong-typed ``models``.
+
+    Missing/null ``models`` is empty. A present non-list is structural error
+    (same policy as :func:`_require_list_section` for top-level sections).
+    """
+    models = rel.get("models")
+    if models is None:
+        return []
+    if not isinstance(models, list):
+        raise ValueError(
+            f"relationship {rel.get('name')!r}: 'models' must be a list, "
+            f"got {type(models).__name__}"
+        )
+    return models
+
+
 def _describe_relationship(rel: dict, lines: list[str]) -> None:
     name = rel["name"]
-    models = rel.get("models") or []
+    models = _relationship_models(rel)
     left = models[0] if len(models) > 0 else "?"
     right = models[1] if len(models) > 1 else "?"
     join_type = rel.get("joinType", "")
@@ -374,7 +391,7 @@ def _column_record(col: dict, model_name: str, mdl_h: str, now: datetime) -> dic
 
 def _relationship_record(rel: dict, mdl_h: str, now: datetime) -> dict:
     name = rel["name"]
-    models = rel.get("models") or []
+    models = _relationship_models(rel)
     join_type = rel.get("joinType", "")
     condition = rel.get("condition", "")
 

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -166,7 +166,7 @@ def _relationship_models(rel: dict, name: str) -> list:
     """Return relationship endpoint models; raise on wrong-typed ``models``.
 
     Missing/null ``models`` is empty. A present non-list is structural error
-    (same policy as :func:`_require_list_section` for top-level sections).
+    (same policy as :func:`_iter_section` for top-level sections).
     """
     models = rel.get("models")
     if models is None:

--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -162,7 +162,7 @@ def _describe_column(col: dict, lines: list[str]) -> None:
     lines.append("".join(parts))
 
 
-def _relationship_models(rel: dict) -> list:
+def _relationship_models(rel: dict, name: str) -> list:
     """Return relationship endpoint models; raise on wrong-typed ``models``.
 
     Missing/null ``models`` is empty. A present non-list is structural error
@@ -173,7 +173,7 @@ def _relationship_models(rel: dict) -> list:
         return []
     if not isinstance(models, list):
         raise ValueError(
-            f"relationship {rel.get('name')!r}: 'models' must be a list, "
+            f"relationship {name!r}: 'models' must be a list, "
             f"got {type(models).__name__}"
         )
     return models
@@ -181,7 +181,7 @@ def _relationship_models(rel: dict) -> list:
 
 def _describe_relationship(rel: dict, lines: list[str]) -> None:
     name = rel["name"]
-    models = _relationship_models(rel)
+    models = _relationship_models(rel, name)
     left = models[0] if len(models) > 0 else "?"
     right = models[1] if len(models) > 1 else "?"
     join_type = rel.get("joinType", "")
@@ -391,7 +391,7 @@ def _column_record(col: dict, model_name: str, mdl_h: str, now: datetime) -> dic
 
 def _relationship_record(rel: dict, mdl_h: str, now: datetime) -> dict:
     name = rel["name"]
-    models = _relationship_models(rel)
+    models = _relationship_models(rel, name)
     join_type = rel.get("joinType", "")
     condition = rel.get("condition", "")
 

--- a/core/wren/tests/unit/test_schema_indexer_rel_models_non_list.py
+++ b/core/wren/tests/unit/test_schema_indexer_rel_models_non_list.py
@@ -7,15 +7,23 @@ import pytest
 from wren.memory.schema_indexer import describe_schema, extract_schema_items
 
 
-@pytest.mark.parametrize("bad", [{"a": 1}, "orders", 5])
-def test_describe_schema_non_list_relationship_models_raises(bad):
-    with pytest.raises(ValueError, match="models"):
+@pytest.mark.parametrize(
+    ("bad", "got"), [({"a": 1}, "dict"), ("orders", "str"), (5, "int")]
+)
+def test_describe_schema_non_list_relationship_models_raises(bad, got):
+    with pytest.raises(
+        ValueError, match=rf"relationship 'r': 'models' must be a list, got {got}"
+    ):
         describe_schema({"relationships": [{"name": "r", "models": bad}]})
 
 
-@pytest.mark.parametrize("bad", [{"a": 1}, "orders", 5])
-def test_extract_schema_items_non_list_relationship_models_raises(bad):
-    with pytest.raises(ValueError, match="models"):
+@pytest.mark.parametrize(
+    ("bad", "got"), [({"a": 1}, "dict"), ("orders", "str"), (5, "int")]
+)
+def test_extract_schema_items_non_list_relationship_models_raises(bad, got):
+    with pytest.raises(
+        ValueError, match=rf"relationship 'r': 'models' must be a list, got {got}"
+    ):
         extract_schema_items({"relationships": [{"name": "r", "models": bad}]})
 
 
@@ -41,6 +49,14 @@ def test_missing_models_still_ok():
     text = describe_schema({"relationships": [{"name": "r1"}]})
     assert "r1" in text
     items = extract_schema_items({"relationships": [{"name": "r1"}]})
+    assert any(i.get("item_name") == "r1" for i in items)
+
+
+def test_explicit_none_models_still_ok():
+    """`models:` with no value parses to None, the shape users hit by accident."""
+    text = describe_schema({"relationships": [{"name": "r1", "models": None}]})
+    assert "r1" in text
+    items = extract_schema_items({"relationships": [{"name": "r1", "models": None}]})
     assert any(i.get("item_name") == "r1" for i in items)
 
 

--- a/core/wren/tests/unit/test_schema_indexer_rel_models_non_list.py
+++ b/core/wren/tests/unit/test_schema_indexer_rel_models_non_list.py
@@ -1,0 +1,59 @@
+"""relationship models must be a list — wrong types raise ValueError (#2590)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wren.memory.schema_indexer import describe_schema, extract_schema_items
+
+
+@pytest.mark.parametrize("bad", [{"a": 1}, "orders", 5])
+def test_describe_schema_non_list_relationship_models_raises(bad):
+    with pytest.raises(ValueError, match="models"):
+        describe_schema({"relationships": [{"name": "r", "models": bad}]})
+
+
+@pytest.mark.parametrize("bad", [{"a": 1}, "orders", 5])
+def test_extract_schema_items_non_list_relationship_models_raises(bad):
+    with pytest.raises(ValueError, match="models"):
+        extract_schema_items({"relationships": [{"name": "r", "models": bad}]})
+
+
+def test_string_models_do_not_emit_truncated_endpoints():
+    """Regression: str models used to index first two characters as endpoints."""
+    m = {
+        "relationships": [
+            {
+                "name": "orders_customers",
+                "models": "orders",
+                "joinType": "MANY_TO_ONE",
+                "condition": "o.cid = c.id",
+            }
+        ]
+    }
+    with pytest.raises(ValueError):
+        describe_schema(m)
+    with pytest.raises(ValueError):
+        extract_schema_items(m)
+
+
+def test_missing_models_still_ok():
+    text = describe_schema({"relationships": [{"name": "r1"}]})
+    assert "r1" in text
+    items = extract_schema_items({"relationships": [{"name": "r1"}]})
+    assert any(i.get("item_name") == "r1" for i in items)
+
+
+def test_valid_list_models_unchanged():
+    text = describe_schema(
+        {
+            "relationships": [
+                {
+                    "name": "r1",
+                    "models": ["orders", "customers"],
+                    "joinType": "MANY_TO_ONE",
+                }
+            ]
+        }
+    )
+    assert "orders → customers" in text


### PR DESCRIPTION
## Summary
Reject non-list `relationship.models` in `schema_indexer` with `ValueError` instead of KeyError/TypeError or silently truncating string endpoints into single-character join sides.

## Motivation
Closes #2590. Applies the #2533 malformed-manifest list policy to relationship `models` at both read sites. (Other inner fields — `columns`, `measures`, `dimensions`, `timeDimensions` — are handled separately in #2586.)

## Real behavior proof
```
pytest tests/unit/test_schema_indexer_rel_models_non_list.py -q
# 9 passed
```
Before: `models: "orders"` rendered `o → r` and indexed `model_name: 'o'`. After: `ValueError` naming the relationship.

## Test plan
- [x] unit tests for describe + extract paths (dict/str/int)
- [x] missing models still OK; valid list unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened relationship schema validation: when a relationship includes `models`, it must be a list; otherwise schema description and extraction now fail fast with a `ValueError`.
  * Prevented incorrect/truncated endpoint output caused by malformed relationship definitions.
  * Continued to accept missing `models` and `models: null` as empty, while keeping valid list-based relationship indexing behavior unchanged.
* **Tests**
  * Added unit tests for non-list `models` inputs, regression coverage for truncated endpoint output, and verification that missing/`null`/valid list cases behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->