### PR TITLE
fix(cube): load/validate like views; fail loud on mdl.json

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -660,6 +660,53 @@ def load_cubes(project_path: Path) -> list[dict]:
     return _load_cubes_v2(project_path)
 
 
+def _report_malformed_cube_members(
+    errors: list[ValidationError], src_path: str, raw: dict
+) -> None:
+    """Report non-list containers and non-mapping member entries."""
+    cube_label = raw.get("name") if isinstance(raw.get("name"), str) else src_path
+    for key in ("measures", "dimensions", "time_dimensions"):
+        val = raw.get(key)
+        if val is None:
+            continue
+        if not isinstance(val, list):
+            errors.append(
+                ValidationError(
+                    "error",
+                    f"{src_path} > {cube_label} > {key}",
+                    f"'{key}' must be a list, got {type(val).__name__}",
+                )
+            )
+            continue
+        for i, item in enumerate(val):
+            if not isinstance(item, dict):
+                errors.append(
+                    ValidationError(
+                        "error",
+                        f"{src_path} > {cube_label} > {key}[{i}]",
+                        f"{key[:-1]} entry must be a mapping, got {type(item).__name__}",
+                    )
+                )
+
+
+def _normalise_cube_member_lists(cube: dict) -> dict:
+    """Drop non-mapping measure/dimension/time_dimension entries.
+
+    ``validate_project`` re-reads the raw YAML so hand-edited mistakes are
+    still reported rather than vanishing quietly (same pattern as views /
+    relationships in #2604 / #2613).
+    """
+    for key in ("measures", "dimensions", "time_dimensions"):
+        raw = cube.get(key)
+        if raw is None:
+            continue
+        if not isinstance(raw, list):
+            cube[key] = []
+            continue
+        cube[key] = [item for item in raw if isinstance(item, dict)]
+    return cube
+
+
 def _load_cubes_v1(project_path: Path) -> list[dict]:
     """Legacy: load cube YAML files from project_path/cubes/*.yml."""
     cubes_dir = project_path / "cubes"
@@ -670,7 +717,7 @@ def _load_cubes_v1(project_path: Path) -> list[dict]:
         data = yaml.safe_load(f.read_text(encoding="utf-8"))
         if isinstance(data, dict):
             data["_source_file"] = f.name
-            cubes.append(data)
+            cubes.append(_normalise_cube_member_lists(data))
     return cubes
 
 
@@ -692,7 +739,7 @@ def _load_cubes_v2(project_path: Path) -> list[dict]:
         data = yaml.safe_load(meta_file.read_text())
         if isinstance(data, dict):
             data["_source_file"] = str(meta_file.relative_to(cubes_dir))
-            cubes.append(data)
+            cubes.append(_normalise_cube_member_lists(data))
     return cubes
 
 
@@ -1267,6 +1314,45 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                     "warning", f"relationships > {rel_name}", "missing join_type"
                 )
             )
+
+    # Cube YAML may contain non-mapping files / member-array junk.
+    # load_cubes() drops those (matching views / relationships). Re-read the
+    # raw files here so hand-edits are reported rather than vanishing quietly.
+    cubes_dir = project_path / "cubes"
+    if cubes_dir.is_dir():
+        if sv == 1:
+            for f in sorted(cubes_dir.glob("*.yml")):
+                raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+                src_path = f"cubes/{f.name}"
+                if not isinstance(raw, dict):
+                    errors.append(
+                        ValidationError(
+                            "error",
+                            src_path,
+                            f"cube file must be a mapping, got {type(raw).__name__}",
+                        )
+                    )
+                    continue
+                _report_malformed_cube_members(errors, src_path, raw)
+        else:
+            for d in sorted(cubes_dir.iterdir()):
+                if not d.is_dir():
+                    continue
+                meta_file = d / "metadata.yml"
+                if not meta_file.exists():
+                    continue
+                raw = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
+                src_path = f"cubes/{d.name}/metadata.yml"
+                if not isinstance(raw, dict):
+                    errors.append(
+                        ValidationError(
+                            "error",
+                            src_path,
+                            f"cube metadata must be a mapping, got {type(raw).__name__}",
+                        )
+                    )
+                    continue
+                _report_malformed_cube_members(errors, src_path, raw)
 
     # Check cubes — only structural / reference checks here. Deep validation
     # (measure cycles, hierarchy levels) runs Rust-side in

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -664,9 +664,15 @@ def _report_malformed_cube_members(
     errors: list[ValidationError], src_path: str, raw: dict
 ) -> None:
     """Report non-list containers and non-mapping member entries."""
