### PR TITLE
fix(context): reject v1 view upgrades that map two views to the same target

### DIFF
--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1705,6 +1705,7 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
     _reject_malformed_v1_model_columns(project_path)
 
     # Models: flat files → directories
+    seen_model_targets: set[str] = set()
     models = _load_models_v1(project_path)
     for model in models:
         source_dir = model.pop("_source_dir", None)
@@ -1717,7 +1718,17 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
             created.append(ref_sql_file.relative_to(project_root).as_posix())
 
         metadata_file = _resolve_upgrade_file(model_dir, "metadata.yml")
-        created.append(metadata_file.relative_to(project_root).as_posix())
+        target = metadata_file.relative_to(project_root).as_posix()
+        # Case-folded: two names differing only in case resolve to the same
+        # directory on a case-insensitive filesystem (macOS APFS default,
+        # Windows), so treat them as the same target everywhere, not just on
+        # a literal string match.
+        if target.casefold() in seen_model_targets:
+            raise UpgradeError(
+                f"Cannot upgrade: multiple legacy models map to '{target}'"
+            )
+        seen_model_targets.add(target.casefold())
+        created.append(target)
 
         if source_dir:
             deleted.append(f"models/{source_dir}.yml")
@@ -1738,11 +1749,12 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
 
         metadata_file = _resolve_upgrade_file(view_dir, "metadata.yml")
         target = metadata_file.relative_to(project_root).as_posix()
-        if target in seen_view_targets:
+        # Case-folded for the same reason as the model guard above.
+        if target.casefold() in seen_view_targets:
             raise UpgradeError(
                 f"Cannot upgrade: multiple legacy views map to '{target}'"
             )
-        seen_view_targets.add(target)
+        seen_view_targets.add(target.casefold())
 
         created.append(target)
 

--- a/core/wren/src/wren/context.py
+++ b/core/wren/src/wren/context.py
@@ -1723,6 +1723,7 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
             deleted.append(f"models/{source_dir}.yml")
 
     # Views: single file → directories
+    seen_view_targets: set[str] = set()
     views = _load_views_v1(project_path)
     for view in views:
         name = view.get("name")
@@ -1736,7 +1737,14 @@ def _plan_v1_to_v2(project_path: Path) -> tuple[list[str], list[str]]:
             created.append(sql_file.relative_to(project_root).as_posix())
 
         metadata_file = _resolve_upgrade_file(view_dir, "metadata.yml")
-        created.append(metadata_file.relative_to(project_root).as_posix())
+        target = metadata_file.relative_to(project_root).as_posix()
+        if target in seen_view_targets:
+            raise UpgradeError(
+                f"Cannot upgrade: multiple legacy views map to '{target}'"
+            )
+        seen_view_targets.add(target)
+
+        created.append(target)
 
     views_file = project_path / "views.yml"
     if views_file.exists():

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1495,6 +1495,111 @@ def test_plan_upgrade_v1_to_v2_rejects_duplicate_view_names(tmp_path):
         ) == source_contents[relative_path]
 
 
