### PR TITLE
refactor(mssql): strip trailing semicolon on unlimited query path for connector consistency

### DIFF
--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -99,10 +99,11 @@ class MSSqlConnector(ConnectorABC):
     ) -> str:
         """Inject a ``LIMIT n`` into a Select so sqlglot emits the tsql
         ``OFFSET 0 ROWS FETCH NEXT n ROWS ONLY`` clause."""
+        # Unlimited path: strip trailing terminators so client-pasted SQL
+        # matches dry_run / limit composition (connector consistency; see #2595).
+        sql = strip_trailing_semicolon(sql)
         if limit is None:
             return sql
-
-        sql = strip_trailing_semicolon(sql)
 
         try:
             parsed = parse_one(sql, dialect=input_dialect)

--- a/core/wren/tests/unit/test_mssql_semicolon.py
+++ b/core/wren/tests/unit/test_mssql_semicolon.py
@@ -21,6 +21,11 @@ def test_raw_cursor_sql_injects_limit_after_multi_semicolon():
     assert ";;" not in out
 
 
-def test_raw_cursor_sql_no_limit_unchanged_except_strip_not_required():
-    # limit None returns original (including trailing ;) — execute path allows it
-    assert MSSqlConnector._raw_cursor_sql("SELECT 1;", None) == "SELECT 1;"
+def test_raw_cursor_sql_no_limit_strips_trailing_semicolon():
+    """Unlimited path strips terminators for connector consistency (#2595).
+
+    Not a pyodbc multi-statement claim: lone trailing ``;`` is accepted by
+    pyodbc. Strip keeps parse/execute input aligned with limit + dry_run.
+    """
+    assert MSSqlConnector._raw_cursor_sql("SELECT 1;", None) == "SELECT 1"
+    assert MSSqlConnector._raw_cursor_sql("SELECT 1;;", None) == "SELECT 1"


### PR DESCRIPTION
## Summary

Strip trailing semicolons on the MSSQL **unlimited** `_raw_cursor_sql` path so it matches dry_run / limited composition and sibling connectors (e.g. #2595 MySQL).

## Context (replaces closed #2566)

@goldmedal correctly challenged #2566: that PR reversed a deliberate `"execute path allows it"` test without a pyodbc failure case, and a lone trailing `;` is accepted by pyodbc. Agreed.

This PR is the same code change **re-framed honestly** as a consistency refactor (title + body + test comments), rebased onto current `main`.

## What changed since the "allows it" test

- Other connectors standardized unlimited-path strip (#2595 MySQL pattern and shared `strip_trailing_semicolon`).
- Limited + dry_run paths already strip; unlimited was the odd one out for terminator shape on client-pasted SQL.
- **No claim** that pyodbc rejects a single statement with a lone `;`.

## Verification

```
./.venv/bin/python -m pytest tests/unit/test_mssql_semicolon.py -v
3 passed
```

@goldmedal ready for review when convenient — thank you again for the careful catch on framing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSSQL query handling by consistently removing trailing semicolons from SQL statements.
  * Supports statements ending with one or multiple semicolons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->