### PR TITLE
fix(clickhouse): coerce LIMIT before SQL interpolation

### DIFF
--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -10,6 +10,7 @@ column-by-column to that schema.
 from __future__ import annotations
 
 import json
+import numbers
 from decimal import Decimal as PyDecimal
 from typing import Any
 from urllib.parse import parse_qsl, unquote, urlparse
@@ -392,8 +393,12 @@ def _coerce_limit(limit: int | None) -> int | None:
     if limit is None:
         return None
     # Reject negatives *before* ``int()`` truncation so a fractional value like
-    # ``-0.5`` cannot slip through as ``LIMIT 0``.
-    if isinstance(limit, (int, float)) and not isinstance(limit, bool) and limit < 0:
+    # ``-0.5`` (float, Decimal, Fraction, ...) cannot slip through as ``LIMIT 0``.
+    if (
+        isinstance(limit, numbers.Number)
+        and not isinstance(limit, bool)
+        and limit < 0
+    ):
         raise ValueError(f"limit must be non-negative, got {limit}")
     coerced = int(limit)
     if coerced < 0:

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -391,6 +391,10 @@ def _coerce_limit(limit: int | None) -> int | None:
     """
     if limit is None:
         return None
+    # Reject negatives *before* ``int()`` truncation so a fractional value like
+    # ``-0.5`` cannot slip through as ``LIMIT 0``.
+    if isinstance(limit, (int, float)) and not isinstance(limit, bool) and limit < 0:
+        raise ValueError(f"limit must be non-negative, got {limit}")
     coerced = int(limit)
     if coerced < 0:
         raise ValueError(f"limit must be non-negative, got {coerced}")

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -394,11 +394,7 @@ def _coerce_limit(limit: int | None) -> int | None:
         return None
     # Reject negatives *before* ``int()`` truncation so a fractional value like
     # ``-0.5`` (float, Decimal, Fraction, ...) cannot slip through as ``LIMIT 0``.
-    if (
-        isinstance(limit, numbers.Number)
-        and not isinstance(limit, bool)
-        and limit < 0
-    ):
+    if isinstance(limit, numbers.Number) and not isinstance(limit, bool) and limit < 0:
         raise ValueError(f"limit must be non-negative, got {limit}")
     coerced = int(limit)
     if coerced < 0:

--- a/core/wren/src/wren/connector/clickhouse.py
+++ b/core/wren/src/wren/connector/clickhouse.py
@@ -383,6 +383,20 @@ def _build_clickhouse_client_kwargs(connection_info: Any) -> dict:
 # --------------------------------------------------------------------------
 
 
+def _coerce_limit(limit: int | None) -> int | None:
+    """Validate and coerce a user-supplied ``limit`` to a non-negative ``int``.
+
+    ``int(limit)`` rejects strings like ``"5 OR 1=1"`` so the value can be
+    safely interpolated into SQL. Negative limits are also rejected.
+    """
+    if limit is None:
+        return None
+    coerced = int(limit)
+    if coerced < 0:
+        raise ValueError(f"limit must be non-negative, got {coerced}")
+    return coerced
+
+
 class ClickHouseConnector(ConnectorABC):
     """Native ``clickhouse-connect`` connector that bypasses ``ibis-project``."""
 
@@ -395,6 +409,7 @@ class ClickHouseConnector(ConnectorABC):
         # Strip the terminating run of ``;`` / whitespace before wrapping —
         # ``SELECT * FROM (SELECT 1;) AS _wren_sub LIMIT N`` is invalid SQL.
         # Semicolons inside string literals are preserved.
+        limit = _coerce_limit(limit)
         stripped = strip_trailing_semicolon(sql)
         statement = stripped
         if limit is not None:

--- a/core/wren/tests/unit/test_clickhouse_coerce_limit.py
+++ b/core/wren/tests/unit/test_clickhouse_coerce_limit.py
@@ -30,6 +30,24 @@ def test_reject_fractional_negative_limit():
         c.query("SELECT 1", limit=-0.5)
 
 
+def test_reject_negative_decimal_limit():
+    # ``Decimal`` and ``Fraction`` are ``numbers.Number`` too; a negative
+    # fractional value must be rejected before ``int()`` truncation.
+    from decimal import Decimal
+
+    c = _connector()
+    with pytest.raises(ValueError, match="non-negative"):
+        c.query("SELECT 1", limit=Decimal("-0.5"))
+
+
+def test_reject_negative_fraction_limit():
+    from fractions import Fraction
+
+    c = _connector()
+    with pytest.raises(ValueError, match="non-negative"):
+        c.query("SELECT 1", limit=Fraction(-1, 2))
+
+
 def test_reject_injection_string():
     c = _connector()
     with pytest.raises(ValueError):

--- a/core/wren/tests/unit/test_clickhouse_coerce_limit.py
+++ b/core/wren/tests/unit/test_clickhouse_coerce_limit.py
@@ -1,0 +1,38 @@
+"""ClickHouse query must coerce LIMIT before SQL interpolation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wren.connector import clickhouse as ch_mod
+
+
+def _connector():
+    c = object.__new__(ch_mod.ClickHouseConnector)
+    c.connection = MagicMock()
+    c._closed = False
+    return c
+
+
+def test_reject_negative_limit():
+    c = _connector()
+    with pytest.raises(ValueError, match="non-negative"):
+        c.query("SELECT 1", limit=-1)
+
+
+def test_reject_injection_string():
+    c = _connector()
+    with pytest.raises(ValueError):
+        c.query("SELECT 1", limit="1; DROP TABLE t")
+
+
+def test_numeric_string_limit_interpolated():
+    c = _connector()
+    with patch.object(ch_mod, "_build_clickhouse_arrow_table", return_value="tbl"):
+        out = c.query("SELECT 1", limit="7")
+    assert out == "tbl"
+    statement = c.connection.query.call_args[0][0]
+    assert "LIMIT 7" in statement
+    assert "DROP" not in statement

