### PR TITLE
fix(memory): reject non-list relationship models in seed queries

### DIFF
--- a/core/wren/src/wren/memory/seed_queries.py
+++ b/core/wren/src/wren/memory/seed_queries.py
@@ -142,7 +142,14 @@ def _relationship_seed(rel: dict, model_layers: dict[str, str]) -> dict | None:
     # "condition": null in the manifest) does not slip a None past `.get()`'s
     # default and crash `len(None)` / `None.strip()`. Mirrors the defensive
     # `rel.get("condition") or ""` in `_relationship_key_columns`.
-    models = rel.get("models") or []
+    models = rel.get("models")
+    if models is None:
+        models = []
+    if not isinstance(models, list):
+        raise ValueError(
+            f"relationship {rel.get('name')!r}: 'models' must be a list, "
+            f"got {type(models).__name__}"
+        )
     condition = (rel.get("condition") or "").strip()
 
     if len(models) < 2 or not condition:

--- a/core/wren/tests/unit/test_seed_queries.py
+++ b/core/wren/tests/unit/test_seed_queries.py
@@ -814,3 +814,29 @@ def test_skips_non_dict_columns():
     sqls = [p["sql"] for p in pairs]
     assert "SELECT * FROM orders LIMIT 100" in sqls
     assert "SELECT SUM(amount) FROM orders" in sqls
+
+
+@pytest.mark.unit
+class TestRelationshipSeedModelsType:
+    def test_string_models_raises(self):
+        manifest = {
+            "models": [_model("orders", "id", [_col("id", "int")])],
+            "relationships": [
+                {
+                    "name": "bad",
+                    "models": "orders",
+                    "condition": "a.id = b.id",
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="models"):
+            generate_seed_queries(manifest)
+
+    def test_dict_models_raises(self):
+        manifest = {
+            "relationships": [
+                {"name": "bad", "models": {"a": 1}, "condition": "x = y"}
+            ]
+        }
+        with pytest.raises(ValueError, match="models"):
+            generate_seed_queries(manifest)


### PR DESCRIPTION
## Summary
`generate_seed_queries` raises `ValueError` on non-list `relationship.models` instead of index/string-slice bugs.

## Motivation
Same structural policy as schema_indexer (#2590 / #2533). Seeds must not invent join endpoints from a string's first characters.

## Real behavior proof
```
pytest tests/unit/test_seed_queries.py -q -k RelationshipSeed
# 2 passed
```

## Test plan
- [x] str/dict `models` raise; suite otherwise unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for relationship model configurations.
  * Clear errors are now shown when model values use an unsupported format.
  * Explicitly empty model configurations are handled correctly.

* **Tests**
  * Added coverage for invalid string and object model values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->