### PR TITLE
fix(context): harden relationships load + validate like views

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1150,10 +1150,24 @@ def validate_project(project_path: Path) -> list[ValidationError]:
     # load_relationships() silently drops those (matching the other loaders),
     # but validate_project reports hand-edited mistakes rather than letting
     # them vanish quietly — re-check the raw entries here.
+    # Also remember the raw list so the field checks below can keep file indices.
+    raw_relationships_list: list | None = None
     rel_file = project_path / "relationships.yml"
     if rel_file.exists():
         raw = yaml.safe_load(rel_file.read_text(encoding="utf-8")) or {}
+        if raw and not isinstance(raw, dict):
+            # Most likely hand-edit: bare list / scalar root (omitted `relationships:` key).
+            errors.append(
+                ValidationError(
+                    "error",
+                    "relationships.yml",
+                    "relationships.yml must be a mapping with a 'relationships' key, "
+                    f"got {type(raw).__name__}",
+                )
+            )
         raw_rels = raw.get("relationships") if isinstance(raw, dict) else None
+        if isinstance(raw_rels, list):
+            raw_relationships_list = raw_rels
         if raw_rels is not None and not isinstance(raw_rels, list):
             errors.append(
                 ValidationError(
@@ -1218,17 +1232,17 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                     )
                 )
 
-    # Check relationships
+    # Check relationships — walk the raw list when available so indices match
+    # the file (filtered loader positions would renumber past dropped junk).
     all_entity_names = model_names | view_names
-    for i, rel in enumerate(relationships):
+    rel_entries = (
+        list(enumerate(raw_relationships_list))
+        if raw_relationships_list is not None
+        else list(enumerate(relationships))
+    )
+    for i, rel in rel_entries:
         if not isinstance(rel, dict):
-            errors.append(
-                ValidationError(
-                    "error",
-                    f"relationships[{i}]",
-                    "relationship entry must be an object",
-                )
-            )
+            # Non-mappings already reported from the raw pass above.
             continue
         rel_name = rel.get("name", f"relationships[{i}]")
         ref_models = rel.get("models") or []

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -703,12 +703,21 @@ def _cube_migration_target(cube: dict, source_file: str | None) -> tuple[str, st
 
 
 def load_relationships(project_path: Path) -> list[dict]:
-    """Load relationships from project_path/relationships.yml."""
+    """Load relationships from project_path/relationships.yml.
+
+    Non-list ``relationships`` values and non-mapping entries are dropped here
+    (matching ``_load_views_v1``). ``validate_project`` re-reads the raw YAML
+    so hand-edited mistakes are still reported rather than vanishing quietly.
+    """
     rel_file = project_path / "relationships.yml"
     if not rel_file.exists():
         return []
     data = yaml.safe_load(rel_file.read_text(encoding="utf-8")) or {}
-    return data.get("relationships", []) if isinstance(data, dict) else []
+    rels = data.get("relationships") if isinstance(data, dict) else None
+    # A bare ``relationships:`` parses to None and means "no relationships".
+    if not isinstance(rels, list):
+        return []
+    return [r for r in rels if isinstance(r, dict)]
 
 
 def load_instructions(project_path: Path) -> str | None:
@@ -1136,6 +1145,32 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                             f"view entry must be a mapping, got {type(v).__name__}",
                         )
                     )
+
+    # relationships.yml may contain non-mapping entries (e.g. `- null`).
+    # load_relationships() silently drops those (matching the other loaders),
+    # but validate_project reports hand-edited mistakes rather than letting
+    # them vanish quietly — re-check the raw entries here.
+    rel_file = project_path / "relationships.yml"
+    if rel_file.exists():
+        raw = yaml.safe_load(rel_file.read_text(encoding="utf-8")) or {}
+        raw_rels = raw.get("relationships") if isinstance(raw, dict) else None
+        if raw_rels is not None and not isinstance(raw_rels, list):
+            errors.append(
+                ValidationError(
+                    "error",
+                    "relationships.yml > relationships",
+                    f"'relationships' must be a list, got {type(raw_rels).__name__}",
+                )
+            )
+        for i, r in enumerate(raw_rels if isinstance(raw_rels, list) else []):
+            if not isinstance(r, dict):
+                errors.append(
+                    ValidationError(
+                        "error",
+                        f"relationships.yml > relationships[{i}]",
+                        f"relationship entry must be a mapping, got {type(r).__name__}",
+                    )
+                )
 
     # Check views
     for i, view in enumerate(views):

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1791,9 +1791,11 @@ def test_validate_project_relationship_indices_match_file(tmp_path: Path) -> Non
         encoding="utf-8",
     )
     errors = validate_project(tmp_path)
-    msgs = [f"{e.path}: {e.message}" if hasattr(e, "path") else e.message for e in errors]
-    # path may be on .location or formatted in message — check both message and str
-    blob = " | ".join(f"{getattr(e, 'path', '')} {e.message}" for e in errors)
-    assert "got int" in blob
-    assert "relationships[1]" in blob  # unnamed entry keeps file index 1
-    assert "missing join_type" in blob or "join_type" in blob
+    diagnostics = [
+        f"{getattr(e, 'path', '')} {e.message}" for e in errors
+    ]
+    assert any("got int" in diagnostic for diagnostic in diagnostics)
+    assert any(
+        "relationships[1]" in diagnostic and "join_type" in diagnostic
+        for diagnostic in diagnostics
+    )

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pytest
 
