### PR TITLE
fix(bigquery): coerce LIMIT before SQL interpolation

### DIFF
--- a/core/wren/src/wren/connector/bigquery.py
+++ b/core/wren/src/wren/connector/bigquery.py
@@ -7,6 +7,16 @@ from loguru import logger
 from wren.connector.base import ConnectorABC, strip_trailing_semicolon
 
 
+def _coerce_limit(limit: int | None) -> int | None:
+    """Validate limit before SQL LIMIT interpolation."""
+    if limit is None:
+        return None
+    coerced = int(limit)
+    if coerced < 0:
+        raise ValueError(f"limit must be non-negative, got {coerced}")
+    return coerced
+
+
 def _apply_limit(sql: str, limit: int) -> str:
     """Push LIMIT into SQL via outer subquery wrap.
 
@@ -51,6 +61,7 @@ class BigQueryConnector(ConnectorABC):
         self.connection = client
 
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        limit = _coerce_limit(limit)
         if limit is not None:
             sql = _apply_limit(sql, limit)
         else:

--- a/core/wren/tests/unit/test_bigquery_coerce_limit.py
+++ b/core/wren/tests/unit/test_bigquery_coerce_limit.py
@@ -1,0 +1,27 @@
+"""BigQuery limit coercion helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from wren.connector.bigquery import _apply_limit, _coerce_limit
+
+pytestmark = pytest.mark.unit
+
+
+def test_coerce_limit_none() -> None:
+    assert _coerce_limit(None) is None
+
+
+def test_coerce_limit_rejects_negative() -> None:
+    with pytest.raises(ValueError):
+        _coerce_limit(-1)
+
+
+def test_coerce_limit_rejects_injection() -> None:
+    with pytest.raises(ValueError):
+        _coerce_limit("1 OR 1=1")
+
+
+def test_apply_limit_uses_int() -> None:
+    assert _apply_limit("SELECT 1;", 2) == "SELECT * FROM (SELECT 1) AS _sub LIMIT 2"


### PR DESCRIPTION
## Summary
BigQuery limit wrap used `int(limit)` only inside `_apply_limit` after a None check; add explicit coerce (negatives/injection) on `query()`.

## Test plan
- `cd core/wren && .venv/bin/python -m pytest tests/unit/test_bigquery_coerce_limit.py -q` (4 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BigQuery query limit handling.
  * Rejects negative or invalid limit values before executing queries.
  * Safely normalizes optional limits and prevents unsafe SQL limit input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->