### PR TITLE
feat(wren): add Xquik dlt loader

### DIFF
--- a/core/wren/src/wren/skills_content/dlt-connector/SKILL.md
+++ b/core/wren/src/wren/skills_content/dlt-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dlt-connector
-description: "Connect SaaS data (HubSpot, Stripe, Salesforce, GitHub, Slack, etc.) to Wren Engine for SQL analysis. Guides the user through the full flow: install dlt, pick a SaaS source, set up credentials, run the data pipeline into DuckDB, then auto-generate a Wren semantic project from the loaded data. Use this skill whenever the user mentions: connecting SaaS data, importing data from an API, dlt pipelines, loading HubSpot/Stripe/Salesforce/GitHub/Slack data, querying SaaS data with SQL, or setting up a new data source from a REST API. Also trigger when the user already has a dlt-produced DuckDB file and wants to create a Wren project from it."
+description: "Connect SaaS and public X data (HubSpot, Stripe, Salesforce, GitHub, Slack, Xquik, etc.) to Wren Engine for SQL analysis. Guides the user through the full flow: install dlt, pick a source, set up credentials, run the data pipeline into DuckDB, then auto-generate a Wren semantic project from the loaded data. Use this skill whenever the user mentions: connecting SaaS data, importing data from an API, dlt pipelines, loading HubSpot/Stripe/Salesforce/GitHub/Slack data, loading Xquik public X search results, querying SaaS data with SQL, or setting up a new data source from a REST API. Also trigger when the user already has a dlt-produced DuckDB file and wants to create a Wren project from it."
 license: Apache-2.0
 metadata:
   author: wrenai
@@ -8,7 +8,7 @@ metadata:
 
 # wren-dlt-connector
 
-> Reference docs (`dlt_sources`) and the `introspect_dlt` script are bundled. Pull references with `wren skills get dlt-connector --full`; fetch a script with `wren skills get dlt-connector --script <name>`.
+> Reference docs (`dlt_sources`) and the `introspect_dlt` and `load_xquik` scripts are bundled. Pull references with `wren skills get dlt-connector --full`; fetch a script with `wren skills get dlt-connector --script <name>`.
 
 Connect SaaS data to Wren Engine for SQL analysis — from zero to a verified, queryable project in one conversation.
 
