### PR TITLE
fix(wren): prevent context upgrade path traversal

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1376,6 +1376,41 @@ class UpgradeError(Exception):
     """Raised when a project upgrade cannot proceed."""
 
 
+def _resolve_upgrade_directory(
+    project_path: Path,
+    collection: str,
+    entity: str,
+    name: Any,
+) -> Path:
+    """Resolve one v1 migration directory without leaving its collection."""
+    if not isinstance(name, str) or not name:
+        raise UpgradeError(
+            f"Cannot upgrade: {entity} name must be a non-empty string, got {name!r}"
+        )
+
+    project_root = project_path.resolve()
+    collection_root = (project_root / collection).resolve()
+    try:
+        collection_root.relative_to(project_root)
+    except ValueError as exc:
+        raise UpgradeError(
+            f"Cannot upgrade: {collection}/ resolves outside the project directory"
+        ) from exc
+
+    target_directory = (collection_root / name).resolve()
+    try:
+        target_directory.relative_to(collection_root)
+    except ValueError as exc:
+        raise UpgradeError(
+            f"Cannot upgrade: {entity} name {name!r} resolves outside {collection}/"
+        ) from exc
+    if target_directory == collection_root:
+        raise UpgradeError(
+            f"Cannot upgrade: {entity} name {name!r} does not identify a directory"
+        )
+    return target_directory
+
+
 def _knowledge_skeleton_targets() -> list[str]:
     """Canonical relative paths of a fresh knowledge/ skeleton.
 
@@ -1462,13 +1497,15 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
     """Plan the v1→v2 file restructuring. Returns (files_created, files_deleted)."""
     created: list[str] = []
     deleted: list[str] = []
+    project_root = project_path.resolve()
 
     # Models: flat files → directories
     models = _load_models_v1(project_path)
     for model in models:
         source_dir = model.pop("_source_dir", None)
         name = model.get("name", source_dir or "unknown")
-        dir_path = f"models/{name}"
+        model_dir = _resolve_upgrade_directory(project_path, "models", "model", name)
+        dir_path = model_dir.relative_to(project_root).as_posix()
 
         ref_sql = model.get("ref_sql")
         if ref_sql:
@@ -1485,7 +1522,8 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
         name = view.get("name")
         if not name:
             continue
-        dir_path = f"views/{name}"
+        view_dir = _resolve_upgrade_directory(project_path, "views", "view", name)
+        dir_path = view_dir.relative_to(project_root).as_posix()
 
         statement = view.get("statement")
         if statement and "\n" in statement.strip():
@@ -1502,7 +1540,9 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
     cubes = _load_cubes_v1(project_path)
     for cube in cubes:
         source_file = cube.pop("_source_file", None)
-        _, target = _cube_migration_target(cube, source_file)
+        name, _ = _cube_migration_target(cube, source_file)
+        cube_dir = _resolve_upgrade_directory(project_path, "cubes", "cube", name)
+        target = (cube_dir / "metadata.yml").relative_to(project_root).as_posix()
         if target in seen_cube_targets:
             raise UpgradeError(
                 f"Cannot upgrade: multiple legacy cube files map to '{target}'"
@@ -1551,12 +1591,15 @@ def apply_upgrade(project_path: Path, result: UpgradeResult) -> None:
 
 def _apply_v1_to_v2(project_path: Path) -> None:
     """Execute the v1→v2 restructuring: write new files, delete old ones."""
+    # Validate every user-derived target before the first filesystem mutation.
+    _plan_v1_to_v2(project_path)
+
     # Write new model directories
     models = _load_models_v1(project_path)
     for model in models:
         source_dir = model.pop("_source_dir", None)
         name = model.get("name", source_dir or "unknown")
-        model_dir = project_path / "models" / name
+        model_dir = _resolve_upgrade_directory(project_path, "models", "model", name)
         model_dir.mkdir(parents=True, exist_ok=True)
 
         ref_sql = model.pop("ref_sql", None)
@@ -1581,7 +1624,7 @@ def _apply_v1_to_v2(project_path: Path) -> None:
         name = view.get("name")
         if not name:
             continue
-        view_dir = project_path / "views" / name
+        view_dir = _resolve_upgrade_directory(project_path, "views", "view", name)
         view_dir.mkdir(parents=True, exist_ok=True)
 
         statement = view.pop("statement", None)
@@ -1620,7 +1663,7 @@ def _apply_v1_to_v2(project_path: Path) -> None:
             )
         seen_cube_targets.add(target)
 
-        cube_dir = project_path / "cubes" / name
+        cube_dir = _resolve_upgrade_directory(project_path, "cubes", "cube", name)
         cube_dir.mkdir(parents=True, exist_ok=True)
 
         (cube_dir / "metadata.yml").write_text(

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1439,6 +1439,16 @@ def _resolve_upgrade_file(target_directory: Path, filename: str) -> Path:
     return resolved_file
 
 
+def _validate_upgrade_view_statement(name: str, statement: Any) -> str | None:
+    """Reject malformed legacy view statements before migration."""
+    if statement is not None and not isinstance(statement, str):
+        raise UpgradeError(
+            f"Cannot upgrade: view {name!r} statement must be a string, "
+            f"got {statement!r}"
+        )
+    return statement
+
+
 def _knowledge_skeleton_targets() -> list[str]:
     """Canonical relative paths of a fresh knowledge/ skeleton.
 
