### PR TITLE
fix(context): harden description checks for bad MDL rows

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1644,13 +1644,21 @@ _VALID_LEVELS = frozenset({"error", "warning", "strict"})
 
 
 def _prop_description(item: dict) -> str | None:
-    return (item.get("properties") or {}).get("description")
+    props = item.get("properties") or {}
+    if not isinstance(props, dict):
+        return None
+    return props.get("description")
 
 
 def _check_descriptions(manifest: dict, *, strict: bool = False) -> list[str]:
     warnings: list[str] = []
 
-    for model in manifest.get("models", []):
+    models = manifest.get("models", []) or []
+    if not isinstance(models, list):
+        models = []
+    for model in models:
+        if not isinstance(model, dict):
+            continue
         name = model.get("name", "<unknown>")
         if not _prop_description(model):
             warnings.append(
@@ -1658,14 +1666,24 @@ def _check_descriptions(manifest: dict, *, strict: bool = False) -> list[str]:
                 "add properties.description to improve memory search and agent comprehension"
             )
         if strict:
-            for col in model.get("columns", []):
+            cols = model.get("columns", []) or []
+            if not isinstance(cols, list):
+                cols = []
+            for col in cols:
+                if not isinstance(col, dict):
+                    continue
                 col_name = col.get("name", "<unknown>")
                 if not _prop_description(col):
                     warnings.append(
                         f"Column '{col_name}' in model '{name}' has no description"
                     )
 
-    for view in manifest.get("views", []):
+    views = manifest.get("views", []) or []
+    if not isinstance(views, list):
+        views = []
+    for view in views:
+        if not isinstance(view, dict):
+            continue
         view_name = view.get("name", "<unknown>")
         if not _prop_description(view):
             warnings.append(

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1117,6 +1117,29 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                     )
                 )
 
+        props = model.get("properties")
+        if props is not None and not isinstance(props, dict):
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"{src_path} > {name}",
+                    "properties must be a mapping",
+                )
+            )
+        for j, col in enumerate(columns):
+            if not isinstance(col, dict):
+                continue
+            col_props = col.get("properties")
+            if col_props is not None and not isinstance(col_props, dict):
+                col_name = col.get("name") or f"columns[{j}]"
+                errors.append(
+                    ValidationError(
+                        "error",
+                        f"{src_path} > {name} > {col_name}",
+                        "properties must be a mapping",
+                    )
+                )
+
     # v1 legacy views.yml may contain non-mapping entries (e.g. `- null`).
     # load_views() silently drops those (matching the other loaders), but
     # validate_project's job is to tell the user about hand-edited mistakes
@@ -1231,6 +1254,16 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                         f"unknown dialect '{view_dialect}'",
                     )
                 )
+
+        view_props = view.get("properties")
+        if view_props is not None and not isinstance(view_props, dict):
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"views/{src_dir}",
+                    "properties must be a mapping",
+                )
+            )
 
     # Check relationships — walk the raw list when available so indices match
     # the file (filtered loader positions would renumber past dropped junk).
@@ -1653,12 +1686,7 @@ def _prop_description(item: dict) -> str | None:
 def _check_descriptions(manifest: dict, *, strict: bool = False) -> list[str]:
     warnings: list[str] = []
 
-    models = manifest.get("models", []) or []
-    if not isinstance(models, list):
-        models = []
-    for model in models:
-        if not isinstance(model, dict):
-            continue
+    for model in manifest.get("models", []):
         name = model.get("name", "<unknown>")
         if not _prop_description(model):
             warnings.append(
@@ -1666,24 +1694,14 @@ def _check_descriptions(manifest: dict, *, strict: bool = False) -> list[str]:
                 "add properties.description to improve memory search and agent comprehension"
             )
         if strict:
-            cols = model.get("columns", []) or []
-            if not isinstance(cols, list):
-                cols = []
-            for col in cols:
-                if not isinstance(col, dict):
-                    continue
+            for col in model.get("columns", []):
                 col_name = col.get("name", "<unknown>")
                 if not _prop_description(col):
                     warnings.append(
                         f"Column '{col_name}' in model '{name}' has no description"
                     )
 
