### PR TITLE
fix(mcp): skip non-list relationship models in describe_model

### DIFF
--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -262,11 +262,15 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
             for col in model.get("columns", []) or []
         ]
 
-        relationships = [
-            rel
-            for rel in load_relationships(ctx.project)
-            if name in (rel.get("models") or [])
-        ]
+        relationships = []
+        for rel in load_relationships(ctx.project):
+            if not isinstance(rel, dict):
+                continue
+            rel_models = rel.get("models")
+            if not isinstance(rel_models, list):
+                continue
+            if name in rel_models:
+                relationships.append(rel)
 
         return {
             "name": model.get("name"),

--- a/core/wren/tests/unit/test_mcp_server.py
+++ b/core/wren/tests/unit/test_mcp_server.py
@@ -405,3 +405,26 @@ def test_query_cube_negative_limit_rejected_consistently():
             limit=-1,
             sql_only=True,
         )
+
+
+def test_describe_model_skips_non_list_relationship_models(tmp_path, monkeypatch):
+    """String relationship models must not match via substring membership."""
+    ctx = _make_ctx(tmp_path)
+    mcp = build_server(ctx)
+    describe_model = _get_tool(mcp, "describe_model")
+
+    monkeypatch.setattr(
+        "wren.context.load_models",
+        lambda project: [{"name": "orders", "columns": [], "primary_key": None}],
+    )
+    monkeypatch.setattr(
+        "wren.context.load_relationships",
+        lambda project: [
+            {"name": "bad", "models": "orders_customers"},
+            {"name": "good", "models": ["orders", "customers"]},
+        ],
+    )
+
+    out = describe_model(name="orders")
+    names = {r.get("name") for r in out["relationships"]}
+    assert names == {"good"}


### PR DESCRIPTION
## Summary
`describe_model` only matches relationships when `models` is a real list, so a string value cannot substring-match a model name.

## Motivation
Related to #2590. `"orders" in "orders_customers"` is True in Python — non-list models would attach junk relationships.

## Real behavior proof
```
pytest tests/unit/test_mcp_server.py::test_describe_model_skips_non_list_relationship_models -q
# 1 passed
```

## Test plan
- [x] string models skipped; valid list kept

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model relationship details to ignore malformed relationship data.
  * Prevented incorrect relationship matches caused by string values being interpreted as model lists.

* **Tests**
  * Added coverage to verify that only valid, list-based model relationships are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->