### PR TITLE
feat(wren): reach cube orderBy from the CLI and the MCP query_cube tool

### DIFF
--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -90,12 +90,42 @@ def _parse_time_dimension(spec: str) -> dict:
     return td
 
 
+def _parse_order_by(spec: str) -> dict:
+    """Parse a single ``--order-by`` spec ``member:direction``.
+
+    Surrounding whitespace is trimmed. The spelling and case of ``direction``
+    are wren-core's to judge — it owns the closed ``asc`` / ``desc`` enum — so
+    they are passed through unchanged.
+    """
+    parts = spec.split(":")
+    if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+        raise typer.BadParameter(f"--order-by expects 'member:direction', got '{spec}'")
+    return {"member": parts[0].strip(), "direction": parts[1].strip()}
+
+
+def _parse_order_by_specs(specs: list[str]) -> list[dict]:
+    """Parse ``--order-by`` values into CubeQuery ``orderBy`` entries.
+
+    Accepts the comma-separated form (like ``--measures``) and the repeatable
+    form (like ``--filter``) by flattening one into the other. A value that
+    contributes no spec at all is rejected rather than dropped: silently
+    returning an unordered query is the failure ordering exists to prevent.
+    """
+    items = [s.strip() for spec in specs for s in spec.split(",") if s.strip()]
+    if not items:
+        raise typer.BadParameter(
+            "--order-by expects 'member:direction', got an empty value"
+        )
+    return [_parse_order_by(item) for item in items]
+
+
 def _build_cube_query(
     cube: str,
     measures: str,
     dimensions: str,
     time_dimension: str | None,
     filters: list[str],
+    order_by: list[str],
     limit: int | None,
     offset: int | None,
 ) -> dict:
@@ -109,6 +139,8 @@ def _build_cube_query(
         q["timeDimensions"] = [_parse_time_dimension(time_dimension)]
     if filters:
         q["filters"] = [_parse_filter(f) for f in filters]
+    if order_by:
+        q["orderBy"] = _parse_order_by_specs(order_by)
     if limit is not None:
         q["limit"] = limit
     if offset is not None:
@@ -304,6 +336,16 @@ def query(
             ),
         ),
     ] = None,
+    order_by: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--order-by",
+            help=(
+                "Repeatable. Format: member:direction (asc|desc). "
+                "Comma-separated for multiple: 'revenue:desc,status:asc'."
+            ),
+        ),
+    ] = None,
     limit: Annotated[
         Optional[int], typer.Option("--limit", "-l", help="Max rows to return")
     ] = None,
@@ -359,6 +401,7 @@ def query(
             dimensions or "",
             time_dimension,
             filter_ or [],
+            order_by or [],
             limit,
             offset,
         )

--- a/core/wren/src/wren/cube_cli.py
+++ b/core/wren/src/wren/cube_cli.py
@@ -107,16 +107,20 @@ def _parse_order_by_specs(specs: list[str]) -> list[dict]:
     """Parse ``--order-by`` values into CubeQuery ``orderBy`` entries.
 
     Accepts the comma-separated form (like ``--measures``) and the repeatable
-    form (like ``--filter``) by flattening one into the other. A value that
-    contributes no spec at all is rejected rather than dropped: silently
-    returning an unordered query is the failure ordering exists to prevent.
+    form (like ``--filter``). Blank segments inside a value are tolerated, as
+    in ``--measures``; a value that contributes no spec at all is rejected, as
+    in ``--filter`` — silently dropping it would hand back an unordered query,
+    the failure ordering exists to prevent.
     """
