### PR TITLE
fix(mcp): harden list_cubes member arrays

### DIFF
--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -296,19 +296,28 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
         from wren.context import load_cubes  # noqa: PLC0415
 
         cubes = load_cubes(ctx.project)
+        if not isinstance(cubes, list):
+            cubes = []
         result = []
         for cube in cubes:
+            if not isinstance(cube, dict):
+                continue
+
+            def _member_names(key: str) -> list:
+                raw = cube.get(key, []) or []
+                if not isinstance(raw, list):
+                    return []
+                return [
+                    m.get("name") for m in raw if isinstance(m, dict)
+                ]
+
             result.append(
                 {
                     "name": cube.get("name"),
                     "base_object": cube.get("base_object"),
-                    "measures": [m.get("name") for m in cube.get("measures", []) or []],
-                    "dimensions": [
-                        d.get("name") for d in cube.get("dimensions", []) or []
-                    ],
-                    "time_dimensions": [
-                        td.get("name") for td in cube.get("time_dimensions", []) or []
-                    ],
+                    "measures": _member_names("measures"),
+                    "dimensions": _member_names("dimensions"),
+                    "time_dimensions": _member_names("time_dimensions"),
                 }
             )
         return {"cubes": result}

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -307,9 +307,7 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
                 raw = cube.get(key, []) or []
                 if not isinstance(raw, list):
                     return []
-                return [
-                    m.get("name") for m in raw if isinstance(m, dict)
-                ]
+                return [m.get("name") for m in raw if isinstance(m, dict)]
 
             result.append(
                 {

--- a/core/wren/tests/unit/test_mcp_server.py
+++ b/core/wren/tests/unit/test_mcp_server.py
@@ -405,3 +405,35 @@ def test_query_cube_negative_limit_rejected_consistently():
             limit=-1,
             sql_only=True,
         )
+
+
+def test_list_cubes_skips_non_dict_members(tmp_path, monkeypatch):
+    ctx = _make_ctx(tmp_path)
+    mcp = build_server(ctx)
+    list_cubes = _get_tool(mcp, "list_cubes")
+
+    def fake_load_cubes(project):
+        return [
+            "bad",
+            {
+                "name": "orders",
+                "base_object": "o",
+                "measures": "nope",
+                "dimensions": [{"name": "id"}, "x"],
+                "time_dimensions": [{"name": "ts"}],
+            },
+        ]
+
+    monkeypatch.setattr("wren.context.load_cubes", fake_load_cubes)
+    out = list_cubes()
+    assert out == {
+        "cubes": [
+            {
+                "name": "orders",
+                "base_object": "o",
+                "measures": [],
+                "dimensions": ["id"],
+                "time_dimensions": ["ts"],
+            }
+        ]
+    }


### PR DESCRIPTION
## What failure does this repair?
MCP `list_cubes` raised `AttributeError: 'str' object has no attribute 'get'` when a cube's `measures`/`dimensions`/`time_dimensions` was non-list or held non-dict members. Repro: call the `list_cubes` tool against a manifest whose cube has `"measures": ["revenue"]` — name extraction called `.get("name")` on the string and the tool failed.

## Summary
`list_cubes` now ignores invalid cube entries and extracts names only from valid dictionary members.

## Verification
```
pytest tests/unit/test_mcp_server.py::test_list_cubes_skips_non_dict_members -q
# 1 passed
```

## Duplicate check
Searched open/closed PRs; #2615 hardens related cube listing but not the member-array normalization in this path. No overlap.
