### PR TITLE
fix(oracle): coerce LIMIT before ROWNUM interpolation

### DIFF
--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -18,6 +18,17 @@ from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
 
 
+def _coerce_limit(limit: int | None) -> int | None:
+    """Validate limit before interpolating into ROWNUM SQL."""
+    if limit is None:
+        return None
+    coerced = int(limit)
+    if coerced < 0:
+        raise ValueError(f"limit must be non-negative, got {coerced}")
+    return coerced
+
+
+
 def _parse_oracle_connection_url(url: str):
     """Parse an Oracle URL after escaping raw brackets in userinfo only.
 
@@ -181,6 +192,7 @@ class OracleConnector(ConnectorABC):
         # Always strip terminating `;` even on the unlimited path: a bare
         # trailing semicolon is rejected by some Oracle clients/drivers even
         # though engines accept multi-statement scripts elsewhere.
+        limit = _coerce_limit(limit)
         sql = strip_trailing_semicolon(sql)
         if limit is not None:
             sql = f"SELECT * FROM ({sql}) t WHERE ROWNUM <= {limit}"

--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -28,7 +28,6 @@ def _coerce_limit(limit: int | None) -> int | None:
     return coerced
 
 
-
 def _parse_oracle_connection_url(url: str):
     """Parse an Oracle URL after escaping raw brackets in userinfo only.
 

--- a/core/wren/tests/unit/test_oracle_coerce_limit.py
+++ b/core/wren/tests/unit/test_oracle_coerce_limit.py
@@ -1,0 +1,66 @@
+"""OracleConnector must coerce limit before ROWNUM interpolation."""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from wren.connector.oracle import OracleConnector, _coerce_limit
+
+pytestmark = pytest.mark.unit
+
+
+def test_coerce_limit_none() -> None:
+    assert _coerce_limit(None) is None
+
+
+def test_coerce_limit_rejects_injection() -> None:
+    with pytest.raises(ValueError):
+        _coerce_limit("1 OR 1=1")
+
+
+def test_coerce_limit_rejects_negative() -> None:
+    with pytest.raises(ValueError):
+        _coerce_limit(-3)
+
+
+class _Cursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql):
+        self.sql = sql
+
+    @property
+    def description(self):
+        return None
+
+    def fetchall(self):
+        return []
+
+
+class _Conn:
+    def __init__(self):
+        self.cursor_obj = _Cursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+def test_query_interpolates_coerced_int(monkeypatch) -> None:
+    # Avoid real oracledb connect
+    conn = _Conn()
+    connector = OracleConnector.__new__(OracleConnector)
+    connector.connection = conn
+    # patch arrow builder to avoid oracledb dependency on description
+    import wren.connector.oracle as oracle_mod
+
+    monkeypatch.setattr(
+        oracle_mod, "_build_oracle_arrow_table", lambda c: pa.table({})
+    )
+    connector.query("SELECT 1;", "5")
+    assert "ROWNUM <= 5" in conn.cursor_obj.sql
+    assert "SELECT 1;" not in conn.cursor_obj.sql


### PR DESCRIPTION
## Summary
Oracle embeds `limit` into `ROWNUM <= {limit}` without validation. Coerce via `int()` and reject negatives (same contract as MySQL).

## Test plan
- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_oracle_coerce_limit.py -q` (4 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle query limit handling by validating and normalizing supplied limits.
  * Rejected negative or unsafe limit values to prevent malformed query execution.
  * Preserved unlimited queries when no limit is specified.

* **Tests**
  * Added coverage for valid, missing, negative, and injection-like limit values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->