### PR TITLE
fix: clarify skipped value truncation

### DIFF
--- a/core/wren/src/wren/utils_cli.py
+++ b/core/wren/src/wren/utils_cli.py
@@ -16,6 +16,7 @@ utils_app = typer.Typer(name="utils", help="Utility commands")
 # report the total but stop naming each one, mirroring context_cli's
 # _WARNING_SUMMARY_THRESHOLD so large batches don't flood stderr.
 _SKIP_REPORT_LIMIT = 10
+_REPR_LIMIT = 120
 
 
 def _skipped_rows(data: object) -> list[tuple[int, object]]:
@@ -53,7 +54,10 @@ def _report_skipped(skipped: list[tuple[int, object]]) -> None:
             err=True,
         )
         for i, v in corrupt[:_SKIP_REPORT_LIMIT]:
-            typer.echo(f"  [{i}] {type(v).__name__}: {v!r:.120}", err=True)
+            value_repr = repr(v)
+            if len(value_repr) > _REPR_LIMIT:
+                value_repr = f"{value_repr[:_REPR_LIMIT]}… ({len(value_repr)} chars)"
+            typer.echo(f"  [{i}] {type(v).__name__}: {value_repr}", err=True)
         remaining = len(corrupt) - _SKIP_REPORT_LIMIT
         if remaining > 0:
             typer.echo(f"  ... and {remaining} more", err=True)

--- a/core/wren/tests/unit/test_type_mapping.py
+++ b/core/wren/tests/unit/test_type_mapping.py
@@ -452,6 +452,7 @@ def test_cli_parse_types_skip_report_truncates_past_limit() -> None:
     assert "Warning: skipped 12 non-mapping row(s)" in result.stderr
     assert "[1] int: 0" in result.stderr
     assert "... and 2 more" in result.stderr
+    assert "[11] int: 10" not in result.stderr
 
 
 def test_cli_parse_types_corrupt_value_repr_is_bounded() -> None:
@@ -463,6 +464,7 @@ def test_cli_parse_types_corrupt_value_repr_is_bounded() -> None:
     )
     _assert_success(result)
     line = next(ln for ln in result.stderr.splitlines() if ln.startswith("  [1]"))
+    assert "… (5002 chars)" in line
     assert len(line) < 200
 
 


### PR DESCRIPTION
## Summary

Closes #2629.

- make truncated skipped-value reprs visibly truncated and report their full repr length
- keep the existing ten-row listing cap
- pin the cap with a negative assertion and tighten the repr regression test

The optional `translate-types` symmetry test is intentionally left out so this PR stays focused on the two concrete follow-ups.

## Validation

- `python -m compileall -q src/wren/utils_cli.py`
- direct `_report_skipped` helper checks for the marker, full length, and row cap
- `git diff --check`

The repository test dependencies are not installed in this sparse checkout (`sqlglot` and the locked `uv` environment are unavailable), so the full pytest and Ruff commands could not run locally.