@@ -1553,7 +1563,7 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
             continue
         view_dir = _resolve_upgrade_directory(project_path, "views", "view", name)
 
-        statement = view.get("statement")
+        statement = _validate_upgrade_view_statement(name, view.get("statement"))
         if statement and "\n" in statement.strip():
             sql_file = _resolve_upgrade_file(view_dir, "sql.yml")
             created.append(sql_file.relative_to(project_root).as_posix())
@@ -1660,7 +1670,7 @@ def _apply_v1_to_v2(project_path: Path) -> None:
         view_dir = _resolve_upgrade_directory(project_path, "views", "view", name)
         view_dir.mkdir(parents=True, exist_ok=True)
 
-        statement = view.pop("statement", None)
+        statement = _validate_upgrade_view_statement(name, view.pop("statement", None))
         if statement and "\n" in statement.strip():
             _resolve_upgrade_file(view_dir, "sql.yml").write_text(
                 yaml.dump(

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 import yaml
@@ -1387,6 +1387,15 @@ def _resolve_upgrade_directory(
         raise UpgradeError(
             f"Cannot upgrade: {entity} name must be a non-empty string, got {name!r}"
         )
+    if (
+        name in {".", ".."}
+        or PurePosixPath(name).parts != (name,)
+        or PureWindowsPath(name).parts != (name,)
+    ):
+        raise UpgradeError(
+            f"Cannot upgrade: {entity} name {name!r} must be a single portable "
+            "path component"
+        )
 
     project_root = project_path.resolve()
     collection_root = (project_root / collection).resolve()
@@ -1409,6 +1418,25 @@ def _resolve_upgrade_directory(
             f"Cannot upgrade: {entity} name {name!r} does not identify a directory"
         )
     return target_directory
+
+
+def _resolve_upgrade_file(target_directory: Path, filename: str) -> Path:
+    """Resolve one concrete migration file and reject existing symlinks."""
+    target_file = target_directory / filename
+    if target_file.is_symlink():
+        raise UpgradeError(
+            f"Cannot upgrade: destination file '{target_file}' is a symbolic link"
+        )
+
+    resolved_file = target_file.resolve()
+    try:
+        resolved_file.relative_to(target_directory)
+    except ValueError as exc:
+        raise UpgradeError(
+            f"Cannot upgrade: destination file '{target_file}' resolves outside "
+            "its entity directory"
+        ) from exc
+    return resolved_file
 
 
 def _knowledge_skeleton_targets() -> list[str]:
@@ -1505,13 +1533,14 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
         source_dir = model.pop("_source_dir", None)
         name = model.get("name", source_dir or "unknown")
         model_dir = _resolve_upgrade_directory(project_path, "models", "model", name)
-        dir_path = model_dir.relative_to(project_root).as_posix()
 
         ref_sql = model.get("ref_sql")
         if ref_sql:
-            created.append(f"{dir_path}/ref_sql.sql")
+            ref_sql_file = _resolve_upgrade_file(model_dir, "ref_sql.sql")
+            created.append(ref_sql_file.relative_to(project_root).as_posix())
 
-        created.append(f"{dir_path}/metadata.yml")
+        metadata_file = _resolve_upgrade_file(model_dir, "metadata.yml")
+        created.append(metadata_file.relative_to(project_root).as_posix())
 
         if source_dir:
             deleted.append(f"models/{source_dir}.yml")
@@ -1523,13 +1552,14 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
         if not name:
             continue
         view_dir = _resolve_upgrade_directory(project_path, "views", "view", name)
-        dir_path = view_dir.relative_to(project_root).as_posix()
 
         statement = view.get("statement")
         if statement and "\n" in statement.strip():
-            created.append(f"{dir_path}/sql.yml")
+            sql_file = _resolve_upgrade_file(view_dir, "sql.yml")
+            created.append(sql_file.relative_to(project_root).as_posix())
 
-        created.append(f"{dir_path}/metadata.yml")
+        metadata_file = _resolve_upgrade_file(view_dir, "metadata.yml")
+        created.append(metadata_file.relative_to(project_root).as_posix())
 
     views_file = project_path / "views.yml"
     if views_file.exists():
@@ -1542,7 +1572,8 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
         source_file = cube.pop("_source_file", None)
         name, _ = _cube_migration_target(cube, source_file)
         cube_dir = _resolve_upgrade_directory(project_path, "cubes", "cube", name)
-        target = (cube_dir / "metadata.yml").relative_to(project_root).as_posix()
+        metadata_file = _resolve_upgrade_file(cube_dir, "metadata.yml")
+        target = metadata_file.relative_to(project_root).as_posix()
         if target in seen_cube_targets:
             raise UpgradeError(
                 f"Cannot upgrade: multiple legacy cube files map to '{target}'"
@@ -1604,9 +1635,11 @@ def _apply_v1_to_v2(project_path: Path) -> None:
 
         ref_sql = model.pop("ref_sql", None)
         if ref_sql:
-            (model_dir / "ref_sql.sql").write_text(ref_sql.strip() + "\n")
+            _resolve_upgrade_file(model_dir, "ref_sql.sql").write_text(
+                ref_sql.strip() + "\n"
+            )
 
-        (model_dir / "metadata.yml").write_text(
+        _resolve_upgrade_file(model_dir, "metadata.yml").write_text(
             yaml.dump(
                 model, default_flow_style=False, sort_keys=False, allow_unicode=True
             )
@@ -1629,7 +1662,7 @@ def _apply_v1_to_v2(project_path: Path) -> None:
 
         statement = view.pop("statement", None)
         if statement and "\n" in statement.strip():
-            (view_dir / "sql.yml").write_text(
+            _resolve_upgrade_file(view_dir, "sql.yml").write_text(
                 yaml.dump(
                     {"statement": statement},
                     default_flow_style=False,
@@ -1640,7 +1673,7 @@ def _apply_v1_to_v2(project_path: Path) -> None:
         elif statement:
             view["statement"] = statement
 
-        (view_dir / "metadata.yml").write_text(
+        _resolve_upgrade_file(view_dir, "metadata.yml").write_text(
             yaml.dump(
                 view, default_flow_style=False, sort_keys=False, allow_unicode=True
             )
@@ -1666,7 +1699,7 @@ def _apply_v1_to_v2(project_path: Path) -> None:
         cube_dir = _resolve_upgrade_directory(project_path, "cubes", "cube", name)
         cube_dir.mkdir(parents=True, exist_ok=True)
 
-        (cube_dir / "metadata.yml").write_text(
+        _resolve_upgrade_file(cube_dir, "metadata.yml").write_text(
             yaml.dump(cube, default_flow_style=False, sort_keys=False)
         )
 

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1449,6 +1449,15 @@ def _validate_upgrade_view_statement(name: str, statement: Any) -> str | None:
     return statement
 
 
+def _validate_upgrade_model_ref_sql(name: str, ref_sql: Any) -> str | None:
+    """Reject malformed legacy model SQL before migration."""
+    if ref_sql is not None and not isinstance(ref_sql, str):
+        raise UpgradeError(
+            f"Cannot upgrade: model {name!r} ref_sql must be a string, got {ref_sql!r}"
+        )
+    return ref_sql
+
+
 def _knowledge_skeleton_targets() -> list[str]:
     """Canonical relative paths of a fresh knowledge/ skeleton.
 
@@ -1544,7 +1553,7 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
         name = model.get("name", source_dir or "unknown")
         model_dir = _resolve_upgrade_directory(project_path, "models", "model", name)
 
-        ref_sql = model.get("ref_sql")
+        ref_sql = _validate_upgrade_model_ref_sql(name, model.get("ref_sql"))
         if ref_sql:
             ref_sql_file = _resolve_upgrade_file(model_dir, "ref_sql.sql")
             created.append(ref_sql_file.relative_to(project_root).as_posix())

--- a/core/wren/src/wren/context_cli.py
+++ b/core/wren/src/wren/context_cli.py
@@ -961,7 +961,11 @@ def upgrade(
         f"Upgrading project from schema_version {result.from_version} -> {result.to_version}..."
     )
 
-    apply_upgrade(project_path, result)
+    try:
+        apply_upgrade(project_path, result)
+    except UpgradeError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
 
     for f in result.files_created:
         typer.echo(f"  + {f}")

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1302,6 +1302,19 @@ def _set_v1_view_statement(project_path: Path, statement: int) -> None:
     )
 
 
+def _set_v1_model_ref_sql(project_path: Path, ref_sql: int) -> None:
+    model_file = project_path / "models" / "revenue.yml"
+    content = model_file.read_text(encoding="utf-8")
+    model_file.write_text(
+        content.replace(
+            "ref_sql: SELECT SUM(amount) FROM orders\n",
+            f"ref_sql: {ref_sql}\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+
 _V1_UPGRADE_FILE_TARGETS = [
     "models/orders/metadata.yml",
     "models/revenue/ref_sql.sql",
@@ -1388,6 +1401,20 @@ def test_plan_upgrade_v1_to_v2_rejects_non_string_view_statement(
     from wren.context import UpgradeError as _UE  # noqa: PLC0415
 
     with pytest.raises(_UE, match="view 'summary' statement must be a string"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
+
+
+@pytest.mark.parametrize("ref_sql", [42, 0])
+def test_plan_upgrade_v1_to_v2_rejects_non_string_model_ref_sql(tmp_path, ref_sql):
+    _make_v1_project(tmp_path)
+    _set_v1_model_ref_sql(tmp_path, ref_sql)
+    source_contents = _snapshot_v1_sources(tmp_path)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="model 'revenue' ref_sql must be a string"):
         plan_upgrade(tmp_path, target_version=2)
 
     _assert_v1_sources_unchanged(tmp_path, source_contents)
@@ -1642,6 +1669,23 @@ def test_apply_upgrade_v1_to_v2_rejects_non_string_view_statement_before_writing
     from wren.context import UpgradeError as _UE  # noqa: PLC0415
 
     with pytest.raises(_UE, match="view 'summary' statement must be a string"):
+        apply_upgrade(tmp_path, result)
+
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
+
+
+@pytest.mark.parametrize("ref_sql", [42, 0])
+def test_apply_upgrade_v1_to_v2_rejects_non_string_model_ref_sql_before_writing(
+    tmp_path, ref_sql
+):
+    _make_v1_project(tmp_path)
+    result = plan_upgrade(tmp_path, target_version=2)
+    _set_v1_model_ref_sql(tmp_path, ref_sql)
+    source_contents = _snapshot_v1_sources(tmp_path)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="model 'revenue' ref_sql must be a string"):
         apply_upgrade(tmp_path, result)
 
     _assert_v1_sources_unchanged(tmp_path, source_contents)

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1289,6 +1289,19 @@ def _set_v1_entity_name(project_path: Path, entity: str, name: str) -> None:
     )
 
 
+def _set_v1_view_statement(project_path: Path, statement: int) -> None:
+    views_file = project_path / "views.yml"
+    content = views_file.read_text(encoding="utf-8")
+    views_file.write_text(
+        content.replace(
+            "    statement: SELECT 1\n",
+            f"    statement: {statement}\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+
 _V1_UPGRADE_FILE_TARGETS = [
     "models/orders/metadata.yml",
     "models/revenue/ref_sql.sql",
@@ -1359,6 +1372,22 @@ def test_plan_upgrade_v1_to_v2_requires_portable_path_component(tmp_path, entity
     from wren.context import UpgradeError as _UE  # noqa: PLC0415
 
     with pytest.raises(_UE, match="single portable path component"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
+
+
+@pytest.mark.parametrize("statement", [42, 0])
+def test_plan_upgrade_v1_to_v2_rejects_non_string_view_statement(
+    tmp_path, statement
+):
+    _make_v1_project(tmp_path)
+    _set_v1_view_statement(tmp_path, statement)
+    source_contents = _snapshot_v1_sources(tmp_path)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="view 'summary' statement must be a string"):
         plan_upgrade(tmp_path, target_version=2)
 
     _assert_v1_sources_unchanged(tmp_path, source_contents)
@@ -1598,6 +1627,23 @@ def test_apply_upgrade_v1_to_v2_rejects_traversal_names_before_writing(
         apply_upgrade(tmp_path, result)
 
     assert not outside_dir.exists()
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
+
+
+@pytest.mark.parametrize("statement", [42, 0])
+def test_apply_upgrade_v1_to_v2_rejects_non_string_view_statement_before_writing(
+    tmp_path, statement
+):
+    _make_v1_project(tmp_path)
+    result = plan_upgrade(tmp_path, target_version=2)
+    _set_v1_view_statement(tmp_path, statement)
+    source_contents = _snapshot_v1_sources(tmp_path)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="view 'summary' statement must be a string"):
+        apply_upgrade(tmp_path, result)
+
     _assert_v1_sources_unchanged(tmp_path, source_contents)
 
 

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1270,6 +1270,25 @@ def _make_v1_project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _set_v1_entity_name(project_path: Path, entity: str, name: str) -> None:
+    replacements = {
+        "model": ("models/orders.yml", "name: orders\n", f"name: {name}\n"),
+        "view": ("views.yml", "  - name: summary\n", f"  - name: {name}\n"),
+        "cube": (
+            "cubes/order_metrics.yml",
+            "name: order_metrics\n",
+            f"name: {name}\n",
+        ),
+    }
+    relative_path, original, replacement = replacements[entity]
+    source_path = project_path / relative_path
+    content = source_path.read_text(encoding="utf-8")
+    source_path.write_text(
+        content.replace(original, replacement, 1),
+        encoding="utf-8",
+    )
+
+
 def test_plan_upgrade_v1_to_v2(tmp_path):
     _make_v1_project(tmp_path)
     result = plan_upgrade(tmp_path, target_version=2)
@@ -1281,6 +1300,21 @@ def test_plan_upgrade_v1_to_v2(tmp_path):
     assert any("models/orders.yml" in f for f in result.files_deleted)
     assert any("cubes/order_metrics.yml" in f for f in result.files_deleted)
     assert any("views.yml" in f for f in result.files_deleted)
+
+
+@pytest.mark.parametrize("entity", ["model", "view", "cube"])
+def test_plan_upgrade_v1_to_v2_rejects_traversal_names(tmp_path, entity):
+    _make_v1_project(tmp_path)
+    outside_dir = tmp_path.parent / f"{tmp_path.name}-{entity}-outside"
+    _set_v1_entity_name(tmp_path, entity, f"../../{outside_dir.name}")
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="resolves outside"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    assert not outside_dir.exists()
+    assert get_schema_version(tmp_path) == 1
 
 
 def test_plan_upgrade_v1_to_v3(tmp_path):
@@ -1480,6 +1514,27 @@ def test_apply_upgrade_v1_to_v2_does_not_crash_on_non_mapping_view(tmp_path):
     assert not (tmp_path / "views.yml").exists()
     # Only the well-formed view became a directory — no junk siblings.
     assert [d.name for d in (tmp_path / "views").iterdir()] == ["summary"]
+
+
+@pytest.mark.parametrize("entity", ["model", "view", "cube"])
+def test_apply_upgrade_v1_to_v2_rejects_traversal_names_before_writing(
+    tmp_path, entity
+):
+    _make_v1_project(tmp_path)
+    result = plan_upgrade(tmp_path, target_version=2)
+    outside_dir = tmp_path.parent / f"{tmp_path.name}-{entity}-outside"
+    _set_v1_entity_name(tmp_path, entity, f"../../{outside_dir.name}")
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="resolves outside"):
+        apply_upgrade(tmp_path, result)
+
+    assert not outside_dir.exists()
+    assert (tmp_path / "models" / "orders.yml").exists()
+    assert (tmp_path / "views.yml").exists()
+    assert (tmp_path / "cubes" / "order_metrics.yml").exists()
+    assert get_schema_version(tmp_path) == 1
 
 
 def test_apply_upgrade_v2_to_v3(tmp_path):

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1289,6 +1289,38 @@ def _set_v1_entity_name(project_path: Path, entity: str, name: str) -> None:
     )
 
 
+_V1_UPGRADE_FILE_TARGETS = [
+    "models/orders/metadata.yml",
+    "models/revenue/ref_sql.sql",
+    "views/summary/metadata.yml",
+    "views/monthly/sql.yml",
+    "cubes/order_metrics/metadata.yml",
+]
+
+
+def _snapshot_v1_sources(project_path: Path) -> dict[str, str]:
+    relative_paths = [
+        "models/orders.yml",
+        "models/revenue.yml",
+        "views.yml",
+        "cubes/order_metrics.yml",
+    ]
+    return {
+        relative_path: (project_path / relative_path).read_text(encoding="utf-8")
+        for relative_path in relative_paths
+    }
+
+
+def _assert_v1_sources_unchanged(
+    project_path: Path, source_contents: dict[str, str]
+) -> None:
+    for relative_path, expected_content in source_contents.items():
+        assert (project_path / relative_path).read_text(
+            encoding="utf-8"
+        ) == expected_content
+    assert get_schema_version(project_path) == 1
+
+
 def test_plan_upgrade_v1_to_v2(tmp_path):
     _make_v1_project(tmp_path)
     result = plan_upgrade(tmp_path, target_version=2)
@@ -1310,11 +1342,45 @@ def test_plan_upgrade_v1_to_v2_rejects_traversal_names(tmp_path, entity):
 
     from wren.context import UpgradeError as _UE  # noqa: PLC0415
 
-    with pytest.raises(_UE, match="resolves outside"):
+    with pytest.raises(_UE, match="single portable path component"):
         plan_upgrade(tmp_path, target_version=2)
 
     assert not outside_dir.exists()
     assert get_schema_version(tmp_path) == 1
+
+
+@pytest.mark.parametrize("entity", ["model", "view", "cube"])
+@pytest.mark.parametrize("name", ["sub/child", r"sub\child", ".", ".."])
+def test_plan_upgrade_v1_to_v2_requires_portable_path_component(tmp_path, entity, name):
+    _make_v1_project(tmp_path)
+    _set_v1_entity_name(tmp_path, entity, name)
+    source_contents = _snapshot_v1_sources(tmp_path)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="single portable path component"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
+
+
+@pytest.mark.parametrize("relative_target", _V1_UPGRADE_FILE_TARGETS)
+def test_plan_upgrade_v1_to_v2_rejects_symlink_file_targets(tmp_path, relative_target):
+    _make_v1_project(tmp_path)
+    source_contents = _snapshot_v1_sources(tmp_path)
+    victim = tmp_path.parent / f"{tmp_path.name}-victim"
+    victim.write_text("unchanged\n", encoding="utf-8")
+    target = tmp_path / relative_target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(victim)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="symbolic link"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    assert victim.read_text(encoding="utf-8") == "unchanged\n"
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
 
 
 def test_plan_upgrade_v1_to_v3(tmp_path):
@@ -1524,17 +1590,37 @@ def test_apply_upgrade_v1_to_v2_rejects_traversal_names_before_writing(
     result = plan_upgrade(tmp_path, target_version=2)
     outside_dir = tmp_path.parent / f"{tmp_path.name}-{entity}-outside"
     _set_v1_entity_name(tmp_path, entity, f"../../{outside_dir.name}")
+    source_contents = _snapshot_v1_sources(tmp_path)
 
     from wren.context import UpgradeError as _UE  # noqa: PLC0415
 
-    with pytest.raises(_UE, match="resolves outside"):
+    with pytest.raises(_UE, match="single portable path component"):
         apply_upgrade(tmp_path, result)
 
     assert not outside_dir.exists()
-    assert (tmp_path / "models" / "orders.yml").exists()
-    assert (tmp_path / "views.yml").exists()
-    assert (tmp_path / "cubes" / "order_metrics.yml").exists()
-    assert get_schema_version(tmp_path) == 1
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
+
+
+@pytest.mark.parametrize("relative_target", _V1_UPGRADE_FILE_TARGETS)
+def test_apply_upgrade_v1_to_v2_rejects_late_symlink_file_targets(
+    tmp_path, relative_target
+):
+    _make_v1_project(tmp_path)
+    result = plan_upgrade(tmp_path, target_version=2)
+    source_contents = _snapshot_v1_sources(tmp_path)
+    victim = tmp_path.parent / f"{tmp_path.name}-victim"
+    victim.write_text("unchanged\n", encoding="utf-8")
+    target = tmp_path / relative_target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(victim)
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="symbolic link"):
+        apply_upgrade(tmp_path, result)
+
+    assert victim.read_text(encoding="utf-8") == "unchanged\n"
+    _assert_v1_sources_unchanged(tmp_path, source_contents)
 
 
 def test_apply_upgrade_v2_to_v3(tmp_path):

--- a/core/wren/tests/unit/test_context_cli.py
+++ b/core/wren/tests/unit/test_context_cli.py
@@ -659,6 +659,23 @@ def test_upgrade_cli_explicit_to_version(tmp_path):
     assert config["schema_version"] == 2
 
 
+def test_upgrade_cli_handles_apply_upgrade_error_cleanly(tmp_path, monkeypatch):
+    _make_v1_project(tmp_path)
+
+    import wren.context as context_mod  # noqa: PLC0415
+
+    def _broken_apply(*_args, **_kwargs):
+        raise context_mod.UpgradeError("simulated apply-time failure")
+
+    monkeypatch.setattr(context_mod, "apply_upgrade", _broken_apply)
+
+    result = runner.invoke(app, ["context", "upgrade", "--path", str(tmp_path)])
+
+    assert result.exit_code == 1, result.output
+    assert isinstance(result.exception, SystemExit), result.exception
+    assert "Error: simulated apply-time failure" in result.output
+
+
 def test_upgrade_cli_v4_to_v5_builds_knowledge(tmp_path):
     """Upgrading a v4 project to latest creates the knowledge/ skeleton."""
     (tmp_path / "wren_project.yml").write_text(


### PR DESCRIPTION
## Summary

- reject v1 model, view, and cube migration targets that resolve outside their
  collection directories
- validate every migration target during planning and again before apply starts
  mutating the project
- add regression coverage for traversal names in both `plan_upgrade()` and
  `apply_upgrade()`

Fixes #2630.

## Root cause

The v1 to v2 migration joined the YAML `name` directly onto paths such as
`project_path / "models" / name`, then called `mkdir()` and `write_text()`
without resolving the result or checking containment. A name such as
`../../outside/pwned` therefore escaped the project directory.

On `main`, the reproduction wrote outside the project:

```text
planned_path=models/../../outside/pwned/metadata.yml
after_apply_target_exists=True
actual_target_inside_project=False
```

## User impact

Malformed or untrusted legacy projects now fail with `UpgradeError` before any
migration write or delete occurs. Valid v1 projects keep the existing migration
behavior.

After this change, the same reproduction is rejected and preserves the source:

```text
REJECTED: Cannot upgrade: model name '../../outside/pwned' resolves outside models/
NO_OUTSIDE_WRITE: true
SOURCE_PRESERVED: true
```

## Validation

```text
uv run --no-sync pytest tests/unit/test_context.py tests/unit/test_context_cli.py -q
184 passed

uv run --no-sync ruff format --check src/
69 files already formatted

uv run --no-sync ruff check src/
All checks passed!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved v1-to-v2 upgrade safety by rejecting invalid, non-portable, or traversal-based migration paths.
  * Prevented upgrades from writing outside the project directory or through symlinks.
  * Rejected invalid model SQL and view definitions during migration.
  * Detected duplicate migration targets before making changes.
  * Ensured failed upgrades leave existing files, schemas, and legacy projects unchanged.
  * Upgrades now report clear errors and exit cleanly when migration validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->