### PR TITLE
fix(dbt): tolerate non-dict column rows in import helpers

### DIFF
--- a/core/wren/src/wren/dbt.py
+++ b/core/wren/src/wren/dbt.py
@@ -1059,7 +1059,12 @@ def _infer_attached_node(node: dict[str, Any]) -> str | None:
 
 
 def _find_column(model: dict[str, Any], column_name: str) -> dict[str, Any] | None:
-    for column in model.get("columns", []):
+    columns = model.get("columns", []) or []
+    if not isinstance(columns, list):
+        return None
+    for column in columns:
+        if not isinstance(column, dict):
+            continue
         if column.get("name") == column_name:
             return column
     return None
@@ -1138,8 +1143,15 @@ def _infer_join_type(model: dict[str, Any], target_model: dict[str, Any]) -> str
 
 def _finalize_column_tests(imported_models: list[dict[str, Any]]) -> None:
     for model in imported_models:
+        if not isinstance(model, dict):
+            continue
         primary_key = model.get("primary_key")
-        for column in model.get("columns", []):
+        columns = model.get("columns", []) or []
+        if not isinstance(columns, list):
+            continue
+        for column in columns:
+            if not isinstance(column, dict):
+                continue
             props = column.setdefault("properties", {})
             tests = sorted(set(props.pop("_dbt_tests", [])))
             statuses = props.pop("_dbt_test_statuses", [])
@@ -1279,7 +1291,8 @@ def _seed_model_payload(model: dict[str, Any]) -> dict[str, Any]:
                 "isCalculated": column.get("is_calculated", False),
                 "properties": _camelize_props(column.get("properties", {})),
             }
-            for column in model.get("columns", [])
+            for column in (model.get("columns", []) or [])
+            if isinstance(column, dict) and column.get("name") is not None
         ],
     }
 

--- a/core/wren/src/wren/dbt.py
+++ b/core/wren/src/wren/dbt.py
@@ -1150,7 +1150,7 @@ def _finalize_column_tests(imported_models: list[dict[str, Any]]) -> None:
         if not isinstance(columns, list):
             continue
         for column in columns:
-            if not isinstance(column, dict):
+            if not isinstance(column, dict) or column.get("name") is None:
                 continue
             props = column.setdefault("properties", {})
             tests = sorted(set(props.pop("_dbt_tests", [])))
@@ -1291,7 +1291,11 @@ def _seed_model_payload(model: dict[str, Any]) -> dict[str, Any]:
                 "isCalculated": column.get("is_calculated", False),
                 "properties": _camelize_props(column.get("properties", {})),
             }
-            for column in (model.get("columns", []) or [])
+            for column in (
+                model.get("columns", [])
+                if isinstance(model.get("columns"), list)
+                else []
+            )
             if isinstance(column, dict) and column.get("name") is not None
         ],
     }

--- a/core/wren/tests/unit/test_dbt_column_guards.py
+++ b/core/wren/tests/unit/test_dbt_column_guards.py
@@ -1,0 +1,45 @@
+from wren.dbt import _finalize_column_tests, _find_column, _seed_model_payload
+
+
+def test_find_column_skips_non_dict_and_non_list():
+    assert _find_column({"columns": "x"}, "id") is None
+    assert _find_column({"columns": [None, {"name": "id"}]}, "id") == {"name": "id"}
+
+
+def test_finalize_column_tests_skips_bad_rows():
+    models = [
+        "bad",
+        {
+            "name": "m",
+            "columns": [
+                "x",
+                {
+                    "name": "id",
+                    "not_null": True,
+                    "properties": {
+                        "_dbt_tests": ["unique"],
+                        "_dbt_test_statuses": ["pass"],
+                    },
+                },
+            ],
+        },
+    ]
+    _finalize_column_tests(models)
+    col = models[1]["columns"][1]
+    assert col["properties"]["dbt_tests"] == "unique"
+    assert col.get("is_primary_key") is True
+    assert models[1]["primary_key"] == "id"
+
+
+def test_seed_model_payload_skips_non_dict_columns():
+    payload = _seed_model_payload(
+        {"name": "m", "columns": ["bad", {"name": "id", "type": "int"}]}
+    )
+    assert payload["columns"] == [
+        {
+            "name": "id",
+            "type": "int",
+            "isCalculated": False,
+            "properties": {},
+        }
+    ]


### PR DESCRIPTION
## What failure does this repair?
`_convert_dbt_artifacts` raised `AttributeError: 'str' object has no attribute 'get'` when a dbt `manifest.json` model carried a non-list `columns` value or a list containing non-dict rows (e.g. a bare string). Repro: import a dbt project whose model has `"columns": ["id"]` — the helper called `.get()` on the string and crashed the import.

## Summary
dbt import helpers crashed when `model.columns` was non-list or held non-dict rows. `_find_column`, `_finalize_column_tests`, and `_seed_model_payload` now skip malformed model and column entries.

## Verification
```
pytest tests/unit/test_dbt_column_guards.py -q
# 3 passed
```

## Duplicate check
Searched open/closed PRs and existing dbt guard coverage; #2514 and #2549 harden the seed/query path but not these import helpers (`_find_column`, `_finalize_column_tests`). No overlap with the row-shape guards added here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing malformed or unexpected dbt model and column metadata.
  * Invalid entries are now safely skipped instead of interrupting artifact conversion.
  * Seeded column output now includes only valid, named columns.
  * Valid dbt test and primary-key metadata continues to be processed correctly.

* **Tests**
  * Added coverage for malformed model and column data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->