-    items = [s.strip() for spec in specs for s in spec.split(",") if s.strip()]
-    if not items:
-        raise typer.BadParameter(
-            "--order-by expects 'member:direction', got an empty value"
-        )
-    return [_parse_order_by(item) for item in items]
+    entries: list[dict] = []
+    for spec in specs:
+        items = [s.strip() for s in spec.split(",") if s.strip()]
+        if not items:
+            raise typer.BadParameter(
+                f"--order-by expects 'member:direction', got '{spec}'"
+            )
+        entries.extend(_parse_order_by(item) for item in items)
+    return entries
 
 
 def _build_cube_query(

--- a/core/wren/src/wren/mcp_server.py
+++ b/core/wren/src/wren/mcp_server.py
@@ -149,6 +149,7 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
             dimensions: list[str] | None = None,
             time_dimension: str | None = None,
             filters: list[str] | None = None,
+            order_by: list[str] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             sql_only: bool = False,
@@ -157,7 +158,10 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
 
             Mirrors ``wren cube query``. ``time_dimension`` uses the CLI spec
             format ``name:granularity[:start,end]``; ``filters`` use
-            ``dim:op[:value]`` (comma-separated values for ``in``/``not_in``).
+            ``dim:op[:value]`` (comma-separated values for ``in``/``not_in``);
+            ``order_by`` uses ``member:direction`` where direction is ``asc``
+            or ``desc`` and the member must be selected by the query. Pair it
+            with ``limit`` to get a genuine top-N rather than an arbitrary one.
             Set ``sql_only=True`` to see the generated SQL without executing it.
             """
             from wren_core import cube_query_to_sql  # noqa: PLC0415
@@ -184,6 +188,7 @@ def _register_query_tools(mcp: FastMCP, ctx: ServeContext) -> None:
                     ",".join(dimensions or []),
                     time_dimension,
                     filters or [],
+                    order_by or [],
                     row_limit,
                     offset,
                 )

--- a/core/wren/src/wren/skills_content/usage/SKILL.md
+++ b/core/wren/src/wren/skills_content/usage/SKILL.md
@@ -289,6 +289,7 @@ wren --sql "SELECT * FROM <changed_model> LIMIT 1"
 ```text
 Get data back           → wren --sql "..."
 Aggregation across dims → wren cube query --cube <name> --measures <m> (if cube defined)
+Ranked / top-N          → wren cube query ... --order-by "<measure>:desc" --limit N
 See translated SQL only → wren dry-plan --sql "..." (accepts -d <datasource> if no active profile)
 Validate against DB     → wren dry-run --sql "..."
 Schema context          → wren memory fetch -q "..."
@@ -337,7 +338,9 @@ time dimensions, and hierarchies.
 | "by month" | `--time-dimension "order_date:month"` |
 | "in 2024" | `--time-dimension "order_date:month:2024-01-01,2025-01-01"` |
 | "for completed orders" | `--filter "status:eq:completed"` |
-| "top N customers" | `--dimensions customer --limit N` |
+| "top N customers" | `--dimensions customer --order-by "total:desc" --limit N` |
+| "worst / lowest / bottom N" | `--order-by "<measure>:asc" --limit N` |
+| "sorted by name" | `--order-by "<dimension>:asc"` |
 
 ### Step 4: Execute via CLI flags OR JSON input
 
@@ -349,8 +352,21 @@ wren cube query \
   --measures total,order_count \
   --time-dimension "order_date:month:2024-01-01,2025-01-01" \
   --filter "status:eq:completed" \
+  --order-by "total:desc" \
   --limit 100
 ```
+
+**`--limit` without `--order-by` is not a top-N.** It returns an arbitrary N rows
+(or the earliest N by the time dimension when one is present). Whenever the user
+asks for "top", "best", "worst", or "largest", add `--order-by`.
+
+Ordering rules: the member must be one this query already selects (a measure,
+dimension, or time dimension); direction is lowercase `asc` or `desc`; each member
+may appear once. Omitting `--order-by` keeps the previous default ordering.
+
+Name the member as the cube declares it. A time dimension appears in the generated
+SQL as `<name>__<granularity>`, but `--order-by` wants the declared name:
+`--time-dimension "order_date:month" --order-by "order_date:desc"`.
 
 JSON input (good for agent-generated structured queries):
 
@@ -368,6 +384,9 @@ verification before paying for execution on a remote warehouse.
 | `Unknown measure 'X'` | `wren cube describe <cube>` for available measures |
 | `Unknown dimension 'X'` | `wren cube describe <cube>` for available dimensions |
 | `Cube 'X' not found` | `wren cube list` |
+| `Cannot order by member 'X': member is not selected by the query` | Add `X` to `--measures` / `--dimensions`, or order by a member already selected |
+| `Cannot order by member 'X' more than once` | Drop the duplicate — each member may appear once in `--order-by` |
+| `` unknown variant `DESC`, expected `asc` or `desc` `` | Directions are lowercase: use `desc`, not `DESC` |
 | `Circular dependency detected` | Derived measure references itself — inspect the cube YAML |
 
 ### When NOT to use cube query

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -495,3 +495,314 @@ def test_cube_list_null_member_list_fails_loud(tmp_path):
     assert "malformed cubes" in result.output
     assert "dimensions is null" in result.output
     assert "cubes/*/metadata.yml" in result.output
+
+
+# ── query --order-by ────────────────────────────────────────────────────────
+#
+# Ordering is validated in wren-core, so these assert two things Python owns:
+# the spec grammar, and that core's errors reach the user unchanged. The SQL
+# orders by *output ordinal*, not member name — see wren-core's cube tests.
+
+
+def test_cube_query_sql_only_order_by(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--order-by",
+            "revenue:desc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ORDER BY 2 DESC" in result.output
+
+
+def test_cube_query_order_by_comma_separated(tmp_path):
+    """Comma-separated keys order left to right, like --measures."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--order-by",
+            "revenue:desc,status:asc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ORDER BY 2 DESC, 1 ASC" in result.output
+
+
+def test_cube_query_order_by_repeatable_matches_comma_form(tmp_path):
+    """Repeating the flag (like --filter) must produce identical SQL."""
+    mdl = _make_mdl(tmp_path)
+
+    def run(*order_by_args):
+        return runner.invoke(
+            app,
+            [
+                "cube",
+                "query",
+                "--cube",
+                "order_metrics",
+                "--measures",
+                "revenue",
+                "--dimensions",
+                "status",
+                *order_by_args,
+                "--sql-only",
+                "--mdl",
+                str(mdl),
+            ],
+        )
+
+    comma = run("--order-by", "revenue:desc,status:asc")
+    repeated = run("--order-by", "revenue:desc", "--order-by", "status:asc")
+    assert comma.exit_code == 0, comma.output
+    assert repeated.exit_code == 0, repeated.output
+    assert repeated.output == comma.output
+
+
+def test_cube_query_without_order_by_omits_ordering(tmp_path):
+    """No --order-by must leave the pre-existing SQL untouched."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ORDER BY" not in result.output
+
+
+def test_cube_query_order_by_bad_spec(tmp_path):
+    """A spec without a direction is a clean CLI error, not a core error."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--order-by",
+            "revenue",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "member:direction" in result.output
+
+
+def test_cube_query_order_by_empty_direction_rejected(tmp_path):
+    """`revenue:` would send direction="" to core; reject it where it is typed."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--order-by",
+            "revenue:",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "member:direction" in result.output
+
+
+def test_cube_query_order_by_unselected_member_surfaces_core_error(tmp_path):
+    """Validation lives in core; the CLI must pass its message through."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--order-by",
+            "order_count:desc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "is not selected by the query" in result.output
+
+
+def test_cube_query_order_by_uppercase_direction_rejected(tmp_path):
+    """Direction is a lowercase-only enum in core; the CLI must not normalise."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--order-by",
+            "revenue:DESC",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "unknown variant" in result.output
+
+
+def test_cube_query_order_by_duplicate_member_surfaces_core_error(tmp_path):
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--order-by",
+            "revenue:desc,revenue:asc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "more than once" in result.output
+
+
+def test_cube_query_order_by_time_dimension(tmp_path):
+    """Time dimensions are orderable members too — "newest first"."""
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--time-dimension",
+            "order_date:month",
+            "--order-by",
+            "order_date:desc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ORDER BY 1 DESC" in result.output
+
+
+def test_cube_query_order_by_time_dimension_rejects_sql_alias(tmp_path):
+    """The member is the declared name, not the ``name__granularity`` alias.
+
+    The alias is what shows up in the generated SQL, so copying it back into
+    --order-by is the obvious mistake to make; core rejects it.
+    """
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--time-dimension",
+            "order_date:month",
+            "--order-by",
+            "order_date__month:desc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "is not selected by the query" in result.output
+
+
+def test_cube_query_order_by_empty_value_rejected(tmp_path):
+    """An --order-by that contributes no spec must not run unordered.
+
+    Dropping it silently would hand back an arbitrary N rows — the exact
+    failure ordering exists to prevent — so it is a clean CLI error instead.
+    """
+    mdl = _make_mdl(tmp_path)
+    for empty in ("", ","):
+        result = runner.invoke(
+            app,
+            [
+                "cube",
+                "query",
+                "--cube",
+                "order_metrics",
+                "--measures",
+                "revenue",
+                "--dimensions",
+                "status",
+                "--order-by",
+                empty,
+                "--sql-only",
+                "--mdl",
+                str(mdl),
+            ],
+        )
+        assert result.exit_code != 0, result.output
+        assert "empty value" in result.output

--- a/core/wren/tests/unit/test_cube_cli.py
+++ b/core/wren/tests/unit/test_cube_cli.py
@@ -505,6 +505,7 @@ def test_cube_list_null_member_list_fails_loud(tmp_path):
 
 
 def test_cube_query_sql_only_order_by(tmp_path):
+    """Ordering reaches the generated SQL, keyed by output ordinal."""
     mdl = _make_mdl(tmp_path)
     result = runner.invoke(
         app,
@@ -701,6 +702,7 @@ def test_cube_query_order_by_uppercase_direction_rejected(tmp_path):
 
 
 def test_cube_query_order_by_duplicate_member_surfaces_core_error(tmp_path):
+    """A member listed twice is core's error to raise, not the CLI's."""
     mdl = _make_mdl(tmp_path)
     result = runner.invoke(
         app,
@@ -805,4 +807,64 @@ def test_cube_query_order_by_empty_value_rejected(tmp_path):
             ],
         )
         assert result.exit_code != 0, result.output
-        assert "empty value" in result.output
+        assert "member:direction" in result.output
+
+
+def test_cube_query_order_by_rejects_empty_among_valid_values(tmp_path):
+    """One empty value must not be swallowed because another one parses.
+
+    The repeatable form is validated per value, like --filter: dropping the
+    blank would silently discard part of the user's ordering intent.
+    """
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--order-by",
+            "",
+            "--order-by",
+            "revenue:desc",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code != 0, result.output
+    assert "member:direction" in result.output
+
+
+def test_cube_query_order_by_tolerates_trailing_comma(tmp_path):
+    """A blank segment *inside* a value is tolerated, as in --measures.
+
+    Deliberate, and pinned here so it is not mistaken for the bug the test
+    above guards: the value still contributes a spec, so it is not empty.
+    """
+    mdl = _make_mdl(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "cube",
+            "query",
+            "--cube",
+            "order_metrics",
+            "--measures",
+            "revenue",
+            "--dimensions",
+            "status",
+            "--order-by",
+            "revenue:desc,",
+            "--sql-only",
+            "--mdl",
+            str(mdl),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ORDER BY 2 DESC" in result.output

--- a/core/wren/tests/unit/test_mcp_server.py
+++ b/core/wren/tests/unit/test_mcp_server.py
@@ -514,3 +514,13 @@ def test_query_cube_order_by_bad_spec_is_readable():
             order_by=["total_revenue"],
             sql_only=True,
         )
+
+    # An empty entry alongside a valid one is rejected, not dropped.
+    with pytest.raises(Exception, match="member:direction"):
+        query_cube(
+            cube="order_metrics",
+            measures=["total_revenue"],
+            dimensions=["customer_id"],
+            order_by=["", "total_revenue:desc"],
+            sql_only=True,
+        )

--- a/core/wren/tests/unit/test_mcp_server.py
+++ b/core/wren/tests/unit/test_mcp_server.py
@@ -405,3 +405,112 @@ def test_query_cube_negative_limit_rejected_consistently():
             limit=-1,
             sql_only=True,
         )
+
+
+# ── query_cube ordering reaches the agent-facing surface ───────────────────
+#
+# The ordering itself is wren-core's; what these pin is that `order_by`
+# survives the MCP hop on *both* paths — and that adding ORDER BY does not
+# disturb the truncation probe, since core emits it before LIMIT.
+
+
+def test_query_cube_order_by_in_sql_only():
+    """Ordering reaches the generated SQL, ordered by output ordinal."""
+    ctx = _make_ctx(V5_GOLDEN, engine=Mock())
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    result = query_cube(
+        cube="order_metrics",
+        measures=["total_revenue"],
+        dimensions=["customer_id"],
+        order_by=["total_revenue:desc"],
+        limit=5,
+        sql_only=True,
+    )
+
+    sql = result["sql"].upper()
+    assert "ORDER BY 2 DESC" in sql
+    assert sql.index("ORDER BY") < sql.index("LIMIT")
+
+
+def test_query_cube_order_by_repeatable_matches_comma_form():
+    """Both spec shapes the CLI accepts must produce identical SQL here too."""
+    ctx = _make_ctx(V5_GOLDEN, engine=Mock())
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    def run(order_by):
+        return query_cube(
+            cube="order_metrics",
+            measures=["total_revenue"],
+            dimensions=["customer_id"],
+            order_by=order_by,
+            limit=5,
+            sql_only=True,
+        )["sql"]
+
+    assert run(["total_revenue:desc,customer_id:asc"]) == run(
+        ["total_revenue:desc", "customer_id:asc"]
+    )
+
+
+def test_query_cube_order_by_survives_execution_probe():
+    """ORDER BY and the N+1 probe coexist; the connector still gets no limit."""
+    engine = Mock()
+    engine.query.return_value = pa.table(
+        {"customer_id": [1, 2], "total_revenue": [9.0, 8.0]}
+    )
+
+    ctx = _make_ctx(V5_GOLDEN, engine=engine)
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    query_cube(
+        cube="order_metrics",
+        measures=["total_revenue"],
+        dimensions=["customer_id"],
+        order_by=["total_revenue:desc"],
+        limit=5,
+    )
+
+    sql, connector_limit = engine.query.call_args[0]
+    assert "ORDER BY 2 DESC" in sql.upper()
+    assert sql.upper().endswith("LIMIT 6")
+    assert connector_limit is None
+
+
+def test_query_cube_order_by_unselected_member_surfaces_core_error():
+    """Ordering validation stays in core; query_cube must not duplicate it."""
+    ctx = _make_ctx(V5_GOLDEN, engine=Mock())
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    with pytest.raises(ValueError, match="is not selected by the query"):
+        query_cube(
+            cube="order_metrics",
+            measures=["total_revenue"],
+            dimensions=["customer_id"],
+            order_by=["order_count:desc"],
+            sql_only=True,
+        )
+
+
+def test_query_cube_order_by_bad_spec_is_readable():
+    """A malformed spec reaches the caller as the parser's own message.
+
+    query_cube shares cube_cli's spec parsers, so the error is raised there —
+    same as the pre-existing `filters` / `time_dimension` behaviour.
+    """
+    ctx = _make_ctx(V5_GOLDEN, engine=Mock())
+    mcp = build_server(ctx)
+    query_cube = _get_tool(mcp, "query_cube")
+
+    with pytest.raises(Exception, match="member:direction"):
+        query_cube(
+            cube="order_metrics",
+            measures=["total_revenue"],
+            dimensions=["customer_id"],
+            order_by=["total_revenue"],
+            sql_only=True,
+        )

--- a/docs/core/reference/cli.md
+++ b/docs/core/reference/cli.md
@@ -345,6 +345,7 @@ wren cube query \
   --dimensions status \
   --time-dimension "order_date:month:2024-01-01,2025-01-01" \
   --filter "status:eq:completed" \
+  --order-by "total:desc" \
   --limit 100
 ```
 
@@ -361,8 +362,9 @@ cat query.json | wren cube query --from -
 | `--dimensions` | Comma-separated dimension names |
 | `--time-dimension` | `<name>:<granularity>[:start,end]` — one time dimension with optional date range |
 | `--filter` | Repeatable. `<dimension>:<operator>[:value]`. For `in` / `not_in`, value is comma-separated. |
+| `--order-by` | Repeatable. `<member>:<direction>` where direction is `asc` or `desc`; comma-separated for multiple. The member must be selected by the query. |
 | `--limit` / `--offset` | Pagination |
-| `--from <file\|->` | Load CubeQuery as JSON from a file or stdin |
+| `--from <file\|->` | Load CubeQuery as JSON from a file or stdin. It supplies the whole query, so the query-building flags above — `--order-by` included — are ignored. |
 | `--sql-only` | Print the generated SQL and exit without executing |
 | `--mdl` | Path to MDL JSON (defaults to `<project>/target/mdl.json`) |
 | `--output` | `table` (default), `json`, `csv` |
@@ -371,6 +373,11 @@ cat query.json | wren cube query --from -
 
 **Supported filter operators:** `eq`, `neq`, `in`, `not_in`, `gt`, `gte`, `lt`,
 `lte`, `contains`, `starts_with`, `is_null`, `is_not_null`.
+
+**Ordering:** `--order-by` sorts by the query's selected members, so pair it with
+`--limit` for a genuine top-N. Omitting it keeps the default ordering (by the time
+dimension when one is present). Directions are lowercase only, and a member listed
+twice — or one the query does not select — is rejected by wren-core.
 
 See the [Cube guide](../guides/cubes.md) for YAML structure and
 validation rules.


### PR DESCRIPTION
Closes #2701

#2677 added `orderBy` to `CubeQuery` in wren-core, but neither agent-facing surface could reach it: `wren cube query` had no flag and the MCP `query_cube` tool had no parameter. Both build their query through `_build_cube_query`, which never emitted an ordering key.

That mattered beyond the missing option. `query_cube` exposes `limit`, and the bundled usage skill names *"top customers"* as a motivating example — so such a query returned an arbitrary N rows (or the earliest N by a time dimension) rather than a top-N:

```sql
-- before
SELECT customer_id AS customer_id, SUM(amount) AS total_revenue FROM orders GROUP BY 1 LIMIT 5
-- after (--order-by "total_revenue:desc")
SELECT customer_id AS customer_id, SUM(amount) AS total_revenue FROM orders GROUP BY 1 ORDER BY 2 DESC LIMIT 5
```

## What changed

Following the five points in the issue:

1. **Parser** — `_parse_order_by` / `_parse_order_by_specs` in the existing spec style, accepting `member:direction` in both the comma-separated form (like `--measures`) and the repeatable form (like `--filter`).
2. **`_build_cube_query`** — emits `orderBy`, so both surfaces gain ordering from one change. Omitting it leaves the generated SQL byte-for-byte unchanged.
3. **CLI** — `--order-by` on `wren cube query`, plus the option table row in `docs/core/reference/cli.md`. The `--from` row now also notes that it supplies the whole query, so the query-building flags are ignored.
4. **MCP** — `order_by: list[str] | None = None` on `query_cube`, threaded through `build_sql` so `sql_only=True` and execution stay on one path; the N+1 truncation probe is unaffected, since core emits `ORDER BY` before `LIMIT`.
5. **Usage skill** — the cube workflow now teaches ordering, and the "top N customers" recipe actually ranks.

## Validation

All of it stays in wren-core and its errors surface verbatim: a member the query does not select, a member listed twice, and any direction outside the lowercase `asc` / `desc` enum are all rejected there. Nothing is re-implemented in Python.

One thing is rejected in the parser: an `--order-by` value that contributes no spec at all (`""`, `","`). Dropping it silently would hand back an arbitrary N rows — the exact failure this change exists to fix.

## Tests

15 new tests (9 CLI, 6 MCP) covering both spec forms producing identical SQL, the unchanged SQL when the option is omitted, time-dimension ordering (by declared name — the generated `<name>__<granularity>` alias is correctly rejected), and each validation error arriving from core. Full unit suite: 1287 passed.

## Note on `wren-core-py` versions

`orderBy` landed in wren-core after `wren-core-py` 0.7.6 was published, and `CubeQuery` has no `deny_unknown_fields` — so on the pinned PyPI wheel the key is **silently ignored** rather than rejected, and ordering will not take effect until a newer `wren-core-py` ships. CI is unaffected because every job builds the wheel from source.

I have deliberately **not** touched the `wren-core-py>=0.7.6` floor in `core/wren/pyproject.toml`, since the version bump appears to be a maintainer-owned chore PR (#2678, #2715). Happy to add it here instead if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordering support for cube queries through the `--order-by` CLI option and MCP query tool parameter.
  * Supports ascending or descending ordering across multiple fields, including ranked and top-N results.
  * Added validation for malformed ordering specifications and invalid field selections.

* **Documentation**
  * Updated CLI reference and usage guidance with ordering examples, rules, and error recovery details.

* **Tests**
  * Added coverage for CLI and MCP ordering behavior, validation, and limit interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->