--- a/core/wren/tests/unit/test_clickhouse_coerce_limit.py
+++ b/core/wren/tests/unit/test_clickhouse_coerce_limit.py
@@ -22,6 +22,14 @@ def test_reject_negative_limit():
         c.query("SELECT 1", limit=-1)
 
 
+def test_reject_fractional_negative_limit():
+    # ``int(-0.5)`` truncates to ``0``; ensure the fractional negative is
+    # rejected before truncation rather than silently becoming ``LIMIT 0``.
+    c = _connector()
+    with pytest.raises(ValueError, match="non-negative"):
+        c.query("SELECT 1", limit=-0.5)
+
+
 def test_reject_injection_string():
     c = _connector()
     with pytest.raises(ValueError):

--- a/core/wren/tests/unit/test_clickhouse_coerce_limit.py
+++ b/core/wren/tests/unit/test_clickhouse_coerce_limit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+from fractions import Fraction
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,16 +35,12 @@ def test_reject_fractional_negative_limit():
 def test_reject_negative_decimal_limit():
     # ``Decimal`` and ``Fraction`` are ``numbers.Number`` too; a negative
     # fractional value must be rejected before ``int()`` truncation.
-    from decimal import Decimal
-
     c = _connector()
     with pytest.raises(ValueError, match="non-negative"):
         c.query("SELECT 1", limit=Decimal("-0.5"))
 
 
 def test_reject_negative_fraction_limit():
-    from fractions import Fraction
-
     c = _connector()
     with pytest.raises(ValueError, match="non-negative"):
         c.query("SELECT 1", limit=Fraction(-1, 2))


### PR DESCRIPTION
## Summary
Coerce `limit` to a non-negative int before ClickHouse LIMIT subquery wrapping.

## Failure / reproduction
Before this change, `ClickHouseConnector.query` interpolated the raw `{limit}` directly into the generated SQL:

```python
sql = f"SELECT * FROM ({sql}) LIMIT {limit}"
```

So a client-supplied bad value flowed straight into the query text. E.g. calling `query(sql, limit=-1)` produced:

```
SELECT * FROM (...) LIMIT -1
```

and a non-numeric value like `limit="1; DROP TABLE t"` interpolated verbatim — an injection-shaped input that should never reach the driver.

## Fix
Add `_coerce_limit` and apply it at the start of `query`: reject negatives and non-integer strings, accept numeric strings, so only a validated non-negative int is ever interpolated.

## Verification
```
cd core/wren && .venv/bin/python -m pytest tests/unit/test_clickhouse_coerce_limit.py -q
3 passed
```
Covers: negative rejection, injection-like/non-numeric rejection, numeric-string acceptance.

## Duplicate check
Searched open PRs/issues for existing ClickHouse limit coercion. Related sibling connector PRs (#2624/#2625/#2626) apply the same pattern to other connectors; this PR is the ClickHouse-specific counterpart and does not overlap their files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of query `LIMIT` inputs by rejecting negative numeric values, including fractional inputs (decimals and fractions), before execution.
  - Prevented negative fractional values from being truncated into non-negative `LIMIT` values.
  - Strengthened limit handling to ensure only valid, non-negative integers are used in generated queries.
- **Tests**
  - Updated and tightened unit coverage for fractional negative `LIMIT` coercion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->