### PR TITLE
fix: target legacy release tags at workflow revision

### DIFF
--- a/.github/workflows/create-rc-release.yaml
+++ b/.github/workflows/create-rc-release.yaml
@@ -93,6 +93,7 @@ jobs:
             ./wren-launcher/dist/wren-launcher-darwin-arm64.tar.gz
             ./wren-launcher/dist/wren-launcher-linux-arm64.tar.gz
           tag_name: ${{ steps.parse_release_version.outputs.release_version }}
+          target_commitish: ${{ github.sha }}
           prerelease: ${{ contains(steps.parse_release_version.outputs.release_version, '-rc.') }}
           generate_release_notes: true
         env:


### PR DESCRIPTION
## Summary

Set `target_commitish` explicitly to the checked-out workflow revision when creating legacy releases.

Without this field, the release action creates a missing tag from the repository default branch even when the workflow was dispatched and built from `legacy/v1`.

## Validation

- `actionlint .github/workflows/create-rc-release.yaml`
- `git diff --check`
- confirmed the corrected `0.29.2` tag resolves to the release workflow revision