### PR TITLE
fix(wren-core): resolve relationship handles by the model they point at

### DIFF
--- a/core/wren-core/core/src/mdl/mod.rs
+++ b/core/wren-core/core/src/mdl/mod.rs
@@ -2122,6 +2122,66 @@ mod test {
         Ok(())
     }
 
+    /// A relationship handle names the join locally, so it may differ from the model it
+    /// points at. Here the handle `customer` on `orders` resolves to the model `customers`.
+    #[tokio::test]
+    async fn test_calculated_column_with_aliased_relationship_handle() -> Result<()> {
+        let ctx = create_wren_ctx(None, None);
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("orders")
+                    .table_reference("orders")
+                    .column(ColumnBuilder::new("order_id", "int").build())
+                    .column(ColumnBuilder::new("customer_id", "int").build())
+                    .column(
+                        ColumnBuilder::new_relationship(
+                            "customer",
+                            "customers",
+                            "orders_customers",
+                        )
+                        .build(),
+                    )
+                    .column(
+                        ColumnBuilder::new_calculated("customer_name", "string")
+                            .expression("customer.name")
+                            .build(),
+                    )
+                    .primary_key("order_id")
+                    .build(),
+            )
+            .model(
+                ModelBuilder::new("customers")
+                    .table_reference("customers")
+                    .column(ColumnBuilder::new("customer_id", "int").build())
+                    .column(ColumnBuilder::new("name", "string").build())
+                    .primary_key("customer_id")
+                    .build(),
+            )
+            .relationship(
+                RelationshipBuilder::new("orders_customers")
+                    .model("orders")
+                    .model("customers")
+                    .join_type(JoinType::ManyToOne)
+                    .condition("orders.customer_id = customers.customer_id")
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+
+        let sql = "SELECT order_id, customer_name FROM orders";
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], Arc::new(HashMap::new()), sql).await?,
+            @r#"SELECT orders.order_id, orders.customer_name FROM (SELECT __relation__1."name" AS customer_name, __relation__1.order_id FROM (SELECT orders.customer_id, customers."name", orders.order_id FROM (SELECT customers.customer_id, customers."name" FROM (SELECT customers.customer_id, customers."name" FROM (SELECT __source.customer_id AS customer_id, __source."name" AS "name" FROM customers AS __source) AS customers) AS customers) AS customers RIGHT OUTER JOIN (SELECT __source.customer_id AS customer_id, __source.order_id AS order_id FROM orders AS __source) AS orders ON customers.customer_id = orders.customer_id) AS __relation__1) AS orders"#
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_rlac_with_requried_properties() -> Result<()> {
         let ctx = create_wren_ctx(None, None);

--- a/core/wren-core/core/src/mdl/utils.rs
+++ b/core/wren-core/core/src/mdl/utils.rs
@@ -229,10 +229,14 @@ pub fn create_wren_calculated_field_expr(
 /// handle `customer` on `orders` may point at the model `customers`. The schema the
 /// expression is planned against is built from the lineage's required fields and is
 /// therefore qualified by model name, so each handle has to be translated to the model it
-/// resolves to. A handle named after its own model translates to itself, which is why only
-/// a differing name fails.
+/// resolves to. On `orders`, `customer.name` becomes `customers.name`.
 ///
-/// On `orders`, both `customer.name` and `orders.customer.name` become `customers.name`.
+/// Every component before the column is a handle on the model reached so far, the first
+/// one included: [`crate::mdl::lineage`] walks the path the same way and rejects a leading
+/// component that is not a column of the base model, so a path cannot arrive here carrying
+/// its own model as a qualifier. A handle that shares a name with the model declaring it
+/// is therefore still a handle.
+///
 /// Returns `None` when the path traverses no relationship, leaving the identifier alone.
 fn resolve_relationship_path(
     wren_mdl: &WrenMDL,
@@ -240,13 +244,11 @@ fn resolve_relationship_path(
     ids: &[Ident],
 ) -> Option<Vec<Ident>> {
     let (column, path) = ids.split_last()?;
+    if path.is_empty() {
+        return None;
+    }
     let mut relation = base_model.to_string();
-    let mut traversed = false;
     for ident in path {
-        // the path may be written starting from the model owning the calculated field
-        if ident.value == relation {
-            continue;
-        }
         let column_ref = wren_mdl.get_column_reference(&from_qualified_name(
             wren_mdl,
             &relation,
@@ -261,9 +263,8 @@ fn resolve_relationship_path(
             .iter()
             .find(|model| *model != &relation)?
             .clone();
-        traversed = true;
     }
-    traversed.then(|| vec![quoted_ident(&relation), column.clone()])
+    Some(vec![quoted_ident(&relation), column.clone()])
 }
 
 /// Create the Logical Expr for the remote column.
@@ -509,6 +510,114 @@ mod tests {
         )?;
         // qualified by the related model, not by the handle that reached it
         assert_eq!(expr.to_string(), "customers.name");
+        Ok(())
+    }
+
+    /// A handle may share a name with the model that declares it. It is still a handle:
+    /// every component before the column names a relationship on the model reached so
+    /// far, the first one included.
+    #[test]
+    fn test_create_wren_expr_handle_named_after_its_own_model() -> Result<()> {
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("orders")
+                    .table_reference("orders")
+                    .column(ColumnBuilder::new("order_id", "integer").build())
+                    .column(ColumnBuilder::new("customer_id", "integer").build())
+                    .column(
+                        ColumnBuilder::new_relationship(
+                            "orders",
+                            "customers",
+                            "orders_customers",
+                        )
+                        .build(),
+                    )
+                    .column(
+                        ColumnBuilder::new_calculated("customer_name", "varchar")
+                            .expression("orders.name")
+                            .build(),
+                    )
+                    .column(
+                        ColumnBuilder::new_calculated("customer_city", "varchar")
+                            .expression("orders.customers.name")
+                            .build(),
+                    )
+                    .primary_key("order_id")
+                    .build(),
+            )
+            .model(
+                ModelBuilder::new("customers")
+                    .table_reference("customers")
+                    .column(ColumnBuilder::new("customer_id", "integer").build())
+                    .column(ColumnBuilder::new("city_id", "integer").build())
+                    .column(ColumnBuilder::new("name", "varchar").build())
+                    .column(
+                        ColumnBuilder::new_relationship(
+                            "customers",
+                            "cities",
+                            "customers_cities",
+                        )
+                        .build(),
+                    )
+                    .primary_key("customer_id")
+                    .build(),
+            )
+            .model(
+                ModelBuilder::new("cities")
+                    .table_reference("cities")
+                    .column(ColumnBuilder::new("city_id", "integer").build())
+                    .column(ColumnBuilder::new("name", "varchar").build())
+                    .primary_key("city_id")
+                    .build(),
+            )
+            .relationship(
+                RelationshipBuilder::new("orders_customers")
+                    .model("orders")
+                    .model("customers")
+                    .join_type(JoinType::ManyToOne)
+                    .condition("orders.customer_id = customers.customer_id")
+                    .build(),
+            )
+            .relationship(
+                RelationshipBuilder::new("customers_cities")
+                    .model("customers")
+                    .model("cities")
+                    .join_type(JoinType::ManyToOne)
+                    .condition("customers.city_id = cities.city_id")
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let ctx = SessionContext::new();
+        let ctx_state = ctx.state_ref();
+        let resolve = |calculated: &str| -> Result<String> {
+            let column_rf = analyzed_mdl
+                .wren_mdl
+                .qualified_references
+                .get(&from_qualified_name(
+                    &analyzed_mdl.wren_mdl,
+                    "orders",
+                    calculated,
+                ))
+                .unwrap();
+            Ok(super::create_wren_calculated_field_expr(
+                column_rf.clone(),
+                Arc::clone(&analyzed_mdl),
+                Arc::clone(&ctx_state),
+            )?
+            .to_string())
+        };
+        // the leading `orders` is the handle declared on `orders`, not the model itself
+        assert_eq!(resolve("customer_name")?, "customers.name");
+        // `customers` has a `name` of its own, so stopping a hop short would plan against
+        // a real but wrong column rather than fail
+        assert_eq!(resolve("customer_city")?, "cities.name");
         Ok(())
     }
 

--- a/core/wren-core/core/src/mdl/utils.rs
+++ b/core/wren-core/core/src/mdl/utils.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use crate::logical_plan::utils::{from_qualified_name, try_map_data_type};
 use crate::mdl::manifest::Model;
-use crate::mdl::{AnalyzedWrenMDL, ColumnReference, Dataset, SessionStateRef};
+use crate::mdl::{AnalyzedWrenMDL, ColumnReference, Dataset, SessionStateRef, WrenMDL};
 
 pub fn to_expr_queue(column: Column) -> VecDeque<String> {
     column.name.split('.').map(String::from).collect()
@@ -188,15 +188,22 @@ pub fn create_wren_calculated_field_expr(
         .collect::<Vec<String>>();
     // Remove all relationship fields from the expression. Only keep the target expression and its source table.
     let expr = column_rf.column.expression.clone().unwrap();
+    let base_model = column_rf.dataset.name();
     let session_state = session_state.read();
     let mut expr = session_state
         .sql_to_expr(&expr, &session_state.config_options().sql_parser.dialect)?;
     let _ = visit_expressions_mut(&mut expr, |e| {
         if let CompoundIdentifier(ids) = e {
-            let name_size = ids.len();
-            if name_size > 2 {
-                let slice = &ids[name_size - 2..name_size];
-                *e = CompoundIdentifier(slice.to_vec());
+            if let Some(resolved) =
+                resolve_relationship_path(&analyzed_wren_mdl.wren_mdl, base_model, ids)
+            {
+                *e = CompoundIdentifier(resolved);
+            } else {
+                let name_size = ids.len();
+                if name_size > 2 {
+                    let slice = &ids[name_size - 2..name_size];
+                    *e = CompoundIdentifier(slice.to_vec());
+                }
             }
         }
         ControlFlow::<()>::Continue(())
@@ -214,6 +221,49 @@ pub fn create_wren_calculated_field_expr(
         return plan_err!("Error for creating schemas: {}", qualified_col);
     };
     session_state.create_logical_expr(&expr.to_string(), &schema)
+}
+
+/// Rewrite a relationship path so that it is qualified by the model the path lands on.
+///
+/// A relationship column is a handle whose name is local to the model declaring it, so a
+/// handle `customer` on `orders` may point at the model `customers`. The schema the
+/// expression is planned against is built from the lineage's required fields and is
+/// therefore qualified by model name, so each handle has to be translated to the model it
+/// resolves to. A handle named after its own model translates to itself, which is why only
+/// a differing name fails.
+///
+/// On `orders`, both `customer.name` and `orders.customer.name` become `customers.name`.
+/// Returns `None` when the path traverses no relationship, leaving the identifier alone.
+fn resolve_relationship_path(
+    wren_mdl: &WrenMDL,
+    base_model: &str,
+    ids: &[Ident],
+) -> Option<Vec<Ident>> {
+    let (column, path) = ids.split_last()?;
+    let mut relation = base_model.to_string();
+    let mut traversed = false;
+    for ident in path {
+        // the path may be written starting from the model owning the calculated field
+        if ident.value == relation {
+            continue;
+        }
+        let column_ref = wren_mdl.get_column_reference(&from_qualified_name(
+            wren_mdl,
+            &relation,
+            &ident.value,
+        ))?;
+        let relationship =
+            wren_mdl.get_relationship(column_ref.column.relationship.as_ref()?)?;
+        // Resolve the related model the way [`crate::mdl::lineage`] does, so the qualifier
+        // matches the schema built from the required fields it collected.
+        relation = relationship
+            .models
+            .iter()
+            .find(|model| *model != &relation)?
+            .clone();
+        traversed = true;
+    }
+    traversed.then(|| vec![quoted_ident(&relation), column.clone()])
 }
 
 /// Create the Logical Expr for the remote column.
@@ -350,8 +400,12 @@ mod tests {
 
     use datafusion::error::Result;
     use datafusion::prelude::SessionContext;
+    use wren_core_base::mdl::JoinType;
 
     use crate::logical_plan::utils::from_qualified_name;
+    use crate::mdl::builder::{
+        ColumnBuilder, ManifestBuilder, ModelBuilder, RelationshipBuilder,
+    };
     use crate::mdl::context::Mode;
     use crate::mdl::manifest::Manifest;
     use crate::mdl::AnalyzedWrenMDL;
@@ -385,6 +439,76 @@ mod tests {
             ctx.state_ref(),
         )?;
         assert_eq!(expr.to_string(), "customer.c_name");
+        Ok(())
+    }
+
+    /// A relationship handle is a local alias, so its name need not match the model it
+    /// points at. Here the handle `customer` on `orders` resolves to the model `customers`.
+    #[test]
+    fn test_create_wren_expr_handle_name_differs_from_model() -> Result<()> {
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("orders")
+                    .table_reference("orders")
+                    .column(ColumnBuilder::new("order_id", "integer").build())
+                    .column(ColumnBuilder::new("customer_id", "integer").build())
+                    .column(
+                        ColumnBuilder::new_relationship(
+                            "customer",
+                            "customers",
+                            "orders_customers",
+                        )
+                        .build(),
+                    )
+                    .column(
+                        ColumnBuilder::new_calculated("customer_name", "varchar")
+                            .expression("customer.name")
+                            .build(),
+                    )
+                    .primary_key("order_id")
+                    .build(),
+            )
+            .model(
+                ModelBuilder::new("customers")
+                    .table_reference("customers")
+                    .column(ColumnBuilder::new("customer_id", "integer").build())
+                    .column(ColumnBuilder::new("name", "varchar").build())
+                    .primary_key("customer_id")
+                    .build(),
+            )
+            .relationship(
+                RelationshipBuilder::new("orders_customers")
+                    .model("orders")
+                    .model("customers")
+                    .join_type(JoinType::ManyToOne)
+                    .condition("orders.customer_id = customers.customer_id")
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let ctx = SessionContext::new();
+        let column_rf = analyzed_mdl
+            .wren_mdl
+            .qualified_references
+            .get(&from_qualified_name(
+                &analyzed_mdl.wren_mdl,
+                "orders",
+                "customer_name",
+            ))
+            .unwrap();
+        let expr = super::create_wren_calculated_field_expr(
+            column_rf.clone(),
+            Arc::clone(&analyzed_mdl),
+            ctx.state_ref(),
+        )?;
+        // qualified by the related model, not by the handle that reached it
+        assert_eq!(expr.to_string(), "customers.name");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

A calculated column or cube dimension whose expression traverses a relationship fails to plan
when the relationship handle is not named after the model it points at. Given a handle
`customer` on `orders` pointing at the model `customers`:

```yaml
- name: customer
  type: customers
  relationship: orders_customers
```

an expression of `customer.name` fails:

```
column 'name' not found in 'customer'
possible column customers.name
```

The only workaround is to rename the handle to `customers`, which forces every relationship
alias to repeat the name of its target model. `docs/core/reference/mdl.md` documents the
singular handle as valid, so this is a gap between the documented model and the engine.

Refs #2658. That issue reports two problems and this addresses one of them; see the last
section, which is why it does not carry a closing keyword.

## Root cause

`create_wren_calculated_field_expr` (`core/wren-core/core/src/mdl/utils.rs`) plans the
expression against a schema assembled from the lineage's `required_fields_map`. The lineage
resolves a relationship path correctly: it follows `Column::relationship` through to the
related model, so every qualifier in that schema is a **model** name.

The expression itself was rewritten separately, by trimming any compound identifier to its
last two identifiers. That drops the leading path but keeps the **handle** name as the
qualifier. The expression therefore asks for `customer.name` while the schema offers
`customers.name`.

The two names coincide whenever a handle is named after the model it points at, which is the
case in every fixture in the repo (`core/wren-core/core/tests/data/mdl.json` declares handle
`customer` of type `customer`, and `core/wren-core-py/tests/test_modeling_core.py` declares
handle `orders` of type `orders`), so no existing test exercised a differing name.

## Fix

`resolve_relationship_path` walks the identifier path through the MDL, resolving each handle
with `get_column_reference` and advancing to the related model the way the lineage does, then
qualifies the rewritten identifier with the model the path lands on. An identifier that
traverses no relationship is returned untouched, and the previous trimming remains as the
fallback for any path the walk cannot resolve, so nothing that planned before changes shape.

## Tests

- `test_create_wren_expr_handle_name_differs_from_model` (`mdl/utils.rs`) calls
  `create_wren_calculated_field_expr` against a manifest whose handle `customer` points at the
  model `customers`, and asserts the built expression is `customers.name`.
- `test_calculated_column_with_aliased_relationship_handle` (`mdl/mod.rs`) puts
  `SELECT order_id, customer_name FROM orders` through `transform_sql_with_ctx` and snapshots
  the generated SQL, covering the join end to end.

Both tests fail without the change and pass with it. `cargo test --lib` is 151 passed / 0
failed; `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D
warnings` are clean.

## Not addressed: relationship traversal in user SQL

#2658 also reports that `SELECT orders.customer.name FROM orders` fails, and proposes that
naming the handle after the model fixes it. That is a separate gap, and this PR does not
touch it.

Relationship traversal in a user query fails regardless of the handle name, because
relationship columns are filtered out of the schema a model registers with DataFusion
(`Model::get_physical_columns` keeps only columns where `relationship.is_none()`), so the path
has nothing to resolve against. Checked against `wren-core` 0.7.3 using this repo's own test
manifest, where the handle `orders` already matches the model `orders`:

```
SELECT customer.orders.o_orderkey FROM my_catalog.my_schema.customer

Schema error: No field named customer.orders.o_orderkey.
Valid fields are my_catalog.my_schema.customer.c_custkey, my_catalog.my_schema.customer.c_name.
```

The same query with a handle renamed to match its model fails identically, so renaming is not
a workaround there. `docs/core/reference/mdl.md` currently states that `orders.customer.first_name`
is valid SQL, so either the engine or that page needs a follow-up. Glad to open a separate
issue for it if that is the preference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calculated columns that reference relationships using aliases different from the related model’s name.
  * Relationship paths are now resolved correctly, producing the expected joins and projected query results.
  * Added regression coverage to help prevent similar query-planning issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->