### PR TITLE
fix(memory): skip unnamed cubes/measures/dimensions in schema_indexer

### DIFF
--- a/core/wren/src/wren/memory/schema_indexer.py
+++ b/core/wren/src/wren/memory/schema_indexer.py
@@ -230,12 +230,25 @@ def _describe_relationship(rel: dict, lines: list[str]) -> None:
 def _describe_cube(cube: dict, lines: list[str]) -> None:
     name = cube.get("name", "")
     base = cube.get("baseObject", "?")
-    lines.append(f"### Cube: {name} (base: {base})")
+    # Type-validate children via _as_list before the unnamed-cube skip below.
     measures = [
         m
         for m in (_as_list(cube.get("measures"), "cube", name, "measures"))
-        if isinstance(m, dict)
+        if isinstance(m, dict) and m.get("name")
     ]
+    dims = [
+        d
+        for d in (_as_list(cube.get("dimensions"), "cube", name, "dimensions"))
+        if isinstance(d, dict) and d.get("name")
+    ]
+    tdims = [
+        td
+        for td in (_as_list(cube.get("timeDimensions"), "cube", name, "timeDimensions"))
+        if isinstance(td, dict) and td.get("name")
+    ]
+    if not name:
+        return
+    lines.append(f"### Cube: {name} (base: {base})")
     if measures:
         lines.append("  Measures:")
         for m in measures:
@@ -248,11 +261,6 @@ def _describe_cube(cube: dict, lines: list[str]) -> None:
             if expr:
                 line += f": {expr}"
             lines.append(line)
-    dims = [
-        d
-        for d in (_as_list(cube.get("dimensions"), "cube", name, "dimensions"))
-        if isinstance(d, dict)
-    ]
     if dims:
         lines.append("  Dimensions:")
         for d in dims:
@@ -265,11 +273,6 @@ def _describe_cube(cube: dict, lines: list[str]) -> None:
             if expr and expr != dname:
                 line += f": {expr}"
             lines.append(line)
-    tdims = [
-        td
-        for td in (_as_list(cube.get("timeDimensions"), "cube", name, "timeDimensions"))
-        if isinstance(td, dict)
-    ]
     if tdims:
         lines.append("  Time dimensions:")
         for td in tdims:
@@ -334,18 +337,24 @@ def extract_schema_items(manifest: dict) -> list[dict]:
     for cube in _iter_section(manifest, "cubes"):
         if not isinstance(cube, dict):
             continue
-        items.append(_cube_record(cube, mdl_h, now))
         cube_name = cube.get("name", "")
-        for measure in _as_list(cube.get("measures"), "cube", cube_name, "measures"):
-            if isinstance(measure, dict):
-                items.append(_measure_record(measure, cube_name, mdl_h, now))
-        for dim in _as_list(cube.get("dimensions"), "cube", cube_name, "dimensions"):
-            if isinstance(dim, dict):
-                items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
-        for tdim in _as_list(
+        # Type-validate children via _as_list before the unnamed-cube skip below.
+        measures = _as_list(cube.get("measures"), "cube", cube_name, "measures")
+        dims = _as_list(cube.get("dimensions"), "cube", cube_name, "dimensions")
+        tdims = _as_list(
             cube.get("timeDimensions"), "cube", cube_name, "timeDimensions"
-        ):
-            if isinstance(tdim, dict):
+        )
+        if not cube_name:
+            continue
+        items.append(_cube_record(cube, mdl_h, now))
+        for measure in measures:
+            if isinstance(measure, dict) and measure.get("name"):
+                items.append(_measure_record(measure, cube_name, mdl_h, now))
+        for dim in dims:
+            if isinstance(dim, dict) and dim.get("name"):
+                items.append(_cube_dimension_record(dim, cube_name, mdl_h, now))
+        for tdim in tdims:
+            if isinstance(tdim, dict) and tdim.get("name"):
                 items.append(_time_dimension_record(tdim, cube_name, mdl_h, now))
 
     return items

