### PR TITLE
ci(release): widen the lock-sync retry window for PyPI propagation

### DIFF
--- a/.github/workflows/sync-wren-core-py-lock.yml
+++ b/.github/workflows/sync-wren-core-py-lock.yml
@@ -66,17 +66,22 @@ jobs:
         working-directory: core/wren
         run: |
           # uv add rewrites the pyproject floor in place and relocks in one step;
-          # --no-sync skips the heavy env. Retry for PyPI index lag after publish.
-          for attempt in 1 2 3 4 5; do
+          # --no-sync skips the heavy env. Retry for PyPI index lag after publish:
+          # the release is only resolvable once the new version reaches the index
+          # uv reads, which has taken longer than the old ~80s window (0.7.6 saw
+          # five straight "only wren-core-py<=0.7.5 is available" failures).
+          attempts=10
+          delay=60
+          for attempt in $(seq 1 "${attempts}"); do
             if uv add --no-sync "wren-core-py>=${VERSION}"; then
               exit 0
             fi
-            if [ "${attempt}" -lt 5 ]; then
-              echo "uv add attempt ${attempt} failed; retrying after PyPI propagation delay"
-              sleep 20
+            if [ "${attempt}" -lt "${attempts}" ]; then
+              echo "uv add attempt ${attempt}/${attempts} failed; retrying in ${delay}s for PyPI propagation"
+              sleep "${delay}"
             fi
           done
-          echo "::error::uv add did not succeed after retries"
+          echo "::error::uv add did not succeed after ${attempts} attempts"
           exit 1
 
       - name: Validate lockfile is consistent


### PR DESCRIPTION
## Problem

`wren-core-py` 0.7.6 published to PyPI successfully, but the follow-up `sync-wren-core-py-lock / sync-lock` job failed, so no `chore(wren): bump wren-core-py to 0.7.6` PR was opened and `core/wren` still pins 0.7.5.

All five `uv add` attempts hit the same resolution error:

```
× No solution found when resolving dependencies for split (markers:
  python_full_version >= '3.14' and sys_platform == 'win32'):
╰─▶ Because only wren-core-py<=0.7.5 is available and your project depends
    on wren-core-py>=0.7.6, we can conclude that your project's requirements
    are unsatisfiable.
```

The published files are fine — 0.7.6 ships the same wheel set as 0.7.5 (`cp311-abi3` for macOS x86_64/arm64, manylinux, win_amd64, plus an sdist, all `requires-python >=3.11`). The marker split in the message is just where the resolver gave up first; the real cause is that the new version was not yet visible in the index uv reads. The existing retry loop (5 attempts, 20s apart) only covered about 80 seconds, and the whole job finished 1m35s after publish.

## Change

Widen the window in the `Bump floor and relock core/wren against published wren-core-py` step:

- 5 attempts → 10, 20s → 60s between them, so it waits up to ~9 minutes rather than ~80 seconds.
- Attempt count and delay become `attempts` / `delay` variables instead of literals repeated in three places, and the retry log now reads `attempt 3/10 failed; retrying in 60s` with the count in the final error too.
- The comment records the failure that motivated the size, so the number is not a bare magic constant next time someone reads it.

Behaviour is otherwise unchanged: success still exits on the first passing attempt, and exhausting all attempts still fails the job.

## Verification

- YAML parses; extracted `run` script passes `bash -n`.
- `actionlint` clean.
- Loop dry-run with `attempts=3, delay=0` prints `1/3`, `2/3`, then errors out after the third — success and exhaustion paths both behave.

## Note

This only prevents future occurrences. The 0.7.6 sync still needs a manual `workflow_dispatch` run of `sync-wren-core-py-lock`; 0.7.6 resolves fine now, so it will pass on the first attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency synchronization reliability by retrying updates up to 10 times with longer delays.
  * Enhanced retry and failure messages with clearer context about attempts and package availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->