-    cube_label = raw.get("name") if isinstance(raw.get("name"), str) else src_path
+    # Prefer cube name; bare path twice reads poorly when name is missing.
+    if isinstance(raw.get("name"), str) and raw["name"]:
+        cube_label = raw["name"]
+    else:
+        cube_label = "cube"
     for key in ("measures", "dimensions", "time_dimensions"):
         val = raw.get(key)
+        # Bare `dimensions:` parses to None and means "no members" (loader
+        # normalises to []). Only non-list non-null values are malformed.
         if val is None:
             continue
         if not isinstance(val, list):
@@ -687,20 +693,32 @@ def _report_malformed_cube_members(
                         f"{key[:-1]} entry must be a mapping, got {type(item).__name__}",
                     )
                 )
+                continue
+            if not isinstance(item.get("name"), str):
+                errors.append(
+                    ValidationError(
+                        "error",
+                        f"{src_path} > {cube_label} > {key}[{i}]",
+                        f"{key[:-1]} entry must have a string 'name'",
+                    )
+                )
 
 
 def _normalise_cube_member_lists(cube: dict) -> dict:
     """Drop non-mapping measure/dimension/time_dimension entries.
+
+    Explicit null keys (YAML ``dimensions:``) become empty lists so the
+    build artifact never carries null member containers into the CLI.
 
     ``validate_project`` re-reads the raw YAML so hand-edited mistakes are
     still reported rather than vanishing quietly (same pattern as views /
     relationships in #2604 / #2613).
     """
     for key in ("measures", "dimensions", "time_dimensions"):
-        raw = cube.get(key)
-        if raw is None:
+        if key not in cube:
             continue
-        if not isinstance(raw, list):
+        raw = cube[key]
+        if raw is None or not isinstance(raw, list):
             cube[key] = []
             continue
         cube[key] = [item for item in raw if isinstance(item, dict)]

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -714,7 +714,10 @@ def _load_cubes_v1(project_path: Path) -> list[dict]:
         return []
     cubes = []
     for f in sorted(cubes_dir.glob("*.yml")):
