### PR TITLE
deps(sdk): raise the wrenai floor to 0.13.1

### DIFF
--- a/sdk/wren-langchain/pyproject.toml
+++ b/sdk/wren-langchain/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   # Core: provides WrenEngine, MemoryStore, profile resolution, MDL handling.
-  "wrenai>=0.7.0",
+  "wrenai>=0.13.1",
   # langchain >=1.0 ships the recommended `langchain.agents.create_agent`
   # entrypoint. Older `langgraph.prebuilt.create_react_agent` still works
   # but emits deprecation warnings and is scheduled for removal in
@@ -50,18 +50,18 @@ dependencies = [
 #   pip install "wren-langchain[mysql,memory]"
 #
 # DuckDB is built into wrenai — no extra needed.
-postgres   = ["wrenai[postgres]>=0.7.0"]
-mysql      = ["wrenai[mysql]>=0.7.0"]
-bigquery   = ["wrenai[bigquery]>=0.7.0"]
-snowflake  = ["wrenai[snowflake]>=0.7.0"]
-clickhouse = ["wrenai[clickhouse]>=0.7.0"]
-trino      = ["wrenai[trino]>=0.7.0"]
-mssql      = ["wrenai[mssql]>=0.7.0"]
-databricks = ["wrenai[databricks]>=0.7.0"]
-redshift   = ["wrenai[redshift]>=0.7.0"]
-spark      = ["wrenai[spark]>=0.7.0"]
-athena     = ["wrenai[athena]>=0.7.0"]
-oracle     = ["wrenai[oracle]>=0.7.0"]
+postgres   = ["wrenai[postgres]>=0.13.1"]
+mysql      = ["wrenai[mysql]>=0.13.1"]
+bigquery   = ["wrenai[bigquery]>=0.13.1"]
+snowflake  = ["wrenai[snowflake]>=0.13.1"]
+clickhouse = ["wrenai[clickhouse]>=0.13.1"]
+trino      = ["wrenai[trino]>=0.13.1"]
+mssql      = ["wrenai[mssql]>=0.13.1"]
+databricks = ["wrenai[databricks]>=0.13.1"]
+redshift   = ["wrenai[redshift]>=0.13.1"]
+spark      = ["wrenai[spark]>=0.13.1"]
+athena     = ["wrenai[athena]>=0.13.1"]
+oracle     = ["wrenai[oracle]>=0.13.1"]
 
 # ── Memory extra ──────────────────────────────────────────────────────────
 # Required to use the three memory tools (wren_fetch_context,
@@ -70,12 +70,12 @@ oracle     = ["wrenai[oracle]>=0.7.0"]
 #
 # Without this, the toolkit auto-detects no memory and exposes only the
 # three runtime tools.
-memory = ["wrenai[memory]>=0.7.0"]
+memory = ["wrenai[memory]>=0.13.1"]
 
 # ── Convenience aggregate ─────────────────────────────────────────────────
 # Installs every datasource + memory at once. Useful for CI / examples,
 # heavyweight for production where you usually want only one datasource.
-all = ["wrenai[all]>=0.7.0"]
+all = ["wrenai[all]>=0.13.1"]
 
 # ── Dev / test deps ───────────────────────────────────────────────────────
 dev = [
@@ -83,7 +83,7 @@ dev = [
   "pytest-mock>=3",
   "ruff>=0.4",
   # Tests run real DuckDB + LanceDB integrations, so memory deps are required.
-  "wrenai[memory]>=0.7.0",
+  "wrenai[memory]>=0.13.1",
 ]
 
 [project.urls]

--- a/sdk/wren-pydantic/pyproject.toml
+++ b/sdk/wren-pydantic/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   # Core: provides WrenEngine, MemoryStore, profile resolution, MDL handling.
-  "wrenai>=0.7.0",
+  "wrenai>=0.13.1",
   # Pydantic AI v1 is GA. Pin major so breaking changes are an explicit
   # opt-in via CHANGELOG.
   "pydantic-ai>=1.0,<2.0",
@@ -46,18 +46,18 @@ dependencies = [
 #   pip install "wren-pydantic[mysql,memory]"
 #
 # DuckDB is built into wrenai — no extra needed.
-postgres   = ["wrenai[postgres]>=0.7.0"]
-mysql      = ["wrenai[mysql]>=0.7.0"]
-bigquery   = ["wrenai[bigquery]>=0.7.0"]
-snowflake  = ["wrenai[snowflake]>=0.7.0"]
-clickhouse = ["wrenai[clickhouse]>=0.7.0"]
-trino      = ["wrenai[trino]>=0.7.0"]
-mssql      = ["wrenai[mssql]>=0.7.0"]
-databricks = ["wrenai[databricks]>=0.7.0"]
-redshift   = ["wrenai[redshift]>=0.7.0"]
-spark      = ["wrenai[spark]>=0.7.0"]
-athena     = ["wrenai[athena]>=0.7.0"]
-oracle     = ["wrenai[oracle]>=0.7.0"]
+postgres   = ["wrenai[postgres]>=0.13.1"]
+mysql      = ["wrenai[mysql]>=0.13.1"]
+bigquery   = ["wrenai[bigquery]>=0.13.1"]
+snowflake  = ["wrenai[snowflake]>=0.13.1"]
+clickhouse = ["wrenai[clickhouse]>=0.13.1"]
+trino      = ["wrenai[trino]>=0.13.1"]
+mssql      = ["wrenai[mssql]>=0.13.1"]
+databricks = ["wrenai[databricks]>=0.13.1"]
+redshift   = ["wrenai[redshift]>=0.13.1"]
+spark      = ["wrenai[spark]>=0.13.1"]
+athena     = ["wrenai[athena]>=0.13.1"]
+oracle     = ["wrenai[oracle]>=0.13.1"]
 
 # ── Memory extra ──────────────────────────────────────────────────────────
 # Required to use the three memory tools (wren_fetch_context,
@@ -66,12 +66,12 @@ oracle     = ["wrenai[oracle]>=0.7.0"]
 #
 # Without this, the toolkit auto-detects no memory and exposes only the
 # three runtime tools.
-memory = ["wrenai[memory]>=0.7.0"]
+memory = ["wrenai[memory]>=0.13.1"]
 
 # ── Convenience aggregate ─────────────────────────────────────────────────
 # Installs every datasource + memory at once. Useful for CI / examples,
 # heavyweight for production where you usually want only one datasource.
-all = ["wrenai[all]>=0.7.0"]
+all = ["wrenai[all]>=0.13.1"]
 
 # ── Dev / test deps ───────────────────────────────────────────────────────
 dev = [
@@ -79,7 +79,7 @@ dev = [
   "pytest-mock>=3",
   "ruff>=0.4",
   # Tests run real DuckDB + LanceDB integrations, so memory deps are required.
-  "wrenai[memory]>=0.7.0",
+  "wrenai[memory]>=0.13.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Both SDKs declared `wrenai>=0.7.0` — the floor they were first added with, when 0.7.0 was
current (May 2026). This moves it to `>=0.13.1`, the newest published `wrenai` and the version
CI actually resolves. 16 constraints per file: the base dependency plus each `wrenai[<extra>]`
passthrough.

## What failure does this repair?

None — **nothing observable changes for a user today**, which is why this is `deps:` and not
`fix:`. `>=0.7.0` already permits 0.13.1, so any resolver run today picks the same `wrenai`
before and after this change.

What it fixes is the declared contract rather than the installed result:

- The floor advertises a compatibility range nobody verifies. Both SDK CI workflows run
  `uv pip install --system -e ".[dev]"` from the SDK directory, and neither pyproject has a
  path dependency or `[tool.uv.sources]` entry — so `wrenai` comes from PyPI and the suites
  have only ever run against the then-latest release. wrenai 0.7.0 has never been tested
  against either SDK.
- With the old floor, a resolver constrained by an unrelated pin can legally satisfy
  `wrenai>=0.7.0` with a release predating the `wren.engine`, `wren.memory.store`,
  `wren.context`, `wren.profile`, and `wren.model.error` APIs both toolkits import at module
  import time — failing at `ImportError` rather than at resolution.

## How is it tested?

The existing `wren-langchain CI` and `wren-pydantic CI` workflows, both of which trigger on
`sdk/wren-*/**` and therefore run on this PR. Their install step is the check that matters
here: a green `lint` / `tests` job proves the raised floor is still satisfiable alongside the
rest of the dependency set (langchain, pydantic-ai, and the memory extras), and that the
resolved `wrenai` still satisfies the imports the test suites exercise.

No new test is added — there is no behaviour to assert on. A test that parsed the pyproject and
asserted on the version string would be exactly the substring-assertion anti-pattern the
contribution bar rules out.

## Duplicate check

Checked every open PR touching `sdk/`:

- **#2589** (`chore: exclude Markdown from ruff format scope`) — touches both of these files,
  but only the `[tool.ruff]` block near the end. No overlap with the dependency table; merges
  in either order.
- **#2427** / **#2428** — the open release PRs for these two SDKs. They touch `version =`,
  the CHANGELOG, and `__init__.py`, not the dependency table.
- **#2558** — `wren-langchain` source only.

Nothing else declares `wrenai` constraints. Both SDKs are changed in one PR rather than one
per package, per *one change, once* — the resulting convention is visible in a single diff.

## Note for whoever merges

`deps` is a released section in this repo's release-please config, so this will add a
**Dependencies** entry to both SDK CHANGELOGs. The already-open 0.2.1 release PRs (#2427,
#2428) will regenerate to include it — they stay 0.2.1, since this is another patch-level
change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package compatibility requirements to support the latest WrenAI release.
  * Aligned all datasource pass-through, memory, aggregate, and development installation options with the updated minimum version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->