+def test_plan_upgrade_v1_to_v2_rejects_case_insensitive_duplicate_view_names(
+    tmp_path,
+):
+    _make_v1_project(tmp_path)
+    source_contents = _snapshot_v1_sources(tmp_path)
+    (tmp_path / "views.yml").write_text(
+        "views:\n"
+        "  - name: Revenue\n"
+        "    statement: SELECT 1\n"
+        "  - name: revenue\n"
+        "    statement: SELECT 2\n"
+    )
+    duplicate_views_contents = (tmp_path / "views.yml").read_text(encoding="utf-8")
+
+    # Use fresh import to avoid stale class reference after importlib.reload in earlier tests.
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="multiple legacy views"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    assert get_schema_version(tmp_path) == 1
+    assert (tmp_path / "views.yml").exists()
+    assert (tmp_path / "views.yml").read_text(
+        encoding="utf-8"
+    ) == duplicate_views_contents
+    assert not (tmp_path / "views").exists()
+    for relative_path in (
+        "models/orders.yml",
+        "models/revenue.yml",
+        "cubes/order_metrics.yml",
+    ):
+        assert (tmp_path / relative_path).read_text(
+            encoding="utf-8"
+        ) == source_contents[relative_path]
+
+
+def test_plan_upgrade_v1_to_v2_rejects_duplicate_model_targets(tmp_path):
+    _make_v1_project(tmp_path)
+    source_contents = _snapshot_v1_sources(tmp_path)
+    (tmp_path / "models" / "orders_copy.yml").write_text(
+        "name: orders\n"
+        "table_reference:\n  table: orders_copy\n"
+        "columns:\n  - name: id\n    type: INTEGER\n"
+    )
+    duplicate_model_contents = (tmp_path / "models" / "orders_copy.yml").read_text(
+        encoding="utf-8"
+    )
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="multiple legacy models"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    assert get_schema_version(tmp_path) == 1
+    assert not (tmp_path / "models" / "orders").exists()
+    assert (tmp_path / "models" / "orders_copy.yml").read_text(
+        encoding="utf-8"
+    ) == duplicate_model_contents
+    for relative_path in (
+        "models/orders.yml",
+        "models/revenue.yml",
+        "views.yml",
+        "cubes/order_metrics.yml",
+    ):
+        assert (tmp_path / relative_path).read_text(
+            encoding="utf-8"
+        ) == source_contents[relative_path]
+
+
+def test_plan_upgrade_v1_to_v2_rejects_case_insensitive_duplicate_model_targets(
+    tmp_path,
+):
+    _make_v1_project(tmp_path)
+    source_contents = _snapshot_v1_sources(tmp_path)
+    (tmp_path / "models" / "orders_upper.yml").write_text(
+        "name: Orders\n"
+        "table_reference:\n  table: orders_upper\n"
+        "columns:\n  - name: id\n    type: INTEGER\n"
+    )
+    duplicate_model_contents = (tmp_path / "models" / "orders_upper.yml").read_text(
+        encoding="utf-8"
+    )
+
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="multiple legacy models"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    assert get_schema_version(tmp_path) == 1
+    assert not (tmp_path / "models" / "orders").exists()
+    assert not (tmp_path / "models" / "Orders").exists()
+    assert (tmp_path / "models" / "orders_upper.yml").read_text(
+        encoding="utf-8"
+    ) == duplicate_model_contents
+    for relative_path in (
+        "models/orders.yml",
+        "models/revenue.yml",
+        "views.yml",
+        "cubes/order_metrics.yml",
+    ):
+        assert (tmp_path / relative_path).read_text(
+            encoding="utf-8"
+        ) == source_contents[relative_path]
+
+
 def test_plan_upgrade_v2_to_v3(tmp_path):
     _make_v2_project(tmp_path)
     result = plan_upgrade(tmp_path, target_version=3)

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1471,6 +1471,7 @@ def test_plan_upgrade_v1_to_v2_rejects_duplicate_view_names(tmp_path):
         "  - name: summary\n"
         "    statement: SELECT 2\n"
     )
+    duplicate_views_contents = (tmp_path / "views.yml").read_text(encoding="utf-8")
 
     # Use fresh import to avoid stale class reference after importlib.reload in earlier tests.
     from wren.context import UpgradeError as _UE  # noqa: PLC0415
@@ -1480,6 +1481,10 @@ def test_plan_upgrade_v1_to_v2_rejects_duplicate_view_names(tmp_path):
 
     assert get_schema_version(tmp_path) == 1
     assert (tmp_path / "views.yml").exists()
