### PR TITLE
fix(redshift): coerce LIMIT before SQL interpolation

### DIFF
--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -57,10 +57,7 @@ class RedshiftConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         limit = _coerce_limit(limit)
         if limit is not None:
-            sql = (
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {limit}"
-            )
+            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _q LIMIT {limit}"
         else:
             # Unlimited path also rejects trailing ``;`` for single statements
             # depending on driver/session settings — strip for consistency.

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -23,7 +23,6 @@ def _coerce_limit(limit: int | None) -> int | None:
     return coerced
 
 
-
 class RedshiftConnector(ConnectorABC):
     def __init__(self, connection_info: RedshiftConnectionUnion):
         import redshift_connector  # noqa: PLC0415

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -13,6 +13,17 @@ from wren.model import (
 from wren.model.error import ErrorCode, WrenError
 
 
+def _coerce_limit(limit: int | None) -> int | None:
+    """Validate limit before SQL LIMIT interpolation."""
+    if limit is None:
+        return None
+    coerced = int(limit)
+    if coerced < 0:
+        raise ValueError(f"limit must be non-negative, got {coerced}")
+    return coerced
+
+
+
 class RedshiftConnector(ConnectorABC):
     def __init__(self, connection_info: RedshiftConnectionUnion):
         import redshift_connector  # noqa: PLC0415
@@ -44,10 +55,11 @@ class RedshiftConnector(ConnectorABC):
         self.connection.autocommit = True
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        limit = _coerce_limit(limit)
         if limit is not None:
             sql = (
                 f"SELECT * FROM ({strip_trailing_semicolon(sql)}) "
-                f"AS _q LIMIT {int(limit)}"
+                f"AS _q LIMIT {limit}"
             )
         else:
             # Unlimited path also rejects trailing ``;`` for single statements

--- a/core/wren/tests/unit/test_redshift_coerce_limit.py
+++ b/core/wren/tests/unit/test_redshift_coerce_limit.py
@@ -1,0 +1,39 @@
+"""RedshiftConnector must coerce limit before SQL interpolation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wren.connector.redshift import RedshiftConnector, _coerce_limit
+
+pytestmark = pytest.mark.unit
+
+
+def test_coerce_limit_rejects_injection() -> None:
+    with pytest.raises(ValueError):
+        _coerce_limit("1; drop")
+
+
+def test_coerce_limit_rejects_negative() -> None:
+    with pytest.raises(ValueError):
+        _coerce_limit(-1)
+
+
+def _make_mock_connector() -> tuple[RedshiftConnector, MagicMock]:
+    connector = RedshiftConnector.__new__(RedshiftConnector)
+    cursor = MagicMock()
+    cursor.description = []
+    cursor.fetchall.return_value = []
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    connector.connection = conn
+    return connector, cursor
+
+
+def test_query_uses_coerced_limit() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.query("SELECT 1;", limit="3")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT 3"


### PR DESCRIPTION
## Summary
Redshift LIMIT path only used `int(limit)` inline without rejecting negatives. Centralize coerce + tests.

## Test plan
- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_redshift_coerce_limit.py -q` (3 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of query limits for Redshift queries.
  * Negative or unsafe limit values are now rejected, while unlimited queries remain supported.
  * String-based limits are normalized before being used in generated SQL.

* **Tests**
  * Added coverage for valid, negative, injection-like, and string limit values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->