### PR TITLE
fix(wren): classify bare TimeoutError as DatabaseTimeoutError in WrenEngine

### DIFF
--- a/core/wren/src/wren/engine.py
+++ b/core/wren/src/wren/engine.py
@@ -32,7 +32,13 @@ from wren.connector.factory import get_connector
 from wren.mdl import get_manifest_extractor, get_session_context, to_json_base64
 from wren.mdl.cte_rewriter import CTERewriter, get_sqlglot_dialect
 from wren.model.data_source import DataSource
-from wren.model.error import DIALECT_SQL, ErrorCode, ErrorPhase, WrenError
+from wren.model.error import (
+    DIALECT_SQL,
+    DatabaseTimeoutError,
+    ErrorCode,
+    ErrorPhase,
+    WrenError,
+)
 from wren.policy import resolve_model_name, validate_sql_policy
 
 
@@ -117,6 +123,8 @@ class WrenEngine:
             return connector.query(dialect_sql, limit)
         except WrenError:
             raise
+        except TimeoutError as e:
+            raise DatabaseTimeoutError(str(e)) from e
         except Exception as e:
             raise WrenError(
                 ErrorCode.GENERIC_USER_ERROR,
@@ -133,6 +141,8 @@ class WrenEngine:
             connector.dry_run(dialect_sql)
         except WrenError:
             raise
+        except TimeoutError as e:
+            raise DatabaseTimeoutError(str(e)) from e
         except Exception as e:
             raise WrenError(
                 ErrorCode.GENERIC_USER_ERROR,

--- a/core/wren/tests/unit/test_engine.py
+++ b/core/wren/tests/unit/test_engine.py
@@ -14,7 +14,7 @@ import pytest
 from wren import WrenEngine
 from wren.config import WrenConfig
 from wren.model.data_source import DataSource
-from wren.model.error import ErrorCode, WrenError
+from wren.model.error import DatabaseTimeoutError, ErrorCode, WrenError
 
 pytestmark = pytest.mark.unit
 
@@ -168,3 +168,44 @@ def test_non_strict_mode_allows_unknown_table(duckdb_engine: WrenEngine):
         duckdb_engine.dry_plan("SELECT * FROM unknown_table")
     except WrenError as e:
         assert e.error_code != ErrorCode.MODEL_NOT_FOUND
+
+
+# ------------------------------------------------------------------
+# Connector-level TimeoutError classification (#2153)
+# ------------------------------------------------------------------
+
+
+class _TimeoutConnector:
+    """Fake connector standing in for one that re-raises a bare TimeoutError,
+    e.g. postgres.py on a canceled statement (see connector/postgres.py)."""
+
+    def query(self, sql: str, limit: int | None = None):
+        raise TimeoutError("canceling statement due to statement timeout")
+
+    def dry_run(self, sql: str) -> None:
+        raise TimeoutError("canceling statement due to statement timeout")
+
+    def close(self) -> None:
+        pass
+
+
+def test_query_classifies_bare_timeout_as_database_timeout():
+    conn_info = {"url": "/tmp", "format": "duckdb"}
+    with WrenEngine(
+        _MANIFEST_STR, DataSource.duckdb, conn_info, fallback=False
+    ) as engine:
+        engine._connector = _TimeoutConnector()
+        with pytest.raises(DatabaseTimeoutError) as exc_info:
+            engine.query('SELECT o_orderkey FROM "orders" LIMIT 1')
+        assert exc_info.value.error_code == ErrorCode.DATABASE_TIMEOUT
+
+
+def test_dry_run_classifies_bare_timeout_as_database_timeout():
+    conn_info = {"url": "/tmp", "format": "duckdb"}
+    with WrenEngine(
+        _MANIFEST_STR, DataSource.duckdb, conn_info, fallback=False
+    ) as engine:
+        engine._connector = _TimeoutConnector()
+        with pytest.raises(DatabaseTimeoutError) as exc_info:
+            engine.dry_run('SELECT o_orderkey FROM "orders" LIMIT 1')
+        assert exc_info.value.error_code == ErrorCode.DATABASE_TIMEOUT


### PR DESCRIPTION
<!--
Keep it short. For a typo fix or a docs tweak, the summary alone is enough -
delete the rest. For anything that changes behaviour, please fill it in.
-->

## Summary

`WrenEngine.query()`/`dry_run()` catch any non-`WrenError` exception from the connector and wrap it as `WrenError(GENERIC_USER_ERROR)`, the same code used for a plain bad SQL query. A connector timeout gets flattened into that same generic bucket, even though four connectors (`postgres`, `athena`, `canner`, `trino`) already special-case `TimeoutError` in their own `except` clauses specifically to keep it from being treated as a generic user error.

## What failure does this repair?

`postgres.py`'s `query()`/`dry_run()` both do `except (WrenError, TimeoutError): raise`, so a canceled-statement `TimeoutError` passes through unwrapped. One layer up, `engine.py`'s `query()`/`dry_run()` only special-case `WrenError`; a bare `TimeoutError` isn't one, so it falls into the generic `except Exception` branch and comes out as `GENERIC_USER_ERROR`, indistinguishable from a bad query. `clickhouse.py` doesn't hit this because its own driver-specific `TIMEOUT_EXCEEDED` path raises `DatabaseTimeoutError` (a `WrenError` subclass) directly, so `engine.py`'s `except WrenError: raise` preserves it correctly.

Reproduced with a fake connector that raises a bare `TimeoutError` (mirrors what `postgres.py` re-raises on a canceled statement):

```
wren.model.error.WrenError: [GENERIC_USER_ERROR] canceling statement due to statement timeout phase=SQL_EXECUTION
```

After the fix, the same call raises `DatabaseTimeoutError` with `error_code == ErrorCode.DATABASE_TIMEOUT`.

## How is it tested?

- `tests/unit/test_engine.py::test_query_classifies_bare_timeout_as_database_timeout` and `::test_dry_run_classifies_bare_timeout_as_database_timeout`: both fail against unmodified `engine.py` (assert `DatabaseTimeoutError`, get `WrenError[GENERIC_USER_ERROR]`) and pass on this branch.
- Full `tests/unit/` suite (the `test-unit` CI job's own invocation, `--ignore=tests/unit/test_memory.py --ignore=tests/unit/test_mcp_server.py`): 1078 passed, 2 skipped (pre-existing skips, unrelated to this change).
- `ruff format --check src/` and `ruff check src/` (the `lint` CI job's own commands): clean.
- Not exercised: an actual timed-out query against a live Postgres/Athena/Canner/Trino connection. The four connectors' own `except (WrenError, TimeoutError): raise` clauses are unchanged by this PR; only `engine.py`'s classification of what they re-raise is new.

## Duplicate check

Swept all open PRs touching `core/wren/src/wren/engine.py`: #2258 (adds a YTsaurus path-rewrite method after `dry_run()`), #2551 and #2552 (both add a `basic_safety_check(sql)` call inside `dry_plan()`). Read each diff directly; none touch the `except` blocks in `query()`/`dry_run()` this PR changes.

Fixes #2153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database timeout failures are now consistently reported as database timeout errors during queries and dry runs.
  * Existing Wren errors continue to be preserved, while other unexpected failures retain generic error handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->