### PR TITLE
docs(core): align quickstart with the jaffle_shop tables it actually builds

### DIFF
--- a/docs/core/get_started/quickstart.md
+++ b/docs/core/get_started/quickstart.md
@@ -20,7 +20,7 @@ This guide drops three things on you in the first few steps. Skim before you sta
 
 - **Wren CLI (`wren`)**: the Python CLI that runs all of this. Connects to a database, holds your modeling files, executes SQL through the context layer, manages a local memory index. ([CLI reference →](/oss/reference/cli))
 - **MDL (Modeling Definition Language)**: YAML files under `models/`, `views/`, and `relationships.yml` that describe your tables, columns, and joins in business terms. The agent reads MDL instead of guessing from raw schema. ([MDL concept →](/oss/concepts/what_is_mdl) · [Wren project guide →](/oss/reference/mdl))
-- **jaffle_shop**: a public sample database from dbt Labs. We use it so you do not need to bring your own database to follow this quickstart. It is a fictional ecommerce business with `customers`, `orders`, `products`, and `supplies`. *(Want to skip jaffle_shop and use your own database? Finish the install in step 2 then jump to [Connect your database](/oss/guides/connect).)*
+- **jaffle_shop**: a public sample database from dbt Labs. We use it so you do not need to bring your own database to follow this quickstart. It is a fictional ecommerce business whose raw data is customers, orders, and payments; `dbt build` turns that into two analytics tables, `customers` and `orders`. *(Want to skip jaffle_shop and use your own database? Finish the install in step 2 then jump to [Connect your database](/oss/guides/connect).)*
 - **Skills**: markdown workflow guides that tell an AI coding agent (Claude Code, Openclaw, Hermes, Codex, etc.) how to operate the CLI. You install one `wren` discovery stub; it fetches the guides from the CLI on demand. Two guides drive this quickstart: `generate-mdl` (one-time scaffolding) and `usage` (day-to-day querying). ([Skills concept →](/oss/reference/skills))
 
 ---
@@ -63,6 +63,19 @@ Verify the database file was created:
 ```bash
 ls jaffle_shop.duckdb
 ```
+
+`dbt build` seeds three raw tables, then builds three staging views and two
+analytics tables on top of them:
+
+| Objects | Names |
+|---------|-------|
+| Analytics tables — **model these** | `customers`, `orders` |
+| Staging views | `stg_customers`, `stg_orders`, `stg_payments` |
+| Raw seeds | `raw_customers`, `raw_orders`, `raw_payments` |
+
+Only `customers` and `orders` matter for this quickstart. The `raw_*` and `stg_*`
+objects are dbt's intermediate layers — leave them out of your Wren project so
+the agent has one unambiguous table per concept.
 
 Note the **absolute path** to this directory. You'll need it when setting up the profile:
 
@@ -227,15 +240,16 @@ claude
 Then ask:
 
 ```
-Use the /wren skill to explore the jaffle_shop database
-and generate the MDL for all tables. The data source is DuckDB.
+Use the /wren skill to explore the jaffle_shop database and generate the MDL
+for the customers and orders tables. Skip the raw_* seeds and stg_* views.
+The data source is DuckDB.
 ```
 
 The `wren` skill recognizes this as a scaffolding task and pulls in the `generate-mdl` guide (`wren skills get generate-mdl`) to drive it.
 
 Claude Code will:
 
-1. **Discover tables**: `customers`, `orders`, `products`, `supplies`, etc.
+1. **Discover tables**: `customers` and `orders`
 2. **Introspect columns and types** using SQLAlchemy or `information_schema`
 3. **Normalize types** via `wren utils parse-type`
 4. **Write model YAML files**, one folder per table under `models/`
@@ -264,7 +278,7 @@ How many customers placed more than one order?
 ```
 
 ```
-What are the top 5 products by total revenue?
+Which 5 customers have the highest lifetime value?
 ```
 
 ```
@@ -371,11 +385,7 @@ After setup, your project directory looks like this:
 ├── models/
 │   ├── customers/
 │   │   └── metadata.yml        # table schema and descriptions
