### PR TITLE
fix(skills): wrap generate-mdl SKILL.md's relationships.yml example under the required key

### DIFF
--- a/core/wren/src/wren/skills_content/generate-mdl/SKILL.md
+++ b/core/wren/src/wren/skills_content/generate-mdl/SKILL.md
@@ -213,12 +213,13 @@ From foreign key constraints discovered in Phase 2:
 
 ```yaml
 # relationships.yml
-- name: orders_customers
-  models:
-    - orders
-    - customers
-  join_type: many_to_one
-  condition: "orders.customer_id = customers.customer_id"
+relationships:
+  - name: orders_customers
+    models:
+      - orders
+      - customers
+    join_type: many_to_one
+    condition: "orders.customer_id = customers.customer_id"
 ```
 
 Join type mapping:

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -2011,6 +2011,47 @@ def test_validate_project_reports_relationships_bare_root(tmp_path: Path) -> Non
     )
 
 
+def _extract_fenced_yaml(markdown: str, heading: str) -> str:
+    """Pull the first ```yaml fenced block under a markdown heading."""
+    after_heading = markdown[markdown.index(heading) :]
+    start = after_heading.index("```yaml") + len("```yaml")
+    end = after_heading.index("```", start)
+    return after_heading[start:end]
+
+
+def test_generate_mdl_skill_step3_example_round_trips(tmp_path: Path) -> None:
+    """The generate-mdl skill's own Step 2/Step 3 examples, fed to the real
+    loader/validator, must produce a clean project. Regression for #2672: Step 3
+    used to ship a bare top-level list, which load_relationships silently drops
+    and validate_project rejects."""
+    from wren.skills_delivery import get_skill  # noqa: PLC0415
+
+    skill = get_skill("generate-mdl")
+    models_yaml = _extract_fenced_yaml(skill, "### Step 2 — Write model files")
+    relationships_yaml = _extract_fenced_yaml(skill, "### Step 3 — Write relationships")
+
+    _make_v2_project(tmp_path)
+    (tmp_path / "models" / "orders").mkdir(parents=True)
+    (tmp_path / "models" / "orders" / "metadata.yml").write_text(
+        models_yaml, encoding="utf-8"
+    )
+    (tmp_path / "models" / "customers").mkdir(parents=True)
+    (tmp_path / "models" / "customers" / "metadata.yml").write_text(
+        "name: customers\n"
+        "table_reference:\n  table: customers\n"
+        "primary_key: customer_id\n"
+        "columns:\n  - name: customer_id\n    type: INTEGER\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "relationships.yml").write_text(relationships_yaml, encoding="utf-8")
+
+    rels = load_relationships(tmp_path)
+    assert len(rels) == 1
+    assert rels[0]["name"] == "orders_customers"
+
+    assert validate_project(tmp_path) == []
+
+
 def test_validate_project_relationship_indices_match_file(tmp_path: Path) -> None:
     """Junk at [0] must not renumber a later unnamed relationship's warnings."""
     (tmp_path / "wren_project.yml").write_text("schema_version: 1\n", encoding="utf-8")


### PR DESCRIPTION
## Root cause

`generate-mdl`'s SKILL.md, Step 3 — Write relationships, showed:

```yaml
# relationships.yml
- name: orders_customers
  models:
    - orders
    - customers
  join_type: many_to_one
  condition: "orders.customer_id = customers.customer_id"
```

a bare top-level YAML list. `load_relationships()` (`core/wren/src/wren/context.py`)
only reads a top-level `relationships:` mapping key:

```python
data = yaml.safe_load(rel_file.read_text(encoding="utf-8")) or {}
rels = data.get("relationships") if isinstance(data, dict) else None
if not isinstance(rels, list):
    return []
```

so an agent following the doc verbatim ends up with a `relationships.yml`
that loads as zero relationships. `validate_project()` does report a clear
`relationships.yml must be a mapping with a 'relationships' key, got list`
error for this exact shape (and by default `wren build` runs validation
first and aborts on it), so the failure today is loud rather than silent —
but the doc's own example has never actually matched what the loader
expects.

## Fix

Wrap the example under the `relationships:` key, matching what
`load_relationships`/`validate_project` require:

```yaml
# relationships.yml
relationships:
  - name: orders_customers
    models:
      - orders
      - customers
    join_type: many_to_one
    condition: "orders.customer_id = customers.customer_id"
```

## Verification

- New regression test (`test_generate_mdl_skill_step3_example_round_trips`
  in `tests/unit/test_context.py`) reads the skill's own served content via
  `wren.skills_delivery.get_skill("generate-mdl")`, extracts the Step 2/Step 3
  YAML blocks, and feeds them through `load_relationships`/`validate_project`.
  Fails on unmodified `main` (`load_relationships` returns 0 relationships
  instead of 1); passes with this fix.
- Full `tests/unit/` (excl. `test_memory.py`/`test_mcp_server.py`, matching
  this repo's `test-unit` CI job): 1146 passed, 2 skipped, no regressions.
- `ruff format --check src/` / `ruff check src/` clean.
- Not verified: an end-to-end `wren context init && wren build` run against a
  live database: this is a pure-doc/test change and doesn't touch runtime code
  paths beyond what the new test already exercises directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the MDL generation workflow’s relationships YAML structure to ensure relationship definitions are recognized properly.

* **Tests**
  * Added regression coverage to verify relationship loading and project validation for generated v2 projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->