--- a/core/wren/tests/unit/test_schema_indexer_unnamed_cubes.py
+++ b/core/wren/tests/unit/test_schema_indexer_unnamed_cubes.py
@@ -1,0 +1,41 @@
+"""cubes/measures/dimensions/timeDimensions follow the unnamed-skip policy (#2591)."""
+
+from __future__ import annotations
+
+from wren.memory.schema_indexer import describe_schema, extract_schema_items
+
+
+def _manifest():
+    return {
+        "cubes": [
+            {"baseObject": "orders", "measures": [{"expression": "sum(x)"}]},
+            {
+                "name": "c1",
+                "baseObject": "orders",
+                "measures": [{"name": "m1"}, {"expression": "sum(z)"}],
+                "dimensions": [{"name": "d1"}, {"expression": "y"}],
+                "timeDimensions": [{"name": "t1"}, {"type": "date"}],
+            },
+        ]
+    }
+
+
+def test_describe_schema_skips_unnamed_cube_and_children():
+    text = describe_schema(_manifest())
+    assert text.count("### Cube:") == 1
+    assert "### Cube: c1" in text
+    assert "m1" in text
+    assert "d1" in text
+    assert "t1" in text
+    # Unnamed cube and unnamed measure/dimension are dropped, not rendered
+    # with an empty label.
+    assert "sum(x)" not in text
+    assert "sum(z)" not in text
+
+
+def test_extract_schema_items_skips_unnamed_cube_and_children():
+    items = extract_schema_items(_manifest())
+    names = {i.get("item_name") for i in items}
+    assert {"c1", "m1", "d1", "t1"} <= names
+    assert "" not in names
+    assert None not in names


### PR DESCRIPTION
## Summary

`schema_indexer.py`'s cube iteration used `isinstance(x, dict)` only, while the model/relationship/view iteration added by #2533 also checks `x.get("name")`. A cube, measure, dimension, or timeDimension with no name was indexed anyway, with `item_name=""`, unlike a nameless model (dropped by #2533).

Adds `and x.get("name")` at the four iteration sites, in both `extract_schema_items` and the `describe_schema` / `_describe_cube` path, per the issue's own stated preference for option 1 (skip unnamed) over option 2 (keep and document).

## A documented choice this respects rather than reverses

`test_extract_unnamed_cube_falls_back_to_unnamed_form` (and the docstring on `_as_list`) deliberately document that a cube is not required to have a name, and pin the `"cube (unnamed): 'measures' must be a list, got int"` message `_as_list` produces for a malformed nested field on an unnamed cube. That test still passes: the child collections are resolved through `_as_list` (so a non-list `measures`/`dimensions`/`timeDimensions` still raises) before the new name check, and only the append-to-output step is skipped when the cube itself has no name.

## Verification

- New regression test (`test_schema_indexer_unnamed_cubes.py`) reproduces the issue's own repro (unnamed cube, unnamed measure/dimension/timeDimension): fails on unmodified `main` (asserts caught 2 rendered `### Cube:` headers instead of 1, and an empty `item_name` in the extracted items) and passes on this branch. Ran both in Docker (`python:3.11-slim`, `uv sync`, `wren.memory.schema_indexer.__file__` provenance-printed).
- Full `tests/unit/` suite, matching this repo's `test-unit` CI job (excludes `test_memory.py`/`test_mcp_server.py`): 1106 passed, 2 skipped.
- `ruff format --check` / `ruff check` on `src/` clean.
- Did not check: line-coverage of the diff via `coverage run`: this repo's `wren_core` PyO3 extension panics under `coverage run` with an unrelated `env_logger` double-init error in this environment. I could not get a coverage report. I reasoned through branch coverage manually against the test scenarios instead of measuring it.

Fixes #2591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unnamed cubes are no longer included in schema descriptions or indexing results.
  * Unnamed measures, dimensions, and time dimensions are excluded from extracted schema data.
  * Named schema elements continue to be included as expected.

* **Tests**
  * Added coverage for handling unnamed cubes and child schema elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->