@@ -60,6 +60,14 @@ pip install "dlt[duckdb]" --break-system-packages
 ```
 
 ### Step 3: Write the pipeline script
+
+For Xquik public X search data, fetch the bundled loader:
+
+```bash
+wren skills get dlt-connector --script load_xquik > load_xquik.py
+```
+
+The `dlt_sources` reference documents its API key and command options.
 
 Create a Python script that:
 1. Imports the dlt source function for the chosen SaaS

--- a/core/wren/src/wren/skills_content/dlt-connector/references/dlt_sources.md
+++ b/core/wren/src/wren/skills_content/dlt-connector/references/dlt_sources.md
@@ -16,8 +16,27 @@
 | Zendesk | Email + API Token | 2 fields | `SOURCES__ZENDESK__SUBDOMAIN`, `__EMAIL`, `__PASSWORD` |
 | Shopify | Admin API Access Token | token string | `SOURCES__SHOPIFY__PRIVATE_APP_PASSWORD` |
 | Airtable | Personal Access Token | `pat...` | `SOURCES__AIRTABLE__ACCESS_TOKEN` |
+| Xquik | API Key | `xq_...` | `XQUIK_API_KEY` |
 
 ## Pipeline Script Templates
+
+### Xquik
+
+Use the bundled loader to put public X search results into DuckDB:
+
+```bash
+export XQUIK_API_KEY="your-key"
+wren skills get dlt-connector --script load_xquik > load_xquik.py
+python load_xquik.py --query 'from:Anthropic Claude' --limit 100
+```
+
+The loader sends the API key in the `x-api-key` header. It requests the
+`2026-04-29` response contract and follows `next_cursor`. It applies `--limit`
+to both the Xquik request and dlt extraction. It merges posts on their `id`, so
+rerunning the same search updates existing rows instead of duplicating them.
+
+The default pipeline creates `xquik.duckdb` with a `tweets` table. Run the
+bundled `introspect_dlt` script against that file to generate the Wren project.
 
 ### HubSpot
 

--- a/core/wren/src/wren/skills_content/dlt-connector/scripts/load_xquik.py
+++ b/core/wren/src/wren/skills_content/dlt-connector/scripts/load_xquik.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Load Xquik public X search results into DuckDB for Wren analysis."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+from typing import Any
+
+_BASE_URL = "https://xquik.com/api/v1/"
+_CONTRACT_VERSION = "2026-04-29"
+_MAX_LIMIT = 10_000
+
+
+def build_xquik_config(
+    query: str,
+    api_key: str,
+    limit: int,
+) -> dict[str, Any]:
+    """Build a bounded dlt REST API source configuration for Xquik."""
+    query = query.strip()
+    api_key = api_key.strip()
+    if not query:
+        raise ValueError("query must not be empty")
+    if not api_key:
+        raise ValueError("api_key must not be empty")
+    if not 1 <= limit <= _MAX_LIMIT:
+        raise ValueError(f"limit must be between 1 and {_MAX_LIMIT}")
+
+    return {
+        "client": {
+            "base_url": _BASE_URL,
+            "headers": {"xquik-api-contract": _CONTRACT_VERSION},
+            "auth": {
+                "type": "api_key",
+                "name": "x-api-key",
+                "api_key": api_key,
+                "location": "header",
+            },
+        },
+        "resources": [
+            {
+                "name": "tweets",
+                "primary_key": "id",
+                "write_disposition": "merge",
+                "endpoint": {
+                    "path": "x/tweets/search",
+                    "params": {"q": query, "limit": limit},
+                    "data_selector": "tweets",
+                    "paginator": {
+                        "type": "cursor",
+                        "cursor_path": "next_cursor",
+                        "cursor_param": "cursor",
+                        "has_more_path": "has_more",
+                    },
+                },
+            }
+        ],
+    }
+
+
+def main() -> None:
+    """Run the Xquik search pipeline."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", required=True, help="X search query")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="maximum posts to request (default: 100)",
+    )
+    parser.add_argument(
+        "--pipeline-name",
+        default="xquik",
+        help="dlt pipeline and DuckDB file name (default: xquik)",
+    )
+    args = parser.parse_args()
+
+    api_key = os.environ.get("XQUIK_API_KEY", "")
+    if not api_key.strip():
+        parser.error("XQUIK_API_KEY is required")
+
+    dlt = importlib.import_module("dlt")
+    rest_api_source = importlib.import_module("dlt.sources.rest_api").rest_api_source
+
+    source = rest_api_source(
+        build_xquik_config(args.query, api_key, args.limit)
+    ).add_limit(args.limit, count_rows=True)
+    pipeline = dlt.pipeline(
+        pipeline_name=args.pipeline_name,
+        destination="duckdb",
+        dataset_name="xquik_data",
+    )
+    print(pipeline.run(source))
+
+
+if __name__ == "__main__":
+    main()

--- a/core/wren/tests/unit/test_skills_cli.py
+++ b/core/wren/tests/unit/test_skills_cli.py
@@ -13,6 +13,13 @@ pytestmark = pytest.mark.unit
 runner = CliRunner()
 
 
+def _load_script_namespace(name):
+    source = skills_delivery.get_script("dlt-connector", name)
+    namespace = {"__name__": f"{name}_test"}
+    exec(compile(source, f"{name}.py", "exec"), namespace)
+    return namespace
+
+
 def test_skills_list_includes_usage_with_references():
     result = runner.invoke(app, ["skills", "list"])
     assert result.exit_code == 0
@@ -116,12 +123,48 @@ def test_get_script_returns_source():
     assert "introspect" in src
 
 
-def test_get_script_via_cli():
-    result = runner.invoke(
-        app, ["skills", "get", "dlt-connector", "--script", "introspect_dlt"]
-    )
+@pytest.mark.parametrize("name", ["introspect_dlt", "load_xquik"])
+def test_get_script_via_cli(name):
+    result = runner.invoke(app, ["skills", "get", "dlt-connector", "--script", name])
     assert result.exit_code == 0
     assert "#!/usr/bin/env python3" in result.output
+
+
+def test_xquik_loader_builds_bounded_search_config():
+    namespace = _load_script_namespace("load_xquik")
+    config = namespace["build_xquik_config"]("from:wrenai", "xq_test", 25)
+    client = config["client"]
+    resource = config["resources"][0]
+    endpoint = resource["endpoint"]
+
+    assert client["base_url"] == "https://xquik.com/api/v1/"
+    assert client["headers"] == {"xquik-api-contract": "2026-04-29"}
+    assert client["auth"] == {
+        "type": "api_key",
+        "name": "x-api-key",
+        "api_key": "xq_test",
+        "location": "header",
+    }
+    assert resource["primary_key"] == "id"
+    assert resource["write_disposition"] == "merge"
+    assert endpoint["params"] == {"q": "from:wrenai", "limit": 25}
+    assert endpoint["data_selector"] == "tweets"
+    assert endpoint["paginator"] == {
+        "type": "cursor",
+        "cursor_path": "next_cursor",
+        "cursor_param": "cursor",
+        "has_more_path": "has_more",
+    }
+
+
+@pytest.mark.parametrize(
+    "query,api_key,limit",
+    [("", "xq_test", 1), ("x", "", 1), ("x", "xq_test", 0), ("x", "xq_test", 10_001)],
+)
+def test_xquik_loader_rejects_invalid_inputs(query, api_key, limit):
+    namespace = _load_script_namespace("load_xquik")
+    with pytest.raises(ValueError):
+        namespace["build_xquik_config"](query, api_key, limit)
 
 
 def test_get_unknown_script_errors():
@@ -137,5 +180,5 @@ def test_list_reports_references_and_scripts():
         "cube_proposals",
         "gap_catalog",
     }
-    assert by_name["dlt-connector"].scripts == ["introspect_dlt"]
+    assert by_name["dlt-connector"].scripts == ["introspect_dlt", "load_xquik"]
     assert by_name["onboarding"].references == []

--- a/core/wren/tests/unit/test_skills_cli.py
+++ b/core/wren/tests/unit/test_skills_cli.py
@@ -14,6 +14,7 @@ runner = CliRunner()
 
 
 def _load_script_namespace(name):
+    """Load one bundled Skill script without invoking its CLI entry point."""
     source = skills_delivery.get_script("dlt-connector", name)
     namespace = {"__name__": f"{name}_test"}
     exec(compile(source, f"{name}.py", "exec"), namespace)
@@ -118,6 +119,7 @@ def test_full_does_not_inline_scripts():
 
 
 def test_get_script_returns_source():
+    """Return an executable bundled script by Skill and script name."""
     src = skills_delivery.get_script("dlt-connector", "introspect_dlt")
     assert src.startswith("#!/usr/bin/env python3")
     assert "introspect" in src
@@ -125,12 +127,14 @@ def test_get_script_returns_source():
 
 @pytest.mark.parametrize("name", ["introspect_dlt", "load_xquik"])
 def test_get_script_via_cli(name):
+    """Return each bundled dlt connector script through the CLI."""
     result = runner.invoke(app, ["skills", "get", "dlt-connector", "--script", name])
     assert result.exit_code == 0
     assert "#!/usr/bin/env python3" in result.output
 
 
 def test_xquik_loader_builds_bounded_search_config():
+    """Configure bounded, authenticated Xquik cursor pagination."""
     namespace = _load_script_namespace("load_xquik")
     config = namespace["build_xquik_config"]("from:wrenai", "xq_test", 25)
     client = config["client"]
@@ -162,6 +166,7 @@ def test_xquik_loader_builds_bounded_search_config():
     [("", "xq_test", 1), ("x", "", 1), ("x", "xq_test", 0), ("x", "xq_test", 10_001)],
 )
 def test_xquik_loader_rejects_invalid_inputs(query, api_key, limit):
+    """Reject empty credentials, empty queries, and unsafe result limits."""
     namespace = _load_script_namespace("load_xquik")
     with pytest.raises(ValueError):
         namespace["build_xquik_config"](query, api_key, limit)
@@ -175,6 +180,7 @@ def test_get_unknown_script_errors():
 
 
 def test_list_reports_references_and_scripts():
+    """List every bundled reference and executable Skill script."""
     by_name = {s.name: s for s in skills_delivery.list_skills()}
     assert set(by_name["enrich-context"].references) == {
         "cube_proposals",


### PR DESCRIPTION
## Summary

Adds a bundled `load_xquik` script to the dlt connector Skill. It loads a bounded X search result into DuckDB and feeds that database into Wren’s existing introspection flow.

## What failure does this repair?

This is a feature, not a bug fix. The dlt connector supports REST sources, but users had no runnable Xquik source. The new script configures authentication, contract versioning, cursor pagination, row limits, merge keys, and the DuckDB destination.

## How is it tested?

- 27 focused Skill delivery tests pass.
- 1,196 CI-equivalent unit tests pass, with 2 existing skips.
- Ruff formatting and lint checks pass.
- Python 3.11 build and wheel-content checks pass.
- A local dlt 1.30 fixture verified 2 cursor pages, request parameters, headers, and 3 records.
- A full local pipeline wrote and queried `xquik_data.tweets` in DuckDB.

No real API key or production request was used.

## Duplicate check

Reviewed all 261 open issues and 74 open pull requests. No Xquik or dlt-connector item overlaps this work. No open pull request changes these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading public X search results from Xquik into DuckDB.
  - Added cursor-based pagination, result limits, and ID-based updates for reliable data loading.
  - Added API-key configuration and a bundled command-line loader for Xquik data.

- **Documentation**
  - Documented Xquik as a verified data source, including setup, usage, generated tables, and Wren introspection guidance.
  - Updated bundled-resource documentation to include the new loader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->