### PR TITLE
fix(wren): oracle, redshift and trino LIMIT wrap breaks on SQL ending in a trailing comment

### DIFF
--- a/core/wren/src/wren/connector/oracle.py
+++ b/core/wren/src/wren/connector/oracle.py
@@ -184,7 +184,10 @@ class OracleConnector(ConnectorABC):
         # though engines accept multi-statement scripts elsewhere.
         sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) t WHERE ROWNUM <= {limit}"
+            # Multiline wrap so a trailing `-- line comment` in the inner SQL
+            # is terminated by the newline instead of swallowing the closing
+            # `) t WHERE ROWNUM <= n` (same technique as postgres.py).
+            sql = f"SELECT * FROM (\n{sql}\n) t WHERE ROWNUM <= {limit}"
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql)
@@ -202,7 +205,7 @@ class OracleConnector(ConnectorABC):
             try:
                 with self.connection.cursor() as cursor:
                     cursor.execute(
-                        f"SELECT * FROM ({strip_trailing_semicolon(sql)}) t "
+                        f"SELECT * FROM (\n{strip_trailing_semicolon(sql)}\n) t "
                         f"WHERE ROWNUM <= 0"
                     )
             except oracledb.DatabaseError as e:

--- a/core/wren/src/wren/connector/redshift.py
+++ b/core/wren/src/wren/connector/redshift.py
@@ -46,7 +46,9 @@ class RedshiftConnector(ConnectorABC):
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         limit = coerce_limit(limit)
         if limit is not None:
-            sql = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _q LIMIT {limit}"
+            # Multiline wrap so a trailing line comment in the inner SQL is
+            # terminated by the newline instead of eating the closing paren.
+            sql = f"SELECT * FROM (\n{strip_trailing_semicolon(sql)}\n) AS _q LIMIT {limit}"
         else:
             # Unlimited path also rejects trailing ``;`` for single statements
             # depending on driver/session settings — strip for consistency.
@@ -61,7 +63,7 @@ class RedshiftConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         with closing(self.connection.cursor()) as cursor:
             cursor.execute(
-                f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS sub LIMIT 0"
+                f"SELECT * FROM (\n{strip_trailing_semicolon(sql)}\n) AS sub LIMIT 0"
             )
 
     def close(self) -> None:

--- a/core/wren/src/wren/connector/trino.py
+++ b/core/wren/src/wren/connector/trino.py
@@ -490,7 +490,10 @@ class TrinoConnector(ConnectorABC):
         # a clean inner SQL so `;` cannot break the subquery wrap.
         sql = strip_trailing_semicolon(sql)
         if limit is not None:
-            sql = f"SELECT * FROM ({sql}) AS _sub LIMIT {limit}"
+            # Multiline wrap so a trailing `-- line comment` in the inner SQL
+            # is terminated by the newline instead of swallowing the closing
+            # `) AS _sub LIMIT n` (same technique as postgres.py).
+            sql = f"SELECT * FROM (\n{sql}\n) AS _sub LIMIT {limit}"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(sql)
@@ -510,7 +513,7 @@ class TrinoConnector(ConnectorABC):
     def dry_run(self, sql: str) -> None:
         trino = _import_trino()
 
-        wrapped = f"SELECT * FROM ({strip_trailing_semicolon(sql)}) AS _sub LIMIT 0"
+        wrapped = f"SELECT * FROM (\n{strip_trailing_semicolon(sql)}\n) AS _sub LIMIT 0"
         try:
             with contextlib.closing(self.connection.cursor()) as cursor:
                 cursor.execute(wrapped)

--- a/core/wren/tests/unit/test_oracle_semicolon.py
+++ b/core/wren/tests/unit/test_oracle_semicolon.py
@@ -45,16 +45,34 @@ def test_query_strips_trailing_semicolon_before_subquery_wrap(monkeypatch) -> No
     )
     connector.query("SELECT 1;", limit=5)
     (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) t WHERE ROWNUM <= 5"
-    assert ";)" not in sent
+    assert sent == "SELECT * FROM (\nSELECT 1\n) t WHERE ROWNUM <= 5"
+    assert ";\n)" not in sent
 
 
 def test_dry_run_strips_trailing_semicolon() -> None:
     connector, cursor = _make_mock_connector()
     connector.dry_run("SELECT 1;  ")
     (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) t WHERE ROWNUM <= 0"
-    assert ";)" not in sent
+    assert sent == "SELECT * FROM (\nSELECT 1\n) t WHERE ROWNUM <= 0"
+    assert ";\n)" not in sent
+
+
+def test_query_limit_survives_trailing_line_comment(monkeypatch) -> None:
+    """Trailing `--` must not eat the wrap (same shape as postgres.py #2728)."""
+    connector, cursor = _make_mock_connector()
+    monkeypatch.setattr(
+        oracle_mod, "_build_oracle_arrow_table", lambda c: pa.table({})
+    )
+    connector.query("SELECT 1 AS x -- pick", limit=5)
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (\nSELECT 1 AS x -- pick\n) t WHERE ROWNUM <= 5"
+
+
+def test_dry_run_limit_survives_trailing_line_comment() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1 AS x -- pick")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (\nSELECT 1 AS x -- pick\n) t WHERE ROWNUM <= 0"
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:

--- a/core/wren/tests/unit/test_redshift_semicolon.py
+++ b/core/wren/tests/unit/test_redshift_semicolon.py
@@ -31,16 +31,31 @@ def test_query_strips_trailing_semicolon_before_subquery_wrap() -> None:
     connector, cursor = _make_mock_connector()
     connector.query("SELECT 1;", limit=5)
     (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) AS _q LIMIT 5"
-    assert ";)" not in sent
+    assert sent == "SELECT * FROM (\nSELECT 1\n) AS _q LIMIT 5"
+    assert ";\n)" not in sent
 
 
 def test_dry_run_strips_trailing_semicolon() -> None:
     connector, cursor = _make_mock_connector()
     connector.dry_run("SELECT 1;  ")
     (sent,), _ = cursor.execute.call_args
-    assert sent == "SELECT * FROM (SELECT 1) AS sub LIMIT 0"
-    assert ";)" not in sent
+    assert sent == "SELECT * FROM (\nSELECT 1\n) AS sub LIMIT 0"
+    assert ";\n)" not in sent
+
+
+def test_query_limit_survives_trailing_line_comment() -> None:
+    """Trailing `--` must not eat the wrap (same shape as postgres.py #2728)."""
+    connector, cursor = _make_mock_connector()
+    connector.query("SELECT 1 AS x -- pick", limit=5)
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (\nSELECT 1 AS x -- pick\n) AS _q LIMIT 5"
+
+
+def test_dry_run_limit_survives_trailing_line_comment() -> None:
+    connector, cursor = _make_mock_connector()
+    connector.dry_run("SELECT 1 AS x -- pick")
+    (sent,), _ = cursor.execute.call_args
+    assert sent == "SELECT * FROM (\nSELECT 1 AS x -- pick\n) AS sub LIMIT 0"
 
 
 def test_helper_preserves_semicolon_inside_string_literal() -> None:

--- a/core/wren/tests/unit/test_trino_semicolon_unlimited.py
+++ b/core/wren/tests/unit/test_trino_semicolon_unlimited.py
@@ -40,3 +40,24 @@ def test_query_with_limit_strips_inside_wrap(connector) -> None:
     sent = cursor.execute.call_args[0][0]
     assert "SELECT 1;" not in sent
     assert "LIMIT 5" in sent
+
+
+def test_query_limit_survives_trailing_line_comment(connector) -> None:
+    """Trailing `--` must not eat the wrap (same shape as postgres.py #2728)."""
+    c, _mod = connector
+    cursor = MagicMock()
+    c.connection.cursor.return_value = cursor
+    with patch("wren.connector.trino._build_trino_arrow_table", return_value=pa.table({"x": [1]})):
+        c.query("SELECT 1 AS x -- pick", limit=5)
+    sent = cursor.execute.call_args[0][0]
+    assert sent == "SELECT * FROM (\nSELECT 1 AS x -- pick\n) AS _sub LIMIT 5"
+
+
+def test_dry_run_limit_survives_trailing_line_comment(connector) -> None:
+    c, _mod = connector
+    cursor = MagicMock()
+    c.connection.cursor.return_value = cursor
+    cursor.fetchall.return_value = []
+    c.dry_run("SELECT 1 AS x -- pick")
+    sent = cursor.execute.call_args[0][0]
+    assert sent == "SELECT * FROM (\nSELECT 1 AS x -- pick\n) AS _sub LIMIT 0"


### PR DESCRIPTION
Fast follow to #2728 (postgres) and #2734 (bigquery/duckdb): oracle.py, redshift.py and trino.py wrap the caller's SQL for LIMIT pushdown and dry-run the same way, on one line, so a trailing SQL line comment eats the closing paren, alias/ROWNUM clause and LIMIT clause:

```
SELECT * FROM (SELECT i FROM t -- pick the column) AS _q LIMIT 3
```

Moved the wrap onto its own line for all six call sites, same technique as postgres.py.

Scoped to these three connectors on purpose. canner.py, clickhouse.py, databricks.py and datafusion.py are the remaining four from the issue's table; two open drafts (#2551, #2552) already touch those same wrap lines for an unrelated change (routing the limit through a parameterized query instead of an f-string), so I left them for whoever picks that up rather than adding a third diff to the same lines. I read both drafts before scoping this: neither fixes the trailing-comment case, they keep the identical single-line wrap.

Added a regression test per connector (query and dry_run) with SQL ending in a trailing comment, fails on the unmodified wrap and passes with it multiline. `tests/unit/` (excluding memory/mcp, matching wren-ci.yml's test-unit job): 1457 passed, 1 skipped, in a container with the oracle/redshift/trino extras installed so those tests actually run instead of skipping. ruff clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Oracle, Redshift, and Trino query wrappers so trailing SQL line comments no longer interfere with generated limits or closing syntax.
  - Improved handling of wrapped queries and dry runs involving trailing semicolons and comments.
  - Preserved generated query limits when SQL ends with a line comment.

- **Tests**
  - Added coverage for trailing line comments in regular queries and dry runs.
  - Updated expectations for multiline wrapped query formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->