### PR TITLE
refactor(core): correct the aliased-scan comments the shortcut invalidated

### DIFF
--- a/core/wren-core/core/src/logical_plan/analyze/model_anlayze.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/model_anlayze.rs
@@ -447,19 +447,15 @@ impl ModelAnalyzeRule {
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
             LogicalPlan::SubqueryAlias(SubqueryAlias { input, alias, .. }) => {
-                // Because the bottom-up transformation is used, the table_scan is already transformed
-                // to the ModelPlanNode before the SubqueryAlias. We should check the patten of Wren-generated model plan like:
-                //      SubqueryAlias -> SubqueryAlias -> Extension -> ModelPlanNode
-                // to get the correct required columns
+                // `shortcut_aliased_table_scan` consumes `SubqueryAlias -> TableScan`
+                // over a model in `f_down`, so a model scan no longer reaches either
+                // arm below: the `SubqueryAlias` arm only rejects an already-analyzed
+                // `ModelPlanNode`, and the `TableScan` arm sees only the scans the
+                // shortcut declined (tables outside the MDL).
                 match Arc::unwrap_or_clone(Arc::clone(&input)) {
-                    LogicalPlan::SubqueryAlias(subquery_alias) => self
-                        .analyze_subquery_alias_model(
-                            subquery_alias,
-                            scope_manager,
-                            current_scope_id,
-                            alias,
-                            cycle_stack,
-                        ),
+                    LogicalPlan::SubqueryAlias(subquery_alias) => {
+                        self.analyze_subquery_alias_model(subquery_alias, alias)
+                    }
                     LogicalPlan::TableScan(table_scan) => {
                         let model_plan = self
                             .analyze_table_scan(
@@ -788,22 +784,25 @@ impl ModelAnalyzeRule {
         }
     }
 
-    /// Rebuilds a `SubqueryAlias -> SubqueryAlias -> Extension -> ModelPlanNode` shape.
-    /// `shortcut_aliased_table_scan` (`f_down`) now intercepts every aliased `TableScan`
-    /// before that nested shape can be produced, so the branch below is defense-in-depth.
+    /// Handles the input of a `SubqueryAlias -> SubqueryAlias -> ...` shape. Any
+    /// `Extension` input is rejected; everything else is passed through unchanged.
     fn analyze_subquery_alias_model(
         &self,
         subquery_alias: SubqueryAlias,
-        _scope_manager: &mut ScopeManager,
-        _current_scope_id: ScopeId,
         alias: TableReference,
-        _cycle_stack: &ModelStack,
     ) -> Result<Transformed<LogicalPlan>> {
         let SubqueryAlias { input, .. } = subquery_alias;
         if let LogicalPlan::Extension(Extension { node }) =
             Arc::unwrap_or_clone(Arc::clone(&input))
         {
             if let Some(model_node) = node.as_any().downcast_ref::<ModelPlanNode>() {
+                // Unreachable: `shortcut_aliased_table_scan` consumes every
+                // `SubqueryAlias -> TableScan` over a model in `f_down`, and the only
+                // producer of a directly-nested `SubqueryAlias` is `ExpandWrenViewRule`,
+                // which plans view bodies with `SessionState::create_logical_plan`
+                // (unoptimized). A view body therefore always has a `Projection` root,
+                // so the inner node is never a bare `TableScan` and this shape never
+                // forms. Revisit if view planning starts handing back optimized plans.
                 internal_err!(
                     "SubqueryAlias wrapping an already-analyzed ModelPlanNode ({}) \
                      reached the bottom-up rebuild path; shortcut_aliased_table_scan \

--- a/core/wren-core/core/src/logical_plan/analyze/model_anlayze.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/model_anlayze.rs
@@ -448,10 +448,11 @@ impl ModelAnalyzeRule {
         match plan {
             LogicalPlan::SubqueryAlias(SubqueryAlias { input, alias, .. }) => {
                 // `shortcut_aliased_table_scan` consumes `SubqueryAlias -> TableScan`
-                // over a model in `f_down`, so a model scan no longer reaches either
-                // arm below: the `SubqueryAlias` arm only rejects an already-analyzed
-                // `ModelPlanNode`, and the `TableScan` arm sees only the scans the
-                // shortcut declined (tables outside the MDL).
+                // over a model in `f_down`, so no model scan reaches the arms below.
+                // The `SubqueryAlias` arm rejects any `Extension` input and flattens
+                // everything else onto the outer alias; the `TableScan` arm sees only
+                // the scans the shortcut declined — tables outside the MDL, or inside
+                // it but not a model.
                 match Arc::unwrap_or_clone(Arc::clone(&input)) {
                     LogicalPlan::SubqueryAlias(subquery_alias) => {
                         self.analyze_subquery_alias_model(subquery_alias, alias)
@@ -784,8 +785,9 @@ impl ModelAnalyzeRule {
         }
     }
 
-    /// Handles the input of a `SubqueryAlias -> SubqueryAlias -> ...` shape. Any
-    /// `Extension` input is rejected; everything else is passed through unchanged.
+    /// Handles the input of a `SubqueryAlias -> SubqueryAlias -> ...` shape. An
+    /// `Extension` input is rejected; any other input is flattened onto the outer
+    /// `alias`, dropping the inner one.
     fn analyze_subquery_alias_model(
         &self,
         subquery_alias: SubqueryAlias,

--- a/core/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -1084,14 +1084,14 @@ impl ModelSourceNode {
                     }
                     // Prune columns the caller cannot access under column-level
                     // security instead of denying. This is an *implicit* all-columns
-                    // expansion (a `count(*)`, or the throwaway inner plan built for
-                    // a model scan referenced with a table alias, whose required
-                    // columns are keyed by the alias so the model is wildcard-
-                    // expanded). A protected column the query never explicitly
-                    // selected must be dropped here — matching `SELECT *` semantics —
-                    // not turned into a hard permission error. Explicit references
-                    // still deny, because they arrive as named required fields (the
-                    // non-wildcard branch / ModelPlanNodeBuilder::build), not here.
+                    // expansion: the scan reached `ModelPlanNodeBuilder` with no
+                    // required fields (a `count(*)`-shaped query), so a wildcard was
+                    // substituted for them. A protected column the query never
+                    // explicitly selected must be dropped here — matching `SELECT *`
+                    // semantics — not turned into a hard permission error. Explicit
+                    // references still deny, because they arrive as named required
+                    // fields (the non-wildcard branch / ModelPlanNodeBuilder::build),
+                    // not here.
                     let (is_valid, _) = validate_clac_rule(
                         model.name(),
                         &column,


### PR DESCRIPTION
## Summary

Follow-up to #2612. That PR replaced the bottom-up rewrite of `SubqueryAlias -> TableScan`
with a pre-order shortcut, but three comments still describe the path it removed. All three
sit on code a reader consults to understand behavior they cannot infer from the code alone,
so they are worth correcting rather than leaving to drift.

- **`ModelSourceNode::new` (`plan.rs`)** documented the wildcard-prune branch as reached by
  "a `count(*)`, or the throwaway inner plan built for a model scan referenced with a table
  alias". #2612 deleted that second trigger. The wildcard is substituted in exactly one place
  (`ModelPlanNodeBuilder::build`, when `required_fields.is_empty()`), so only the
  `count(*)`-shaped case reaches it now. This comment carries the column-level-security
  prune-vs-deny rationale from #2449, which is why a stale trigger list there matters more
  than a normal stale comment.
- **`analyze_subquery_alias_model`'s doc** still opened with "Rebuilds a
  `SubqueryAlias -> SubqueryAlias -> Extension -> ModelPlanNode` shape". It rejects that
  shape now.
- **`analyze_model_internal`'s `SubqueryAlias` arm** still explained itself as "because the
  bottom-up transformation is used, the table_scan is already transformed to the
  ModelPlanNode before the SubqueryAlias" — which is what the shortcut stopped doing.

It also writes down the invariant the `internal_err!` rests on. The existing message implies
the branch is unreachable because the shortcut intercepts every shape; that is not quite the
reason. The shortcut only declines to fire on a *directly nested* `SubqueryAlias`, and the
one thing that produces that shape here is `ExpandWrenViewRule`, which plans view bodies with
`SessionState::create_logical_plan` — unoptimized. A view body therefore always has a
`Projection` root, so the inner node is never a bare `TableScan`. That is a property of how
views are planned today, not something this rule owns, so it is now stated with a pointer to
revisit if view planning changes.

`analyze_subquery_alias_model`'s three `_`-prefixed parameters, dead since #2612, go with it.

## What failure does this repair?

None. Comments plus one private signature; no plan, SQL, or public API changes.

## How is it tested?

No new tests — there is no behavior to assert. The parameter removal is compiler-checked and
the rest is comments.

- `RUST_MIN_STACK=8388608 cargo test --lib --tests --bins` — 149 passed
- `cargo test -p wren-sqllogictest` — `tpch.slt`, `model.slt`, `view.slt`, `type.slt` pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean; working tree clean after the test run

Separately verified while reviewing #2612: 20 query shapes (view + alias, view `count(*)`,
CTE with an outer alias, nested subquery alias, self-join, view-join-model, `IN` / `EXISTS` /
correlated-scalar subqueries, `UNION ALL`, column aliases) produce byte-identical SQL against
that PR's merge-base, and none of them reaches the `internal_err!` branch.

Not checked: whether any shape outside those 20 can form a directly-nested
`SubqueryAlias -> SubqueryAlias -> TableScan`. The claim above is structural, not exhaustive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wildcard column expansion and inaccessible-column handling in model sources.
  * Updated guidance for nested subquery alias analysis.

* **Refactor**
  * Simplified nested subquery-alias model handling without changing user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->