### PR TITLE
feat(ui): surface a Wren AI Cloud upgrade entry point in the sidebar

### DIFF
--- a/wren-ui/src/components/sidebar/index.tsx
+++ b/wren-ui/src/components/sidebar/index.tsx
@@ -42,7 +42,7 @@ const StyledButton = styled(Button)`
 
 const CloudCTA = styled(Link)`
   display: block;
-  margin: 12px 12px 8px;
+  margin: 12px 12px 0;
   padding: 8px 12px;
   border: 1px solid var(--geekblue-3);
   border-radius: 8px;
@@ -66,6 +66,10 @@ const CloudCTATitle = styled.div`
   font-size: 13px;
   font-weight: 600;
   color: var(--geekblue-6);
+`;
+
+const CloudCTAContact = styled.div`
+  margin: 8px 12px 8px;
 `;
 
 type Props = (ModelingSidebarProps | HomeSidebarProps) & {
@@ -116,7 +120,7 @@ export default function Sidebar(props: Props) {
       <DynamicSidebar {...props} pathname={router.pathname} />
       <LearningSection />
       <CloudCTA
-        href="https://cloud.getwren.ai/?utm_campaign=383986378-OSS"
+        href="https://cloud.getwren.ai/?utm_campaign=383986378-OSS%20Paid%20Conversion&utm_source=OSS%20UI&utm_medium=cta&utm_content=upgrade_cta"
         target="_blank"
         rel="noopener noreferrer"
         data-ph-capture="true"
@@ -127,9 +131,23 @@ export default function Sidebar(props: Props) {
           Upgrade to Wren AI Cloud
         </CloudCTATitle>
         <div className="text-xs gray-8 mt-1">
-          Team collaboration, hosted deployment, and API access
+          Shared projects, embedded AI API, and enterprise-grade access control.
         </div>
       </CloudCTA>
+      <CloudCTAContact className="text-xs gray-8">
+        Need air-gapped or on-prem?{' '}
+        <Link
+          className="geekblue-6"
+          style={{ textDecoration: 'underline' }}
+          href="https://www.getwren.ai/en/contact?utm_campaign=383986378-OSS%20Paid%20Conversion&utm_source=OSS%20UI&utm_medium=cta&utm_content=talk_to_sales"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-ph-capture="true"
+          data-ph-capture-attribute-name="cta_talk_to_sales"
+        >
+          Talk to sales
+        </Link>
+      </CloudCTAContact>
       <div className="border-t border-gray-4 pt-2">
         <StyledButton type="text" block onClick={onSettingsClick}>
           <SettingOutlined className="text-md" />

--- a/wren-ui/src/components/sidebar/index.tsx
+++ b/wren-ui/src/components/sidebar/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { Button } from 'antd';
 import styled from 'styled-components';
 import { Path } from '@/utils/enum';
-import { DiscordIcon, GithubIcon } from '@/utils/icons';
+import { DiscordIcon, GithubIcon, SparklesIcon } from '@/utils/icons';
 import SettingOutlined from '@ant-design/icons/SettingOutlined';
 import Home, { Props as HomeSidebarProps } from './Home';
 import Modeling, { Props as ModelingSidebarProps } from './Modeling';
@@ -38,6 +38,34 @@ const StyledButton = styled(Button)`
   &:focus {
     background-color: var(--gray-4);
   }
+`;
+
+const CloudCTA = styled(Link)`
+  display: block;
+  margin: 12px 12px 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--geekblue-3);
+  border-radius: 8px;
+  background-color: var(--geekblue-1);
+  color: var(--gray-8);
+  transition:
+    background-color 0.3s,
+    border-color 0.3s;
+
+  &:hover,
+  &:focus {
+    background-color: var(--geekblue-2);
+    border-color: var(--geekblue-4);
+    color: var(--gray-8);
+  }
+`;
+
+const CloudCTATitle = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--geekblue-6);
 `;
 
 type Props = (ModelingSidebarProps | HomeSidebarProps) & {
@@ -87,6 +115,21 @@ export default function Sidebar(props: Props) {
     <Layout className="d-flex flex-column">
       <DynamicSidebar {...props} pathname={router.pathname} />
       <LearningSection />
+      <CloudCTA
+        href="https://cloud.getwren.ai/?utm_campaign=383986378-OSS"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-ph-capture="true"
+        data-ph-capture-attribute-name="cta_go_to_cloud"
+      >
+        <CloudCTATitle>
+          <SparklesIcon className="mr-2" style={{ width: 16 }} />
+          Upgrade to Wren AI Cloud
+        </CloudCTATitle>
+        <div className="text-xs gray-8 mt-1">
+          Team collaboration, hosted deployment, and API access
+        </div>
+      </CloudCTA>
       <div className="border-t border-gray-4 pt-2">
         <StyledButton type="text" block onClick={onSettingsClick}>
           <SettingOutlined className="text-md" />


### PR DESCRIPTION
## What

Adds a Wren AI Cloud entry point to the sidebar, between the Learning section and
the `Settings / Discord / GitHub` footer links.

```
─────────────────────────────────────
 Learning                          ›
 ...
┌──────────────────────────────────┐
│  ✨ Upgrade to Wren AI Cloud     │
│  Team collaboration, hosted      │
│  deployment, and API access      │
└──────────────────────────────────┘
─────────────────────────────────────
 ⚙  Settings
 💬  Discord
 🐙  GitHub
```

## Why

Self-hosted users have no in-product path to the hosted offering — the sidebar's
outbound links were limited to Discord and GitHub.

## Details

- Single file touched: `wren-ui/src/components/sidebar/index.tsx`.
- The card is a `styled(Link)`, matching the existing `styled(Link)` usage in
  `SidebarTree.tsx`, so the whole card is clickable rather than just the text.
- Colors come from the existing CSS variables (`--geekblue-1/2/3/4/6`, `--gray-8`);
  no new hard-coded values. Hover deepens the background and border together.
- Reuses the already-exported `SparklesIcon` from `@/utils/icons`; no new dependency.
- Follows the neighbouring links' PostHog convention
  (`data-ph-capture-attribute-name="cta_go_to_cloud"`), so its click-through can be
  measured alongside the Discord and GitHub links.
- Opens in a new tab with `rel="noopener noreferrer"`.

## Verification

- `yarn check-types` — pass
- `next lint` — `✔ No ESLint warnings or errors`
- `prettier --check` on the touched file — pass
- Ran `wren-ui` locally (Node 20, SQLite) and confirmed the card renders in the
  sidebar on `/modeling`, `/home`, `/knowledge/question-sql-pairs` and
  `/api-management/history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