-│   ├── orders/
-│   │   └── metadata.yml
-│   ├── products/
-│   │   └── metadata.yml
-│   └── supplies/
+│   └── orders/
 │       └── metadata.yml
 ├── views/
 ├── cubes/                      # only if you did Step 8
@@ -397,7 +407,8 @@ Key files to customize:
 
   ```markdown
   ## Naming Conventions
-  - "revenue" always means order total, not supply cost
+  - "revenue" always means the order `amount`, not one of the per-payment-method
+    columns like `credit_card_amount`
   - "active customers" means customers with at least one order in the last 90 days
 
   ## Query Rules


### PR DESCRIPTION
## Problem

The quickstart tells readers to clone `dbt-labs/jaffle_shop_duckdb`, but describes the dataset from the newer `dbt-labs/jaffle-shop` project. It promises `products` and `supplies` tables that the cloned project never builds.

I ran the guide end to end on a clean Python 3.11 venv. **Steps 0–4 all pass** — `dbt build` reports `PASS=28 WARN=0 ERROR=0 SKIP=0` and `wren profile debug` validates the connection — so the setup flow itself is fine. What `dbt build` actually produces is:

| Objects | Names |
|---------|-------|
| Analytics tables | `customers`, `orders` |
| Staging views | `stg_customers`, `stg_orders`, `stg_payments` |
| Raw seeds | `raw_customers`, `raw_orders`, `raw_payments` |

No `products`, no `supplies`. Those are marts models in `dbt-labs/jaffle-shop`, a different repo.

This is documentation drift rather than an upstream data change: the clone URL has pointed at `jaffle_shop_duckdb` since #1530, and the `products` / `supplies` wording was introduced later, in #2285.

Reader-visible dead ends:

- the dataset summary under "Terms used in this guide"
- the "Discover tables" list in Step 6
- the Step 7 sample question *"What are the top 5 products by total revenue?"* — unanswerable
- the project layout listing `models/products/` and `models/supplies/`
- the sample business rule `"revenue" always means order total, not supply cost`

## Fix

Aligns every dataset reference with what `dbt build` produces, and adds a short table to Step 1 so readers know which objects to model.

Also narrows the Step 6 prompt from "all tables" to `customers` and `orders`: read literally, it scaffolds all eight objects, including dbt's raw and staging layers.

This matches `examples/v5-jaffle/`, which already models exactly `customers` and `orders` with `SUM(amount)` / `COUNT(*)`.

Step 8's `revenue` cube is untouched — the legacy `orders` table has `amount`, `status` and `order_date`, so that section already worked.

## Deliberately not included

Two upstream changes from `dbt-labs/jaffle_shop_duckdb` (2026-03-02, "Modernize tooling") that are currently harmless, but may deserve a follow-up:

1. Upstream now declares `requires-python = ">=3.13"` and its README says Python >= 3.13, while this guide says Python 3.11+. The guide installs with `pip install dbt-core dbt-duckdb` rather than `uv sync`, so it bypasses that constraint — verified working on 3.11. A reader who switches to upstream's own instructions would hit it.
2. Upstream added `require-dbt-version: [">=1.11.0", "<2.0.0"]`. `pip install dbt-core` currently resolves 1.12.0 and satisfies it, but this guide pins nothing — so a future adapter release that caps dbt-core below 1.11 would make `dbt build` fail hard.

## Verification

- Cloned `dbt-labs/jaffle_shop_duckdb` at `36bde6cb` into a clean Python 3.11 venv; `pip install dbt-core dbt-duckdb` resolved dbt-core 1.12.0 + dbt-duckdb 1.10.1; `dbt build` → `PASS=28 WARN=0 ERROR=0 SKIP=0`
- Enumerated the built objects via `information_schema.tables` in the resulting `jaffle_shop.duckdb`
- `wren profile add --from-file` + `wren profile debug` against that directory → connection validated
- Checked that the 53 `quickstart-with-agent/*` pages only link to this quickstart and do not duplicate the stale table names

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quickstart guide to match the current `jaffle_shop` dataset structure.
  * Clarified build outputs, including raw seeds, staging views, and analytics tables.
  * Revised examples to focus on customer lifetime value and order amount as revenue.
  * Removed outdated references to products and supplies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->