### PR TITLE
fix(wren): postgres LIMIT pushdown breaks on SQL ending in a trailing comment

### DIFF
--- a/core/wren/src/wren/connector/postgres.py
+++ b/core/wren/src/wren/connector/postgres.py
@@ -317,7 +317,10 @@ class PostgresConnector(ConnectorABC):
         # client-pasted statements match dry_run / limited composition rules.
         sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _sub LIMIT {limit}"
+            # Multiline wrap so a trailing `-- line comment` in the inner SQL
+            # is terminated by the newline instead of swallowing the closing
+            # `) AS _sub LIMIT n` (same technique as athena.py/snowflake.py).
+            sql = f"SELECT * FROM (\n{sql}\n) AS _sub LIMIT {limit}"
 
         try:
             with self.connection.cursor() as cursor:
@@ -336,7 +339,7 @@ class PostgresConnector(ConnectorABC):
             ) from e
 
     def dry_run(self, sql: str) -> None:
-        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
+        wrapped = f"SELECT * FROM (\n{strip_trailing_semicolon(sql)}\n) AS _sub LIMIT 0"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(wrapped)

--- a/core/wren/tests/connectors/test_postgres.py
+++ b/core/wren/tests/connectors/test_postgres.py
@@ -461,15 +461,15 @@ def test_query_strips_trailing_semicolon_before_subquery_wrap() -> None:
     connector, cursor = _make_mock_connector()
     connector.query("SELECT 1;", limit=5)
     (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) AS _sub LIMIT 5"
-    assert ";)" not in sent
+    assert sent == "SELECT * FROM (\nSELECT 1\n) AS _sub LIMIT 5"
+    assert ";\n)" not in sent
 
 
 def test_dry_run_strips_trailing_semicolon() -> None:
     connector, cursor = _make_mock_connector()
     connector.dry_run("SELECT 1;  ")
     (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) AS _sub LIMIT 0"
+    assert sent == "SELECT * FROM (\nSELECT 1\n) AS _sub LIMIT 0"
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:

--- a/core/wren/tests/unit/test_postgres_semicolon_unlimited.py
+++ b/core/wren/tests/unit/test_postgres_semicolon_unlimited.py
@@ -59,5 +59,35 @@ def test_limited_query_wraps_after_strip(monkeypatch):
     connector.query("SELECT 1 AS x;", limit=9)
 
     cursor.execute.assert_called_once_with(
-        "SELECT * FROM (SELECT 1 AS x) AS _sub LIMIT 9"
+        "SELECT * FROM (\nSELECT 1 AS x\n) AS _sub LIMIT 9"
+    )
+
+
+def test_query_limit_survives_trailing_line_comment(monkeypatch):
+    """Trailing `--` must not eat the wrap (same shape as athena.py #2457)."""
+    connector = PostgresConnector.__new__(PostgresConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+    monkeypatch.setattr(
+        postgres_mod, "_build_pg_arrow_table", lambda cur: pa.table({"x": [1]})
+    )
+
+    connector.query("SELECT 1 AS x -- pick", limit=9)
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 AS x -- pick\n) AS _sub LIMIT 9"
+    )
+
+
+def test_dry_run_limit_survives_trailing_line_comment():
+    connector = PostgresConnector.__new__(PostgresConnector)
+    connector.connection = MagicMock()
+    cursor = MagicMock()
+    connector.connection.cursor.return_value.__enter__.return_value = cursor
+
+    connector.dry_run("SELECT 1 AS x -- pick")
+
+    cursor.execute.assert_called_once_with(
+        "SELECT * FROM (\nSELECT 1 AS x -- pick\n) AS _sub LIMIT 0"
     )


### PR DESCRIPTION
Fixes #2727.

PostgresConnector wraps the caller's SQL for LIMIT pushdown and for dry_run as `SELECT * FROM (<sql>) AS _sub LIMIT n`, built on one line. When `<sql>` ends in a single-line SQL comment, the comment eats the rest of the line, including the closing paren, the alias, and the LIMIT clause, so the query fails with a syntax error instead of running with the limit applied.

athena.py and snowflake.py have the identical wrap and fixed the same defect (#2457, #2456) by putting the wrapped SQL on its own line, so a trailing comment stops at the newline instead of continuing into the wrap. This applies the same fix to postgres.py's `query()` and `dry_run()`.

The other single-line connectors (redshift, canner, duckdb, trino, oracle, clickhouse, databricks' dry_run, datafusion) have the same shape and are not touched here, to keep this PR to the one connector.

Updated the existing wrap-format assertion for the new multiline shape and added a regression test per path (query, dry_run) with a trailing comment. Ran `tests/unit/` (1252 passed, 2 skipped, one unrelated pre-existing CLI-introspection file excluded for a missing extra in my environment) and `ruff format`/`ruff check` on both changed files, all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed PostgreSQL queries containing trailing line comments so wrapped queries continue to apply row limits correctly.
  - Corrected limited-query and dry-run behavior to prevent comments from interfering with generated SQL.
  - Preserved expected results for regular limited queries and dry runs, including queries ending with semicolons or line comments.
  - Improved generated SQL formatting to ensure trailing comments do not unintentionally consume closing clauses or limit statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->