### PR TITLE
fix(langchain): forward session properties to the engine

### DIFF
--- a/sdk/wren-langchain/src/wren_langchain/_toolkit.py
+++ b/sdk/wren-langchain/src/wren_langchain/_toolkit.py
@@ -58,24 +58,42 @@ class WrenToolkit:
 
     # ── Direct Python API ──────────────────────────────────────────────────
 
-    def query(self, sql: str, limit: int | None = None) -> pa.Table:
-        """Execute SQL through the Wren context layer. Returns a pyarrow Table."""
+    def query(
+        self,
+        sql: str,
+        limit: int | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> pa.Table:
+        """Execute SQL through the Wren context layer. Returns a pyarrow Table.
+
+        ``properties`` carries MDL session properties and is forwarded to the
+        engine's planning path. A model guarded by row-level access control
+        needs the value its rule declares required, so without it planning
+        fails and the model cannot be read through this method at all.
+        """
         engine = self._build_engine()
         try:
-            result = engine.query(sql, limit=limit)
+            result = engine.query(sql, limit=limit, properties=properties)
         finally:
             self._connector_cache = engine._connector
         return result
 
-    def dry_plan(self, sql: str) -> str:
-        """Plan SQL through MDL and return the expanded SQL in target dialect."""
-        return self._build_engine().dry_plan(sql)
+    def dry_plan(self, sql: str, properties: dict[str, Any] | None = None) -> str:
+        """Plan SQL through MDL and return the expanded SQL in target dialect.
 
-    def dry_run(self, sql: str) -> None:
-        """Validate SQL by planning and asking the DB to plan it without executing."""
+        ``properties`` carries MDL session properties (see :meth:`query`); RLAC
+        predicates are injected during planning, so they apply here too.
+        """
+        return self._build_engine().dry_plan(sql, properties=properties)
+
+    def dry_run(self, sql: str, properties: dict[str, Any] | None = None) -> None:
+        """Validate SQL by planning and asking the DB to plan it without executing.
+
+        ``properties`` carries MDL session properties (see :meth:`query`).
+        """
         engine = self._build_engine()
         try:
-            engine.dry_run(sql)
+            engine.dry_run(sql, properties=properties)
         finally:
             self._connector_cache = engine._connector
 

--- a/sdk/wren-langchain/tests/unit/test_toolkit_runtime.py
+++ b/sdk/wren-langchain/tests/unit/test_toolkit_runtime.py
@@ -26,7 +26,7 @@ def test_query_invokes_wren_engine_with_resolved_manifest(
         result = toolkit.query("SELECT 1", limit=10)
 
     assert result is fake_table
-    fake_engine.query.assert_called_once_with("SELECT 1", limit=10)
+    fake_engine.query.assert_called_once_with("SELECT 1", limit=10, properties=None)
     # Engine constructed with manifest bytes + datasource + connection_info
     engine_ctor.assert_called_once()
     kwargs = engine_ctor.call_args.kwargs
@@ -106,7 +106,9 @@ def test_dry_plan_delegates_to_engine(tmp_project, fake_active_profile):
         result = toolkit.dry_plan("SELECT * FROM orders")
 
     assert result == "SELECT * FROM cte_orders"
-    fake_engine.dry_plan.assert_called_once_with("SELECT * FROM orders")
+    fake_engine.dry_plan.assert_called_once_with(
+        "SELECT * FROM orders", properties=None
+    )
 
 
 def test_dry_run_delegates_to_engine(tmp_project, fake_active_profile):
@@ -118,4 +120,54 @@ def test_dry_run_delegates_to_engine(tmp_project, fake_active_profile):
     with patch("wren_langchain._toolkit.WrenEngine", return_value=fake_engine):
         toolkit.dry_run("SELECT 1")
 
-    fake_engine.dry_run.assert_called_once_with("SELECT 1")
+    fake_engine.dry_run.assert_called_once_with("SELECT 1", properties=None)
+
+
+def test_query_forwards_session_properties(tmp_project, fake_active_profile):
+    """Session properties reach the engine, so RLAC-protected models are readable."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine.query.return_value = pa.table({"x": [1]})
+    fake_engine._connector = MagicMock()
+    properties = {"session_user_id": "'u_42'"}
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_langchain._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.query("SELECT * FROM orders", limit=5, properties=properties)
+
+    fake_engine.query.assert_called_once_with(
+        "SELECT * FROM orders", limit=5, properties=properties
+    )
+
+
+def test_dry_plan_forwards_session_properties(tmp_project, fake_active_profile):
+    """dry_plan forwards properties: RLAC predicates are injected while planning."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine.dry_plan.return_value = "SELECT 1"
+    fake_engine._connector = MagicMock()
+    properties = {"session_user_id": "'u_42'"}
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_langchain._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.dry_plan("SELECT * FROM orders", properties=properties)
+
+    fake_engine.dry_plan.assert_called_once_with(
+        "SELECT * FROM orders", properties=properties
+    )
+
+
+def test_dry_run_forwards_session_properties(tmp_project, fake_active_profile):
+    """dry_run forwards properties so validation matches what query will run."""
+    fake_engine = MagicMock(name="engine")
+    fake_engine._connector = MagicMock()
+    properties = {"session_user_id": "'u_42'"}
+
+    toolkit = WrenToolkit.from_project(tmp_project)
+
+    with patch("wren_langchain._toolkit.WrenEngine", return_value=fake_engine):
+        toolkit.dry_run("SELECT * FROM orders", properties=properties)
+
+    fake_engine.dry_run.assert_called_once_with(
+        "SELECT * FROM orders", properties=properties
+    )


### PR DESCRIPTION
## What changes

`WrenToolkit.query()`, `dry_plan()` and `dry_run()` now accept `properties`
and forward it to the engine, so a caller can supply MDL session properties
per call, the same fix already needed on the `wren-pydantic` side (#2684).

`WrenEngine.query/dry_plan/dry_run` already accept `properties`
(`core/wren/src/wren/engine.py`); the langchain toolkit simply never passed
it through, so a model guarded by row-level access control could not be
read through this SDK at all: planning fails when a required session
property is missing, and there was no way to supply one.

Fixes #2691 (companion issue for wren-langchain; see #2638 for the identical wren-pydantic gap)

## Why the LangChain tools are unchanged

`wren_query` / `wren_dry_plan` keep their current signatures on purpose.
Turning a session property into a model-fillable tool argument would let the
LLM choose the identity that RLAC is keyed on, which is a separate design
question (toolkit- or run-scoped binding), so this PR only opens the direct
Python API.

## How this was verified

- 3 new tests assert `properties` reaches `WrenEngine.query/dry_plan/dry_run`.
- 3 existing delegation tests updated for the new `properties=None` default
  call contract.
- Confirmed the new tests fail against the unmodified toolkit (6 failed) and
  pass with the fix (6 passed), same Docker image both times.
- Full suite: `pytest -v` on Python 3.11 and 3.12 (this module's CI matrix),
  119 passed / 2 deselected (the `slow` marker) on both. `ruff check .` and
  `ruff format --check .` clean on both.
- Not verified: an actual RLAC-protected project end to end. The engine-side
  behavior is the existing, already-tested path; this PR only closes the gap
  in what the toolkit forwards to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional session properties to query, plan, and validation operations.
  * Supports row-level access-control predicates through session properties.

* **Tests**
  * Added coverage for default and custom session properties across query, planning, and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->