### PR TITLE
fix(cube): harden list against non-dict cube/measure rows

### DIFF
--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -174,9 +174,7 @@ def list_cubes(mdl: _MdlOpt = None) -> None:
             raw = cube.get(key, []) or []
             if not isinstance(raw, list):
                 return ""
-            return ", ".join(
-                m.get("name", "") for m in raw if isinstance(m, dict)
-            )
+            return ", ".join(m.get("name", "") for m in raw if isinstance(m, dict))
 
         measures = _names("measures")
         dims = _names("dimensions")

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -165,13 +165,22 @@ def list_cubes(mdl: _MdlOpt = None) -> None:
         typer.echo("No cubes defined.")
         return
     for cube in cubes:
+        if not isinstance(cube, dict):
+            continue
         name = cube.get("name", "<unnamed>")
         base = cube.get("baseObject", "?")
-        measures = ", ".join(m.get("name", "") for m in cube.get("measures", []))
-        dims = ", ".join(d.get("name", "") for d in cube.get("dimensions", []))
-        time_dims = ", ".join(
-            td.get("name", "") for td in cube.get("timeDimensions", [])
-        )
+
+        def _names(key: str) -> str:
+            raw = cube.get(key, []) or []
+            if not isinstance(raw, list):
+                return ""
+            return ", ".join(
+                m.get("name", "") for m in raw if isinstance(m, dict)
+            )
+
+        measures = _names("measures")
+        dims = _names("dimensions")
+        time_dims = _names("timeDimensions")
         typer.echo(f"  {name} (base: {base})")
         if measures:
             typer.echo(f"    measures: {measures}")

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -174,7 +174,11 @@ def list_cubes(mdl: _MdlOpt = None) -> None:
             raw = cube.get(key, []) or []
             if not isinstance(raw, list):
                 return ""
-            return ", ".join(m.get("name", "") for m in raw if isinstance(m, dict))
+            return ", ".join(
+                m["name"]
+                for m in raw
+                if isinstance(m, dict) and isinstance(m.get("name"), str)
+            )
 
         measures = _names("measures")
         dims = _names("dimensions")

--- a/core/wren/tests/unit/test_cube_cli_list_guards.py
+++ b/core/wren/tests/unit/test_cube_cli_list_guards.py
@@ -27,5 +27,7 @@ def test_list_cubes_skips_bad_rows(capsys):
     assert result.exit_code == 0
     out = result.stdout
     assert "orders" in out
+    assert "bad" not in out
+    assert "measures:" not in out
     assert "dimensions: id" in out
     assert "time dimensions: ts" in out

--- a/core/wren/tests/unit/test_cube_cli_list_guards.py
+++ b/core/wren/tests/unit/test_cube_cli_list_guards.py
@@ -1,0 +1,31 @@
+"""cube list must tolerate non-dict cubes and non-list measure arrays."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from wren.cube_cli import cube_app
+
+
+def test_list_cubes_skips_bad_rows(capsys):
+    manifest = {
+        "cubes": [
+            "bad",
+            {
+                "name": "orders",
+                "baseObject": "o",
+                "measures": "nope",
+                "dimensions": [{"name": "id"}],
+                "timeDimensions": [None, {"name": "ts"}],
+            },
+        ]
+    }
+    with patch("wren.cube_cli._load_manifest_dict", return_value=manifest):
+        runner = CliRunner()
+        result = runner.invoke(cube_app, ["list"])
+    assert result.exit_code == 0
+    out = result.stdout
+    assert "orders" in out
+    assert "dimensions: id" in out
+    assert "time dimensions: ts" in out


### PR DESCRIPTION
## What failure does this repair?
`wren cube list` crashed on a malformed manifest. When a cube row was not a dict (e.g. `None`/string slipped into the `cubes` list), or when `measures`/`dimensions`/`timeDimensions` were non-list values, `list_cubes` assumed dict/list shapes and raised while iterating.

Observed error:
```
AttributeError: 'NoneType' object has no attribute 'get'
```
(also `TypeError` when a scalar field was iterated as a list).

## Fix
`list_cubes` now skips cube rows that aren't dicts and only extracts names from list-valued member fields, so a single bad row can't abort the whole listing.

## Verification
```
pytest tests/unit/test_cube_cli_list_guards.py -q
# 1 passed
```

## Duplicate check
Searched open/closed PRs for cube CLI list hardening — no existing/duplicate PR covers this guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cube listing command’s resilience when manifests contain malformed or unexpected entries.
  * Invalid cube records are skipped, while incomplete measure, dimension, and time dimension data no longer causes failures.
  * Valid cube information continues to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->