### PR TITLE
fix(core): reject collapsed relationship joins

### DIFF
--- a/core/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/core/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -943,15 +943,71 @@ fn merge_graph(
         };
         let source = node_map.get(&source).unwrap();
         let target = node_map.get(&target).unwrap();
-        // Skip duplicate edges between the same pair of nodes: the same
-        // relationship may appear in multiple calc-col sub-graphs (e.g. two
-        // calc cols traversing the same relationship), and adding parallel
-        // edges would produce redundant joins downstream.
-        if graph.find_edge(*source, *target).is_none() {
+        // The same relationship may appear in multiple calculated-column
+        // sub-graphs, in which case the duplicate edge is safe to skip. Two
+        // different relationships between the same models cannot be merged,
+        // though: downstream graph traversal can use only one edge and would
+        // silently generate a join with the wrong condition.
+        if let Some(existing_edge) = graph.find_edge(*source, *target) {
+            let existing_link = &graph[existing_edge];
+            let incoming_link = &new_graph[edge];
+            if existing_link != incoming_link {
+                return plan_err!(
+                    "Multiple relationships from '{}' to '{}' require distinct join aliases; \
+                     cannot merge '{}' with '{}'",
+                    graph[*source],
+                    graph[*target],
+                    existing_link,
+                    incoming_link
+                );
+            }
+        } else {
             graph.add_edge(*source, *target, new_graph[edge].clone());
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod merge_graph_tests {
+    use super::*;
+    use crate::mdl::builder::ModelBuilder;
+
+    #[test]
+    fn rejects_distinct_relationships_between_the_same_models() {
+        let orders = Dataset::Model(ModelBuilder::new("orders").build());
+        let addresses = Dataset::Model(ModelBuilder::new("addresses").build());
+
+        let mut graph = Graph::new();
+        let orders_node = graph.add_node(orders.clone());
+        let addresses_node = graph.add_node(addresses.clone());
+        graph.add_edge(
+            orders_node,
+            addresses_node,
+            DatasetLink {
+                join_type: JoinType::ManyToOne,
+                condition: "orders.bill_to_id = addresses.address_id".to_string(),
+            },
+        );
+
+        let mut incoming = Graph::new();
+        let incoming_orders = incoming.add_node(orders);
+        let incoming_addresses = incoming.add_node(addresses);
+        incoming.add_edge(
+            incoming_orders,
+            incoming_addresses,
+            DatasetLink {
+                join_type: JoinType::ManyToOne,
+                condition: "orders.ship_to_id = addresses.address_id".to_string(),
+            },
+        );
+
+        let error = merge_graph(&mut graph, &incoming)
+            .expect_err("distinct relationships must not collapse into one join");
+        let message = error.to_string();
+        assert!(message.contains("orders.bill_to_id"), "{message}");
+        assert!(message.contains("orders.ship_to_id"), "{message}");
+    }
 }
 
 impl PartialOrd for ModelPlanNode {


### PR DESCRIPTION
## Summary

- Detect different DatasetLink values when calculated-column graphs merge the same model pair.
- Return a planning error containing both join conditions instead of silently keeping whichever relationship was merged first.
- Preserve deduplication when the incoming relationship is genuinely identical.

This is the short-term containment described in #2688. It prevents plausible-but-wrong SQL while full first-class relationship aliases remain a larger architectural change.

## What failure does this repair?

The regression test builds bill-to and ship-to edges from orders to addresses with different join conditions, then merges the two graphs.

Before this change:

    cargo test -p wren-semantic-core --lib rejects_distinct_relationships_between_the_same_models -- --nocapture

failed with:

    distinct relationships must not collapse into one join: ()

The unit value shows merge_graph returned Ok and silently discarded the incoming ship-to edge. In the role-playing-dimension query from #2688, that causes both calculated cities to use the bill-to join.

After this change, the same graph merge returns a plan error that names both conflicting conditions.

## How is it tested?

- Targeted regression: 1 passed.
- Full core library suite: 153 passed, 0 failed.
- cargo clippy -p wren-semantic-core --all-targets -- -D warnings: passed.
- The test is a normal core library unit test and runs in the default Rust test target.

## Duplicate check

Searched open PRs for #2688, relationship handles, and distinct join aliases; the issue still has no linked PR. #976 was also reviewed and is an unrelated, service-only semantics-enrichment alias change that does not touch wren-core or relationship planning.

Addresses #2688.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning when multiple relationships connect the same datasets.
  * Distinct join conditions are now preserved and reported as planning errors instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->