### PR TITLE
feat(wren): add a torch-free onnx embedding backend for wren memory

### DIFF
--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -266,6 +266,35 @@ jobs:
           WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
         run: uv run --no-sync pytest tests/unit/test_memory.py -v
 
+  test-embedding-parity:
+    name: embedding backend parity
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core/wren
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Install both embedding extras
+        # Each of the two jobs above installs one backend, so the parity test
+        # importorskips out of both. It is the assertion existing stores
+        # depend on — a store written by one backend has to stay readable by
+        # the other — so it needs a job where both are present.
+        run: uv sync --locked --extra memory --extra memory-onnx
+      - name: Cache models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-parity-paraphrase-MiniLM-L3-v2
+      - name: Compare backends
+        env:
+          WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
+        run: uv run --no-sync pytest tests/unit/test_memory.py -v -k TestOnnxVectorParity
+
   test-mcp:
     name: mcp tests
     runs-on: ubuntu-latest

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -213,6 +213,59 @@ jobs:
           WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
         run: uv run --no-sync pytest tests/unit/test_memory.py -v
 
+  test-memory-onnx:
+    name: memory tests (onnx, torch-free)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core/wren
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./core/wren-core-py/target/
+          key: ${{ runner.os }}-cargo-wren-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build wren-core-py wheel
+        working-directory: core/wren-core-py
+        run: |
+          uv sync --locked --no-install-project
+          uv run --no-sync maturin build
+      - name: Install dependencies
+        run: |
+          uv sync --locked --extra memory-onnx
+          uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
+      - name: Assert the install is torch-free
+        # The whole point of this extra: on linux-x86_64 the sentence-transformers
+        # path resolves the CUDA build of torch. If torch reappears here, the
+        # extra has regressed.
+        run: |
+          if uv run --no-sync python -c "import importlib.util as u; raise SystemExit(0 if u.find_spec('torch') else 1)"; then
+            echo "::error::torch was installed by the memory-onnx extra"
+            exit 1
+          fi
+      - name: Cache ONNX model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-onnx-paraphrase-MiniLM-L3-v2
+      - name: Run memory tests
+        env:
+          WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
+        run: uv run --no-sync pytest tests/unit/test_memory.py -v
+
   test-mcp:
     name: mcp tests
     runs-on: ubuntu-latest

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -281,6 +281,8 @@ jobs:
         working-directory: core/wren
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -298,10 +298,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-parity-paraphrase-MiniLM-L3-v2
+          key: hf-parity-paraphrase-multilingual-MiniLM-L12-v2
       - name: Compare backends
-        env:
-          WREN_EMBEDDING_MODEL: paraphrase-MiniLM-L3-v2
         run: uv run --no-sync pytest tests/unit/test_memory.py -v -k TestOnnxVectorParity
 
   test-mcp:

--- a/.github/workflows/wren-ci.yml
+++ b/.github/workflows/wren-ci.yml
@@ -249,11 +249,18 @@ jobs:
           uv pip install --reinstall --no-index --find-links ../wren-core-py/target/wheels/ wren-core-py
       - name: Assert the install is torch-free
         # The whole point of this extra: on linux-x86_64 the sentence-transformers
-        # path resolves the CUDA build of torch. If torch reappears here, the
-        # extra has regressed.
+        # path resolves the CUDA build of torch plus triton and sixteen nvidia-*
+        # packages. Checking torch alone would miss a resolution that drops
+        # torch but keeps the CUDA payload, which is where the gigabytes are.
         run: |
           if uv run --no-sync python -c "import importlib.util as u; raise SystemExit(0 if u.find_spec('torch') else 1)"; then
             echo "::error::torch was installed by the memory-onnx extra"
+            exit 1
+          fi
+          cuda=$(uv pip list --format=freeze | grep -iE '^(nvidia-|triton==)' || true)
+          if [ -n "$cuda" ]; then
+            echo "::error::CUDA packages were installed by the memory-onnx extra"
+            echo "$cuda"
             exit 1
           fi
       - name: Cache ONNX model

--- a/core/wren/README.md
+++ b/core/wren/README.md
@@ -25,6 +25,7 @@ pip install 'wrenai[spark]'        # Spark
 pip install 'wrenai[athena]'       # Athena
 pip install 'wrenai[oracle]'       # Oracle
 pip install 'wrenai[memory]'       # Schema & query memory (LanceDB)
+pip install 'wrenai[memory-onnx]'  # Same, torch-free (onnxruntime instead of PyTorch)
 pip install 'wrenai[ui]'           # Browser-based profile form (starlette + uvicorn)
 pip install 'wrenai[main]'         # memory + interactive prompts + ui
 pip install 'wrenai[all]'          # All connectors + main
@@ -133,7 +134,8 @@ flags.
 | `strict_mode` | `false` | When `true`, every table in a query must be defined in the MDL. Queries referencing undeclared tables are rejected before execution. |
 | `denied_functions` | `[]` | List of function names (case-insensitive) that are forbidden in queries. |
 
-**6. (Optional) Index schema for semantic search** (requires `wrenai[memory]`):
+**6. (Optional) Index schema for semantic search** (requires `wrenai[memory]`,
+or `wrenai[memory-onnx]` for a torch-free install):
 
 ```bash
 wren memory index                              # index MDL schema
@@ -142,6 +144,12 @@ wren memory store --nl "top customers" --sql "SELECT ..."  # store NL→SQL pair
 wren memory recall -q "best customers"         # retrieve similar past queries
 wren memory watch                              # auto-reindex on schema/query changes
 ```
+
+`memory-onnx` runs the same weights through onnxruntime instead of PyTorch, so
+it produces the same vectors and existing indexes stay valid -- it is a much
+smaller install, not a different index. When both extras are present, onnx is
+used; set `WREN_EMBEDDING_BACKEND=sentence-transformers` to override, and
+`wren memory status` reports which one is live.
 
 **7. (Optional) Build a shareable GenBI app** — turn the context layer into a
 browser-side dashboard (powered by `wren-core-wasm`) and deploy it to Vercel or

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -67,7 +67,11 @@ memory-onnx = [
   "lancedb>=0.6",
   "onnxruntime>=1.17",
   "tokenizers>=0.15",
-  "huggingface-hub>=0.23",
+  # >=0.25: EntryNotFoundError / LocalEntryNotFoundError moved into
+  # huggingface_hub.errors there. embeddings.py imports them inside an
+  # `except OSError` handler, so on an older hub the ImportError would
+  # replace the error being classified.
+  "huggingface-hub>=0.25",
   "numpy>=1.24",
 ]
 interactive = ["InquirerPy>=0.3.4"]

--- a/core/wren/pyproject.toml
+++ b/core/wren/pyproject.toml
@@ -61,6 +61,15 @@ spark = ["pyspark>=3.5"]
 athena = ["pyathena[pandas]>=3"]
 oracle = ["oracledb>=2"]
 memory = ["lancedb>=0.6", "sentence-transformers>=3.0.0"]
+# Alternative to `memory`, not an addition: same vectors, no torch. Deliberately
+# excluded from `all`, which installs the sentence-transformers backend.
+memory-onnx = [
+  "lancedb>=0.6",
+  "onnxruntime>=1.17",
+  "tokenizers>=0.15",
+  "huggingface-hub>=0.23",
+  "numpy>=1.24",
+]
 interactive = ["InquirerPy>=0.3.4"]
 ui = ["starlette>=1.3.1", "uvicorn>=0.29", "jinja2>=3.1", "python-multipart>=0.0.31"]
 mcp = ["mcp[cli]>=1.19"]

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -464,6 +464,11 @@ def status(
     if info["backend"] == "grep":
         typer.echo(f"  knowledge/sql: {info['pairs']} pair(s)")
         return
+    # Two backends produce these vectors and only one of them pulls torch, so
+    # which one is live is the first thing to check when an install is bigger
+    # or slower than expected.
+    if info.get("embedding_backend"):
+        typer.echo(f"  embeddings: {info['embedding_backend']} ({info['model']})")
     tables = info.get("tables", {})
     if not tables:
         typer.echo("No tables indexed yet.")

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -220,8 +220,14 @@ def index(
             pass  # instructions are optional; never fail index because of them
 
     mem_store = _get_store(path)
+    from wren.memory.embeddings import UnsupportedPoolingError  # noqa: PLC0415
+
     try:
         result = mem_store.index_schema(manifest, seed_queries=not no_seed)
+    except UnsupportedPoolingError as e:
+        # Not a manifest problem; the message already names the way out.
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1) from e
     except ValueError as e:
         typer.echo(f"Malformed manifest: {e}", err=True)
         raise typer.Exit(1) from e

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from datetime import datetime, timezone
@@ -104,6 +105,24 @@ def _get_store(path: str | None):
             err=True,
         )
         raise typer.Exit(1)
+
+
+@contextlib.contextmanager
+def _report_backend_errors():
+    """Report an embedding backend that cannot serve the model as itself.
+
+    These surface lazily from the first encode, so every command that embeds
+    can raise one -- not just ``index``. Each message already names the way
+    out, so echoing it is enough; without this they reach the user as a
+    traceback whose most informative line is a 404.
+    """
+    from wren.memory.embeddings import OnnxBackendError  # noqa: PLC0415
+
+    try:
+        yield
+    except OnnxBackendError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1) from e
 
 
 def _print_results(results: list[dict], output: str) -> None:
