### PR TITLE
fix(memory): validate imported query pair field types

### DIFF
--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -1026,6 +1026,13 @@ def load(
         if "nl" not in p or "sql" not in p:
             typer.echo(f"Error: pair #{i + 1} missing 'nl' or 'sql'.", err=True)
             raise typer.Exit(1)
+        for field in ("nl", "sql", "source", "datasource"):
+            if field in p and not isinstance(p[field], str):
+                typer.echo(
+                    f"Error: pair #{i + 1} field '{field}' must be a string.",
+                    err=True,
+                )
+                raise typer.Exit(1)
 
     # ── Summary ──
     from collections import Counter  # noqa: PLC0415

--- a/core/wren/tests/unit/test_memory_load_cli.py
+++ b/core/wren/tests/unit/test_memory_load_cli.py
@@ -1,0 +1,60 @@
+"""Validation tests for ``wren memory load`` YAML input."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from wren.cli import app
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("nl", ["not", "text"]),
+        ("sql", ["not", "text"]),
+        ("source", {"bad": "value"}),
+        ("datasource", {"bad": "value"}),
+    ],
+)
+def test_dry_run_rejects_non_string_pair_fields(tmp_path, field, value) -> None:
+    pair = {"nl": "hello", "sql": "SELECT 1", field: value}
+    input_file = tmp_path / "queries.yml"
+    input_file.write_text(
+        yaml.safe_dump({"version": 1, "pairs": [pair]}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["memory", "load", str(input_file), "--dry-run"],
+    )
+
+    assert result.exit_code == 1
+    assert f"pair #1 field '{field}' must be a string" in result.output
+    assert "Would load" not in result.output
+
+
+def test_dry_run_accepts_string_pair_fields(tmp_path) -> None:
+    pair = {
+        "nl": "hello",
+        "sql": "SELECT 1",
+        "source": "user",
+        "datasource": "postgres",
+    }
+    input_file = tmp_path / "queries.yml"
+    input_file.write_text(
+        yaml.safe_dump({"version": 1, "pairs": [pair]}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["memory", "load", str(input_file), "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "Would load 1 pair(s) (user: 1)" in result.output


### PR DESCRIPTION
## Summary

- validate the `nl`, `sql`, `source`, and `datasource` fields before loading query pairs
- return a deterministic CLI error for non-string values
- keep valid `--dry-run` input and its summary output unchanged
- add dependency-free CLI regression tests for every validated field

## Root cause

`wren memory load` checked that each pair was an object with `nl` and `sql` keys,
but it did not validate the types consumed by the summary and storage paths.

This produced two observable failure modes on the current `main` branch:

- non-string `nl`, `sql`, or `datasource` values passed `--dry-run` with exit code 0
  and a `Would load` summary, even though execution expects strings
- a mapping-valued `source` reached `Counter` and raised the raw exception
  `TypeError: unhashable type: 'dict'`

The CLI is the input boundary for this user-provided YAML, so it now rejects these
values before summary generation or store construction.

## User impact

`wren memory load --dry-run` now fulfills its validation contract: malformed pair
fields return exit code 1 with the pair number and field name instead of reporting a
false success or leaking an internal Python exception.

## Validation

- confirmed all four regression cases failed before the production change
- `ruff format --check src/`
- `ruff check src/`
- related memory CLI tests — 29 passed
- non-memory unit suite — 1128 passed, 58 skipped, 6 deselected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for memory load data.
  * Clear field-specific errors are now shown when `nl`, `sql`, `source`, or `datasource` values are not strings.
  * Invalid entries are rejected before loading, while valid entries continue to load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->