### PR TITLE
fix(core-py): declare the engine version the bindings build against

### DIFF
--- a/core/wren-core-py/Cargo.toml
+++ b/core/wren-core-py/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["extension-module", "abi3-py311"] }
-wren-core = { path = "../wren-core/core", package = "wren-semantic-core" }
+wren-core = { version = "0.3.1", path = "../wren-core/core", package = "wren-semantic-core" }
 wren-core-base = { path = "../wren-core-base", features = ["python-binding"] }
 datafusion-common = "53.0.0"
 base64 = "0.22.1"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -108,6 +108,11 @@
           "jsonpath": "$.workspace.dependencies.wren-core-base.version"
         },
         {
+          "path": "/core/wren-core-py/Cargo.toml",
+          "type": "toml",
+          "jsonpath": "$.dependencies.wren-core.version"
+        },
+        {
           "path": "/core/wren-core-py/Cargo.lock",
           "type": "toml",
           "jsonpath": "$.package[?(@.name.value=='wren-semantic-core')].version"


### PR DESCRIPTION
## Problem

`wren-core-py` depends on `wren-core` and `wren-core-base` by **path only**. release-please
attributes commits to packages by file path, so a `feat:`/`fix:` under `core/wren-core` is
attributed to `wren-semantic-core` and never to this package — and the release commit that bumps
the core crates is a `chore(main): release …` commit release-please skips by design.

Net effect: there is no commit that can open a release PR for `wren-core-py`, so everything that
shipped in `wren-semantic-core` 0.3.1 is unreachable from PyPI. The newest published wheel is
0.7.3, built against the pre-0.3.x engine.

`wren-core-wasm` has the same path-only relationship and the same gap.

## Change

- `core/wren-core-py/Cargo.toml`: declare `version = "0.3.1"` alongside the existing path
  dependency on the engine, so the manifest states which engine release a wheel embeds.
- `release-please-config.json`: add that field to the core crates' `extra-files`, so a future
  engine bump updates the declared version in the same commit as the crate versions and the
  manifest cannot go stale (a stale floor would fail the build once the engine reaches 0.4).

Resolution is unchanged: the path dependency still wins for local builds, and the committed
lockfile still satisfies the manifest under `--locked`.

Merging this commit is also what unblocks the release — it is a `fix` under
`core/wren-core-py`, so release-please will open a `wren-core-py` release PR whose wheel carries
the 0.3.1 engine.

## Verification

- `cargo metadata --locked` in `core/wren-core-py` — resolves against the committed
  `Cargo.lock`, unchanged.
- `taplo fmt --check` — clean.
- Compile and test coverage comes from the Core Python CI job on this PR (`cargo test`,
  `maturin develop`, `pytest`), which is path-triggered by this change.

## Follow-up

This commit unblocks one release; it does not close the gap. A follow-up will automate the
missing step — after the core crates publish, open a PR carrying a `fix` commit that touches
`core/wren-core-py` and `core/wren-core-wasm`, so both bindings get a release line of their own
rather than needing a hand-written commit each time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release configuration to improve consistency and reliability across package builds.
  * No user-facing functionality or interface changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->