+    assert (tmp_path / "views.yml").read_text(
+        encoding="utf-8"
+    ) == duplicate_views_contents
+    assert not (tmp_path / "views").exists()
     for relative_path in (
         "models/orders.yml",
         "models/revenue.yml",

--- a/core/wren/tests/unit/test_context.py
+++ b/core/wren/tests/unit/test_context.py
@@ -1461,6 +1461,35 @@ def test_plan_upgrade_v1_to_v2_rejects_duplicate_cube_targets(tmp_path):
         plan_upgrade(tmp_path, target_version=2)
 
 
+def test_plan_upgrade_v1_to_v2_rejects_duplicate_view_names(tmp_path):
+    _make_v1_project(tmp_path)
+    source_contents = _snapshot_v1_sources(tmp_path)
+    (tmp_path / "views.yml").write_text(
+        "views:\n"
+        "  - name: summary\n"
+        "    statement: SELECT 1\n"
+        "  - name: summary\n"
+        "    statement: SELECT 2\n"
+    )
+
+    # Use fresh import to avoid stale class reference after importlib.reload in earlier tests.
+    from wren.context import UpgradeError as _UE  # noqa: PLC0415
+
+    with pytest.raises(_UE, match="multiple legacy views"):
+        plan_upgrade(tmp_path, target_version=2)
+
+    assert get_schema_version(tmp_path) == 1
+    assert (tmp_path / "views.yml").exists()
+    for relative_path in (
+        "models/orders.yml",
+        "models/revenue.yml",
+        "cubes/order_metrics.yml",
+    ):
+        assert (tmp_path / relative_path).read_text(
+            encoding="utf-8"
+        ) == source_contents[relative_path]
+
+
 def test_plan_upgrade_v2_to_v3(tmp_path):
     _make_v2_project(tmp_path)
     result = plan_upgrade(tmp_path, target_version=3)


### PR DESCRIPTION
Fixes #2695

**Root cause**

`_plan_v1_to_v2`'s cube loop already refuses to upgrade when two legacy cube files resolve to the same target directory (`seen_cube_targets`, raises `UpgradeError` before any write). The views loop right above it has no equivalent check: it resolves each view's target purely from `view.get("name")`, so two `views.yml` entries sharing the same `name` map to the same `views/<name>/` directory. `_apply_v1_to_v2` then writes both views into that directory (the second write overwrites the first) and deletes `views.yml`, the only other copy, right after.

**Fix**

Mirror the existing cube guard for views: track resolved `metadata.yml` targets in a `seen_view_targets` set while planning, and raise `UpgradeError` on a repeat before `_apply_v1_to_v2` performs any filesystem write (it calls `_plan_v1_to_v2` first for exactly this reason).

**Verification**

- New test `test_plan_upgrade_v1_to_v2_rejects_duplicate_view_names` (`tests/unit/test_context.py`), mirroring the existing `..._rejects_duplicate_cube_targets` test: fails on main (`DID NOT RAISE UpgradeError`) and passes on this branch, confirmed both ways in the same Docker image.
- Also reproduced end to end outside the test suite: built a v1 project with two `views.yml` entries named `summary`, ran `plan_upgrade`/`apply_upgrade` on main and got a silently clobbered `views/summary/metadata.yml` with `views.yml` deleted; same input on this branch raises `UpgradeError` before any file is touched.
- Full `tests/unit/` suite (excluding `test_memory.py`/`test_mcp_server.py`, matching the CI job's own scope): 1191 passed, 2 skipped.
- `ruff format --check` and `ruff check` clean on both changed files.
- Not run: the connector/UI/memory/mcp CI jobs, since this change touches neither their code paths nor their extras.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented v1-to-v2 upgrade plans from proceeding when multiple legacy views or models target the same destination.
  * Added detection for name conflicts that differ only by letter case.
  * Ensured failed upgrade plans leave the schema version and source files unchanged, without creating partial destination files or directories.

* **Tests**
  * Added regression coverage for duplicate view and model mappings, including case-insensitive conflicts and prevention of partial migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->