-from wren.context import load_relationships, validate_project, (
+from wren.context import (
+    load_relationships,
+    validate_project,
     UpgradeError,
     _convert_keys,
     _snake_to_camel,

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from wren.context import (
+from wren.context import load_relationships, validate_project, (
     UpgradeError,
     _convert_keys,
     _snake_to_camel,
@@ -1733,3 +1733,34 @@ def test_validate_manifest_invalid_datasource():
     manifest = {**_SEM_BASE_MANIFEST, "views": [_VALID_VIEW]}
     result = validate_manifest(_b64(manifest), "not-a-datasource")
     assert len(result["errors"]) == 1
+
+
+def test_load_relationships_filters_non_dict_entries(tmp_path: Path) -> None:
+    (tmp_path / "relationships.yml").write_text(
+        "relationships:\n  - not-a-mapping\n  - 42\n  - name: ok\n    models: [a, b]\n    join_type: MANY_TO_ONE\n    condition: a.id = b.id\n",
+        encoding="utf-8",
+    )
+    rels = load_relationships(tmp_path)
+    assert len(rels) == 1
+    assert rels[0]["name"] == "ok"
+
+
+def test_validate_project_reports_non_dict_relationship_entries(tmp_path: Path) -> None:
+    # Minimal project scaffold for validate_project
+    (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")
+    (tmp_path / "relationships.yml").write_text(
+        "relationships:\n  - not-a-mapping\n  - 42\n",
+        encoding="utf-8",
+    )
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any("relationship entry must be a mapping, got str" in m for m in msgs)
+    assert any("relationship entry must be a mapping, got int" in m for m in msgs)
+
+
+def test_validate_project_reports_relationships_not_list(tmp_path: Path) -> None:
+    (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")
+    (tmp_path / "relationships.yml").write_text("relationships: nope\n", encoding="utf-8")
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any("'relationships' must be a list" in m for m in msgs)

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -8,8 +8,6 @@ from pathlib import Path
 import pytest
 
 from wren.context import (
-    load_relationships,
-    validate_project,
     UpgradeError,
     _convert_keys,
     _snake_to_camel,
@@ -1765,4 +1763,37 @@ def test_validate_project_reports_relationships_not_list(tmp_path: Path) -> None
     (tmp_path / "relationships.yml").write_text("relationships: nope\n", encoding="utf-8")
     errors = validate_project(tmp_path)
     msgs = [e.message for e in errors]
-    assert any("'relationships' must be a list" in m for m in msgs)
+    assert any("'relationships' must be a list, got str" in m for m in msgs)
+
+
+def test_validate_project_reports_relationships_bare_root(tmp_path: Path) -> None:
+    (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")
+    (tmp_path / "relationships.yml").write_text(
+        "- name: ok\n  models: [a, b]\n  join_type: MANY_TO_ONE\n  condition: a.id = b.id\n",
+        encoding="utf-8",
+    )
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any(
+        "relationships.yml must be a mapping with a 'relationships' key, got list" in m
+        for m in msgs
+    )
+
+
+def test_validate_project_relationship_indices_match_file(tmp_path: Path) -> None:
+    """Junk at [0] must not renumber a later unnamed relationship's warnings."""
+    (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")
+    (tmp_path / "relationships.yml").write_text(
+        "relationships:\n"
+        "  - 42\n"
+        "  - models: [a, b]\n"
+        "    condition: a.id = b.id\n",
+        encoding="utf-8",
+    )
+    errors = validate_project(tmp_path)
+    msgs = [f"{e.path}: {e.message}" if hasattr(e, "path") else e.message for e in errors]
+    # path may be on .location or formatted in message — check both message and str
+    blob = " | ".join(f"{getattr(e, 'path', '')} {e.message}" for e in errors)
+    assert "got int" in blob
+    assert "relationships[1]" in blob  # unnamed entry keeps file index 1
+    assert "missing join_type" in blob or "join_type" in blob


### PR DESCRIPTION
## Summary
Relationships counterpart of 9bdae39c (#2604):
- `load_relationships` filters to `list[dict]` (drop non-mapping entries)
- `validate_project` re-reads **raw** `relationships.yml` and reports:
  - `'relationships' must be a list, got …`
  - `relationship entry must be a mapping, got …`

## Motivation
After #2604, views report hand-edited junk; relationships silently dropped it. Same class of bad data, opposite UX.

## Note on siblings
This supersedes the split approach in #2607 (reporting half only / models-field only). Downstream consumer re-guards #2606/#2608 become unnecessary once context normalizes the contract — closing those as follow-through.

## Verification
```bash
cd core/wren && python -m pytest tests/unit/test_context.py -q -k relationship
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for relationship configuration files.
  * Invalid relationship entries are now reported clearly instead of causing unexpected behavior.
  * Relationship collections with unsupported formats now produce validation errors.
  * Valid relationship definitions continue to load while malformed entries are safely ignored.
  * Validation now preserves the original location of entries, making configuration errors easier to identify and fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->