### PR TITLE
refactor(core): derive Default for CubeQuery

### DIFF
--- a/core/wren-core/core/src/mdl/cube.rs
+++ b/core/wren-core/core/src/mdl/cube.rs
@@ -13,7 +13,11 @@ use serde::{Deserialize, Serialize};
 use crate::mdl::manifest::{Cube, CubeDimension, Manifest, Measure, TimeDimension};
 
 /// A structured cube query — the input to [`cube_query_to_sql`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Every field satisfies [`Default`], so callers should use struct-update
+/// syntax (`..Default::default()`) and only name the fields they care about.
+/// New optional fields can then be added without breaking downstream code.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CubeQuery {
     pub cube: String,
@@ -647,13 +651,7 @@ mod tests {
     fn query(cube: &str) -> CubeQuery {
         CubeQuery {
             cube: cube.to_string(),
-            measures: vec![],
-            dimensions: vec![],
-            time_dimensions: vec![],
-            filters: vec![],
-            order_by: vec![],
-            limit: None,
-            offset: None,
+            ..Default::default()
         }
     }
 

--- a/core/wren-core/core/tests/cube_public_api.rs
+++ b/core/wren-core/core/tests/cube_public_api.rs
@@ -27,14 +27,11 @@ fn cube_query_public_order_by_types_generate_sql_without_a_limit() {
         cube: "OrdersCube".to_string(),
         measures: vec!["revenue".to_string()],
         dimensions: vec!["status".to_string()],
-        time_dimensions: vec![],
-        filters: vec![],
         order_by: vec![CubeOrderBy {
             member: "revenue".to_string(),
             direction: SortDirection::Desc,
         }],
-        limit: None,
-        offset: None,
+        ..Default::default()
     };
 
     assert_eq!(


### PR DESCRIPTION
## What changed

- derive `Default` for `CubeQuery`
- construct `CubeQuery` via `..Default::default()` in the two existing struct literals

## Why

Follow-up on the review of #2677. `CubeQuery` is a public type with all-public fields, so a struct literal has to name every field. Adding `orderBy` in #2677 was therefore a source-breaking change for anyone constructing a `CubeQuery` directly.

Every field already satisfies `Default`, so the derive costs nothing and lets callers name only the fields they care about:

```rust
let query = CubeQuery {
    cube: "OrdersCube".to_string(),
    measures: vec!["revenue".to_string()],
    dimensions: vec!["status".to_string()],
    order_by: vec![CubeOrderBy {
        member: "revenue".to_string(),
        direction: SortDirection::Desc,
    }],
    ..Default::default()
};
```

Future optional fields then stay additive rather than breaking downstream builds.

No behavioural change: `#[derive(Default)]` only generates `impl Default for CubeQuery`. Field-level `#[serde(default)]` already resolved against each *field's* `Default`, so deserialization is untouched.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --tests --bins` — lib 160 passed, `cube_public_api` 1 passed, sqllogictests passed
- `wren-core-py`: `cargo test` 37 passed, `maturin develop` + `pytest` 46 passed (incl. 13 cube binding tests)
- Mutation check that the derive is load-bearing, not merely exercised: removing it fails compilation at both call sites — `error[E0277]: the trait bound `CubeQuery: Default` is not satisfied` at `core/src/mdl/cube.rs:654` and `core/tests/cube_public_api.rs:34`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cube queries can now be initialized with default values, making it easier to add optional query fields without requiring updates to existing callers.
  * Added guidance for constructing cube queries using default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->