@@ -220,17 +239,15 @@ def index(
             pass  # instructions are optional; never fail index because of them
 
     mem_store = _get_store(path)
-    from wren.memory.embeddings import UnsupportedPoolingError  # noqa: PLC0415
 
-    try:
-        result = mem_store.index_schema(manifest, seed_queries=not no_seed)
-    except UnsupportedPoolingError as e:
-        # Not a manifest problem; the message already names the way out.
-        typer.echo(str(e), err=True)
-        raise typer.Exit(1) from e
-    except ValueError as e:
-        typer.echo(f"Malformed manifest: {e}", err=True)
-        raise typer.Exit(1) from e
+    # Backend errors are RuntimeErrors, so they pass the ValueError branch
+    # untouched and land in the handler -- none of them is a manifest problem.
+    with _report_backend_errors():
+        try:
+            result = mem_store.index_schema(manifest, seed_queries=not no_seed)
+        except ValueError as e:
+            typer.echo(f"Malformed manifest: {e}", err=True)
+            raise typer.Exit(1) from e
     typer.echo(
         f"Indexed {result['schema_items']} schema items"
         + (f", {result['seed_queries']} seed queries" if result["seed_queries"] else "")
@@ -392,9 +409,10 @@ def store(
         from wren.memory.store import MemoryStore  # noqa: PLC0415
 
         resolved = path or str(_default_memory_path())
-        MemoryStore(path=resolved).store_query(
-            nl, sql, datasource=datasource, tags=tags
-        )
+        with _report_backend_errors():
+            MemoryStore(path=resolved).store_query(
+                nl, sql, datasource=datasource, tags=tags
+            )
     except ModuleNotFoundError as e:
         if (e.name or "").split(".")[0] not in {
             "lancedb",
@@ -427,7 +445,8 @@ def recall(
         typer.echo(str(e), err=True)
         raise typer.Exit(1)
     idx = get_index(project, path or str(_default_memory_path()))
-    results = idx.search(query, limit=limit, datasource=datasource)
+    with _report_backend_errors():
+        results = idx.search(query, limit=limit, datasource=datasource)
     _annotate_markdown_paths(results)
     _print_results(results, output)
 

--- a/core/wren/src/wren/memory/cli.py
+++ b/core/wren/src/wren/memory/cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
 import os
 from datetime import datetime, timezone
@@ -11,10 +10,37 @@ from typing import Annotated, Optional
 
 import typer
 import yaml
+from typer.core import TyperGroup
+
+
+class _MemoryGroup(TyperGroup):
+    """Report an embedding backend that cannot serve the model, from any command.
+
+    These failures surface lazily from the first encode, so every command that
+    embeds can raise one -- `index`, `store`, `recall`, `fetch`, and whatever
+    is added next. Handling them per call site means each new command has to
+    remember; handling them here means it inherits. Each message already names
+    the way out, so echoing it is enough.
+
+    Scoped to `OnnxBackendError` rather than `RuntimeError`: `typer.Exit`
+    subclasses `RuntimeError`, so the wider catch would rewrite every exit code
+    in this sub-app to 1.
+    """
+
+    def invoke(self, ctx):
+        from wren.memory.embeddings import OnnxBackendError  # noqa: PLC0415
+
+        try:
+            return super().invoke(ctx)
+        except OnnxBackendError as e:
+            typer.echo(str(e), err=True)
+            raise typer.Exit(1) from e
+
 
 memory_app = typer.Typer(
     name="memory",
     help="Schema and query memory backed by LanceDB.",
+    cls=_MemoryGroup,
 )
 
 _WREN_HOME = Path(os.environ.get("WREN_HOME", Path.home() / ".wren"))
@@ -105,24 +131,6 @@ def _get_store(path: str | None):
             err=True,
         )
         raise typer.Exit(1)
-
-
-@contextlib.contextmanager
-def _report_backend_errors():
-    """Report an embedding backend that cannot serve the model as itself.
-
-    These surface lazily from the first encode, so every command that embeds
-    can raise one -- not just ``index``. Each message already names the way
-    out, so echoing it is enough; without this they reach the user as a
-    traceback whose most informative line is a 404.
-    """
-    from wren.memory.embeddings import OnnxBackendError  # noqa: PLC0415
-
-    try:
-        yield
-    except OnnxBackendError as e:
-        typer.echo(str(e), err=True)
-        raise typer.Exit(1) from e
 
 
 def _print_results(results: list[dict], output: str) -> None:
@@ -240,14 +248,13 @@ def index(
 
     mem_store = _get_store(path)
 
-    # Backend errors are RuntimeErrors, so they pass the ValueError branch
-    # untouched and land in the handler -- none of them is a manifest problem.
-    with _report_backend_errors():
-        try:
-            result = mem_store.index_schema(manifest, seed_queries=not no_seed)
-        except ValueError as e:
-            typer.echo(f"Malformed manifest: {e}", err=True)
-            raise typer.Exit(1) from e
+    # Backend errors are RuntimeErrors, so they pass this branch untouched and
+    # reach _MemoryGroup -- none of them is a manifest problem.
+    try:
+        result = mem_store.index_schema(manifest, seed_queries=not no_seed)
+    except ValueError as e:
+        typer.echo(f"Malformed manifest: {e}", err=True)
+        raise typer.Exit(1) from e
     typer.echo(
         f"Indexed {result['schema_items']} schema items"
         + (f", {result['seed_queries']} seed queries" if result["seed_queries"] else "")
@@ -409,10 +416,9 @@ def store(
         from wren.memory.store import MemoryStore  # noqa: PLC0415
 
         resolved = path or str(_default_memory_path())
-        with _report_backend_errors():
-            MemoryStore(path=resolved).store_query(
-                nl, sql, datasource=datasource, tags=tags
-            )
+        MemoryStore(path=resolved).store_query(
+            nl, sql, datasource=datasource, tags=tags
+        )
     except ModuleNotFoundError as e:
         if (e.name or "").split(".")[0] not in {
             "lancedb",
@@ -445,8 +451,7 @@ def recall(
         typer.echo(str(e), err=True)
         raise typer.Exit(1)
     idx = get_index(project, path or str(_default_memory_path()))
-    with _report_backend_errors():
-        results = idx.search(query, limit=limit, datasource=datasource)
+    results = idx.search(query, limit=limit, datasource=datasource)
     _annotate_markdown_paths(results)
     _print_results(results, output)
 

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -191,6 +191,31 @@ def _hf_file(repo_id: str, filename: str) -> str:
         return hf_hub_download(repo_id, filename)
 
 
+def _is_absent_from_repo(error: OSError) -> bool:
+    """True when the hub answered "no such file", as opposed to not answering.
+
+    A remote 404 is the only response that means the repo does not publish the
+    file. ``LocalEntryNotFoundError`` is the opposite -- nothing cached *and*
+    the hub unreachable -- and a rate limit or dropped connection say nothing
+    about the file at all. Reporting either as absence is how a transient
+    fault acquires a permanent-sounding explanation.
+
+    Tested against the pair rather than ``RemoteEntryNotFoundError``, which
+    only exists from huggingface-hub 1.x; the pair discriminates identically
+    on both. Needs >= 0.25 all the same, which is where they moved into
+    ``huggingface_hub.errors`` -- before that this import raises inside the
+    caller's ``except`` handler, replacing the error being classified.
+    """
+    from huggingface_hub.errors import (  # noqa: PLC0415
+        EntryNotFoundError,
+        LocalEntryNotFoundError,
+    )
+
+    return isinstance(error, EntryNotFoundError) and not isinstance(
+        error, LocalEntryNotFoundError
+    )
+
+
 def _read_json(repo_id: str, filename: str) -> dict | None:
     """Read a small JSON config from the model repo, or None when absent.
 
@@ -206,17 +231,7 @@ def _read_json(repo_id: str, filename: str) -> dict | None:
     try:
         path = _hf_file(repo_id, filename)
     except OSError as e:
-        from huggingface_hub.errors import (  # noqa: PLC0415
-            EntryNotFoundError,
-            LocalEntryNotFoundError,
-        )
-
-        # A remote 404 is the only answer that means "this repo does not
-        # publish the file". LocalEntryNotFoundError is the opposite: nothing
-        # cached *and* the hub unreachable, so presence is unknown.
-        if isinstance(e, EntryNotFoundError) and not isinstance(
-            e, LocalEntryNotFoundError
-        ):
+        if _is_absent_from_repo(e):
             return None
         raise OnnxBackendError(
             f"'{filename}' for '{repo_id}' could not be fetched: {e}. Whether "
@@ -335,16 +350,24 @@ class OnnxEmbeddings:
             except OSError as e:
                 # onnx is selected on importability alone, so a
                 # WREN_EMBEDDING_MODEL that works under sentence-transformers
-                # reaches this. Not falling back: a network blip and a repo
-                # with no export both arrive as OSError, and quietly loading
-                # torch on a bad connection is the outcome this extra exists
-                # to avoid. Name the override and let the caller choose.
-                raise MissingOnnxExportError(
+                # reaches this. Only a 404 means the export is really missing;
+                # anything else and the remedy is to retry, not to switch
+                # backends. Deliberately not falling back on the 404 either:
+                # quietly loading torch is the outcome this extra exists to
+                # avoid, so name the override and let the caller choose.
+                if _is_absent_from_repo(e):
+                    raise MissingOnnxExportError(
+                        f"'{self._repo_id}' does not publish '{onnx_file}', "
+                        "which the onnx embedding backend needs. Set "
+                        "WREN_EMBEDDING_BACKEND=sentence-transformers to use "
+                        "this model, or point WREN_ONNX_MODEL_FILE at the "
+                        "right path."
+                    ) from e
+                raise OnnxBackendError(
                     f"'{onnx_file}' could not be fetched for '{self._repo_id}': "
-                    f"{e}. The onnx embedding backend needs a repo that "
-                    "publishes an ONNX export. Set "
-                    "WREN_EMBEDDING_BACKEND=sentence-transformers to use this "
-                    "model, or point WREN_ONNX_MODEL_FILE at the right path."
+                    f"{e}. Retry when the Hugging Face cache or network is "
+                    "available, or set "
+                    "WREN_EMBEDDING_BACKEND=sentence-transformers."
                 ) from e
 
             session = onnxruntime.InferenceSession(

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -34,6 +34,13 @@ ONNX_BACKEND = "onnx"
 SENTENCE_TRANSFORMERS_BACKEND = "sentence-transformers"
 
 
+class UnsupportedPoolingError(RuntimeError):
+    """The onnx backend cannot reproduce this model's pooling mode.
+
+    Not a ``ValueError``: the CLI reports those as a malformed manifest.
+    """
+
+
 def _disable_transformers_progress_bar() -> None:
     # Imported lazily: transformers ships with the optional `memory` extra,
     # so this module must stay importable when that extra is not installed.
@@ -200,7 +207,7 @@ def _require_mean_pooling(repo_id: str) -> None:
         for key, value in config.items()
         if key.startswith("pooling_mode_") and value
     )
-    raise ValueError(
+    raise UnsupportedPoolingError(
         f"The onnx embedding backend implements mean pooling, but '{repo_id}' "
         f"pools with {active or ['an unrecognized mode']}. Set "
         "WREN_EMBEDDING_BACKEND=sentence-transformers to use this model."

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -194,16 +194,36 @@ def _hf_file(repo_id: str, filename: str) -> str:
 def _read_json(repo_id: str, filename: str) -> dict | None:
     """Read a small JSON config from the model repo, or None when absent.
 
-    A corrupt file is not treated as absent. ``_require_mean_pooling`` reads
-    "absent" as "assume mean pooling", so swallowing the error there would
-    wave a CLS-pooled model through with quietly wrong vectors -- and
-    ``json.JSONDecodeError`` is a ``ValueError``, so letting it escape would
-    put it behind the CLI's "Malformed manifest:" instead.
+    "Absent" means the hub answered 404. A cache miss that could not be
+    checked online, a rate limit and a dropped connection are not absence, and
+    neither is a corrupt file. The distinction matters because
+    ``_require_mean_pooling`` reads "absent" as "assume mean pooling": report
+    any of those as absence and a network blip waves a CLS-pooled model
+    through with quietly wrong vectors. ``json.JSONDecodeError`` is also a
+    ``ValueError``, so letting it escape would put it behind the CLI's
+    "Malformed manifest:".
     """
     try:
         path = _hf_file(repo_id, filename)
-    except OSError:
-        return None
+    except OSError as e:
+        from huggingface_hub.errors import (  # noqa: PLC0415
+            EntryNotFoundError,
+            LocalEntryNotFoundError,
+        )
+
+        # A remote 404 is the only answer that means "this repo does not
+        # publish the file". LocalEntryNotFoundError is the opposite: nothing
+        # cached *and* the hub unreachable, so presence is unknown.
+        if isinstance(e, EntryNotFoundError) and not isinstance(
+            e, LocalEntryNotFoundError
+        ):
+            return None
+        raise OnnxBackendError(
+            f"'{filename}' for '{repo_id}' could not be fetched: {e}. Whether "
+            "this model is usable here could not be determined; retry with the "
+            "Hugging Face cache or network available, or set "
+            "WREN_EMBEDDING_BACKEND=sentence-transformers."
+        ) from e
     try:
         return json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
@@ -225,7 +245,15 @@ def _max_seq_length(repo_id: str) -> int:
     the default model reports 512 there against a real length of 128, so
     reading it would diverge from the sentence-transformers backend.
     """
-    config = _read_json(repo_id, "sentence_bert_config.json") or {}
+    try:
+        config = _read_json(repo_id, "sentence_bert_config.json") or {}
+    except OnnxBackendError:
+        # Truncation length is soft where pooling mode is not. An ONNX-native
+        # mirror legitimately ships no sentence_bert_config.json, so an
+        # offline run with the rest of the model cached should fall back here
+        # rather than fail -- getting the length wrong degrades recall,
+        # getting the pooling wrong corrupts the index.
+        config = {}
     value = config.get("max_seq_length")
     if isinstance(value, int) and value > 0:
         return value

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -29,6 +29,9 @@ _DEFAULT_MODEL = os.getenv(
 )
 _DEFAULT_DIM = 384
 _DEFAULT_MAX_SEQ_LENGTH = 128
+# Matches SentenceTransformer.encode's default batch_size, so peak memory
+# per encode call is the same on both backends.
+_ENCODE_BATCH_SIZE = 32
 
 ONNX_BACKEND = "onnx"
 SENTENCE_TRANSFORMERS_BACKEND = "sentence-transformers"
@@ -266,34 +269,48 @@ class OnnxEmbeddings:
             return runtime
 
     def _encode(self, texts: list[str]) -> list:
-        """Tokenize, run the encoder, mean-pool under the mask, L2 normalize."""
+        """Tokenize, run the encoder, mean-pool under the mask, L2 normalize.
+
+        Runs in fixed-size chunks. ``SentenceTransformer.encode`` defaults to
+        ``batch_size=32`` and lancedb's adapter does not override it, so
+        feeding a whole manifest to one ``session.run`` would make peak memory
+        scale with the manifest on this backend alone. Mean pooling and
+        normalization are both per-row, so chunking cannot move a vector; it
+        also confines padding to each chunk instead of the whole batch.
+        """
         import numpy as np  # noqa: PLC0415
 
         if not texts:
             return []
 
         session, tokenizer, input_names = self._runtime()
-        encodings = tokenizer.encode_batch(texts)
-        ids = np.array([e.ids for e in encodings], dtype=np.int64)
-        mask = np.array([e.attention_mask for e in encodings], dtype=np.int64)
+        vectors: list = []
+        for start in range(0, len(texts), _ENCODE_BATCH_SIZE):
+            encodings = tokenizer.encode_batch(
+                texts[start : start + _ENCODE_BATCH_SIZE]
+            )
+            ids = np.array([e.ids for e in encodings], dtype=np.int64)
+            mask = np.array([e.attention_mask for e in encodings], dtype=np.int64)
 
-        feeds = {"input_ids": ids, "attention_mask": mask}
-        if "token_type_ids" in input_names:
-            feeds["token_type_ids"] = np.zeros_like(ids)
+            feeds = {"input_ids": ids, "attention_mask": mask}
+            if "token_type_ids" in input_names:
+                feeds["token_type_ids"] = np.zeros_like(ids)
 
-        hidden = session.run(None, feeds)[0]
-        # Attention-masked mean pooling, matching 1_Pooling/config.json.
-        weights = mask[..., None].astype(np.float32)
-        pooled = (hidden * weights).sum(axis=1) / np.clip(
-            weights.sum(axis=1), 1e-9, None
-        )
-        # LanceDB's SentenceTransformerEmbeddings defaults to normalize=True and
-        # the sentence-transformers backend does not override it, so every
-        # vector already in a store is L2-normalized. Skipping this would leave
-        # old and new rows on different scales and skew distance ranking.
-        norms = np.linalg.norm(pooled, axis=1, keepdims=True)
-        pooled = pooled / np.clip(norms, 1e-12, None)
-        return list(pooled.astype(np.float32))
+            hidden = session.run(None, feeds)[0]
+            # Attention-masked mean pooling, matching 1_Pooling/config.json.
+            weights = mask[..., None].astype(np.float32)
+            pooled = (hidden * weights).sum(axis=1) / np.clip(
+                weights.sum(axis=1), 1e-9, None
+            )
+            # LanceDB's SentenceTransformerEmbeddings defaults to normalize=True
+            # and the sentence-transformers backend does not override it, so
+            # every vector already in a store is L2-normalized. Skipping this
+            # would leave old and new rows on different scales and skew
+            # distance ranking.
+            norms = np.linalg.norm(pooled, axis=1, keepdims=True)
+            pooled = pooled / np.clip(norms, 1e-12, None)
+            vectors.extend(pooled.astype(np.float32))
+        return vectors
 
     def compute_source_embeddings(self, texts) -> list:
         """Embed documents for indexing."""

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -1,25 +1,49 @@
 """Embedding function abstraction for Wren Memory.
 
-The sentence-transformer loads from the local HF cache before falling back to
-an online-capable load. Model construction is single-flighted per process.
+Two interchangeable backends produce the same vectors:
+
+- ``sentence-transformers`` — the original backend, via the ``memory`` extra.
+- ``onnx`` — torch-free, via the ``memory-onnx`` extra. Runs the *same*
+  weights through onnxruntime, reproducing the sentence-transformers pipeline
+  (tokenize, encode, attention-masked mean pooling) so existing LanceDB
+  tables stay valid.
+
+``WREN_EMBEDDING_BACKEND=onnx|sentence-transformers`` forces a choice;
+otherwise onnx is preferred when importable. Either backend loads from the
+local HF cache before falling back to an online-capable load, and model
+construction is single-flighted per process.
 """
 
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import threading
+from importlib.util import find_spec
+from pathlib import Path
 
 _DEFAULT_MODEL = os.getenv(
     "WREN_EMBEDDING_MODEL", "paraphrase-multilingual-MiniLM-L12-v2"
 )
 _DEFAULT_DIM = 384
+_DEFAULT_MAX_SEQ_LENGTH = 128
+
+ONNX_BACKEND = "onnx"
+SENTENCE_TRANSFORMERS_BACKEND = "sentence-transformers"
 
 
 def _disable_transformers_progress_bar() -> None:
     # Imported lazily: transformers ships with the optional `memory` extra,
     # so this module must stay importable when that extra is not installed.
-    from transformers.utils import logging as transformers_logging  # noqa: PLC0415
+    # The onnx backend does not depend on transformers at all, and this call
+    # only silences a progress bar, so its absence is not an error.
+    try:
+        from transformers.utils import (  # noqa: PLC0415
+            logging as transformers_logging,
+        )
+    except ImportError:
+        return
 
     transformers_logging.disable_progress_bar()
 
@@ -28,6 +52,8 @@ _local_first_embedding_cls = None
 _local_first_embedding_cls_lock = threading.Lock()
 _model_cache_lock = threading.Lock()
 _model_cache: tuple[tuple[str, str, bool], object] | None = None
+_onnx_runtime_cache_lock = threading.Lock()
+_onnx_runtime_cache: tuple[tuple[str, str], tuple] | None = None
 
 
 def _get_local_first_embedding_class():
@@ -74,14 +100,194 @@ def _get_local_first_embedding_class():
         return _local_first_embedding_cls
 
 
+def _onnx_available() -> bool:
+    return bool(find_spec("onnxruntime")) and bool(find_spec("tokenizers"))
+
+
+def _sentence_transformers_available() -> bool:
+    return bool(find_spec("sentence_transformers"))
+
+
+def embedding_backend_available() -> bool:
+    """True when at least one embedding backend is importable."""
+    return _onnx_available() or _sentence_transformers_available()
+
+
+def resolve_embedding_backend(env: str | None = None) -> str:
+    """Return the embedding backend that will actually be used.
+
+    Honors an explicit ``WREN_EMBEDDING_BACKEND=onnx|sentence-transformers``
+    (or *env*), else auto-detects. A requested backend whose extra is missing
+    falls back to the other one rather than failing: both produce the same
+    vectors, so the fallback is invisible to an existing store.
+    """
+    choice = (
+        (env if env is not None else os.environ.get("WREN_EMBEDDING_BACKEND", ""))
+        .strip()
+        .lower()
+    )
+    if choice == SENTENCE_TRANSFORMERS_BACKEND and _sentence_transformers_available():
+        return SENTENCE_TRANSFORMERS_BACKEND
+    if choice == ONNX_BACKEND and _onnx_available():
+        return ONNX_BACKEND
+    # Empty or unrecognized value, or the requested extra is not installed.
+    return ONNX_BACKEND if _onnx_available() else SENTENCE_TRANSFORMERS_BACKEND
+
+
+def _resolve_repo_id(model_name: str) -> str:
+    """Expand a bare sentence-transformers model name into its HF repo id."""
+    return model_name if "/" in model_name else f"sentence-transformers/{model_name}"
+
+
+def _hf_file(repo_id: str, filename: str) -> str:
+    """Resolve *filename* from the local HF cache, then fall back online.
+
+    Mirrors the local-first loading of the sentence-transformers backend: a
+    cache miss under ``local_files_only`` raises ``LocalEntryNotFoundError``,
+    which is an ``OSError``.
+    """
+    from huggingface_hub import hf_hub_download  # noqa: PLC0415
+
+    try:
+        return hf_hub_download(repo_id, filename, local_files_only=True)
+    except OSError:
+        return hf_hub_download(repo_id, filename)
+
+
+def _read_json(repo_id: str, filename: str) -> dict | None:
+    """Read a small JSON config from the model repo, or None when absent."""
+    try:
+        return json.loads(Path(_hf_file(repo_id, filename)).read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def _max_seq_length(repo_id: str) -> int:
+    config = _read_json(repo_id, "sentence_bert_config.json") or {}
+    value = config.get("max_seq_length")
+    return value if isinstance(value, int) and value > 0 else _DEFAULT_MAX_SEQ_LENGTH
+
+
+def _require_mean_pooling(repo_id: str) -> None:
+    """Reject models this backend would silently embed the wrong way.
+
+    Only mean pooling is implemented here. A CLS- or max-pooled model would
+    still produce a 384-vector, so without this check it would be indexed
+    with quietly wrong vectors instead of failing.
+    """
+    config = _read_json(repo_id, "1_Pooling/config.json")
+    if config is None or config.get("pooling_mode_mean_tokens"):
+        return
+    active = sorted(
+        key.removeprefix("pooling_mode_")
+        for key, value in config.items()
+        if key.startswith("pooling_mode_") and value
+    )
+    raise ValueError(
+        f"The onnx embedding backend implements mean pooling, but '{repo_id}' "
+        f"pools with {active or ['an unrecognized mode']}. Set "
+        "WREN_EMBEDDING_BACKEND=sentence-transformers to use this model."
+    )
+
+
+class OnnxEmbeddings:
+    """Torch-free embedding function backed by onnxruntime.
+
+    Reproduces the sentence-transformers pipeline for mean-pooling models:
+    tokenize to the model's ``max_seq_length``, run the encoder, then average
+    the token vectors under the attention mask. The weights are the ONNX
+    export published in the same HF repo as the torch weights, so vectors
+    match the sentence-transformers backend to float32 rounding and existing
+    LanceDB tables stay valid.
+
+    Implements the ``compute_source_embeddings`` / ``compute_query_embeddings``
+    pair that :class:`~wren.memory.store.MemoryStore` calls.
+    """
+
+    def __init__(self, name: str = _DEFAULT_MODEL):
+        self.name = name
+        self._repo_id = _resolve_repo_id(name)
+
+    @classmethod
+    def create(cls, name: str = _DEFAULT_MODEL, **_kwargs) -> OnnxEmbeddings:
+        """Match the ``create`` factory of the sentence-transformers adapter."""
+        return cls(name)
+
+    def _runtime(self):
+        """Build the tokenizer and session once, single-flighted per process."""
+        global _onnx_runtime_cache
+        onnx_file = os.getenv("WREN_ONNX_MODEL_FILE", "onnx/model.onnx")
+        key = (self._repo_id, onnx_file)
+
+        with _onnx_runtime_cache_lock:
+            if _onnx_runtime_cache is not None and _onnx_runtime_cache[0] == key:
+                return _onnx_runtime_cache[1]
+
+            import onnxruntime  # noqa: PLC0415
+            from tokenizers import Tokenizer  # noqa: PLC0415
+
+            _require_mean_pooling(self._repo_id)
+
+            tokenizer = Tokenizer.from_file(_hf_file(self._repo_id, "tokenizer.json"))
+            tokenizer.enable_truncation(max_length=_max_seq_length(self._repo_id))
+            tokenizer.enable_padding()
+
+            session = onnxruntime.InferenceSession(
+                _hf_file(self._repo_id, onnx_file),
+                providers=["CPUExecutionProvider"],
+            )
+            runtime = (session, tokenizer, {i.name for i in session.get_inputs()})
+            _onnx_runtime_cache = (key, runtime)
+            return runtime
+
+    def _encode(self, texts: list[str]) -> list:
+        import numpy as np  # noqa: PLC0415
+
+        if not texts:
+            return []
+
+        session, tokenizer, input_names = self._runtime()
+        encodings = tokenizer.encode_batch(texts)
+        ids = np.array([e.ids for e in encodings], dtype=np.int64)
+        mask = np.array([e.attention_mask for e in encodings], dtype=np.int64)
+
+        feeds = {"input_ids": ids, "attention_mask": mask}
+        if "token_type_ids" in input_names:
+            feeds["token_type_ids"] = np.zeros_like(ids)
+
+        hidden = session.run(None, feeds)[0]
+        # Attention-masked mean pooling, matching 1_Pooling/config.json.
+        weights = mask[..., None].astype(np.float32)
+        pooled = (hidden * weights).sum(axis=1) / np.clip(
+            weights.sum(axis=1), 1e-9, None
+        )
+        # LanceDB's SentenceTransformerEmbeddings defaults to normalize=True and
+        # the sentence-transformers backend does not override it, so every
+        # vector already in a store is L2-normalized. Skipping this would leave
+        # old and new rows on different scales and skew distance ranking.
+        norms = np.linalg.norm(pooled, axis=1, keepdims=True)
+        pooled = pooled / np.clip(norms, 1e-12, None)
+        return list(pooled.astype(np.float32))
+
+    def compute_source_embeddings(self, texts) -> list:
+        return self._encode(list(texts))
+
+    def compute_query_embeddings(self, query) -> list:
+        return self._encode([query] if isinstance(query, str) else list(query))
+
+
 def get_embedding_function(model_name: str = _DEFAULT_MODEL):
-    """Return a LanceDB sentence-transformers embedding function.
+    """Return the embedding function for the resolved backend.
 
     The returned object implements ``compute_source_embeddings(texts)``
-    and ``compute_query_embeddings(query)`` used by :class:`MemoryStore`.
+    and ``compute_query_embeddings(query)`` used by :class:`MemoryStore`,
+    and both backends emit the same vectors for a given model.
 
     The adapter is instantiated directly, without mutating LanceDB's registry.
     """
+    if resolve_embedding_backend() == ONNX_BACKEND:
+        return OnnxEmbeddings.create(name=model_name)
+
     _disable_transformers_progress_bar()
 
     local_first_cls = _get_local_first_embedding_class()

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -72,6 +72,7 @@ def _get_local_first_embedding_class():
             """Sentence-transformers embedding function with local-first loading."""
 
             def get_embedding_model(self):
+                """Load from the HF cache first, then fall back online."""
                 global _model_cache
                 key = (self.name, self.device, self.trust_remote_code)
 
@@ -102,10 +103,12 @@ def _get_local_first_embedding_class():
 
 
 def _onnx_available() -> bool:
+    """True when the ``memory-onnx`` extra is importable."""
     return bool(find_spec("onnxruntime")) and bool(find_spec("tokenizers"))
 
 
 def _sentence_transformers_available() -> bool:
+    """True when the ``memory`` extra is importable."""
     return bool(find_spec("sentence_transformers"))
 
 
@@ -176,6 +179,7 @@ def _read_json(repo_id: str, filename: str) -> dict | None:
 
 
 def _max_seq_length(repo_id: str) -> int:
+    """Read the model's truncation length, falling back to the ST default."""
     config = _read_json(repo_id, "sentence_bert_config.json") or {}
     value = config.get("max_seq_length")
     return value if isinstance(value, int) and value > 0 else _DEFAULT_MAX_SEQ_LENGTH
@@ -218,6 +222,7 @@ class OnnxEmbeddings:
     """
 
     def __init__(self, name: str = _DEFAULT_MODEL):
+        """Record the model name; the session is built lazily on first encode."""
         self.name = name
         self._repo_id = _resolve_repo_id(name)
 
@@ -254,6 +259,7 @@ class OnnxEmbeddings:
             return runtime
 
     def _encode(self, texts: list[str]) -> list:
+        """Tokenize, run the encoder, mean-pool under the mask, L2 normalize."""
         import numpy as np  # noqa: PLC0415
 
         if not texts:
@@ -283,9 +289,11 @@ class OnnxEmbeddings:
         return list(pooled.astype(np.float32))
 
     def compute_source_embeddings(self, texts) -> list:
+        """Embed documents for indexing."""
         return self._encode(list(texts))
 
     def compute_query_embeddings(self, query) -> list:
+        """Embed one query string, or a batch of them."""
         return self._encode([query] if isinstance(query, str) else list(query))
 
 

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import threading
 from importlib.util import find_spec
@@ -130,8 +131,20 @@ def resolve_embedding_backend(env: str | None = None) -> str:
         return SENTENCE_TRANSFORMERS_BACKEND
     if choice == ONNX_BACKEND and _onnx_available():
         return ONNX_BACKEND
-    # Empty or unrecognized value, or the requested extra is not installed.
-    return ONNX_BACKEND if _onnx_available() else SENTENCE_TRANSFORMERS_BACKEND
+
+    resolved = ONNX_BACKEND if _onnx_available() else SENTENCE_TRANSFORMERS_BACKEND
+    if choice in (ONNX_BACKEND, SENTENCE_TRANSFORMERS_BACKEND):
+        # Falling back keeps the process running, but someone who asked for
+        # onnx specifically to avoid torch should not have to infer from a
+        # slow cold start that they did not get it.
+        logging.getLogger(__name__).warning(
+            "WREN_EMBEDDING_BACKEND=%s was requested but its extra is not "
+            "installed; using %s instead. Install wren[%s] to get it.",
+            choice,
+            resolved,
+            "memory-onnx" if choice == ONNX_BACKEND else "memory",
+        )
+    return resolved
 
 
 def _resolve_repo_id(model_name: str) -> str:

--- a/core/wren/src/wren/memory/embeddings.py
+++ b/core/wren/src/wren/memory/embeddings.py
@@ -37,11 +37,22 @@ ONNX_BACKEND = "onnx"
 SENTENCE_TRANSFORMERS_BACKEND = "sentence-transformers"
 
 
-class UnsupportedPoolingError(RuntimeError):
-    """The onnx backend cannot reproduce this model's pooling mode.
+class OnnxBackendError(RuntimeError):
+    """The onnx backend cannot serve the configured model.
 
-    Not a ``ValueError``: the CLI reports those as a malformed manifest.
+    Deliberately not a ``ValueError``: the CLI reports those as a malformed
+    manifest, and none of these are a manifest problem. Every subclass names
+    ``WREN_EMBEDDING_BACKEND=sentence-transformers`` in its message, because
+    that is the way out of all of them.
     """
+
+
+class UnsupportedPoolingError(OnnxBackendError):
+    """The onnx backend cannot reproduce this model's pooling mode."""
+
+
+class MissingOnnxExportError(OnnxBackendError):
+    """The model repo does not publish the ONNX graph this backend needs."""
 
 
 def _disable_transformers_progress_bar() -> None:
@@ -181,18 +192,49 @@ def _hf_file(repo_id: str, filename: str) -> str:
 
 
 def _read_json(repo_id: str, filename: str) -> dict | None:
-    """Read a small JSON config from the model repo, or None when absent."""
+    """Read a small JSON config from the model repo, or None when absent.
+
+    A corrupt file is not treated as absent. ``_require_mean_pooling`` reads
+    "absent" as "assume mean pooling", so swallowing the error there would
+    wave a CLS-pooled model through with quietly wrong vectors -- and
+    ``json.JSONDecodeError`` is a ``ValueError``, so letting it escape would
+    put it behind the CLI's "Malformed manifest:" instead.
+    """
     try:
-        return json.loads(Path(_hf_file(repo_id, filename)).read_text(encoding="utf-8"))
+        path = _hf_file(repo_id, filename)
     except OSError:
         return None
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise OnnxBackendError(
+            f"'{filename}' for '{repo_id}' could not be read: {e}. The cached "
+            f"copy at {path} looks corrupt; delete it to refetch, or set "
+            "WREN_EMBEDDING_BACKEND=sentence-transformers."
+        ) from e
 
 
 def _max_seq_length(repo_id: str) -> int:
-    """Read the model's truncation length, falling back to the ST default."""
+    """Read the model's truncation length, falling back to the ST default.
+
+    ONNX-native mirrors publish ``onnx/model.onnx`` but no
+    ``sentence_bert_config.json``, so the default is what an onnx user
+    typically gets. It is correct for the 128-length models, but a 512-length
+    model would truncate here with no other signal, hence the log line. Note
+    ``config.json``'s ``max_position_embeddings`` is *not* a usable fallback:
+    the default model reports 512 there against a real length of 128, so
+    reading it would diverge from the sentence-transformers backend.
+    """
     config = _read_json(repo_id, "sentence_bert_config.json") or {}
     value = config.get("max_seq_length")
-    return value if isinstance(value, int) and value > 0 else _DEFAULT_MAX_SEQ_LENGTH
+    if isinstance(value, int) and value > 0:
+        return value
+    logging.getLogger(__name__).debug(
+        "'%s' declares no max_seq_length; truncating at the default of %d.",
+        repo_id,
+        _DEFAULT_MAX_SEQ_LENGTH,
+    )
+    return _DEFAULT_MAX_SEQ_LENGTH
 
 
 def _require_mean_pooling(repo_id: str) -> None:
@@ -260,8 +302,25 @@ class OnnxEmbeddings:
             tokenizer.enable_truncation(max_length=_max_seq_length(self._repo_id))
             tokenizer.enable_padding()
 
+            try:
+                onnx_path = _hf_file(self._repo_id, onnx_file)
+            except OSError as e:
+                # onnx is selected on importability alone, so a
+                # WREN_EMBEDDING_MODEL that works under sentence-transformers
+                # reaches this. Not falling back: a network blip and a repo
+                # with no export both arrive as OSError, and quietly loading
+                # torch on a bad connection is the outcome this extra exists
+                # to avoid. Name the override and let the caller choose.
+                raise MissingOnnxExportError(
+                    f"'{onnx_file}' could not be fetched for '{self._repo_id}': "
+                    f"{e}. The onnx embedding backend needs a repo that "
+                    "publishes an ONNX export. Set "
+                    "WREN_EMBEDDING_BACKEND=sentence-transformers to use this "
+                    "model, or point WREN_ONNX_MODEL_FILE at the right path."
+                ) from e
+
             session = onnxruntime.InferenceSession(
-                _hf_file(self._repo_id, onnx_file),
+                onnx_path,
                 providers=["CPUExecutionProvider"],
             )
             runtime = (session, tokenizer, {i.name for i in session.get_inputs()})

--- a/core/wren/src/wren/memory/index_backend.py
+++ b/core/wren/src/wren/memory/index_backend.py
@@ -6,7 +6,8 @@ over them:
 - ``GrepIndex`` — dependency-free token/substring search. The default when the
   ``memory`` extra is absent; ``knowledge/sql/`` *is* the index (nothing to build).
 - ``LanceDBIndex`` — semantic search via the ``memory`` extra (lancedb +
-  sentence-transformers), with LanceDB as a derived index.
+  sentence-transformers) or ``memory-onnx`` (lancedb + onnxruntime), with
+  LanceDB as a derived index.
 
 Backend selection: ``WREN_MEMORY_BACKEND=grep|lancedb`` forces a choice;
 otherwise LanceDB is used when its extra is importable, else Grep.
@@ -141,7 +142,14 @@ class LanceDBIndex(MemoryIndex):
 
 
 def _extra_available() -> bool:
-    return bool(find_spec("lancedb")) and bool(find_spec("sentence_transformers"))
+    """True when LanceDB and some embedding backend are both importable.
+
+    Either embedding extra qualifies — pinning this to sentence-transformers
+    would silently downgrade a ``memory-onnx`` install to Grep.
+    """
+    from wren.memory.embeddings import embedding_backend_available  # noqa: PLC0415
+
+    return bool(find_spec("lancedb")) and embedding_backend_available()
 
 
 def resolve_backend(env: str | None = None) -> str:

--- a/core/wren/src/wren/memory/store.py
+++ b/core/wren/src/wren/memory/store.py
@@ -12,6 +12,7 @@ from wren.memory.embeddings import (
     _DEFAULT_DIM,
     _DEFAULT_MODEL,
     get_embedding_function,
+    resolve_embedding_backend,
     warm_up,
 )
 from wren.memory.schema_indexer import (
@@ -627,8 +628,18 @@ class MemoryStore:
     # ── Housekeeping ──────────────────────────────────────────────────────
 
     def status(self) -> dict:
-        """Return index statistics."""
-        info: dict = {"path": str(self._path), "tables": {}}
+        """Return index statistics, including which embedding backend is live.
+
+        Reported from ``resolve_embedding_backend()`` rather than from a
+        constructed model, so asking for status never loads one. It is the
+        same resolution the store itself would use on its next embed.
+        """
+        info: dict = {
+            "path": str(self._path),
+            "embedding_backend": resolve_embedding_backend(),
+            "model": self._model_name,
+            "tables": {},
+        }
         for name in _table_names(self._db):
             table = self._db.open_table(name)
             info["tables"][name] = table.count_rows()

--- a/core/wren/tests/unit/test_index_backend.py
+++ b/core/wren/tests/unit/test_index_backend.py
@@ -97,6 +97,42 @@ def test_cli_index_grep_is_noop(tmp_path, monkeypatch):
     assert "2 pair(s)" in result.output
 
 
+def test_cli_status_names_the_embedding_backend(tmp_path, monkeypatch):
+    # The rendering, not the resolution: a store carrying an onnx install has
+    # to say so, otherwise the only signal that torch was avoided is a
+    # directory listing.
+    class _FakeIndex:
+        def status(self):
+            return {
+                "backend": "lancedb",
+                "embedding_backend": "onnx",
+                "model": "paraphrase-multilingual-MiniLM-L12-v2",
+                "tables": {"schema_items": 11},
+            }
+
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "wren.memory.index_backend.get_index", lambda *a, **k: _FakeIndex()
+    )
+
+    result = runner.invoke(app, ["memory", "status"])
+    assert result.exit_code == 0, result.output
+    assert "Backend: lancedb" in result.output
+    assert "embeddings: onnx (paraphrase-multilingual-MiniLM-L12-v2)" in result.output
+
+
+def test_cli_status_omits_embeddings_for_grep(tmp_path, monkeypatch):
+    # The grep backend embeds nothing, so naming a backend there would be a
+    # claim about a model that was never loaded.
+    monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+    monkeypatch.setenv("WREN_MEMORY_BACKEND", "grep")
+    _seed(tmp_path)
+
+    result = runner.invoke(app, ["memory", "status"])
+    assert result.exit_code == 0, result.output
+    assert "embeddings:" not in result.output
+
+
 def test_cli_status_and_reset_and_check_grep(tmp_path, monkeypatch):
     monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
     monkeypatch.setenv("WREN_MEMORY_BACKEND", "grep")

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1612,6 +1612,26 @@ class TestEmbeddingBackendResolution:
         )
         assert chosen == "onnx"
 
+    def test_unhonored_request_warns(self, monkeypatch, caplog):
+        # Someone who sets onnx specifically to avoid torch should not have to
+        # infer from a slow cold start that the fallback kicked in.
+        with caplog.at_level("WARNING"):
+            chosen = self._resolve(monkeypatch, onnx=False, st=True, env="onnx")
+        assert chosen == "sentence-transformers"
+        assert "memory-onnx" in caplog.text
+
+    def test_honored_request_does_not_warn(self, monkeypatch, caplog):
+        with caplog.at_level("WARNING"):
+            self._resolve(monkeypatch, onnx=True, st=True, env="onnx")
+        assert caplog.text == ""
+
+    def test_unrecognized_value_does_not_warn(self, monkeypatch, caplog):
+        # Only a request for a real backend that could not be honored is worth
+        # a warning; an empty or bogus value just means "auto-detect".
+        with caplog.at_level("WARNING"):
+            self._resolve(monkeypatch, onnx=False, st=True, env="nonsense")
+        assert caplog.text == ""
+
     def test_unrecognized_value_auto_detects(self, monkeypatch):
         chosen = self._resolve(monkeypatch, onnx=False, st=True, env="nonsense")
         assert chosen == "sentence-transformers"

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1850,23 +1850,15 @@ class TestOnnxEmbeddings:
         assert issubclass(embeddings.OnnxBackendError, RuntimeError)
         assert not issubclass(embeddings.OnnxBackendError, ValueError)
 
-    def test_a_repo_without_an_onnx_export_names_the_way_out(self, monkeypatch):
-        # onnx is chosen on importability alone, so a WREN_EMBEDDING_MODEL that
-        # worked under sentence-transformers can land here. Surfacing the raw
-        # 404 as a traceback would make a working config look broken.
-        # _runtime imports onnxruntime before it reaches the stubbed _hf_file,
-        # and this is the only test here that enters the real _runtime -- so it
-        # needs the gate TestOnnxVectorParity uses. The `memory` job installs
-        # sentence-transformers only.
-        pytest.importorskip("onnxruntime", reason="wren[memory-onnx] not installed")
-
+    def _runtime_with_hf_error(self, monkeypatch, error):
+        """Drive _runtime to the ONNX-graph fetch, which raises *error*."""
         import tokenizers  # noqa: PLC0415
 
         from wren.memory import embeddings  # noqa: PLC0415
 
-        def _missing(_repo, filename):
+        def _fetch(_repo, filename):
             if filename.endswith(".onnx"):
-                raise OSError("404 Client Error")
+                raise error
             return "/dev/null"
 
         # The tokenizer loads first -- _runtime does the cheap checks before
@@ -1875,14 +1867,57 @@ class TestOnnxEmbeddings:
         monkeypatch.setattr(
             tokenizers.Tokenizer, "from_file", staticmethod(lambda _p: _StubTokenizer())
         )
-        monkeypatch.setattr(embeddings, "_hf_file", _missing)
+        monkeypatch.setattr(embeddings, "_hf_file", _fetch)
         monkeypatch.setattr(embeddings, "_require_mean_pooling", lambda _repo: None)
         monkeypatch.setattr(embeddings, "_max_seq_length", lambda _repo: 128)
         monkeypatch.setattr(embeddings, "_onnx_runtime_cache", None)
+        return embeddings
+
+    def test_a_repo_without_an_onnx_export_names_the_way_out(self, monkeypatch):
+        # onnx is chosen on importability alone, so a WREN_EMBEDDING_MODEL that
+        # worked under sentence-transformers can land here. Surfacing the raw
+        # 404 as a traceback would make a working config look broken.
+        pytest.importorskip("onnxruntime", reason="wren[memory-onnx] not installed")
+
+        remote_404, _ = self._hf_errors()
+        embeddings = self._runtime_with_hf_error(monkeypatch, remote_404)
 
         with pytest.raises(embeddings.MissingOnnxExportError) as excinfo:
             embeddings.OnnxEmbeddings("acme/no-onnx")._runtime()
         assert "WREN_EMBEDDING_BACKEND=sentence-transformers" in str(excinfo.value)
+
+    def test_an_unreachable_hub_is_not_called_a_missing_export(self, monkeypatch):
+        # Same conflation _read_json no longer makes: a rate limit or a dropped
+        # connection would tell the user that a repo which does publish an ONNX
+        # export does not, and point them at the wrong remedy.
+        pytest.importorskip("onnxruntime", reason="wren[memory-onnx] not installed")
+
+        _, offline = self._hf_errors()
+        embeddings = self._runtime_with_hf_error(monkeypatch, offline)
+
+        with pytest.raises(embeddings.OnnxBackendError) as excinfo:
+            embeddings.OnnxEmbeddings("acme/cached-elsewhere")._runtime()
+        assert not isinstance(excinfo.value, embeddings.MissingOnnxExportError)
+        assert "retry" in str(excinfo.value).lower()
+
+    def test_the_declared_hub_floor_is_where_the_error_classes_live(self):
+        # _read_json and _runtime import these inside an `except OSError`
+        # handler, so on a version where they are absent the ImportError
+        # replaces the error being classified. They moved into
+        # huggingface_hub.errors in 0.25; before that they are in
+        # huggingface_hub.utils._errors and this import raises. No CI job can
+        # reach that -- the lock pins 1.8 -- but `pip install
+        # 'wrenai[memory-onnx]'` into an env holding an older hub can.
+        import tomllib  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        extras = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"][
+            "optional-dependencies"
+        ]
+        (pin,) = [d for d in extras["memory-onnx"] if d.startswith("huggingface-hub")]
+        floor = tuple(int(part) for part in pin.split(">=")[1].split("."))
+        assert floor >= (0, 25), pin
 
     def test_corrupt_pooling_config_is_not_reported_as_a_bad_manifest(
         self, monkeypatch, tmp_path

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1766,7 +1766,7 @@ class TestOnnxEmbeddings:
                 "pooling_mode_cls_token": True,
             },
         )
-        with pytest.raises(ValueError, match="mean pooling"):
+        with pytest.raises(embeddings.UnsupportedPoolingError, match="mean pooling"):
             embeddings._require_mean_pooling("some/model")
 
     def test_bare_model_name_expands_to_the_sentence_transformers_repo(self):

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1854,6 +1854,12 @@ class TestOnnxEmbeddings:
         # onnx is chosen on importability alone, so a WREN_EMBEDDING_MODEL that
         # worked under sentence-transformers can land here. Surfacing the raw
         # 404 as a traceback would make a working config look broken.
+        # _runtime imports onnxruntime before it reaches the stubbed _hf_file,
+        # and this is the only test here that enters the real _runtime -- so it
+        # needs the gate TestOnnxVectorParity uses. The `memory` job installs
+        # sentence-transformers only.
+        pytest.importorskip("onnxruntime", reason="wren[memory-onnx] not installed")
+
         import tokenizers  # noqa: PLC0415
 
         from wren.memory import embeddings  # noqa: PLC0415

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -478,18 +478,28 @@ def _make_fake_model_class(calls: list, raise_on=None):
 
 @pytest.mark.unit
 class TestLocalFirstEmbeddings:
-    def _adapter(self, name: str):
+    @pytest.fixture(autouse=True)
+    def _require_sentence_transformers(self):
+        # Must run before the test body: these tests monkeypatch
+        # "sentence_transformers.SentenceTransformer" by string, which imports
+        # the module, so an importorskip inside _adapter comes too late under
+        # the memory-onnx extra.
         pytest.importorskip(
             "sentence_transformers", reason="wren[memory] extras not installed"
         )
-        from wren.memory.embeddings import get_embedding_function  # noqa: PLC0415
+
+    def _adapter(self, name: str):
+        from wren.memory.embeddings import (  # noqa: PLC0415
+            _get_local_first_embedding_class,
+        )
 
         # The adapter class is built function-locally (no top-level lancedb
-        # import); get_embedding_function is the public factory that returns
-        # an instance of it. The constructed model is cached module-wide,
-        # keyed by (name, device, trust_remote_code), so each test must use
-        # a distinct *name* — otherwise two tests would share one cache slot.
-        return get_embedding_function(model_name=name)
+        # import). Build it directly rather than through
+        # get_embedding_function, which dispatches to onnx when both extras
+        # are installed. The constructed model is cached module-wide, keyed by
+        # (name, device, trust_remote_code), so each test must use a distinct
+        # *name* — otherwise two tests would share one cache slot.
+        return _get_local_first_embedding_class().create(name=name)
 
     def test_first_construction_is_local_files_only(self, monkeypatch):
         calls: list[dict] = []
@@ -617,10 +627,11 @@ class TestLocalFirstEmbeddingsConcurrency:
                 return np.zeros((len(texts), 3), dtype="float32")
 
         monkeypatch.setattr("sentence_transformers.SentenceTransformer", _FakeModel)
-        adapters = [
-            embeddings_module.get_embedding_function(model_name="concurrent-model")
-            for _ in range(5)
-        ]
+        # Build the adapter directly: get_embedding_function dispatches to onnx
+        # when both extras are installed, and this test is about the
+        # sentence-transformers single-flight cache.
+        adapter_cls = embeddings_module._get_local_first_embedding_class()
+        adapters = [adapter_cls.create(name="concurrent-model") for _ in range(5)]
 
         def _compute(adapter):
             barrier.wait()
@@ -640,13 +651,23 @@ class TestLocalFirstEmbeddingsConcurrency:
 # These require lancedb + sentence-transformers (wren[memory] extra).
 
 
+def _require_memory_extra() -> None:
+    """Skip unless LanceDB and some embedding backend are importable.
+
+    Gating on sentence-transformers specifically would skip this whole suite
+    under the memory-onnx extra, where running it is the point.
+    """
+    pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
+    from wren.memory.embeddings import embedding_backend_available  # noqa: PLC0415
+
+    if not embedding_backend_available():
+        pytest.skip("no embedding backend: install wren[memory] or wren[memory-onnx]")
+
+
 @pytest.fixture
 def memory_store(tmp_path):
     """Create a MemoryStore backed by a temp directory."""
-    pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
-    pytest.importorskip(
-        "sentence_transformers", reason="wren[memory] extras not installed"
-    )
+    _require_memory_extra()
 
     from wren.memory.store import MemoryStore  # noqa: PLC0415
 
@@ -989,10 +1010,7 @@ class TestMemoryStoreLazyModelLoad:
 @pytest.fixture
 def wren_memory(tmp_path):
     """Create a WrenMemory instance backed by a temp directory."""
-    pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
-    pytest.importorskip(
-        "sentence_transformers", reason="wren[memory] extras not installed"
-    )
+    _require_memory_extra()
 
     from wren.memory import WrenMemory  # noqa: PLC0415
 
@@ -1498,10 +1516,7 @@ class TestMarkdownSourcedIndex:
 
     def test_lancedb_backend_via_get_index(self, tmp_path, monkeypatch):
         """With the extra, get_index resolves to LanceDBIndex and recalls semantically."""
-        pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
-        pytest.importorskip(
-            "sentence_transformers", reason="wren[memory] extras not installed"
-        )
+        _require_memory_extra()
         monkeypatch.setenv("WREN_MEMORY_BACKEND", "lancedb")
         from wren.memory.index_backend import get_index  # noqa: PLC0415
         from wren.memory.markdown import write_query_markdown  # noqa: PLC0415
@@ -1515,10 +1530,7 @@ class TestMarkdownSourcedIndex:
 
     def test_cli_export_migrates_query_history_to_markdown(self, tmp_path, monkeypatch):
         """`wren memory export` writes existing LanceDB pairs to knowledge/sql/."""
-        pytest.importorskip("lancedb", reason="wren[memory] extras not installed")
-        pytest.importorskip(
-            "sentence_transformers", reason="wren[memory] extras not installed"
-        )
+        _require_memory_extra()
         from typer.testing import CliRunner  # noqa: PLC0415
 
         from wren.cli import app  # noqa: PLC0415
@@ -1543,3 +1555,256 @@ class TestMarkdownSourcedIndex:
         fm = parse_query_markdown(user_md)
         assert fm["source"] == "user"
         assert "created_at" in fm  # timestamp preserved
+
+
+# ── ONNX embedding backend ────────────────────────────────────────────────
+
+
+class _FakeEncoding:
+    def __init__(self, ids: list[int], attention_mask: list[int]):
+        self.ids = ids
+        self.attention_mask = attention_mask
+
+
+class _FakeTokenizer:
+    def __init__(self, encodings: list[_FakeEncoding]):
+        self._encodings = encodings
+
+    def encode_batch(self, texts):
+        return self._encodings[: len(texts)]
+
+
+class _FakeSession:
+    """Returns a canned last_hidden_state and records the feeds it got."""
+
+    def __init__(self, hidden):
+        self._hidden = hidden
+        self.feeds: dict | None = None
+
+    def run(self, _outputs, feeds):
+        self.feeds = feeds
+        return [self._hidden]
+
+
+@pytest.mark.unit
+class TestEmbeddingBackendResolution:
+    def _resolve(self, monkeypatch, *, onnx: bool, st: bool, env: str | None = None):
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        monkeypatch.setattr(embeddings, "_onnx_available", lambda: onnx)
+        monkeypatch.setattr(embeddings, "_sentence_transformers_available", lambda: st)
+        return embeddings.resolve_embedding_backend(env)
+
+    def test_prefers_onnx_when_both_installed(self, monkeypatch):
+        assert self._resolve(monkeypatch, onnx=True, st=True, env="") == "onnx"
+
+    def test_explicit_sentence_transformers_is_honored(self, monkeypatch):
+        chosen = self._resolve(
+            monkeypatch, onnx=True, st=True, env="sentence-transformers"
+        )
+        assert chosen == "sentence-transformers"
+
+    def test_explicit_choice_falls_back_when_extra_missing(self, monkeypatch):
+        # Both backends emit the same vectors, so falling back keeps an
+        # existing store readable instead of failing the process.
+        chosen = self._resolve(
+            monkeypatch, onnx=True, st=False, env="sentence-transformers"
+        )
+        assert chosen == "onnx"
+
+    def test_unrecognized_value_auto_detects(self, monkeypatch):
+        chosen = self._resolve(monkeypatch, onnx=False, st=True, env="nonsense")
+        assert chosen == "sentence-transformers"
+
+    def test_availability_helper_reports_either_backend(self, monkeypatch):
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        monkeypatch.setattr(embeddings, "_onnx_available", lambda: True)
+        monkeypatch.setattr(
+            embeddings, "_sentence_transformers_available", lambda: False
+        )
+        assert embeddings.embedding_backend_available() is True
+
+
+@pytest.mark.unit
+class TestOnnxEmbeddings:
+    def _embedder(self, monkeypatch, hidden, encodings, input_names):
+        import numpy as np  # noqa: PLC0415
+
+        from wren.memory.embeddings import OnnxEmbeddings  # noqa: PLC0415
+
+        session = _FakeSession(np.array(hidden, dtype="float32"))
+        monkeypatch.setattr(
+            OnnxEmbeddings,
+            "_runtime",
+            lambda _self: (session, _FakeTokenizer(encodings), input_names),
+        )
+        return OnnxEmbeddings("fake-model"), session
+
+    def test_mean_pooling_ignores_padded_positions(self, monkeypatch):
+        import numpy as np  # noqa: PLC0415
+
+        # Row 0 attends to two tokens, row 1 to one. The masked-out vectors
+        # are large on purpose: if they leaked in, the means would not match.
+        embedder, _ = self._embedder(
+            monkeypatch,
+            hidden=[
+                [[1.0, 1.0], [3.0, 3.0], [999.0, 999.0]],
+                [[5.0, 5.0], [777.0, 777.0], [888.0, 888.0]],
+            ],
+            encodings=[
+                _FakeEncoding([1, 2, 0], [1, 1, 0]),
+                _FakeEncoding([3, 0, 0], [1, 0, 0]),
+            ],
+            input_names={"input_ids", "attention_mask"},
+        )
+        vectors = np.array(embedder.compute_source_embeddings(["a", "b"]))
+        # Means are [2, 2] and [5, 5]; output is L2-normalized, so both
+        # collapse onto the same unit vector.
+        unit = 1 / np.sqrt(2)
+        np.testing.assert_allclose(vectors, [[unit, unit], [unit, unit]], atol=1e-6)
+
+    def test_output_is_l2_normalized(self, monkeypatch):
+        import numpy as np  # noqa: PLC0415
+
+        # LanceDB's sentence-transformers adapter defaults to normalize=True,
+        # so vectors already in a store are unit length. Emitting unnormalized
+        # vectors would put old and new rows on different scales.
+        embedder, _ = self._embedder(
+            monkeypatch,
+            hidden=[[[3.0, 4.0]]],
+            encodings=[_FakeEncoding([1], [1])],
+            input_names={"input_ids", "attention_mask"},
+        )
+        vector = np.array(embedder.compute_source_embeddings(["a"])[0])
+        np.testing.assert_allclose(vector, [0.6, 0.8], atol=1e-6)
+        assert np.isclose(np.linalg.norm(vector), 1.0, atol=1e-6)
+
+    def test_token_type_ids_only_sent_when_the_model_declares_it(self, monkeypatch):
+        encodings = [_FakeEncoding([1, 2], [1, 1])]
+        hidden = [[[1.0], [1.0]]]
+
+        embedder, session = self._embedder(
+            monkeypatch, hidden, encodings, {"input_ids", "attention_mask"}
+        )
+        embedder.compute_source_embeddings(["a"])
+        assert "token_type_ids" not in session.feeds
+
+        embedder, session = self._embedder(
+            monkeypatch,
+            hidden,
+            encodings,
+            {"input_ids", "attention_mask", "token_type_ids"},
+        )
+        embedder.compute_source_embeddings(["a"])
+        assert session.feeds["token_type_ids"].tolist() == [[0, 0]]
+
+    def test_query_embeddings_accept_a_bare_string(self, monkeypatch):
+        import numpy as np  # noqa: PLC0415
+
+        embedder, _ = self._embedder(
+            monkeypatch,
+            hidden=[[[3.0, 4.0]]],
+            encodings=[_FakeEncoding([1], [1])],
+            input_names={"input_ids", "attention_mask"},
+        )
+        vectors = embedder.compute_query_embeddings("a")
+        assert len(vectors) == 1
+        np.testing.assert_allclose(np.array(vectors[0]), [0.6, 0.8], atol=1e-6)
+
+    def test_empty_input_short_circuits_before_the_model(self, monkeypatch):
+        from wren.memory.embeddings import OnnxEmbeddings  # noqa: PLC0415
+
+        def _explode(_self):
+            raise AssertionError("the model must not be loaded for empty input")
+
+        monkeypatch.setattr(OnnxEmbeddings, "_runtime", _explode)
+        assert OnnxEmbeddings("fake-model").compute_source_embeddings([]) == []
+
+    def test_non_mean_pooled_model_is_rejected(self, monkeypatch):
+        # A CLS-pooled model still yields a 384-vector, so without this guard
+        # it would be indexed with quietly wrong vectors.
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        monkeypatch.setattr(
+            embeddings,
+            "_read_json",
+            lambda _repo, _name: {
+                "pooling_mode_mean_tokens": False,
+                "pooling_mode_cls_token": True,
+            },
+        )
+        with pytest.raises(ValueError, match="mean pooling"):
+            embeddings._require_mean_pooling("some/model")
+
+    def test_bare_model_name_expands_to_the_sentence_transformers_repo(self):
+        from wren.memory.embeddings import _resolve_repo_id  # noqa: PLC0415
+
+        assert (
+            _resolve_repo_id("paraphrase-multilingual-MiniLM-L12-v2")
+            == "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+        )
+        assert _resolve_repo_id("acme/custom-model") == "acme/custom-model"
+
+
+@pytest.mark.unit
+class TestLanceDBExtraDetection:
+    def test_onnx_only_install_still_selects_lancedb(self, monkeypatch):
+        # Pinning detection to sentence-transformers would silently downgrade
+        # a memory-onnx install to the Grep backend.
+        from wren.memory import embeddings, index_backend  # noqa: PLC0415
+
+        monkeypatch.setattr(index_backend, "find_spec", lambda _name: object())
+        monkeypatch.setattr(embeddings, "_onnx_available", lambda: True)
+        monkeypatch.setattr(
+            embeddings, "_sentence_transformers_available", lambda: False
+        )
+        assert index_backend.resolve_backend("") == "lancedb"
+
+    def test_no_embedding_backend_downgrades_to_grep(self, monkeypatch):
+        from wren.memory import embeddings, index_backend  # noqa: PLC0415
+
+        monkeypatch.setattr(index_backend, "find_spec", lambda _name: object())
+        monkeypatch.setattr(embeddings, "_onnx_available", lambda: False)
+        monkeypatch.setattr(
+            embeddings, "_sentence_transformers_available", lambda: False
+        )
+        assert index_backend.resolve_backend("") == "grep"
+
+
+@pytest.mark.slow
+@pytest.mark.unit
+class TestOnnxVectorParity:
+    def test_onnx_matches_sentence_transformers(self):
+        """Both backends must emit the same vectors for the default model.
+
+        Existing LanceDB tables are typed with a fixed-size 384 vector and
+        hold sentence-transformers output, so a switch to onnx has to be
+        readable without a reindex. Slow lane: downloads both models.
+        """
+        pytest.importorskip("onnxruntime", reason="wren[memory-onnx] not installed")
+        pytest.importorskip(
+            "sentence_transformers", reason="wren[memory] extras not installed"
+        )
+        import numpy as np  # noqa: PLC0415
+
+        from wren.memory.embeddings import (  # noqa: PLC0415
+            _DEFAULT_MODEL,
+            OnnxEmbeddings,
+            _get_local_first_embedding_class,
+        )
+
+        # Build the sentence-transformers adapter directly: going through
+        # get_embedding_function() would dispatch to onnx and compare it
+        # against itself.
+        texts = ["revenue by customer", "台北的營收是多少", "월별 매출 추이"]
+        onnx_vecs = np.array(
+            OnnxEmbeddings(_DEFAULT_MODEL).compute_source_embeddings(texts)
+        )
+        st_vecs = np.array(
+            _get_local_first_embedding_class()
+            .create(name=_DEFAULT_MODEL)
+            .compute_source_embeddings(texts)
+        )
+        assert onnx_vecs.shape == st_vecs.shape == (len(texts), 384)
+        np.testing.assert_allclose(onnx_vecs, st_vecs, atol=1e-5)

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1598,6 +1598,27 @@ class _FakeSession:
         return [self._hidden]
 
 
+class _CountingTokenizer:
+    """Encodes each text as the single token its integer value names."""
+
+    def encode_batch(self, texts):
+        return [_FakeEncoding([int(t)], [1]) for t in texts]
+
+
+class _BatchRecordingSession:
+    """Echoes each row's token id into the hidden state, recording batch sizes."""
+
+    def __init__(self):
+        self.batch_sizes: list[int] = []
+
+    def run(self, _outputs, feeds):
+        import numpy as np  # noqa: PLC0415
+
+        ids = feeds["input_ids"]
+        self.batch_sizes.append(int(ids.shape[0]))
+        return [np.array([[[float(row[0]), 1.0]] for row in ids], dtype="float32")]
+
+
 @pytest.mark.unit
 class TestEmbeddingBackendResolution:
     def _resolve(self, monkeypatch, *, onnx: bool, st: bool, env: str | None = None):
@@ -1743,6 +1764,45 @@ class TestOnnxEmbeddings:
         vectors = embedder.compute_query_embeddings("a")
         assert len(vectors) == 1
         np.testing.assert_allclose(np.array(vectors[0]), [0.6, 0.8], atol=1e-6)
+
+    def _batched_embedder(self, monkeypatch):
+        from wren.memory.embeddings import OnnxEmbeddings  # noqa: PLC0415
+
+        session = _BatchRecordingSession()
+        monkeypatch.setattr(
+            OnnxEmbeddings,
+            "_runtime",
+            lambda _self: (
+                session,
+                _CountingTokenizer(),
+                {"input_ids", "attention_mask"},
+            ),
+        )
+        return OnnxEmbeddings("fake-model"), session
+
+    def test_a_large_batch_is_split_before_it_reaches_the_model(self, monkeypatch):
+        # sentence-transformers' encode() caps at batch_size=32, so an
+        # unchunked run here would make peak memory scale with the manifest on
+        # the onnx path alone -- the same MemoryStore call going O(1) to O(n)
+        # purely by switching backend. extract_schema_items emits a record per
+        # column, so the count tracks total field count, not table count.
+        embedder, session = self._batched_embedder(monkeypatch)
+        embedder.compute_source_embeddings([str(i) for i in range(70)])
+        assert session.batch_sizes == [32, 32, 6]
+
+    def test_chunking_leaves_the_vectors_unchanged(self, monkeypatch):
+        # Mean pooling and L2 normalization are both per-row, so how rows are
+        # grouped cannot move a vector. This is what lets the parity gate keep
+        # covering the backend without adjustment.
+        import numpy as np  # noqa: PLC0415
+
+        texts = [str(i) for i in range(70)]
+        embedder, _ = self._batched_embedder(monkeypatch)
+        chunked = np.array(embedder.compute_source_embeddings(texts))
+        one_at_a_time = np.array(
+            [embedder.compute_source_embeddings([t])[0] for t in texts]
+        )
+        np.testing.assert_array_equal(chunked, one_at_a_time)
 
     def test_empty_input_short_circuits_before_the_model(self, monkeypatch):
         from wren.memory.embeddings import OnnxEmbeddings  # noqa: PLC0415

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1901,6 +1901,89 @@ class TestOnnxEmbeddings:
         with pytest.raises(embeddings.OnnxBackendError, match="could not be read"):
             embeddings._read_json("acme/model", "1_Pooling/config.json")
 
+    def _hf_errors(self):
+        """A hub 404 and an unreachable hub, as `_read_json` must tell apart.
+
+        The 404 is a stand-in rather than a real `RemoteEntryNotFoundError`:
+        that one's constructor needs a live HTTP response object, and its
+        client is httpx under huggingface-hub 1.x but was requests before --
+        neither of which is in the `memory-onnx` dependency closure. What is
+        under test is where the error sits in the hierarchy, which the
+        stand-in reproduces exactly.
+        """
+        from huggingface_hub.errors import (  # noqa: PLC0415
+            EntryNotFoundError,
+            LocalEntryNotFoundError,
+        )
+
+        class _Remote404(EntryNotFoundError, OSError):
+            pass
+
+        return (
+            _Remote404("404 Client Error"),
+            LocalEntryNotFoundError("cannot reach hub and nothing is cached"),
+        )
+
+    def test_a_remote_404_still_means_absent(self, monkeypatch):
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        remote_404, _ = self._hf_errors()
+
+        def _raise(_repo, _name):
+            raise remote_404
+
+        monkeypatch.setattr(embeddings, "_hf_file", _raise)
+        assert embeddings._read_json("acme/model", "1_Pooling/config.json") is None
+
+    def test_an_unreachable_hub_is_not_reported_as_absent(self, monkeypatch):
+        # _require_mean_pooling reads None as "no pooling config" and returns
+        # early, so treating a dropped connection as absence would wave a
+        # CLS-pooled model through -- the same silent-wrong-vectors outcome the
+        # guard exists to prevent, reached from a third direction.
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        _, offline = self._hf_errors()
+
+        def _raise(_repo, _name):
+            raise offline
+
+        monkeypatch.setattr(embeddings, "_hf_file", _raise)
+        with pytest.raises(embeddings.OnnxBackendError, match="could not be fetched"):
+            embeddings._read_json("acme/model", "1_Pooling/config.json")
+
+    def test_the_pooling_guard_does_not_pass_a_model_it_could_not_check(
+        self, monkeypatch
+    ):
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        _, offline = self._hf_errors()
+
+        def _raise(_repo, _name):
+            raise offline
+
+        monkeypatch.setattr(embeddings, "_hf_file", _raise)
+        with pytest.raises(embeddings.OnnxBackendError):
+            embeddings._require_mean_pooling("acme/model")
+
+    def test_an_unreadable_sequence_length_falls_back_instead_of_failing(
+        self, monkeypatch, caplog
+    ):
+        # Truncation length is soft where pooling mode is not: an ONNX-native
+        # mirror legitimately ships no sentence_bert_config.json, and an
+        # offline run with the rest of the model cached should not die on
+        # being unable to confirm that.
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        _, offline = self._hf_errors()
+
+        def _raise(_repo, _name):
+            raise offline
+
+        monkeypatch.setattr(embeddings, "_hf_file", _raise)
+        with caplog.at_level("DEBUG", logger="wren.memory.embeddings"):
+            assert embeddings._max_seq_length("Xenova/some-model") == 128
+        assert "128" in caplog.text
+
     def test_a_defaulted_sequence_length_is_logged(self, monkeypatch, caplog):
         # ONNX-native mirrors publish onnx/model.onnx but no
         # sentence_bert_config.json, so this default is what an onnx user
@@ -1995,6 +2078,23 @@ class TestBackendErrorsReachTheUser:
         monkeypatch.setattr(index_backend, "get_index", lambda *_a, **_kw: _Index())
         self._assert_clean_exit(self._invoke(["memory", "recall", "-q", "revenue"]))
 
+    def test_fetch_reports_it(self, tmp_path, monkeypatch, error_name):
+        # `fetch` embeds via get_context -> _search_schema whenever the schema
+        # is above the character threshold, and it is the second command in
+        # README section 6 -- a likely place to first meet a backend error.
+        from wren.memory import cli  # noqa: PLC0415
+
+        error = self._error(error_name)
+
+        class _Store:
+            def get_context(self, *_a, **_kw):
+                raise error
+
+        monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+        monkeypatch.setattr(cli, "_load_manifest", lambda _mdl: {"models": []})
+        monkeypatch.setattr(cli, "_get_store", lambda _path: _Store())
+        self._assert_clean_exit(self._invoke(["memory", "fetch", "-q", "revenue"]))
+
     def test_store_reports_it(self, tmp_path, monkeypatch, error_name):
         # `store` writes the markdown first and only then indexes, so the pair
         # is not lost -- but the indexing failure still has to be legible.
@@ -2016,6 +2116,65 @@ class TestBackendErrorsReachTheUser:
                 ["memory", "store", "--nl", "Total revenue", "--sql", "SELECT 1"]
             )
         )
+
+
+@pytest.mark.unit
+class TestBackendErrorHandlingIsStructural:
+    """The handler must cover commands nobody has written yet.
+
+    Wrapping call sites one at a time means the matrix above can only ever
+    enumerate what already exists -- the next command that embeds inherits
+    nothing. Handling it on the group closes the class.
+    """
+
+    def test_the_memory_app_installs_the_handling_group(self):
+        from wren.memory.cli import _MemoryGroup, memory_app  # noqa: PLC0415
+
+        assert memory_app.info.cls is _MemoryGroup
+
+    def test_an_unwrapped_command_is_still_covered(self):
+        import typer  # noqa: PLC0415
+        from typer.testing import CliRunner  # noqa: PLC0415
+
+        from wren.memory.cli import _MemoryGroup  # noqa: PLC0415
+        from wren.memory.embeddings import (  # noqa: PLC0415
+            UnsupportedPoolingError,
+        )
+
+        # Stands in for the next command to embed: no try/except of its own.
+        sub = typer.Typer(cls=_MemoryGroup)
+
+        @sub.command()
+        def brand_new():
+            raise UnsupportedPoolingError(
+                "Set WREN_EMBEDDING_BACKEND=sentence-transformers to use this model."
+            )
+
+        root = typer.Typer()
+        root.add_typer(sub, name="memory")
+        result = CliRunner().invoke(root, ["memory", "brand-new"])
+        assert result.exit_code == 1, result.output
+        assert "WREN_EMBEDDING_BACKEND=sentence-transformers" in result.output
+        assert "Traceback" not in result.output
+
+    def test_an_ordinary_exit_code_is_not_swallowed(self):
+        import typer  # noqa: PLC0415
+        from typer.testing import CliRunner  # noqa: PLC0415
+
+        from wren.memory.cli import _MemoryGroup  # noqa: PLC0415
+
+        # typer.Exit subclasses RuntimeError, so a handler written against
+        # RuntimeError instead of OnnxBackendError would rewrite every exit
+        # code in the sub-app to 1.
+        sub = typer.Typer(cls=_MemoryGroup)
+
+        @sub.command()
+        def bails():
+            raise typer.Exit(3)
+
+        root = typer.Typer()
+        root.add_typer(sub, name="memory")
+        assert CliRunner().invoke(root, ["memory", "bails"]).exit_code == 3
 
 
 @pytest.mark.unit

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -1598,6 +1598,16 @@ class _FakeSession:
         return [self._hidden]
 
 
+class _StubTokenizer:
+    """Stands in for tokenizers.Tokenizer where only its construction matters."""
+
+    def enable_truncation(self, **_kwargs):
+        pass
+
+    def enable_padding(self, **_kwargs):
+        pass
+
+
 class _CountingTokenizer:
     """Encodes each text as the single token its integer value names."""
 
@@ -1829,6 +1839,84 @@ class TestOnnxEmbeddings:
         with pytest.raises(embeddings.UnsupportedPoolingError, match="mean pooling"):
             embeddings._require_mean_pooling("some/model")
 
+    def test_the_pooling_guard_is_an_onnx_backend_error(self):
+        # cli.py orders its `except` clauses on the RuntimeError/ValueError
+        # split, so widening the hierarchy must not cross that line.
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        assert issubclass(
+            embeddings.UnsupportedPoolingError, embeddings.OnnxBackendError
+        )
+        assert issubclass(embeddings.OnnxBackendError, RuntimeError)
+        assert not issubclass(embeddings.OnnxBackendError, ValueError)
+
+    def test_a_repo_without_an_onnx_export_names_the_way_out(self, monkeypatch):
+        # onnx is chosen on importability alone, so a WREN_EMBEDDING_MODEL that
+        # worked under sentence-transformers can land here. Surfacing the raw
+        # 404 as a traceback would make a working config look broken.
+        import tokenizers  # noqa: PLC0415
+
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        def _missing(_repo, filename):
+            if filename.endswith(".onnx"):
+                raise OSError("404 Client Error")
+            return "/dev/null"
+
+        # The tokenizer loads first -- _runtime does the cheap checks before
+        # fetching the large graph -- so it has to be stubbed to reach the
+        # fetch under test.
+        monkeypatch.setattr(
+            tokenizers.Tokenizer, "from_file", staticmethod(lambda _p: _StubTokenizer())
+        )
+        monkeypatch.setattr(embeddings, "_hf_file", _missing)
+        monkeypatch.setattr(embeddings, "_require_mean_pooling", lambda _repo: None)
+        monkeypatch.setattr(embeddings, "_max_seq_length", lambda _repo: 128)
+        monkeypatch.setattr(embeddings, "_onnx_runtime_cache", None)
+
+        with pytest.raises(embeddings.MissingOnnxExportError) as excinfo:
+            embeddings.OnnxEmbeddings("acme/no-onnx")._runtime()
+        assert "WREN_EMBEDDING_BACKEND=sentence-transformers" in str(excinfo.value)
+
+    def test_corrupt_pooling_config_is_not_reported_as_a_bad_manifest(
+        self, monkeypatch, tmp_path
+    ):
+        # json.JSONDecodeError is a ValueError, so letting it escape would put
+        # a corrupt HF cache entry behind cli.py's "Malformed manifest:" -- the
+        # same misattribution the pooling guard exists to avoid. Returning None
+        # instead would be worse: the guard would read it as "no pooling
+        # config" and wave a CLS-pooled model through.
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        corrupt = tmp_path / "config.json"
+        corrupt.write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(embeddings, "_hf_file", lambda _r, _f: str(corrupt))
+
+        with pytest.raises(embeddings.OnnxBackendError, match="could not be read"):
+            embeddings._read_json("acme/model", "1_Pooling/config.json")
+
+    def test_a_defaulted_sequence_length_is_logged(self, monkeypatch, caplog):
+        # ONNX-native mirrors publish onnx/model.onnx but no
+        # sentence_bert_config.json, so this default is what an onnx user
+        # typically gets. It is right for the 128-length models, but a
+        # 512-length model would truncate with no signal at all.
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        monkeypatch.setattr(embeddings, "_read_json", lambda _r, _f: None)
+        with caplog.at_level("DEBUG", logger="wren.memory.embeddings"):
+            assert embeddings._max_seq_length("Xenova/some-model") == 128
+        assert "128" in caplog.text
+
+    def test_a_declared_sequence_length_is_not_logged(self, monkeypatch, caplog):
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        monkeypatch.setattr(
+            embeddings, "_read_json", lambda _r, _f: {"max_seq_length": 512}
+        )
+        with caplog.at_level("DEBUG", logger="wren.memory.embeddings"):
+            assert embeddings._max_seq_length("acme/model") == 512
+        assert caplog.text == ""
+
     def test_bare_model_name_expands_to_the_sentence_transformers_repo(self):
         from wren.memory.embeddings import _resolve_repo_id  # noqa: PLC0415
 
@@ -1837,6 +1925,91 @@ class TestOnnxEmbeddings:
             == "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
         )
         assert _resolve_repo_id("acme/custom-model") == "acme/custom-model"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "error_name", ["UnsupportedPoolingError", "MissingOnnxExportError"]
+)
+class TestBackendErrorsReachTheUser:
+    """A backend that cannot serve the model must say so, from any command.
+
+    These failures surface lazily from the first encode, so every command that
+    embeds can raise one -- not just `index`, which was the only one that
+    handled it.
+    """
+
+    def _invoke(self, args):
+        from typer.testing import CliRunner  # noqa: PLC0415
+
+        from wren.cli import app  # noqa: PLC0415
+
+        return CliRunner().invoke(app, args)
+
+    def _error(self, error_name):
+        from wren.memory import embeddings  # noqa: PLC0415
+
+        return getattr(embeddings, error_name)(
+            "The onnx backend cannot serve this model. Set "
+            "WREN_EMBEDDING_BACKEND=sentence-transformers to use this model."
+        )
+
+    def _assert_clean_exit(self, result):
+        assert result.exit_code == 1, result.output
+        assert "WREN_EMBEDDING_BACKEND=sentence-transformers" in result.output
+        assert "Traceback" not in result.output
+        assert "Malformed manifest" not in result.output
+
+    def test_index_reports_it_and_not_as_a_manifest_problem(
+        self, tmp_path, monkeypatch, error_name
+    ):
+        from wren.memory import cli  # noqa: PLC0415
+
+        error = self._error(error_name)
+
+        class _Store:
+            def index_schema(self, *_a, **_kw):
+                raise error
+
+        monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+        monkeypatch.setattr(cli, "_load_manifest", lambda _mdl: {"models": []})
+        monkeypatch.setattr(cli, "_get_store", lambda _path: _Store())
+        self._assert_clean_exit(self._invoke(["memory", "index", "--no-queries"]))
+
+    def test_recall_reports_it(self, tmp_path, monkeypatch, error_name):
+        from wren.memory import index_backend  # noqa: PLC0415
+
+        error = self._error(error_name)
+
+        class _Index:
+            def search(self, *_a, **_kw):
+                raise error
+
+        monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+        monkeypatch.setattr(index_backend, "get_index", lambda *_a, **_kw: _Index())
+        self._assert_clean_exit(self._invoke(["memory", "recall", "-q", "revenue"]))
+
+    def test_store_reports_it(self, tmp_path, monkeypatch, error_name):
+        # `store` writes the markdown first and only then indexes, so the pair
+        # is not lost -- but the indexing failure still has to be legible.
+        from wren.memory import store as store_mod  # noqa: PLC0415
+
+        error = self._error(error_name)
+
+        class _Store:
+            def __init__(self, **_kw):
+                pass
+
+            def store_query(self, *_a, **_kw):
+                raise error
+
+        monkeypatch.setenv("WREN_PROJECT_HOME", str(tmp_path))
+        monkeypatch.setattr(store_mod, "MemoryStore", _Store)
+        self._assert_clean_exit(
+            self._invoke(
+                ["memory", "store", "--nl", "Total revenue", "--sql", "SELECT 1"]
+            )
+        )
 
 
 @pytest.mark.unit

--- a/core/wren/tests/unit/test_memory.py
+++ b/core/wren/tests/unit/test_memory.py
@@ -745,6 +745,18 @@ class TestMemoryStore:
         info = memory_store.status()
         assert info["tables"]["schema_items"] == 11
 
+    def test_status_reports_the_live_embedding_backend(self, memory_store):
+        # Two backends write these vectors and only one of them pulls torch,
+        # so status has to say which one is actually resolved — not merely
+        # which extras happen to be importable.
+        from wren.memory.embeddings import (  # noqa: PLC0415
+            resolve_embedding_backend,
+        )
+
+        info = memory_store.status()
+        assert info["embedding_backend"] == resolve_embedding_backend()
+        assert info["model"]
+
     def test_reset(self, memory_store):
         memory_store.index_schema(_MANIFEST)
         memory_store.reset()

--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -3732,7 +3732,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "google-auth", marker = "extra == 'bigquery'" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.40,<4" },
-    { name = "huggingface-hub", marker = "extra == 'memory-onnx'", specifier = ">=0.23" },
+    { name = "huggingface-hub", marker = "extra == 'memory-onnx'", specifier = ">=0.25" },
     { name = "inquirerpy", marker = "extra == 'interactive'", specifier = ">=0.3.4" },
     { name = "jinja2", marker = "extra == 'ui'", specifier = ">=3.1" },
     { name = "lancedb", marker = "extra == 'memory'", specifier = ">=0.6" },

--- a/core/wren/uv.lock
+++ b/core/wren/uv.lock
@@ -411,7 +411,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -444,37 +444,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -590,6 +590,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -730,6 +738,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -738,6 +747,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -746,6 +756,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -754,6 +765,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -762,6 +774,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1507,7 +1520,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -1519,7 +1532,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1549,9 +1562,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1563,7 +1576,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1622,6 +1635,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a8/0520890321b8ff40b908cf165a93eb58fbc8f85c14db637277ea866c9544/onnxruntime-1.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:07c5907474dec4a2792fd7626b753dc66707808385a6d9eecf993db0066a9d0f", size = 21420890, upload-time = "2026-08-17T22:53:33.429Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/8bd3e0008ff8d386305351109a7329ea57e51a3ab57bc92340f29c4a5b5d/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:16925ef8497e2c07e4b5ae15b504079b3ab3f65e22c58efd10dde0f3caea969a", size = 20803602, upload-time = "2026-08-17T22:53:36.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/91/a66cd77f28379ede419672edda3184f1eb286db215dce1e7b976fae2d63b/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:85f8e8406c52658735fe5c7fbfd3ebaa1ed340768324f6252e4274e374580a23", size = 23113193, upload-time = "2026-08-17T22:53:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/82/2da968405c42340f03de0bcdb63be09ae1004f820b2295590d48951b5cf2/onnxruntime-1.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4f427afac434b0070fe992b540ddf20a7aff2265f760f314d91331935b6b98", size = 13999253, upload-time = "2026-08-17T22:53:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/70c9c893bf732ee66124c2d8de6a21fc9361ec62cf378f857043efcbf0eb/onnxruntime-1.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:4eae472cf7dc3107dec1bb53cd6d142d1964616d08aae48654cd4254b2363c4b", size = 13741410, upload-time = "2026-08-17T22:53:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/80/381c1e9efed9cc32d00aa7cab0547dc84116cec906c3ffe3613686d6963a/onnxruntime-1.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3a3814c041251d6a77fdf513fb282056538ee826d2f1178a0df3c549d3fff6ba", size = 21430049, upload-time = "2026-08-17T22:53:48.286Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/4be0e345d38fe707a701ca07e8f63c05b152a2e6285d1e43a7faf63fedd2/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d2fb19e848f7c33ed8d3182b52504aaa11c5e8da438bbb47296f85b133cbcf6b", size = 20816870, upload-time = "2026-08-17T22:53:51.169Z" },
+    { url = "https://files.pythonhosted.org/packages/96/eb/e6968f5e41aac3125f2ff5708855f09cb0b70d85ed3115b625b0b58305ba/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2b80d8c7ec2cc7438e4da3760b88c24568cba72c9ace96d668800a6c79419acb", size = 23136745, upload-time = "2026-08-17T22:53:53.92Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/80/5b28f1f1111210fc4a336ddbc6950f468ebf9a6a265420568f4f43fa33ce/onnxruntime-1.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:4acf2b4948b7ede87221ca6332344b8facdc8059d6ac751a7d367d04532b02dd", size = 14001407, upload-time = "2026-08-17T22:53:56.486Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d6/6883f89ea4b044e6e8447ebfaf9bcecdf457b7d80a683635e130b25498e0/onnxruntime-1.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:dc61a79cb39afd66ab3f01fd2c23591a7f01de89c1668e1fb6315067fc279164", size = 13746981, upload-time = "2026-08-17T22:53:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a3/718e1b83096a1bc7b0fc8014c23d4cf795559fe666961cfac4fc038a4871/onnxruntime-1.29.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e74b278af1d949876f5d91d1268fd6c680e79f2bac194967394eaba9fdf69e7e", size = 21431104, upload-time = "2026-08-17T22:54:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/17/c75e78ddc1fe69b6ebaef7fe88ac83f29bfe10955e3a0d2436d93473c91c/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:939e5d65f332e6d399774b2bd0d3559fd8fa629c1e77833db29d968d2384f23d", size = 20818488, upload-time = "2026-08-17T22:54:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/9f197c578d3d3d7bea16971e233e5483981228eec73748585cf7b5933403/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c0c37b92f67ed68dd36221ce0403e1d9bd4f7efce724439978a2597848530e5", size = 23136994, upload-time = "2026-08-17T22:54:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/24/53/4616a55d2495679cfd0195f968feb3d74fe30e26467d168ee243ac97c089/onnxruntime-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:4a3129ae56e70d2618ff773920166916310370a7e3cacb60b9e0e8910092725f", size = 14350643, upload-time = "2026-08-17T22:54:28.794Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0f/c338cb5500a522c7e671a3bb1276f4562404fbecce8a0e274565aa968484/onnxruntime-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:e417ef8628dcce310d2d53023e750ea298ec14d4341ae6dc3a572bfd9bc7fa97", size = 14124294, upload-time = "2026-08-17T22:54:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e7/61064289a9a1301b25c1f0f574fe98aba31c2d388db3c1dbec664f78621f/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:11264bb58f7b7cf6af835ab10d36838d73680580820fd6f51d90124a1ca8f449", size = 20826174, upload-time = "2026-08-17T22:54:34.283Z" },
+    { url = "https://files.pythonhosted.org/packages/60/21/d0c04b561b46e9bff89b5f500fb7415b8ca0669f7902204f76ab06bb0c7e/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1ea91cef3b971506e51ae9c37c16d027774ec64994a524ec1bdfb027d68a9832", size = 23138547, upload-time = "2026-08-17T22:54:37.491Z" },
 ]
 
 [[package]]
@@ -3624,6 +3674,13 @@ memory = [
     { name = "lancedb" },
     { name = "sentence-transformers" },
 ]
+memory-onnx = [
+    { name = "huggingface-hub" },
+    { name = "lancedb" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+]
 mssql = [
     { name = "pyodbc" },
 ]
@@ -3675,13 +3732,17 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "google-auth", marker = "extra == 'bigquery'" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.40,<4" },
+    { name = "huggingface-hub", marker = "extra == 'memory-onnx'", specifier = ">=0.23" },
     { name = "inquirerpy", marker = "extra == 'interactive'", specifier = ">=0.3.4" },
     { name = "jinja2", marker = "extra == 'ui'", specifier = ">=3.1" },
     { name = "lancedb", marker = "extra == 'memory'", specifier = ">=0.6" },
+    { name = "lancedb", marker = "extra == 'memory-onnx'", specifier = ">=0.6" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.19" },
     { name = "mysqlclient", marker = "extra == 'mysql'", specifier = ">=2.2" },
+    { name = "numpy", marker = "extra == 'memory-onnx'", specifier = ">=1.24" },
+    { name = "onnxruntime", marker = "extra == 'memory-onnx'", specifier = ">=1.17" },
     { name = "opendal", specifier = ">=0.45" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=2" },
     { name = "pandas", specifier = ">=2" },
@@ -3704,6 +3765,7 @@ requires-dist = [
     { name = "snowflake-connector-python", extras = ["pandas"], marker = "extra == 'snowflake'", specifier = ">=3.10" },
     { name = "sqlglot", specifier = ">=29" },
     { name = "starlette", marker = "extra == 'ui'", specifier = ">=1.3.1" },
+    { name = "tokenizers", marker = "extra == 'memory-onnx'", specifier = ">=0.15" },
     { name = "trino", marker = "extra == 'trino'", specifier = ">=0.333,<1" },
     { name = "typer", specifier = ">=0.12" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -3712,7 +3774,7 @@ requires-dist = [
     { name = "wrenai", extras = ["interactive", "ui"], marker = "extra == 'main'" },
     { name = "wrenai", extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "athena", "oracle", "spark", "main", "memory", "mcp"], marker = "extra == 'all'" },
 ]
-provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "interactive", "ui", "mcp", "main", "all"]
+provides-extras = ["postgres", "mysql", "bigquery", "snowflake", "clickhouse", "trino", "mssql", "databricks", "redshift", "spark", "athena", "oracle", "memory", "memory-onnx", "interactive", "ui", "mcp", "main", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #2643.

## Why

`wrenai[memory]` pulls sentence-transformers and therefore torch. Resolving that extra for `linux-x86_64` produces torch, triton and **sixteen `nvidia-*` packages** — verified with `uv pip compile --python-platform x86_64-unknown-linux-gnu`. As the issue notes, an extra cannot pin a package index, so there is no way to say "torch, but the CPU wheel" from inside `pyproject.toml`.

## What

A `wrenai[memory-onnx]` extra — lancedb, onnxruntime, tokenizers — as an *alternative* to `memory` rather than an addition, selected at runtime with `WREN_EMBEDDING_BACKEND=onnx|sentence-transformers` and defaulting to onnx when it is importable. It is deliberately excluded from `all`, which keeps installing the sentence-transformers backend.

The weights are the ONNX export **published in the same HF repo as the torch weights** (`onnx/model.onnx`), so nothing is re-exported or converted, and the existing local-first HF cache resolution carries over unchanged. The backend reproduces the sentence-transformers pipeline: tokenize to the model's `max_seq_length`, encode, attention-masked mean pooling, L2 normalize.

It slots in behind the existing abstraction — `MemoryStore` only ever calls `compute_source_embeddings` / `compute_query_embeddings`, so it is untouched.

## Evaluation

Against the questions the issue asked:

| | sentence-transformers | onnx |
|---|---|---|
| Cold start to first embedding (cached model, median of 3) | 20.3 s | **3.0 s** |
| Installed size, macOS arm64 | 817 MB | **133 MB** |
| `linux-x86_64` resolution | torch + triton + 16 × `nvidia-*` | none of them |
| Vector dimension | 384 | 384 |

**Retrieval parity.** Worst-case cosine between the two backends is `1.00000000`, max absolute delta `6.11e-07` — float32 rounding — over English, Traditional Chinese, Japanese and Korean inputs. The vectors are equal, not merely close, so **existing LanceDB tables need no reindex**. End-to-end recall against a real store resolves cross-lingual queries correctly (`哪些客戶花最多錢` → `top customers by net spend`).

**Weights and caching.** `hf_hub_download(..., local_files_only=True)` first, falling back to an online fetch on `LocalEntryNotFoundError` — the same local-first shape, and the same `OSError` branch, as the sentence-transformers adapter.

**Platform coverage.** onnxruntime publishes wheels for linux/macOS/Windows on x86_64 and arm64. Verified locally on macOS arm64; the new CI job covers linux-x86_64.

## Two things that would have degraded silently

**Normalization.** LanceDB's `SentenceTransformerEmbeddings` defaults to `normalize=True` and the existing adapter does not override it, so every vector already in a store is L2-normalized. My first implementation skipped this and the parity test caught it. Unnormalized output would have left old and new rows on different scales and skewed distance ranking — while still looking fine in any cosine-based smoke test, because cosine is scale-invariant.

**Pooling mode.** Only mean pooling is implemented. A CLS-pooled model would still yield a 384-vector, so `1_Pooling/config.json` is checked and anything else raises instead of being indexed with quietly wrong vectors.

## What the change requires

Two edits outside the issue's text that the feature does not work without, flagging them so they are not mistaken for drive-by changes:

1. **`_extra_available()`** in `index_backend.py` tested for `sentence_transformers` by name, so a `memory-onnx` install would have been silently downgraded to the Grep backend — the extra would have done nothing.
2. **Three sentence-transformers-specific tests** went through `get_embedding_function`, which now dispatches to onnx when both extras are installed. Left alone they exercise the wrong backend, and the concurrency one hangs waiting on a fake model that is never constructed. They build the adapter directly now. `TestLocalFirstEmbeddings` also needed its `importorskip` moved into an autouse fixture — it monkeypatches `sentence_transformers` by string, which imports the module before an in-body skip can fire.

## Also included — happy to split these out

3. **Test gating.** The store and `WrenMemory` suites gated on `sentence_transformers`, so they skipped wholesale under `memory-onnx` — exactly where running them proves something. Regated on either backend: 53 skips become 104 executed tests on an onnx-only install.
4. **A CI job** installing `memory-onnx`, asserting torch is absent, and running the memory suite. Without it nothing would notice torch creeping back into the resolution. This is the one piece that stands alone cleanly; note that dropping 3 as well would leave it running very little.

## Verification

| Environment | Result |
|---|---|
| `memory` only (mirrors the existing CI job) | 111 passed, 1 skipped |
| `memory-onnx` only, torch absent | 105 passed, 7 skipped |
| Both extras installed | 112 passed |
| `uvx ruff format --check src/` and `ruff check src/` | clean |
| `uv lock --check` | clean — adds only `onnxruntime` and `flatbuffers` |
| No extras installed | `wren.memory.embeddings` still imports; backend resolves to Grep |

`tests/unit/test_served_content_guard.py` has 3 failures locally, identical on `main` — unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PyTorch-free ONNX embedding backend for vector search.
  * Added the `memory-onnx` installation option.
  * Added automatic embedding backend selection and configuration.
  * Memory status now displays the active embedding backend and model.
  * ONNX embeddings remain compatible with existing vectors.

* **Bug Fixes**
  * Improved command-line reporting for embedding configuration and loading errors.

* **Tests**
  * Added ONNX embedding, backend detection, and vector compatibility coverage.
  * Added CI checks for torch-free installation and embedding parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->