-        data = yaml.safe_load(f.read_text(encoding="utf-8"))
+        try:
+            data = yaml.safe_load(f.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            continue
         if isinstance(data, dict):
             data["_source_file"] = f.name
             cubes.append(_normalise_cube_member_lists(data))
@@ -736,7 +739,10 @@ def _load_cubes_v2(project_path: Path) -> list[dict]:
         meta_file = d / "metadata.yml"
         if not meta_file.exists():
             continue
-        data = yaml.safe_load(meta_file.read_text())
+        try:
+            data = yaml.safe_load(meta_file.read_text())
+        except yaml.YAMLError:
+            continue
         if isinstance(data, dict):
             data["_source_file"] = str(meta_file.relative_to(cubes_dir))
             cubes.append(_normalise_cube_member_lists(data))
@@ -1322,8 +1328,18 @@ def validate_project(project_path: Path) -> list[ValidationError]:
     if cubes_dir.is_dir():
         if sv == 1:
             for f in sorted(cubes_dir.glob("*.yml")):
-                raw = yaml.safe_load(f.read_text(encoding="utf-8"))
                 src_path = f"cubes/{f.name}"
+                try:
+                    raw = yaml.safe_load(f.read_text(encoding="utf-8"))
+                except yaml.YAMLError as e:
+                    errors.append(
+                        ValidationError(
+                            "error",
+                            src_path,
+                            f"invalid YAML: {e}",
+                        )
+                    )
+                    continue
                 if not isinstance(raw, dict):
                     errors.append(
                         ValidationError(
@@ -1341,8 +1357,18 @@ def validate_project(project_path: Path) -> list[ValidationError]:
                 meta_file = d / "metadata.yml"
                 if not meta_file.exists():
                     continue
-                raw = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
                 src_path = f"cubes/{d.name}/metadata.yml"
+                try:
+                    raw = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
+                except yaml.YAMLError as e:
+                    errors.append(
+                        ValidationError(
+                            "error",
+                            src_path,
+                            f"invalid YAML: {e}",
+                        )
+                    )
+                    continue
                 if not isinstance(raw, dict):
                     errors.append(
                         ValidationError(

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -161,12 +161,13 @@ def _require_cubes_list(manifest: dict) -> list:
     The CLI reads target/mdl.json from `wren context build`. Skipping bad
     rows here would hide a producer bug and look like an empty listing.
     """
-    if "cubes" not in manifest or manifest["cubes"] is None:
+    if "cubes" not in manifest:
         return []
     cubes = manifest["cubes"]
-    if not isinstance(cubes, list):
+    if cubes is None or not isinstance(cubes, list):
+        kind = "null" if cubes is None else f"not a list (got {type(cubes).__name__})"
         typer.echo(
-            f"Error: malformed cubes in mdl.json (cubes is not a list, got {type(cubes).__name__}).\n"
+            f"Error: malformed cubes in mdl.json (cubes is {kind}).\n"
             "  Hint: re-run `wren context build`.",
             err=True,
         )

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -171,6 +171,10 @@ def _require_cubes_list(manifest: dict) -> list:
             err=True,
         )
         raise typer.Exit(1)
+    member_hint = (
+        "  Hint: fix the cube definition in cubes/*/metadata.yml, "
+        "then re-run `wren context build`."
+    )
     for i, cube in enumerate(cubes):
         if not isinstance(cube, dict):
             typer.echo(
@@ -180,14 +184,18 @@ def _require_cubes_list(manifest: dict) -> list:
             )
             raise typer.Exit(1)
         for key in ("measures", "dimensions", "timeDimensions"):
-            members = cube.get(key)
-            if members is None:
+            # Explicit null must not slip through: list_cubes joins members
+            # with cube.get(key, []), which still returns None when the key
+            # is present and null — bare TypeError two frames later.
+            if key not in cube:
                 continue
-            if not isinstance(members, list):
+            members = cube[key]
+            if members is None or not isinstance(members, list):
                 name = cube.get("name", f"entry {i}")
+                kind = "null" if members is None else f"not a list (got {type(members).__name__})"
                 typer.echo(
-                    f"Error: malformed cubes in mdl.json ({name!r} {key} is not a list).\n"
-                    "  Hint: re-run `wren context build`.",
+                    f"Error: malformed cubes in mdl.json ({name!r} {key} is {kind}).\n"
+                    f"{member_hint}",
                     err=True,
                 )
                 raise typer.Exit(1)
@@ -196,7 +204,7 @@ def _require_cubes_list(manifest: dict) -> list:
                     name = cube.get("name", f"entry {i}")
                     typer.echo(
                         f"Error: malformed cubes in mdl.json ({name!r} {key}[{j}] is not an object).\n"
-                        "  Hint: re-run `wren context build`.",
+                        f"{member_hint}",
                         err=True,
                     )
                     raise typer.Exit(1)
@@ -204,7 +212,7 @@ def _require_cubes_list(manifest: dict) -> list:
                     name = cube.get("name", f"entry {i}")
                     typer.echo(
                         f"Error: malformed cubes in mdl.json ({name!r} {key}[{j}].name is not a string).\n"
-                        "  Hint: re-run `wren context build`.",
+                        f"{member_hint}",
                         err=True,
                     )
                     raise typer.Exit(1)

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -150,7 +150,57 @@ def _load_manifest_dict(mdl: str | None) -> dict:
     if not isinstance(manifest, dict):
         typer.echo("Error: MDL JSON must be an object.", err=True)
         raise typer.Exit(1)
+    _require_cubes_list(manifest)
     return manifest
+
+
+def _require_cubes_list(manifest: dict) -> list:
+    """mdl.json is a build artifact: fail loud on malformed cubes.
+
+    Project YAML is normalised in load_cubes + reported by validate_project.
+    The CLI reads target/mdl.json from `wren context build`. Skipping bad
+    rows here would hide a producer bug and look like an empty listing.
+    """
+    if "cubes" not in manifest or manifest["cubes"] is None:
+        return []
+    cubes = manifest["cubes"]
+    if not isinstance(cubes, list):
+        typer.echo(
+            f"Error: malformed cubes in mdl.json (cubes is not a list, got {type(cubes).__name__}).\n"
+            "  Hint: re-run `wren context build`.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    for i, cube in enumerate(cubes):
+        if not isinstance(cube, dict):
+            typer.echo(
+                f"Error: malformed cubes in mdl.json (entry {i} is not an object).\n"
+                "  Hint: re-run `wren context build`.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        for key in ("measures", "dimensions", "timeDimensions"):
+            members = cube.get(key)
+            if members is None:
+                continue
+            if not isinstance(members, list):
+                name = cube.get("name", f"entry {i}")
+                typer.echo(
+                    f"Error: malformed cubes in mdl.json ({name!r} {key} is not a list).\n"
+                    "  Hint: re-run `wren context build`.",
+                    err=True,
+                )
+                raise typer.Exit(1)
+            for j, item in enumerate(members):
+                if not isinstance(item, dict):
+                    name = cube.get("name", f"entry {i}")
+                    typer.echo(
+                        f"Error: malformed cubes in mdl.json ({name!r} {key}[{j}] is not an object).\n"
+                        "  Hint: re-run `wren context build`.",
+                        err=True,
+                    )
+                    raise typer.Exit(1)
+    return cubes
 
 
 # ── wren cube list ─────────────────────────────────────────────────────────
@@ -160,7 +210,7 @@ def _load_manifest_dict(mdl: str | None) -> dict:
 def list_cubes(mdl: _MdlOpt = None) -> None:
     """List all cubes defined in the project."""
     manifest = _load_manifest_dict(mdl)
-    cubes = manifest.get("cubes", []) or []
+    cubes = manifest.get("cubes") or []
     if not cubes:
         typer.echo("No cubes defined.")
         return

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -200,6 +200,14 @@ def _require_cubes_list(manifest: dict) -> list:
                         err=True,
                     )
                     raise typer.Exit(1)
+                if not isinstance(item.get("name"), str):
+                    name = cube.get("name", f"entry {i}")
+                    typer.echo(
+                        f"Error: malformed cubes in mdl.json ({name!r} {key}[{j}].name is not a string).\n"
+                        "  Hint: re-run `wren context build`.",
+                        err=True,
+                    )
+                    raise typer.Exit(1)
     return cubes
 
 

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -192,7 +192,11 @@ def _require_cubes_list(manifest: dict) -> list:
             members = cube[key]
             if members is None or not isinstance(members, list):
                 name = cube.get("name", f"entry {i}")
-                kind = "null" if members is None else f"not a list (got {type(members).__name__})"
+                kind = (
+                    "null"
+                    if members is None
+                    else f"not a list (got {type(members).__name__})"
+                )
                 typer.echo(
                     f"Error: malformed cubes in mdl.json ({name!r} {key} is {kind}).\n"
                     f"{member_hint}",

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -302,12 +302,20 @@ def _register_context_tools(mcp: FastMCP, ctx: ServeContext) -> None:
                 {
                     "name": cube.get("name"),
                     "base_object": cube.get("base_object"),
-                    "measures": [m.get("name") for m in cube.get("measures", []) or []],
+                    "measures": [
+                        m.get("name")
+                        for m in cube.get("measures", []) or []
+                        if isinstance(m, dict) and isinstance(m.get("name"), str)
+                    ],
                     "dimensions": [
-                        d.get("name") for d in cube.get("dimensions", []) or []
+                        d.get("name")
+                        for d in cube.get("dimensions", []) or []
+                        if isinstance(d, dict) and isinstance(d.get("name"), str)
                     ],
                     "time_dimensions": [
-                        td.get("name") for td in cube.get("time_dimensions", []) or []
+                        td.get("name")
+                        for td in cube.get("time_dimensions", []) or []
+                        if isinstance(td, dict) and isinstance(td.get("name"), str)
                     ],
                 }
             )

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1269,6 +1269,18 @@ def test_validate_project_reports_v1_non_mapping_cube_file(tmp_path):
     assert load_cubes(tmp_path) == []
 
 
+def test_validate_project_reports_invalid_cube_yaml(tmp_path):
+    (tmp_path / "wren_project.yml").write_text(
+        "schema_version: 1\nname: test\ndata_source: postgres\n"
+    )
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "broken.yml").write_text("name: [unterminated\n")
+    errors = validate_project(tmp_path)
+    assert any("invalid YAML" in e.message for e in errors)
+    assert load_cubes(tmp_path) == []
+
+
 def test_validate_cube_ok(tmp_path):
     _make_v2_cube_project(tmp_path)
     _write_cube(

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1214,6 +1214,61 @@ def test_validate_cube_bad_hierarchy(tmp_path):
     assert any("nonexistent_dim" in e.message for e in errors)
 
 
+def test_load_cubes_drops_non_dict_member_entries(tmp_path):
+    _make_v2_cube_project(tmp_path)
+    _write_cube(
+        tmp_path,
+        "om",
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures:\n"
+        "  - name: c\n    expression: 'COUNT(*)'\n    type: BIGINT\n"
+        "  - nope\n"
+        "dimensions: not-a-list\n",
+    )
+    cubes = load_cubes(tmp_path)
+    assert len(cubes) == 1
+    assert [m["name"] for m in cubes[0]["measures"]] == ["c"]
+    assert cubes[0]["dimensions"] == []
+
+
+def test_validate_project_reports_malformed_cube_members(tmp_path):
+    _make_v2_cube_project(tmp_path)
+    _write_cube(
+        tmp_path,
+        "om",
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures: nope\n",
+    )
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any("'measures' must be a list, got str" in m for m in msgs)
+
+
+def test_validate_project_reports_non_mapping_cube_metadata(tmp_path):
+    _make_v2_cube_project(tmp_path)
+    cube_dir = tmp_path / "cubes" / "bad"
+    cube_dir.mkdir(parents=True)
+    (cube_dir / "metadata.yml").write_text("- just a list\n")
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any("cube metadata must be a mapping, got list" in m for m in msgs)
+
+
+def test_validate_project_reports_v1_non_mapping_cube_file(tmp_path):
+    (tmp_path / "wren_project.yml").write_text(
+        "schema_version: 1\nname: test\ndata_source: postgres\n"
+    )
+    cubes_dir = tmp_path / "cubes"
+    cubes_dir.mkdir()
+    (cubes_dir / "bad.yml").write_text("- not-a-mapping\n")
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any("cube file must be a mapping" in m for m in msgs)
+    assert load_cubes(tmp_path) == []
+
+
 def test_validate_cube_ok(tmp_path):
     _make_v2_cube_project(tmp_path)
     _write_cube(

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1249,6 +1249,28 @@ def test_normalise_cube_null_member_lists():
     assert out["time_dimensions"] == [{"name": "d", "expression": "x"}]
 
 
+def test_load_cubes_normalises_empty_member_keys(tmp_path):
+    """v2 empty YAML keys must reach [] via load_cubes (not only the helper)."""
+    _make_v2_cube_project(tmp_path)
+    _write_cube(
+        tmp_path,
+        "om",
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures:\n"
+        "  - name: total\n"
+        "    expression: SUM(o_totalprice)\n"
+        "    type: double\n"
+        "dimensions:\n"
+        "time_dimensions:\n",
+    )
+    cubes = load_cubes(tmp_path)
+    assert len(cubes) == 1
+    assert cubes[0]["dimensions"] == []
+    assert cubes[0]["time_dimensions"] == []
+    assert [m["name"] for m in cubes[0]["measures"]] == ["total"]
+
+
 def test_validate_project_reports_member_without_name(tmp_path):
     """Nameless measures must fail validate (not only cube list after build)."""
     _make_v2_cube_project(tmp_path)
@@ -1308,6 +1330,15 @@ def test_validate_project_reports_invalid_cube_yaml(tmp_path):
     cubes_dir = tmp_path / "cubes"
     cubes_dir.mkdir()
     (cubes_dir / "broken.yml").write_text("name: [unterminated\n")
+    errors = validate_project(tmp_path)
+    assert any("invalid YAML" in e.message for e in errors)
+    assert load_cubes(tmp_path) == []
+
+
+def test_validate_project_reports_invalid_v2_cube_yaml(tmp_path):
+    """Directory layout metadata.yml parse errors must report invalid YAML too."""
+    _make_v2_cube_project(tmp_path)
+    _write_cube(tmp_path, "om", "name: [unterminated\n")
     errors = validate_project(tmp_path)
     assert any("invalid YAML" in e.message for e in errors)
     assert load_cubes(tmp_path) == []

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1232,6 +1232,41 @@ def test_load_cubes_drops_non_dict_member_entries(tmp_path):
     assert cubes[0]["dimensions"] == []
 
 
+
+def test_normalise_cube_null_member_lists():
+    """YAML `dimensions:` (null) must become [] so mdl.json never carries null."""
+    from wren.context import _normalise_cube_member_lists
+
+    cube = {
+        "name": "order_metrics",
+        "base_object": "orders",
+        "measures": None,
+        "dimensions": None,
+        "time_dimensions": [{"name": "d", "expression": "x"}],
+    }
+    out = _normalise_cube_member_lists(cube)
+    assert out["measures"] == []
+    assert out["dimensions"] == []
+    assert out["time_dimensions"] == [{"name": "d", "expression": "x"}]
+
+
+def test_validate_project_reports_member_without_name(tmp_path):
+    """Nameless measures must fail validate (not only cube list after build)."""
+    _make_v2_cube_project(tmp_path)
+    _write_cube(
+        tmp_path,
+        "om",
+        "name: order_metrics\n"
+        "base_object: orders\n"
+        "measures:\n"
+        "  - expression: SUM(o_totalprice)\n"
+        "    type: double\n",
+    )
+    errors = validate_project(tmp_path)
+    msgs = [e.message for e in errors]
+    assert any("must have a string 'name'" in m for m in msgs)
+
+
 def test_validate_project_reports_malformed_cube_members(tmp_path):
     _make_v2_cube_project(tmp_path)
     _write_cube(

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1232,7 +1232,6 @@ def test_load_cubes_drops_non_dict_member_entries(tmp_path):
     assert cubes[0]["dimensions"] == []
 
 
-
 def test_normalise_cube_null_member_lists():
     """YAML `dimensions:` (null) must become [] so mdl.json never carries null."""
     from wren.context import _normalise_cube_member_lists
@@ -1272,9 +1271,7 @@ def test_validate_project_reports_malformed_cube_members(tmp_path):
     _write_cube(
         tmp_path,
         "om",
-        "name: order_metrics\n"
-        "base_object: orders\n"
-        "measures: nope\n",
+        "name: order_metrics\nbase_object: orders\nmeasures: nope\n",
     )
     errors = validate_project(tmp_path)
     msgs = [e.message for e in errors]
@@ -1862,7 +1859,9 @@ def test_validate_project_reports_non_dict_relationship_entries(tmp_path: Path) 
 
 def test_validate_project_reports_relationships_not_list(tmp_path: Path) -> None:
     (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")
-    (tmp_path / "relationships.yml").write_text("relationships: nope\n", encoding="utf-8")
+    (tmp_path / "relationships.yml").write_text(
+        "relationships: nope\n", encoding="utf-8"
+    )
     errors = validate_project(tmp_path)
     msgs = [e.message for e in errors]
     assert any("'relationships' must be a list, got str" in m for m in msgs)
@@ -1886,16 +1885,11 @@ def test_validate_project_relationship_indices_match_file(tmp_path: Path) -> Non
     """Junk at [0] must not renumber a later unnamed relationship's warnings."""
     (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")
     (tmp_path / "relationships.yml").write_text(
-        "relationships:\n"
-        "  - 42\n"
-        "  - models: [a, b]\n"
-        "    condition: a.id = b.id\n",
+        "relationships:\n  - 42\n  - models: [a, b]\n    condition: a.id = b.id\n",
         encoding="utf-8",
     )
     errors = validate_project(tmp_path)
-    diagnostics = [
-        f"{getattr(e, 'path', '')} {e.message}" for e in errors
-    ]
+    diagnostics = [f"{getattr(e, 'path', '')} {e.message}" for e in errors]
     assert any("got int" in diagnostic for diagnostic in diagnostics)
     assert any(
         "relationships[1]" in diagnostic and "join_type" in diagnostic

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -413,6 +413,30 @@ def test_cube_describe_malformed_cubes_fails_loud(tmp_path):
     assert "malformed cubes" in result.output
 
 
+def test_cube_list_non_string_member_names_fail_loud(tmp_path):
+    """Numeric member names must fail loud (not TypeError in join)."""
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    for key in ("measures", "dimensions", "timeDimensions"):
+        cube = {
+            "name": "orders",
+            "baseObject": "orders",
+            "measures": [],
+            "dimensions": [],
+            "timeDimensions": [],
+        }
+        cube[key] = [{"name": 1, "type": "VARCHAR"}]
+        mdl_file.write_text(
+            json.dumps({"catalog": "c", "schema": "s", "cubes": [cube]})
+        )
+        result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+        assert result.exit_code == 1, key
+        assert "malformed cubes" in result.output, key
+        assert "name is not a string" in result.output, key
+        assert "wren context build" in result.output, key
+
+
 def test_cube_query_missing_required(tmp_path):
     mdl = _make_mdl(tmp_path)
     result = runner.invoke(

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -358,6 +358,61 @@ def test_cube_list_bad_mdl_json(tmp_path):
     assert "invalid MDL JSON" in result.output
 
 
+def test_cube_list_malformed_cubes_scalar_fails_loud(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(json.dumps({"catalog": "c", "schema": "s", "cubes": "abc"}))
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 1
+    assert "malformed cubes" in result.output
+    assert "wren context build" in result.output
+    assert result.output.strip() != ""
+
+
+def test_cube_list_malformed_cubes_object_fails_loud(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(
+        json.dumps({"catalog": "c", "schema": "s", "cubes": {"name": "orders"}})
+    )
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 1
+    assert "malformed cubes" in result.output
+
+
+def test_cube_list_non_object_entry_fails_loud(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(
+        json.dumps(
+            {
+                "catalog": "c",
+                "schema": "s",
+                "cubes": ["bad", {"name": "orders", "measures": []}],
+            }
+        )
+    )
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 1
+    assert "entry 0 is not an object" in result.output
+    assert "wren context build" in result.output
+
+
+def test_cube_describe_malformed_cubes_fails_loud(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(json.dumps({"catalog": "c", "schema": "s", "cubes": "abc"}))
+    result = runner.invoke(
+        app, ["cube", "describe", "orders", "--mdl", str(mdl_file)]
+    )
+    assert result.exit_code == 1
+    assert "malformed cubes" in result.output
+
+
 def test_cube_query_missing_required(tmp_path):
     mdl = _make_mdl(tmp_path)
     result = runner.invoke(

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -406,9 +406,7 @@ def test_cube_describe_malformed_cubes_fails_loud(tmp_path):
     target.mkdir(parents=True)
     mdl_file = target / "mdl.json"
     mdl_file.write_text(json.dumps({"catalog": "c", "schema": "s", "cubes": "abc"}))
-    result = runner.invoke(
-        app, ["cube", "describe", "orders", "--mdl", str(mdl_file)]
-    )
+    result = runner.invoke(app, ["cube", "describe", "orders", "--mdl", str(mdl_file)])
     assert result.exit_code == 1
     assert "malformed cubes" in result.output
 

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -445,3 +445,32 @@ def test_cube_query_missing_required(tmp_path):
     )
     assert result.exit_code == 1
     assert "required" in result.output.lower()
+
+
+def test_cube_list_null_member_list_fails_loud(tmp_path):
+    """Present-but-null dimensions must not TypeError in list join."""
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(
+        json.dumps(
+            {
+                "catalog": "c",
+                "schema": "s",
+                "cubes": [
+                    {
+                        "name": "orders",
+                        "baseObject": "orders",
+                        "measures": [],
+                        "dimensions": None,
+                        "timeDimensions": [],
+                    }
+                ],
+            }
+        )
+    )
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 1
+    assert "malformed cubes" in result.output
+    assert "dimensions is null" in result.output
+    assert "cubes/*/metadata.yml" in result.output

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -94,6 +94,29 @@ def test_cube_list_empty(tmp_path):
     assert "No cubes defined" in result.output
 
 
+def test_cube_list_missing_cubes_key_is_empty(tmp_path):
+    """Absent cubes field is the serde default (empty list), not malformed."""
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(json.dumps({"catalog": "c", "schema": "s"}))
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 0
+    assert "No cubes defined" in result.output
+
+
+def test_cube_list_null_cubes_fails_loud(tmp_path):
+    """Explicit cubes: null is invalid (Rust Vec rejects null; missing is empty)."""
+    target = tmp_path / "target"
+    target.mkdir(parents=True)
+    mdl_file = target / "mdl.json"
+    mdl_file.write_text(json.dumps({"catalog": "c", "schema": "s", "cubes": None}))
+    result = runner.invoke(app, ["cube", "list", "--mdl", str(mdl_file)])
+    assert result.exit_code == 1
+    assert "malformed cubes" in result.output
+    assert "null" in result.output
+
+
 # ── describe ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Failure
`load_cubes` dropped bad YAML quietly with no `validate_project` cube-member checks. CLI `wren cube list`/`describe` crashed or went blank on malformed `target/mdl.json` (build artifact).

## Fix
- Loader + `validate_project` follow #2613 / #2604 (drop + report raw YAML).
- CLI fails loud at `_load_manifest_dict` with a `wren context build` hint.
- MCP listing only reads string names from dict members (loader already `list[dict]`).

Replaces #2615 and #2617 (goldmedal 2026-08-14).

## Verification
`pytest tests/unit/test_context.py -k cube tests/unit/test_cube_cli.py` — 38 passed.

## Duplicate check
No open PR with this loader+validate+loud-CLI split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cube loading and validation for malformed YAML, metadata, and member definitions.
  - Explicitly empty member lists are handled correctly, while missing lists remain valid and malformed collections produce clear errors.
  - Added clearer repair guidance for invalid entries and members without names.
  - Cube listings now include only valid named measures, dimensions, and time dimensions, excluding malformed entries.
  - Improved validation messages for missing cube names by using a clear fallback label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->