### PR TITLE
fix(wren): connect MSSqlConnector with autocommit so statements are not left in an open transaction

### DIFF
--- a/core/wren/src/wren/connector/mssql.py
+++ b/core/wren/src/wren/connector/mssql.py
@@ -469,7 +469,9 @@ def _connect_mssql_pyodbc(
     for key, value in connect_kwargs.items():
         connection_parts.append(f"{key}={_escape_odbc_value(str(value))}")
 
-    connection = pyodbc.connect(";".join(connection_parts))
+    # pyodbc defaults to autocommit=False, which would leave this cached,
+    # long-lived connection in one never-committed transaction.
+    connection = pyodbc.connect(";".join(connection_parts), autocommit=True)
     _register_mssql_output_converters(connection)
 
     if statement_timeout is not None:

--- a/core/wren/tests/unit/test_mssql_connection.py
+++ b/core/wren/tests/unit/test_mssql_connection.py
@@ -228,6 +228,27 @@ def test_mssql_both_credentials_emits_uid_and_pwd() -> None:
     assert "Trusted_Connection" not in parts
 
 
+def test_mssql_connects_with_autocommit() -> None:
+    """pyodbc defaults to autocommit=False, so every statement on this
+    long-lived, process-cached connection would otherwise run inside a
+    transaction that is never committed. Mirrors the other connectors
+    (redshift.py, canner.py, mysql.py) that already turn autocommit on."""
+    fake = _FakePyodbc()
+    with patch("wren.connector.mssql.pyodbc", fake):
+        _connect_mssql_pyodbc(
+            host="h",
+            port="1433",
+            database="db",
+            user="alice",
+            password="secret",
+            driver="ODBC Driver 18 for SQL Server",
+        )
+
+    fake.connect.assert_called_once()
+    _args, kwargs = fake.connect.call_args
+    assert kwargs.get("autocommit") is True
+
+
 # ---------------------------------------------------------------------------
 # 3. statement_timeout validated before connect()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`MSSqlConnector` opens its `pyodbc` connection without `autocommit=True`, so every statement runs inside one implicit transaction that is never committed for the connection's whole process life. This connects `autocommit=True` in `_connect_mssql_pyodbc`, matching the shape already used by `canner.py`, `mysql.py`, and `redshift.py`.

## What failure does this repair?

pyodbc defaults to `autocommit=False`. `_connect_mssql_pyodbc` calls `pyodbc.connect(";".join(connection_parts))` with no `autocommit` argument, and nothing in `mssql.py` calls `.commit()`, `.rollback()`, or sets `.autocommit` afterward. Since `WrenEngine._get_connector()` caches this connector for the engine's lifetime, the connection stays in one open transaction for as long as the process runs, which blocks SQL Server's transaction log truncation for the whole time (`log_reuse_wait_desc = 'ACTIVE_TRANSACTION'`) and leaves any write statement issued through the connector uncommitted.

Fixes #2704.

## How is it tested?

- New unit test `test_mssql_connects_with_autocommit` in `tests/unit/test_mssql_connection.py`, which patches `wren.connector.mssql.pyodbc` (same fixture the file's other tests already use) and asserts `pyodbc.connect` is called with `autocommit=True`. Runs in CI's `test-unit` job (`pytest tests/unit/`).
- Docker differential against the same test file, both directions, `python:3.11-slim`, dependencies from `uv sync --locked` (which resolves the published `wren-core-py==0.7.5` wheel, no local Rust build needed since this change does not touch `wren-core-py`): 1 failed / 18 passed on unmodified `main` (`56e007d`), 19 passed on this branch.
- Full `tests/unit/` (excluding `test_memory.py` / `test_mcp_server.py`, matching `wren-ci.yml`'s `test-unit` job exactly): 1240 passed, 2 skipped, on the branch.
- `ruff format --check src/` and `ruff check src/` (the `lint` job's exact commands): clean.
- Not run: `tests/connectors/test_mssql.py`, the live-SQL-Server integration suite. It needs `testcontainers[mssql]` and a real SQL Server container, and `wren-ci.yml`'s `test-connector` matrix only covers `postgres`/`mysql`, so this file does not execute in CI either. I read it to confirm the fault (its own setup connections already do `conn.autocommit = True`, working around the exact gap this PR closes) but did not attempt to stand up a container for it.

## Duplicate check

`competing-prs.sh` against `core/wren/src/wren/connector/mssql.py`, run at scout time and again immediately before this push (70/70 open PRs swept both times): 2 candidates, `#2551` and `#2552`, both drafts from the same author reworking row-limit handling in `MSSqlConnector.query`. Neither touches connection setup, autocommit, or transactions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MSSQL connections now automatically commit statements, helping prevent changes from remaining in uncommitted transactions.
- **Tests**
  - Added coverage to verify that MSSQL connections use automatic commit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->