### PR TITLE
docs: Refine readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 *Your agents generate, deploy, and govern dashboards from any database, grounded in a context layer they can actually trust.*
 
-**Wren AI is an open-source generative BI (GenBI) engine — a governed text-to-SQL and semantic-layer platform, powered by an open AI context layer, deployable as an enterprise solution with row- and column-level governance across 22+ data sources.**
+**Wren AI is an open-source generative BI (GenBI) engine — a governed text-to-SQL and semantic-layer platform, powered by an open AI context layer, across 22+ data sources.**
 
 [Docs](https://docs.getwren.ai) · [Discord](https://discord.gg/5DvshJqG8Z) · [Vision](https://www.getwren.ai/post/the-missing-context-layer-for-ai-agents-over-business-data) · [Blog](https://www.getwren.ai/blog)
 
@@ -53,7 +53,7 @@ What makes the output trustworthy is the layer underneath: an open **AI context 
 - **Knowledge management built in.** Business meaning, approved definitions, and proven examples are captured as a reviewable, version-controlled **semantic layer (MDL)**, not buried in prompts.
 - **Open by default.** Open-sourced core, SDK, and skills under the Apache-2.0 license.
 - **Correctness as primitives.** Rich schema retrieval, dry-plan validation, structured errors with hints, value profiling, eval runner. The agent orchestrates; the trace lives in its reasoning.
-- **Enterprise-ready governance.** Row-level and column-level access control (RLAC / CLAC), governed execution, and audit-friendly, Git-reviewable context — see [Enterprise governance & security](#enterprise-governance--security).
+- **Governed execution, reviewable context.** Dry-plan validation, row limits, and structured errors keep agent-generated SQL inside guardrails, and every definition and example lives in Git — reviewable, versioned, diff-able. (Row/column-level security and access control are Cloud / self-hosted — see [Open core: OSS vs. Cloud / self-hosted](#open-core-oss-vs-cloud--self-hosted).)
 - **Sits on top of your existing stack.** Warehouse, transformation pipelines, your existing semantic layer. Not another tool to maintain.
 
 ## How Wren compares
@@ -72,7 +72,6 @@ What makes the output trustworthy is the layer underneath: an open **AI context 
 - You want **AI agents to produce trustworthy BI**, answers *and* dashboards, not just plausible SQL.
 - Your business logic (definitions, enums, units, approved joins) lives **outside the database** and your agents keep getting it wrong.
 - You want an **AI context layer** and **semantic layer** that are **open, reviewable, and version-controlled**, usable by every agent and person, not gated behind one vendor's UI.
-- You need an **enterprise solution** with row/column-level governance you can audit.
 
 **Skip Wren if** you only need a one-off chart from a single CSV, or you're happy letting an agent guess at SQL with no governance.
 
@@ -171,37 +170,23 @@ MDL covers:
 
 - **Models, columns, relationships, and views** — the shape of your data, decoupled from any one warehouse.
 - **Cubes and metrics** — approved, reusable definitions so "revenue" means the same thing everywhere.
-- **Row-level and column-level access control (RLAC / CLAC)** — governance defined once, enforced at query time.
 - **Business context beyond the schema** — enums, units, approved joins, and definitions in version-controlled `instructions.md` and `queries.yml`.
 
 Unlike a bare semantic layer that only stores definitions, Wren pairs the semantic layer with an **AI context layer** — memory, examples, and unstructured company knowledge — and a governed execution engine, so the same definitions that describe your data also *run* it correctly across 22+ sources.
 
-## Enterprise governance & security
-
-Wren is built to run as an **enterprise solution**, self-hosted or on your own cloud, with governance that agents can't route around:
-
-- **Row-level & column-level access control (RLAC / CLAC)** enforced at query time through the semantic layer.
-- **Governed execution primitives** — functions, dry-plan validation, row limits, and structured errors keep agent-generated SQL inside guardrails.
-- **Open, auditable context** — every definition, permission, and example lives in Git: reviewable, versioned, and diff-able, not buried in a vendor UI.
-- **Self-hosted & open-source core** under Apache-2.0 — deploy in your own environment, keep your data where it is.
-- **On the roadmap:** audit logs, rate limits, approval workflows, and a data-flow inspector (see [What's next](#whats-next)).
-
-For a maintained, hosted, and commercially supported deployment, see [Wren AI Commercial](https://getwren.ai).
-
 ## What's Included
 
-- **Modeling Definition Language (MDL) — the semantic layer**: models, columns, relationships, views, cubes, metrics, row-level / column-level access control (RLAC / CLAC)
+- **Modeling Definition Language (MDL) — the semantic layer**: models, columns, relationships, views, cubes, metrics
 - **Engine**: Apache DataFusion based, 22+ data sources (BigQuery, Snowflake, PostgreSQL, ClickHouse, Amazon Redshift, Databricks, DuckDB, and more)
 - **GenBI dashboards**: agent-built, browser-side apps powered by [`wren-core-wasm`](https://docs.getwren.ai/oss/sdk/wasm), deployable to Vercel / Cloudflare Pages
 - **Knowledge & memory — the AI context layer**: business meaning in version-controlled `instructions.md` and `queries.yml`, plus a local LanceDB memory index (hybrid retrieval) for recall
 - **Agent SDK**: `wren-langchain` (LangChain / LangGraph), `wren-pydantic`; reference Python integration for other stacks
-- **Governed execution primitives**: functions, dry-plan, row limits, access control
+- **Governed execution primitives**: functions, dry-plan, row limits, structured errors
 
 ## What's next
 
 - **End-to-end correctness primitives**: value profiling, rich retrieval, structured errors, golden eval runner
 - **Agent-native distribution**: first-class SDKs across major agent frameworks; see [GitHub Discussions](https://github.com/Canner/WrenAI/discussions) for what's prioritized next
-- **Full governed execution**: audit logs, rate limits, approval workflow, data-flow inspector
 
 Full roadmap and design notes: see the [introduction](https://docs.getwren.ai/oss/introduction).
 
@@ -213,23 +198,36 @@ Generative BI (GenBI) is business intelligence produced by AI agents: instead of
 
 ### Does Wren AI do text-to-SQL?
 
-Yes — Wren does **governed** text-to-SQL: agents turn natural-language questions into SQL that's planned against your semantic layer (MDL), dry-plan validated, and access-controlled. It then goes beyond text-to-SQL to deploy dashboards and manage the context that keeps answers correct.
+Yes — Wren does **governed** text-to-SQL: agents turn natural-language questions into SQL that's planned against your semantic layer (MDL) and dry-plan validated. It then goes beyond text-to-SQL to deploy dashboards and manage the context that keeps answers correct.
 
 ### Is Wren AI a semantic layer?
 
-Yes. Wren is a governed semantic layer expressed in MDL — models, metrics, relationships, and RLAC/CLAC governance — and it pairs that semantic layer with an AI context layer (memory, examples, unstructured knowledge) so agents inherit your business definitions.
+Yes. Wren is a governed semantic layer expressed in MDL — models, metrics, and relationships — and it pairs that semantic layer with an AI context layer (memory, examples, unstructured knowledge) so agents inherit your business definitions.
 
 ### What is an AI context layer?
 
 An AI context layer is the reviewable, version-controlled knowledge that agents need but schemas don't provide: business semantics, approved definitions, examples, memory, and governance. It's what makes generative BI trustworthy. Read the vision: [The missing context layer for AI agents over business data](https://www.getwren.ai/post/the-missing-context-layer-for-ai-agents-over-business-data).
 
-### Can I run Wren AI as an enterprise solution?
+### What's in OSS vs. Wren AI Cloud / self-hosted?
 
-Yes. Wren is open-source (Apache-2.0) and self-hostable, with enterprise-grade governance — row/column-level access control, governed execution, and open auditable context. For a hosted, commercially supported version, see [Wren AI Commercial](https://getwren.ai).
+The open-source engine in this repo — MDL semantic layer, governed text-to-SQL, MCP server, CLI, and 22+ connectors — is free forever and self-hostable under Apache-2.0. Row- and column-level security, access control with users and groups, the GenBI UI and dashboards, GenBI Apps, agentic mode, context preparation, and support/SLAs are commercial, delivered as Wren AI Cloud or self-hosted Enterprise Plus. The boundary is published: [Open core — what's OSS vs. commercial](https://www.getwren.ai/en/open-core).
 
 ### Which data sources does Wren AI support?
 
 22+ sources via an Apache DataFusion engine, including BigQuery, Snowflake, PostgreSQL, ClickHouse, Amazon Redshift, Databricks, and DuckDB. See [Connect a database](https://docs.getwren.ai/oss/guides/connect).
+
+## Open core: OSS vs. Cloud / self-hosted
+
+Wren AI is **open core**. The context engine in this repo — MDL semantic layer, governed text-to-SQL, MCP server, CLI, and 22+ connectors — is open source under Apache-2.0, free forever, and self-hostable. It runs without us.
+
+The following are **commercial**, delivered as **Wren AI Cloud** or self-hosted **Enterprise Plus**:
+
+- **Row- and column-level security (RLS / CLS)** and access control with users & groups
+- **GenBI UI, dashboards, embedded & APIs**
+- **Scenario AI harnesses** — GenBI Apps, Agentic Mode, AI-assisted context preparation
+- **Advanced security & audit, support & SLAs**, plus cloud / VPC / air-gapped deployment
+
+Same engine underneath, and your MDL stays in your git either way. The full boundary is published — see **[Open core: what's OSS vs. commercial →](https://www.getwren.ai/en/open-core)**.
 
 ## A note on the "GenBI" name
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@
   </picture>
 </a>
 
+
+[![WrenAI — open-source generative BI (GenBI): semantic layer and AI context layer for AI agents](https://github.com/Canner/WrenAI/raw/main/misc/wrenai_logo.png)](https://getwren.ai)
+
 ### Open-source GenBI: generative BI for AI agents.
 
 *Your agents generate, deploy, and govern dashboards from any database, grounded in a context layer they can actually trust.*
 
+**Wren AI is an open-source generative BI (GenBI) engine — a governed text-to-SQL and semantic-layer platform, powered by an open AI context layer, deployable as an enterprise solution with row- and column-level governance across 22+ data sources.**
+
 [Docs](https://docs.getwren.ai) · [Discord](https://discord.gg/5DvshJqG8Z) · [Vision](https://www.getwren.ai/post/the-missing-context-layer-for-ai-agents-over-business-data) · [Blog](https://www.getwren.ai/blog)
 
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/Canner/WrenAI/blob/main/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/wrenai?label=wrenai)](https://pypi.org/project/wrenai/)
 [![GitHub Release](https://img.shields.io/github/v/release/Canner/WrenAI?logo=github&label=release)](https://github.com/Canner/WrenAI/releases)
 [![Discord](https://img.shields.io/discord/1227143286951514152?logo=discord&label=Discord)](https://discord.gg/5DvshJqG8Z)
@@ -27,41 +32,29 @@
 
 > 📣 **2026-05-07**: Wren Engine has merged into this repo under [`core/`](./core). The previous `Canner/wren-engine` repo is archived. The previous WrenAI GenBI app (the Docker-based chat-first BI product) is preserved on the [`legacy/v1`](https://github.com/Canner/WrenAI/tree/legacy/v1) branch (tag `v1-final`) and is now **Wren GenBI Classic**; see [A note on the "GenBI" name](#a-note-on-the-genbi-name) below. [Read the announcement →](https://github.com/Canner/WrenAI/discussions/2205)
 
-<!--
-  📺 HERO DEMO (place here)
-  ─────────────────────────
-  Suggested: a 10-second silent loop showing GenBI end to end:
-    1. User asks their agent (in plain language) for a dashboard
-    2. Agent writes governed SQL via the Wren context layer, builds the app
-    3. `wren genbi deploy` produces a live, shareable dashboard URL
-  Format: .gif (≤2 MB) or .mp4 (autoplay-muted).
-  Save under  /assets/wrenai-demo.gif  and use the line below:
-
-  <img src="./assets/wrenai-demo.gif" alt="Wren GenBI in action" width="820" />
--->
-
 ---
 
 ## What WrenAI is
 
-WrenAI is the **open-source GenBI engine**: it lets AI agents **generate, deploy, and govern** business intelligence, from a SQL answer to a shareable dashboard, across 22+ data sources.
+WrenAI is the **open-source generative BI (GenBI) engine**: it lets AI agents **generate, deploy, and govern** business intelligence, from a governed **text-to-SQL** answer to a shareable dashboard, across 22+ data sources.
 
-What makes the output trustworthy is the layer underneath: an open **context layer** that gives agents what schemas don't. That means business semantics, approved definitions, examples, memory, and governance, plus the unstructured company knowledge that lives in your docs, wikis, and chat threads. Generative BI is only as good as the context it stands on, and Wren is that context, made reviewable and reusable by every agent you already run.
+What makes the output trustworthy is the layer underneath: an open **AI context layer** plus a governed **semantic layer (MDL)** that gives agents what schemas don't. That means business semantics, approved definitions, examples, memory, and governance, plus the unstructured company knowledge that lives in your docs, wikis, and chat threads. Generative BI is only as good as the context it stands on, and Wren is that context, made reviewable and reusable by every agent you already run.
 
-![Wren AI architecture](./misc/wren-ai-architecture.png)
+![Wren AI generative BI architecture — semantic layer and AI context layer for AI agents](./misc/wren-ai-architecture.png)
 
 ## GenBI in three beats: Generate · Deploy · Know
 
-- **Generate.** Your agent turns a business question into *governed* SQL and charts. Schema-aware retrieval, MDL planning, dry-plan validation, and structured errors keep it correct instead of confidently wrong.
+- **Generate.** Your agent turns a business question into *governed* **text-to-SQL** and charts. Schema-aware retrieval, MDL planning, dry-plan validation, and structured errors keep it correct instead of confidently wrong.
 - **Deploy.** Turn any answer into a shareable, browser-side dashboard powered by [`wren-core-wasm`](https://docs.getwren.ai/oss/sdk/wasm) and ship it to your own Vercel or Cloudflare Pages account with one command.
 - **Know.** The knowledge that makes all of this correct lives in versionable, evidence-linked files: semantic models (MDL), company definitions (`instructions.md`), and a memory of what worked. Reviewable. Git-friendly. Never locked inside someone else's UI.
 
 ## Why agent builders pick WrenAI
 
-- **Generative BI, end to end.** Not just text-to-SQL. Generate the answer, deploy the dashboard, share the URL, all driven by the agents you already use.
-- **Knowledge management built in.** Business meaning, approved definitions, and proven examples are captured as reviewable, version-controlled context, not buried in prompts.
+- **Generative BI, end to end.** Wren does **governed text-to-SQL** — and goes beyond it: generate the answer, deploy the dashboard, share the URL, all driven by the agents you already use.
+- **Knowledge management built in.** Business meaning, approved definitions, and proven examples are captured as a reviewable, version-controlled **semantic layer (MDL)**, not buried in prompts.
 - **Open by default.** Open-sourced core, SDK, and skills under the Apache-2.0 license.
 - **Correctness as primitives.** Rich schema retrieval, dry-plan validation, structured errors with hints, value profiling, eval runner. The agent orchestrates; the trace lives in its reasoning.
+- **Enterprise-ready governance.** Row-level and column-level access control (RLAC / CLAC), governed execution, and audit-friendly, Git-reviewable context — see [Enterprise governance & security](#enterprise-governance--security).
 - **Sits on top of your existing stack.** Warehouse, transformation pipelines, your existing semantic layer. Not another tool to maintain.
 
 ## How Wren compares
@@ -79,7 +72,8 @@ What makes the output trustworthy is the layer underneath: an open **context lay
 
 - You want **AI agents to produce trustworthy BI**, answers *and* dashboards, not just plausible SQL.
 - Your business logic (definitions, enums, units, approved joins) lives **outside the database** and your agents keep getting it wrong.
-- You want context that's **open, reviewable, and version-controlled**, usable by every agent and person, not gated behind one vendor's UI.
+- You want an **AI context layer** and **semantic layer** that are **open, reviewable, and version-controlled**, usable by every agent and person, not gated behind one vendor's UI.
+- You need an **enterprise solution** with row/column-level governance you can audit.
 
 **Skip Wren if** you only need a one-off chart from a single CSV, or you're happy letting an agent guess at SQL with no governance.
 
@@ -170,12 +164,37 @@ wren ask "<question>" --direct     # wrap a question for a stronger agent
 
 Fast at first. Deep when you need it. Always reviewable and Git-friendly.
 
+## Semantic layer (MDL)
+
+Wren **is** a governed semantic layer, expressed in the **Modeling Definition Language (MDL)** — a Git-friendly, reviewable definition of what your data *means*, not just where it lives. Every text-to-SQL answer and dashboard is planned against it, so agents inherit your business truth instead of guessing.
+
+MDL covers:
+
+- **Models, columns, relationships, and views** — the shape of your data, decoupled from any one warehouse.
+- **Cubes and metrics** — approved, reusable definitions so "revenue" means the same thing everywhere.
+- **Row-level and column-level access control (RLAC / CLAC)** — governance defined once, enforced at query time.
+- **Business context beyond the schema** — enums, units, approved joins, and definitions in version-controlled `instructions.md` and `queries.yml`.
+
+Unlike a bare semantic layer that only stores definitions, Wren pairs the semantic layer with an **AI context layer** — memory, examples, and unstructured company knowledge — and a governed execution engine, so the same definitions that describe your data also *run* it correctly across 22+ sources.
+
+## Enterprise governance & security
+
+Wren is built to run as an **enterprise solution**, self-hosted or on your own cloud, with governance that agents can't route around:
+
+- **Row-level & column-level access control (RLAC / CLAC)** enforced at query time through the semantic layer.
+- **Governed execution primitives** — functions, dry-plan validation, row limits, and structured errors keep agent-generated SQL inside guardrails.
+- **Open, auditable context** — every definition, permission, and example lives in Git: reviewable, versioned, and diff-able, not buried in a vendor UI.
+- **Self-hosted & open-source core** under Apache-2.0 — deploy in your own environment, keep your data where it is.
+- **On the roadmap:** audit logs, rate limits, approval workflows, and a data-flow inspector (see [What's next](#whats-next)).
+
+For a maintained, hosted, and commercially supported deployment, see [Wren AI Commercial](https://getwren.ai).
+
 ## What's Included
 
-- **Modeling Definition Language (MDL)**: models, columns, relationships, views, cubes, metrics, row-level / column-level access control (RLAC / CLAC)
-- **Engine**: Apache DataFusion based, 22+ data sources
+- **Modeling Definition Language (MDL) — the semantic layer**: models, columns, relationships, views, cubes, metrics, row-level / column-level access control (RLAC / CLAC)
+- **Engine**: Apache DataFusion based, 22+ data sources (BigQuery, Snowflake, PostgreSQL, ClickHouse, Amazon Redshift, Databricks, DuckDB, and more)
 - **GenBI dashboards**: agent-built, browser-side apps powered by [`wren-core-wasm`](https://docs.getwren.ai/oss/sdk/wasm), deployable to Vercel / Cloudflare Pages
-- **Knowledge & memory**: business meaning in version-controlled `instructions.md` and `queries.yml`, plus a local LanceDB memory index (hybrid retrieval) for recall
+- **Knowledge & memory — the AI context layer**: business meaning in version-controlled `instructions.md` and `queries.yml`, plus a local LanceDB memory index (hybrid retrieval) for recall
 - **Agent SDK**: `wren-langchain` (LangChain / LangGraph), `wren-pydantic`; reference Python integration for other stacks
 - **Governed execution primitives**: functions, dry-plan, row limits, access control
 
@@ -186,6 +205,32 @@ Fast at first. Deep when you need it. Always reviewable and Git-friendly.
 - **Full governed execution**: audit logs, rate limits, approval workflow, data-flow inspector
 
 Full roadmap and design notes: see the [introduction](https://docs.getwren.ai/oss/introduction).
+
+## FAQ
+
+### What is generative BI (GenBI)?
+
+Generative BI (GenBI) is business intelligence produced by AI agents: instead of manually building charts, an agent generates governed SQL, deploys a dashboard, and shares it — grounded in an AI context layer so the output is trustworthy, not just plausible. Wren AI is the open-source GenBI engine.
+
+### Does Wren AI do text-to-SQL?
+
+Yes — Wren does **governed** text-to-SQL: agents turn natural-language questions into SQL that's planned against your semantic layer (MDL), dry-plan validated, and access-controlled. It then goes beyond text-to-SQL to deploy dashboards and manage the context that keeps answers correct.
+
+### Is Wren AI a semantic layer?
+
+Yes. Wren is a governed semantic layer expressed in MDL — models, metrics, relationships, and RLAC/CLAC governance — and it pairs that semantic layer with an AI context layer (memory, examples, unstructured knowledge) so agents inherit your business definitions.
+
+### What is an AI context layer?
+
+An AI context layer is the reviewable, version-controlled knowledge that agents need but schemas don't provide: business semantics, approved definitions, examples, memory, and governance. It's what makes generative BI trustworthy. Read the vision: [The missing context layer for AI agents over business data](https://www.getwren.ai/post/the-missing-context-layer-for-ai-agents-over-business-data).
+
+### Can I run Wren AI as an enterprise solution?
+
+Yes. Wren is open-source (Apache-2.0) and self-hostable, with enterprise-grade governance — row/column-level access control, governed execution, and open auditable context. For a hosted, commercially supported version, see [Wren AI Commercial](https://getwren.ai).
+
+### Which data sources does Wren AI support?
+
+22+ sources via an Apache DataFusion engine, including BigQuery, Snowflake, PostgreSQL, ClickHouse, Amazon Redshift, Databricks, and DuckDB. See [Connect a database](https://docs.getwren.ai/oss/guides/connect).
 
 ## A note on the "GenBI" name
 
@@ -222,7 +267,7 @@ We build in the open. Issues, PRs, connector contributions, SDK integrations, do
 - Looking for somewhere to start? Try the [`good first issue`](https://github.com/Canner/WrenAI/labels/good%20first%20issue) label.
 
 <details>
-<summary><strong>Project structure</strong> (click to expand)</summary>
+<summary><b>Project structure (click to expand)</b></summary>
 
 ```
 core/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 </a>
 
 
-[![WrenAI — open-source generative BI (GenBI): semantic layer and AI context layer for AI agents](https://github.com/Canner/WrenAI/raw/main/misc/wrenai_logo.png)](https://getwren.ai)
 
 ### Open-source GenBI: generative BI for AI agents.
 


### PR DESCRIPTION
<!--
Keep it short. For a typo fix or a docs tweak, the summary alone is enough —
delete the rest. For anything that changes behaviour, please fill it in.
-->

## Summary

Refines the README’s GenBI positioning and SEO, emphasizing governed text-to-SQL, the semantic and AI context layers, enterprise governance, and supported data sources. Adds clearer comparisons, audience guidance, and FAQs.

## What failure does this repair?

<!--
Required for `fix:`. Paste the reproduction and the ACTUAL error output — not a
description of what you believe happens.

If you have not observed the failure, this is a hypothesis rather than a bug:
please open an issue with what you tried instead of a PR.

If nothing observable changes for a user, say so, and title the PR `refactor:`
or `chore:` rather than `fix:`.
-->

## How is it tested?

<!--
Which test exercises the changed code, and does it run in CI? Some test files
are gated behind optional extras or containers and are skipped by the default
jobs — a test placed in one of those never executes.
-->

## Duplicate check

<!--
Which open PRs did you check this against? Duplicate PRs against the same file
are closed without review, and a mechanical change repeated across several
files or connectors belongs in one PR rather than one PR per file.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to position WrenAI as an open-source GenBI engine combining governed text-to-SQL, dashboards, AI context, and a semantic layer.
  * Expanded guidance on key benefits, target audiences, semantic modeling, and enterprise governance.
  * Clarified included components and frequently asked questions.
  * Simplified the project structure overview for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->