### PR TITLE
feat(pydantic): forward session properties to the engine

### DIFF
--- a/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
+++ b/sdk/wren-pydantic/src/wren_pydantic/_toolkit.py
@@ -118,24 +118,42 @@ class WrenToolkit:
 
     # ── Direct Python API (sync only — see module docstring) ──────────────
 
-    def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        """Execute SQL through the Wren context layer. Returns a pyarrow Table."""
+    def query(
+        self,
+        sql: str,
+        limit: int | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> pa.Table:
+        """Execute SQL through the Wren context layer. Returns a pyarrow Table.
+
+        ``properties`` carries MDL session properties and is forwarded to the
+        engine's planning path. A model guarded by row-level access control
+        needs the value its rule declares required — without it planning fails,
+        so RLAC-protected models cannot be read at all.
+        """
         engine = self._build_engine()
         try:
-            result = engine.query(sql, limit=limit)
+            result = engine.query(sql, limit=limit, properties=properties)
         finally:
             self._connector_cache = engine._connector
         return result
 
-    def dry_plan(self, sql: str) -> str:
-        """Plan SQL through MDL and return the expanded SQL in target dialect."""
-        return self._build_engine().dry_plan(sql)
+    def dry_plan(self, sql: str, properties: dict[str, Any] | None = None) -> str:
+        """Plan SQL through MDL and return the expanded SQL in target dialect.
 
-    def dry_run(self, sql: str) -> None:
-        """Validate SQL by planning and asking the DB to plan it without executing."""
+        ``properties`` carries MDL session properties (see :meth:`query`); RLAC
+        predicates are injected during planning, so they apply here too.
+        """
+        return self._build_engine().dry_plan(sql, properties=properties)
+
+    def dry_run(self, sql: str, properties: dict[str, Any] | None = None) -> None:
+        """Validate SQL by planning and asking the DB to plan it without executing.
+
+        ``properties`` carries MDL session properties (see :meth:`query`).
+        """
         engine = self._build_engine()
         try:
-            engine.dry_run(sql)
+            engine.dry_run(sql, properties=properties)
         finally:
             self._connector_cache = engine._connector
 

--- a/sdk/wren-pydantic/tests/unit/test_toolkit_runtime.py
+++ b/sdk/wren-pydantic/tests/unit/test_toolkit_runtime.py
@@ -26,7 +26,7 @@ def test_query_invokes_wren_engine_with_resolved_manifest(
         result = toolkit.query("SELECT 1", limit=10)
 
     assert result is fake_table
-    fake_engine.query.assert_called_once_with("SELECT 1", limit=10)
+    fake_engine.query.assert_called_once_with("SELECT 1", limit=10, properties=None)
     # Engine constructed with manifest bytes + datasource + connection_info
     engine_ctor.assert_called_once()
     kwargs = engine_ctor.call_args.kwargs
@@ -106,7 +106,9 @@ def test_dry_plan_delegates_to_engine(tmp_project, fake_active_profile):
         result = toolkit.dry_plan("SELECT * FROM orders")
 
     assert result == "SELECT * FROM cte_orders"
-    fake_engine.dry_plan.assert_called_once_with("SELECT * FROM orders")
+    fake_engine.dry_plan.assert_called_once_with(
+        "SELECT * FROM orders", properties=None
+    )
 
 
 def test_dry_run_delegates_to_engine(tmp_project, fake_active_profile):
@@ -118,4 +120,54 @@ def test_dry_run_delegates_to_engine(tmp_project, fake_active_profile):
     with patch("wren_pydantic._toolkit.WrenEngine", return_value=fake_engine):
         toolkit.dry_run("SELECT 1")
 
-    fake_engine.dry_run.assert_called_once_with("SELECT 1")
+    fake_engine.dry_run.assert_called_once_with("SELECT 1", properties=None)
+
+
+def test_query_forwards_session_properties(tmp_project, fake_active_profile):
+    """Session properties reach the engine, so RLAC-protected models are readable."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine.query.return_value = pa.table({"x": [1]})
+    fake_engine._connector = MagicMock()
+    properties = {"session_user_id": "'u_42'"}
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_pydantic._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.query("SELECT * FROM orders", limit=5, properties=properties)
+
+    fake_engine.query.assert_called_once_with(
+        "SELECT * FROM orders", limit=5, properties=properties
+    )
+
+
+def test_dry_plan_forwards_session_properties(tmp_project, fake_active_profile):
+    """dry_plan forwards properties: RLAC predicates are injected while planning."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine.dry_plan.return_value = "SELECT 1"
+    fake_engine._connector = MagicMock()
+    properties = {"session_user_id": "'u_42'"}
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_pydantic._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.dry_plan("SELECT * FROM orders", properties=properties)
+
+    fake_engine.dry_plan.assert_called_once_with(
+        "SELECT * FROM orders", properties=properties
+    )
+
+
+def test_dry_run_forwards_session_properties(tmp_project, fake_active_profile):
+    """dry_run forwards properties so validation matches what query will run."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine._connector = MagicMock()
+    properties = {"session_user_id": "'u_42'"}
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_pydantic._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.dry_run("SELECT * FROM orders", properties=properties)
+
+    fake_engine.dry_run.assert_called_once_with(
+        "SELECT * FROM orders", properties=properties
+    )


### PR DESCRIPTION
## What changes

`WrenToolkit.query()`, `dry_plan()` and `dry_run()` now accept `properties` and forward
it to the engine, so a caller can supply MDL session properties per call.

`WrenEngine.query/dry_plan/dry_run` already accept `properties` (`core/wren/src/wren/engine.py`)
— the toolkit simply never passed it, so a model guarded by row-level access control could
not be read through the SDK at all: planning fails when a required session property is
missing, and there was no way to supply one.

Closes #2638.

## Why the Pydantic AI tools are unchanged

`wren_query` / `wren_dry_plan` keep their current signatures on purpose. Their `ctx` is
documented as ignored because "the toolkit already captures all required state"
(`_tools.py`), and turning a session property into a model-fillable tool argument would let
the LLM choose the identity that RLAC is keyed on — the model would be deciding which rows
it is allowed to see. Binding session state for agent runs is a separate design question
(toolkit- or run-scoped), so this PR only opens the direct Python API that the issue asks
for.

## How this was verified

Scope of the claim: these tests assert the parameter reaches `WrenEngine`. I did not stand
up a live RLAC project against a real data source, so this PR does not claim an end-to-end
RLAC observation — the engine-side behaviour is the existing, already-tested path.

- 3 new tests assert `properties` is forwarded by `query` / `dry_plan` / `dry_run`.
- 3 existing delegation assertions updated to record the new call contract
  (`properties=None` by default), since they pinned the exact kwargs.
- Confirmed the new tests fail without the source change (6 failed with `_toolkit.py`
  reverted, 8 passed with it).
- `pytest tests/unit` → 103 passed. `ruff check .` and `ruff format --check .` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional session properties to query, plan preview, and dry-run operations.
  * Session properties are forwarded to the Wren engine, enabling them to influence planning and row-level access control predicates.

* **Bug Fixes**
  * Preserved existing connector caching behavior for queries.
  * Added coverage ensuring custom session properties are passed through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->