### PR TITLE
fix(wren): bound the session-context cache to 32 LRU entries

### DIFF
--- a/core/wren/.claude/CLAUDE.md
+++ b/core/wren/.claude/CLAUDE.md
@@ -39,7 +39,7 @@ Uses `uv` (not Poetry). `pyproject.toml` uses `hatchling` as build backend.
 - **WrenEngine** is the main entry point. It accepts a base64-encoded MDL JSON string, a `DataSource`, and a connection dict.
 - **Query flow**: `_plan()` → wren-core `SessionContext.transform_sql()` → `_transpile()` via sqlglot → connector `.query()`.
 - **Manifest extraction**: `_plan()` tries to extract a minimal sub-manifest scoped to the query's referenced tables before calling wren-core — this reduces planning overhead. Falls back to the full manifest on error.
-- **`get_session_context` is `@cache`-decorated** — same `(manifest_str, function_path, properties, data_source)` tuple reuses the same SessionContext. Avoid mutating session state.
+- **`get_session_context` is `@lru_cache(maxsize=32)`-decorated** — same `(manifest_str, function_path, properties, data_source)` tuple reuses the same SessionContext; least-recently-used entries are evicted past 32. Never mutate session state: eviction makes the next call for the same tuple rebuild a fresh SessionContext, so any mutation silently disappears at an unpredictable point.
 - **Write dialect mapping**: `canner` → `trino`; file sources (`local_file`, `s3_file`, `minio_file`, `gcs_file`) → `duckdb`. All others use `data_source.name` directly.
 - **WrenEngine is a context manager** (`__enter__` / `__exit__` call `close()`).
 - **Profile-based workflow**: When no explicit `--connection-*` flags are given, the CLI auto-discovers the active profile from `~/.wren/profiles.yml`. Profiles store datasource type + connection fields.

--- a/core/wren/src/wren/mdl/__init__.py
+++ b/core/wren/src/wren/mdl/__init__.py
@@ -1,17 +1,23 @@
 """MDL processing utilities backed by wren-core-py."""
 
-from functools import cache
+from functools import lru_cache
 
 import wren_core
 
 
-@cache
+@lru_cache(maxsize=32)
 def get_session_context(
     manifest_str: str | None,
     function_path: str | None,
     properties: frozenset | None = None,
     data_source: str | None = None,
 ) -> wren_core.SessionContext:
+    """Build (or reuse) a SessionContext for the given manifest tuple.
+
+    Bounded LRU: the cache key includes the per-query extracted manifest
+    (engine.py ``extract_by``), so an unbounded cache would grow one
+    SessionContext per distinct table subset for the life of the process.
+    """
     return wren_core.SessionContext(
         manifest_str, function_path, properties, data_source
     )

--- a/core/wren/tests/unit/test_session_context_cache.py
+++ b/core/wren/tests/unit/test_session_context_cache.py
@@ -20,6 +20,10 @@ class _FakeSessionContext:
 @pytest.fixture()
 def fake_session_context(monkeypatch):
     # Keep this unit test fast and isolated from the native SessionContext.
+    # setattr targets the shared wren_core module object (wren.mdl does
+    # `import wren_core`), so the fake is process-wide until monkeypatch
+    # restores it; clearing the cache on both sides of the yield keeps
+    # fake-backed entries from leaking into other tests.
     monkeypatch.setattr(wren.mdl.wren_core, "SessionContext", _FakeSessionContext)
     get_session_context.cache_clear()
     yield