-    views = manifest.get("views", []) or []
-    if not isinstance(views, list):
-        views = []
-    for view in views:
-        if not isinstance(view, dict):
-            continue
+    for view in manifest.get("views", []):
         view_name = view.get("name", "<unknown>")
         if not _prop_description(view):
             warnings.append(

--- a/core/wren/tests/unit/test_check_descriptions_guards.py
+++ b/core/wren/tests/unit/test_check_descriptions_guards.py
@@ -1,0 +1,28 @@
+from wren.context import _check_descriptions
+
+
+def test_check_descriptions_skips_non_dict_models_and_columns():
+    warnings = _check_descriptions(
+        {
+            "models": [
+                "bad",
+                {
+                    "name": "orders",
+                    "properties": "oops",
+                    "columns": "x",
+                },
+                {
+                    "name": "ok",
+                    "properties": {"description": "d"},
+                    "columns": [None, {"name": "id"}],  # missing col desc when strict
+                },
+            ],
+            "views": ["nope", {"name": "v1"}],
+        },
+        strict=True,
+    )
+    # orders model missing desc; ok column id missing desc; v1 view missing desc
+    joined = "\n".join(warnings)
+    assert "Model 'orders'" in joined
+    assert "Column 'id' in model 'ok'" in joined
+    assert "View 'v1'" in joined

--- a/core/wren/tests/unit/test_check_descriptions_guards.py
+++ b/core/wren/tests/unit/test_check_descriptions_guards.py
@@ -1,28 +1,60 @@
-from wren.context import _check_descriptions
+"""Guards for non-mapping properties and safe description lookup."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from wren.context import _prop_description, validate_project
 
 
-def test_check_descriptions_skips_non_dict_models_and_columns():
-    warnings = _check_descriptions(
-        {
-            "models": [
-                "bad",
-                {
-                    "name": "orders",
-                    "properties": "oops",
-                    "columns": "x",
-                },
-                {
-                    "name": "ok",
-                    "properties": {"description": "d"},
-                    "columns": [None, {"name": "id"}],  # missing col desc when strict
-                },
-            ],
-            "views": ["nope", {"name": "v1"}],
-        },
-        strict=True,
+def test_prop_description_non_mapping_returns_none():
+    assert _prop_description({"properties": "oops"}) is None
+    assert _prop_description({"properties": {"description": "ok"}}) == "ok"
+    assert _prop_description({}) is None
+
+
+def test_validate_project_reports_non_mapping_properties(tmp_path: Path):
+    (tmp_path / "wren_project.yml").write_text(
+        "name: demo\ndata_source: postgres\nschema_version: 2\n",
+        encoding="utf-8",
     )
-    # orders model missing desc; ok column id missing desc; v1 view missing desc
-    joined = "\n".join(warnings)
-    assert "Model 'orders'" in joined
-    assert "Column 'id' in model 'ok'" in joined
-    assert "View 'v1'" in joined
+    model_dir = tmp_path / "models" / "orders"
+    model_dir.mkdir(parents=True)
+    (model_dir / "metadata.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: orders
+            table_reference:
+              table: orders
+            properties: oops
+            columns:
+              - name: id
+                type: INTEGER
+                properties: not-a-map
+            """
+        ),
+        encoding="utf-8",
+    )
+    view_dir = tmp_path / "views" / "v1"
+    view_dir.mkdir(parents=True)
+    (view_dir / "metadata.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: v1
+            properties: []
+            """
+        ),
+        encoding="utf-8",
+    )
+    (view_dir / "sql.yml").write_text(
+        "statement: SELECT 1\n",
+        encoding="utf-8",
+    )
+
+    errors = validate_project(tmp_path)
+    messages = [f"{e.path}: {e.message}" for e in errors]
+    joined = "\n".join(messages)
+    assert "properties must be a mapping" in joined
+    # model + column + view
+    assert sum("properties must be a mapping" in m for m in messages) == 3


### PR DESCRIPTION
## Summary
Malformed `properties` (non-mapping) on models/views/columns used to surface as a generic AttributeError from description checks (`'str' object has no attribute 'get'`), wrapped by the CLI as `Semantic validation failed`.

This PR reports a clear project-validation error instead: **`properties must be a mapping`**, and keeps `_prop_description` safe if it still sees a non-dict.

## What failure does this repair?
```text
# before (main): wren context validate with properties: oops on a model
✗ Semantic validation failed: 'str' object has no attribute 'get'
# exit 1, no pointer that properties shape is wrong

# after:
✗ models/orders/metadata.yml > orders: properties must be a mapping
```

## Duplicate check
- Overlaps conceptually with loader normalisation work (#2604/#2613/#2614) for columns/rows, but this is specifically **properties mapping** at `validate_project` (input boundary), not collection filters in `_check_descriptions`.
- Dropped the earlier dead models/views guards per maintainer feedback.

## Verification
```bash
cd core/wren && uv run pytest tests/unit/test_check_descriptions_guards.py -q
# 2 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project validation for malformed model, column, and view properties.
  * Validation now reports clear errors when properties are not provided as mappings.
  * Description checks safely handle missing or invalid properties without causing additional failures.

* **Tests**
  * Added coverage for valid, missing, and malformed properties.
  * Added validation tests confirming errors are reported for invalid model, column, and view properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->