--- a/core/wren/tests/unit/test_session_context_cache.py
+++ b/core/wren/tests/unit/test_session_context_cache.py
@@ -1,0 +1,59 @@
+"""Tests bounded LRU behavior for get_session_context."""
+
+import pytest
+
+import wren.mdl
+from wren.mdl import get_session_context
+
+pytestmark = pytest.mark.unit
+
+# Asserted literally, never derived from the cache under test: the tests,
+# not the implementation, pin the capacity policy.
+EXPECTED_MAXSIZE = 32
+
+
+class _FakeSessionContext:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+
+
+@pytest.fixture()
+def fake_session_context(monkeypatch):
+    # Keep this unit test fast and isolated from the native SessionContext.
+    monkeypatch.setattr(wren.mdl.wren_core, "SessionContext", _FakeSessionContext)
+    get_session_context.cache_clear()
+    yield
+    get_session_context.cache_clear()
+
+
+def _manifest(i: int) -> str:
+    # Mirrors production keying: engine.py passes the per-query extracted
+    # manifest as manifest_str, so distinct table subsets are distinct keys.
+    return f"manifest-{i}"
+
+
+def test_cache_is_bounded_to_32(fake_session_context):
+    # Pin the configured cache bound as part of the public cache policy.
+    assert get_session_context.cache_info().maxsize == EXPECTED_MAXSIZE
+
+    for i in range(EXPECTED_MAXSIZE + 4):
+        get_session_context(_manifest(i), None, None, None)
+    assert get_session_context.cache_info().currsize == EXPECTED_MAXSIZE
+
+
+def test_cache_evicts_least_recently_used(fake_session_context):
+    initial_contexts = [
+        get_session_context(_manifest(i), None, None, None)
+        for i in range(EXPECTED_MAXSIZE)
+    ]
+    # Holding the originals keeps the evicted instance alive: the identity
+    # assertions prove removal from the cache, not object destruction.
+    victim = initial_contexts[1]
+
+    # Refresh key 0, then overflow by one: key 1 becomes the LRU and is
+    # evicted; key 0 survives.
+    kept = get_session_context(_manifest(0), None, None, None)
+    get_session_context(_manifest(EXPECTED_MAXSIZE), None, None, None)
+
+    assert get_session_context(_manifest(0), None, None, None) is kept
+    assert get_session_context(_manifest(1), None, None, None) is not victim


### PR DESCRIPTION
## Summary

`get_session_context` used `functools.cache`, and its cache key includes the per-query extracted manifest. As a long-lived process encountered distinct extracted manifests, the cache retained one `SessionContext` for each argument tuple for the lifetime of the process.

This PR replaces it with `lru_cache(maxsize=32)`. The cache now retains at most the 32 most recently used session contexts; an evicted entry is rebuilt when its argument tuple is used again.

## What failure does this repair?

The previous cache had no entry-count bound. `WrenEngine._plan()` passes the per-query extracted sub-manifest through:

`extract_by(tables) → effective_manifest → get_session_context(...)`

On the unfixed code, calling `get_session_context` with N distinct `manifest_str` values grows `cache_info().currsize` to N, while `cache_info().maxsize` remains `None`. Each entry retains a `SessionContext` and its analyzed manifest state, so varied workloads can accumulate retained contexts indefinitely.

The value 32 is an explicit initial policy: it establishes a hard bound while keeping recently used planning contexts warm. It is not derived from production memory or cache-hit measurements. Configurability can be added later if operational evidence shows that a different bound is needed.

The runtime-ownership prerequisite shipped in wren-core-py v0.7.2 via #2510: session contexts use a process-wide runtime rather than owning independent runtimes. Evicting a cached context therefore does not tear down a context-specific worker pool.

Cache eviction removes only the cache's reference. An in-flight caller retains its local reference until the operation completes. As with `functools.cache`, `lru_cache` is internally synchronized; concurrent misses may briefly build the same value more than once, but only one entry is retained for that key.

## How is it tested?

`tests/unit/test_session_context_cache.py` uses the decorated production function while replacing the native `SessionContext` constructor with a fake:

- `test_cache_is_bounded_to_32` pins the capacity against the test-side `EXPECTED_MAXSIZE = 32` and verifies that `currsize` stops at the bound.
- `test_cache_evicts_least_recently_used` verifies that access refreshes recency, the surviving key returns the same instance, and the evicted key is rebuilt as a different instance.
- Test keys vary `manifest_str`, matching the production `extract_by → effective_manifest → get_session_context` path.
- The original instance is kept alive during the eviction assertion, so object identity proves removal from the cache rather than object destruction.

The regression tests were also verified against the unfixed `@cache` decorator: the capacity assertion reports `maxsize=None`, and the eviction assertion fails because the supposedly evicted key still returns its original instance.

Verification:

- Targeted cache tests: 2 passed
- Default-CI-equivalent unit suite: 1042 passed, 2 skipped
- Ruff check and format check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Session context caching is now limited to 32 entries, preventing unbounded memory growth.
  * Least-recently-used entries are automatically removed as new contexts are created.

* **Documentation**
  * Clarified cache eviction behavior and the need to avoid mutating cached session state.

* **Tests**
  * Added coverage for the cache limit and least-recently-used eviction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->