### PR TITLE
ci: prepare approval-gated managed Wren releases

### DIFF
--- a/.github/workflows/managed-wren-release-ci.yml
+++ b/.github/workflows/managed-wren-release-ci.yml
@@ -1,0 +1,36 @@
+name: Managed Wren release contracts
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/managed-wren-runtime.yml'
+      - '.github/workflows/managed-wren-release-ci.yml'
+      - 'apps/genbi/scripts/managed-wren-release*'
+      - 'apps/genbi/managed-wren/release-inputs.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/managed-wren-runtime.yml'
+      - '.github/workflows/managed-wren-release-ci.yml'
+      - 'apps/genbi/scripts/managed-wren-release*'
+      - 'apps/genbi/managed-wren/release-inputs.json'
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    name: Release contracts (no runtime downloads or publication)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Check standalone helper syntax
+        run: node --check apps/genbi/scripts/managed-wren-release.mjs
+      - name: Test exact inventory, approval and workflow boundaries
+        run: node --test apps/genbi/scripts/managed-wren-release.test.mjs

--- a/.github/workflows/managed-wren-release-ci.yml
+++ b/.github/workflows/managed-wren-release-ci.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Check standalone helper syntax
         run: node --check apps/genbi/scripts/managed-wren-release.mjs
       - name: Test exact inventory, approval and workflow boundaries

--- a/.github/workflows/managed-wren-runtime.yml
+++ b/.github/workflows/managed-wren-runtime.yml
@@ -1,0 +1,109 @@
+name: Stage managed Wren runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      runtime_tag:
+        description: Immutable managed-Wren release tag
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: managed-wren-${{ inputs.runtime_tag }}
+  cancel-in-progress: false
+
+jobs:
+  stage:
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate immutable release tag before fetching
+        env:
+          RUNTIME_TAG: ${{ inputs.runtime_tag }}
+        run: node apps/genbi/scripts/managed-wren-release.mjs validate-tag "$RUNTIME_TAG"
+      - name: Resolve exact closure and emit review metadata only
+        env:
+          RUNTIME_TAG: ${{ inputs.runtime_tag }}
+        run: |
+          mkdir -p release/wheels release/runtime
+          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 --python-version 3.11 --implementation cp --dest release/wheels 'wrenai==0.13.0'
+          python - <<'PY'
+          import hashlib, json, pathlib, urllib.request, zipfile
+          rows = []
+          for wheel in sorted(pathlib.Path('release/wheels').glob('*.whl')):
+            with zipfile.ZipFile(wheel) as z:
+              meta = next(n for n in z.namelist() if n.endswith('.dist-info/METADATA'))
+              values = dict(line.split(': ', 1) for line in z.read(meta).decode('utf8', 'replace').splitlines() if ': ' in line)
+            sha256 = hashlib.sha256(wheel.read_bytes()).hexdigest()
+            release = json.load(urllib.request.urlopen('https://pypi.org/pypi/{}/{}/json'.format(values['Name'], values['Version'])))
+            source = next((item['url'] for item in release['urls'] if item['filename'] == wheel.name and item['digests']['sha256'] == sha256), None)
+            if not source: raise SystemExit('could not establish exact source identity for ' + wheel.name)
+            rows.append({'filename': wheel.name, 'sha256': sha256, 'distribution': values['Name'].lower().replace('-', '_'), 'version': values['Version'], 'license': values.get('License', 'UNKNOWN'), 'sourceUrl': source})
+          pathlib.Path('release/wheel-inputs.json').write_text(json.dumps(rows))
+          pathlib.Path('release/wheel-license-inventory.json').write_text(json.dumps({'schema': 1, 'wheels': rows}, indent=2))
+          PY
+          curl --fail --location --proto '=https' --tlsv1.2 -o release/python.tar.gz 'https://github.com/astral-sh/python-build-standalone/releases/download/20260901/cpython-3.11.16%2B20260901-aarch64-apple-darwin-install_only.tar.gz'
+          test "$(shasum -a 256 release/python.tar.gz | awk '{print $1}')" = 50424fa409e8ae84b82a3052522f64695b47dff2158b70bb7358e0ebd6c085c9
+          /usr/bin/tar -tzf release/python.tar.gz | python -c "import json,sys; paths=[p.strip() for p in sys.stdin if any(x in p.upper() for x in ('LICENSE','COPYING','NOTICE'))]; print(json.dumps({'schema':1,'archiveSha256':'50424fa409e8ae84b82a3052522f64695b47dff2158b70bb7358e0ebd6c085c9','bundledLicenseEvidence':[{'path':p,'declaredLicense':'REVIEW_REQUIRED'} for p in paths]},indent=2))" > release/pbs-license-inventory.json
+          /usr/bin/tar -xpzf release/python.tar.gz -C release/runtime
+          /bin/chmod 700 release/runtime
+          release/runtime/python/bin/python3.11 -m venv release/runtime/venv
+          python - <<'PY'
+          import json, pathlib
+          rows = json.loads(pathlib.Path('release/wheel-inputs.json').read_text())
+          pathlib.Path('release/requirements.txt').write_text(''.join('{}=={} --hash=sha256:{}\n'.format(row['distribution'], row['version'], row['sha256']) for row in rows))
+          PY
+          release/runtime/venv/bin/python -m pip install --no-index --no-deps --require-hashes --find-links release/wheels -r release/requirements.txt
+          node apps/genbi/scripts/managed-wren-release.mjs release "$RUNTIME_TAG"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: managed-wren-review-metadata
+          path: release/*.json
+
+  publish-approved-runtime:
+    needs: stage
+    environment: managed-wren-license-approved
+    permissions:
+      contents: write
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: managed-wren-review-metadata
+          path: release
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Require protected-environment digest approval
+        env:
+          APPROVAL_DIGEST: ${{ secrets.MANAGED_WREN_APPROVAL_SHA256 }}
+        run: |
+          test -n "$APPROVAL_DIGEST"
+          test "$APPROVAL_DIGEST" = "$(cat release/managed-wren-manifest.candidate.json release/pbs-license-inventory.json release/wheel-license-inventory.json | shasum -a 256 | awk '{print $1}')"
+      - name: Re-fetch and verify exact release assets
+        run: |
+          mkdir -p release/assets
+          node apps/genbi/scripts/managed-wren-release.mjs verify-publish release release/assets
+      - name: Publish verified assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUNTIME_TAG: ${{ inputs.runtime_tag }}
+        run: |
+          node apps/genbi/scripts/managed-wren-release.mjs validate-tag "$RUNTIME_TAG"
+          gh release create "$RUNTIME_TAG" --target "$GITHUB_SHA" --latest=false release/assets/* release/*.json

--- a/.github/workflows/managed-wren-runtime.yml
+++ b/.github/workflows/managed-wren-runtime.yml
@@ -44,40 +44,14 @@ jobs:
           export PYTHON_SHA256
           mkdir -p release/wheels release/runtime
           python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 --python-version 3.11 --implementation cp --dest release/wheels "wrenai==$WRENAI_VERSION"
-          python - <<'PY'
-          import email.parser, hashlib, json, pathlib, urllib.request, zipfile
-          rows = []
-          for wheel in sorted(pathlib.Path('release/wheels').glob('*.whl')):
-            with zipfile.ZipFile(wheel) as z:
-              entries = [n for n in z.namelist() if n.endswith('.dist-info/METADATA')]
-              if len(entries) != 1: raise SystemExit('wheel must have exactly one METADATA entry')
-              meta = email.parser.BytesParser().parsebytes(z.read(entries[0]))
-            if len(meta.get_all('Name', [])) != 1 or len(meta.get_all('Version', [])) != 1:
-              raise SystemExit('wheel must declare one Name and Version')
-            expressions = meta.get_all('License-Expression', [])
-            if len(expressions) > 1: raise SystemExit('wheel has ambiguous License-Expression')
-            licenses = [v for v in meta.get_all('License', []) if v.strip() and v.strip() != 'UNKNOWN']
-            classifiers = [v for v in meta.get_all('Classifier', []) if v.startswith('License ::')]
-            license_value = '; '.join(expressions or licenses or classifiers) or 'UNKNOWN'
-            sha256 = hashlib.sha256(wheel.read_bytes()).hexdigest()
-            release = json.load(urllib.request.urlopen('https://pypi.org/pypi/{}/{}/json'.format(meta['Name'], meta['Version']), timeout=30))
-            source = next((item['url'] for item in release['urls'] if item['filename'] == wheel.name and item['digests']['sha256'] == sha256), None)
-            if not source: raise SystemExit('could not establish exact source identity for ' + wheel.name)
-            rows.append({'filename': wheel.name, 'sha256': sha256, 'distribution': meta['Name'].lower().replace('-', '_'), 'version': meta['Version'], 'license': license_value, 'sourceUrl': source})
-          pathlib.Path('release/wheel-inputs.json').write_text(json.dumps(rows))
-          pathlib.Path('release/wheel-license-inventory.json').write_text(json.dumps({'schema': 1, 'wheels': rows}, indent=2))
-          PY
+          python apps/genbi/scripts/managed-wren-release.py wheels
           curl --fail --location --proto '=https' --tlsv1.2 -o release/python.tar.gz "$PYTHON_URL"
           test "$(shasum -a 256 release/python.tar.gz | awk '{print $1}')" = "$PYTHON_SHA256"
-          /usr/bin/tar -tzf release/python.tar.gz | python -c "import json,os,sys; paths=[p.strip() for p in sys.stdin if any(x in p.upper() for x in ('LICENSE','COPYING','NOTICE'))]; print(json.dumps({'schema':1,'archiveSha256':os.environ['PYTHON_SHA256'],'bundledLicenseEvidence':[{'path':p,'declaredLicense':'REVIEW_REQUIRED'} for p in paths]},indent=2))" > release/pbs-license-inventory.json
+          /usr/bin/tar -tzf release/python.tar.gz | python apps/genbi/scripts/managed-wren-release.py pbs > release/pbs-license-inventory.json
           /usr/bin/tar -xpzf release/python.tar.gz -C release/runtime
           /bin/chmod 700 release/runtime
           release/runtime/python/bin/python3.11 -m venv release/runtime/venv
-          python - <<'PY'
-          import json, pathlib
-          rows = json.loads(pathlib.Path('release/wheel-inputs.json').read_text())
-          pathlib.Path('release/requirements.txt').write_text(''.join('{}=={} --hash=sha256:{}\n'.format(row['distribution'], row['version'], row['sha256']) for row in rows))
-          PY
+          python apps/genbi/scripts/managed-wren-release.py requirements
           release/runtime/venv/bin/python -m pip install --no-index --no-deps --require-hashes --find-links release/wheels -r release/requirements.txt
           node apps/genbi/scripts/managed-wren-release.mjs release "$RUNTIME_TAG"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/managed-wren-runtime.yml
+++ b/.github/workflows/managed-wren-runtime.yml
@@ -37,26 +37,39 @@ jobs:
         env:
           RUNTIME_TAG: ${{ inputs.runtime_tag }}
         run: |
+          set -euo pipefail
+          PYTHON_URL="$(node -p "require('./apps/genbi/managed-wren/release-inputs.json').python.url")"
+          PYTHON_SHA256="$(node -p "require('./apps/genbi/managed-wren/release-inputs.json').python.sha256")"
+          WRENAI_VERSION="$(node -p "require('./apps/genbi/managed-wren/release-inputs.json').wrenai.version")"
+          export PYTHON_SHA256
           mkdir -p release/wheels release/runtime
-          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 --python-version 3.11 --implementation cp --dest release/wheels 'wrenai==0.13.0'
+          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 --python-version 3.11 --implementation cp --dest release/wheels "wrenai==$WRENAI_VERSION"
           python - <<'PY'
-          import hashlib, json, pathlib, urllib.request, zipfile
+          import email.parser, hashlib, json, pathlib, urllib.request, zipfile
           rows = []
           for wheel in sorted(pathlib.Path('release/wheels').glob('*.whl')):
             with zipfile.ZipFile(wheel) as z:
-              meta = next(n for n in z.namelist() if n.endswith('.dist-info/METADATA'))
-              values = dict(line.split(': ', 1) for line in z.read(meta).decode('utf8', 'replace').splitlines() if ': ' in line)
+              entries = [n for n in z.namelist() if n.endswith('.dist-info/METADATA')]
+              if len(entries) != 1: raise SystemExit('wheel must have exactly one METADATA entry')
+              meta = email.parser.BytesParser().parsebytes(z.read(entries[0]))
+            if len(meta.get_all('Name', [])) != 1 or len(meta.get_all('Version', [])) != 1:
+              raise SystemExit('wheel must declare one Name and Version')
+            expressions = meta.get_all('License-Expression', [])
+            if len(expressions) > 1: raise SystemExit('wheel has ambiguous License-Expression')
+            licenses = [v for v in meta.get_all('License', []) if v.strip() and v.strip() != 'UNKNOWN']
+            classifiers = [v for v in meta.get_all('Classifier', []) if v.startswith('License ::')]
+            license_value = '; '.join(expressions or licenses or classifiers) or 'UNKNOWN'
             sha256 = hashlib.sha256(wheel.read_bytes()).hexdigest()
-            release = json.load(urllib.request.urlopen('https://pypi.org/pypi/{}/{}/json'.format(values['Name'], values['Version'])))
+            release = json.load(urllib.request.urlopen('https://pypi.org/pypi/{}/{}/json'.format(meta['Name'], meta['Version']), timeout=30))
             source = next((item['url'] for item in release['urls'] if item['filename'] == wheel.name and item['digests']['sha256'] == sha256), None)
             if not source: raise SystemExit('could not establish exact source identity for ' + wheel.name)
-            rows.append({'filename': wheel.name, 'sha256': sha256, 'distribution': values['Name'].lower().replace('-', '_'), 'version': values['Version'], 'license': values.get('License', 'UNKNOWN'), 'sourceUrl': source})
+            rows.append({'filename': wheel.name, 'sha256': sha256, 'distribution': meta['Name'].lower().replace('-', '_'), 'version': meta['Version'], 'license': license_value, 'sourceUrl': source})
           pathlib.Path('release/wheel-inputs.json').write_text(json.dumps(rows))
           pathlib.Path('release/wheel-license-inventory.json').write_text(json.dumps({'schema': 1, 'wheels': rows}, indent=2))
           PY
-          curl --fail --location --proto '=https' --tlsv1.2 -o release/python.tar.gz 'https://github.com/astral-sh/python-build-standalone/releases/download/20260901/cpython-3.11.16%2B20260901-aarch64-apple-darwin-install_only.tar.gz'
-          test "$(shasum -a 256 release/python.tar.gz | awk '{print $1}')" = 50424fa409e8ae84b82a3052522f64695b47dff2158b70bb7358e0ebd6c085c9
-          /usr/bin/tar -tzf release/python.tar.gz | python -c "import json,sys; paths=[p.strip() for p in sys.stdin if any(x in p.upper() for x in ('LICENSE','COPYING','NOTICE'))]; print(json.dumps({'schema':1,'archiveSha256':'50424fa409e8ae84b82a3052522f64695b47dff2158b70bb7358e0ebd6c085c9','bundledLicenseEvidence':[{'path':p,'declaredLicense':'REVIEW_REQUIRED'} for p in paths]},indent=2))" > release/pbs-license-inventory.json
+          curl --fail --location --proto '=https' --tlsv1.2 -o release/python.tar.gz "$PYTHON_URL"
+          test "$(shasum -a 256 release/python.tar.gz | awk '{print $1}')" = "$PYTHON_SHA256"
+          /usr/bin/tar -tzf release/python.tar.gz | python -c "import json,os,sys; paths=[p.strip() for p in sys.stdin if any(x in p.upper() for x in ('LICENSE','COPYING','NOTICE'))]; print(json.dumps({'schema':1,'archiveSha256':os.environ['PYTHON_SHA256'],'bundledLicenseEvidence':[{'path':p,'declaredLicense':'REVIEW_REQUIRED'} for p in paths]},indent=2))" > release/pbs-license-inventory.json
           /usr/bin/tar -xpzf release/python.tar.gz -C release/runtime
           /bin/chmod 700 release/runtime
           release/runtime/python/bin/python3.11 -m venv release/runtime/venv

--- a/apps/genbi/managed-wren/release-inputs.json
+++ b/apps/genbi/managed-wren/release-inputs.json
@@ -1,0 +1,21 @@
+{
+  "schema": 1,
+  "platform": "darwin-arm64",
+  "compatibility": {
+    "genbi": "0.0.4",
+    "profile": "genbi-native-v4"
+  },
+  "python": {
+    "version": "3.11.16",
+    "release": "20260901",
+    "filename": "cpython-3.11.16+20260901-aarch64-apple-darwin-install_only.tar.gz",
+    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260901/cpython-3.11.16%2B20260901-aarch64-apple-darwin-install_only.tar.gz",
+    "sha256": "50424fa409e8ae84b82a3052522f64695b47dff2158b70bb7358e0ebd6c085c9"
+  },
+  "wrenai": {
+    "version": "0.13.0",
+    "filename": "wrenai-0.13.0-py3-none-any.whl",
+    "url": "https://files.pythonhosted.org/packages/7f/40/2de81f1a3fe332ebfb8ec5db0161ce4b521dee5c1d0d4adf9c5693651b51/wrenai-0.13.0-py3-none-any.whl",
+    "sha256": "1cb14927c9a1e1925a7295c2772e5852254c6cc370db640ccc33b6cd04e95dae"
+  }
+}

--- a/apps/genbi/scripts/managed-wren-release.mjs
+++ b/apps/genbi/scripts/managed-wren-release.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/** Generate and verify exact managed-Wren release evidence; it never publishes. */
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readFile, readdir, readlink, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const digest = (value) => createHash("sha256").update(value).digest("hex");
+const fileDigest = async (target) => digest(await readFile(target));
+const stableJson = (value) => Array.isArray(value) ? "[" + value.map(stableJson).join(",") + "]" : value && typeof value === "object" ? "{" + Object.keys(value).sort().map((key) => JSON.stringify(key) + ":" + stableJson(value[key])).join(",") + "}" : JSON.stringify(value);
+const filenameFromUrl = (url) => decodeURIComponent(new URL(url).pathname.split("/").at(-1) ?? "");
+const exactName = (value) => /^[A-Za-z0-9._+%-]+$/.test(value);
+const exactHash = (value) => /^[a-f0-9]{64}$/.test(value);
+export function validateRuntimeTag(value) {
+  if (typeof value !== "string" || !/^managed-wren-[A-Za-z0-9][A-Za-z0-9._-]{0,100}$/.test(value) || value.includes("..") || value.endsWith(".") || value.endsWith(".lock")) {
+    throw new Error("runtime tag must be a safe managed-wren-* release tag");
+  }
+  return value;
+}
+const treeDigest = async (root) => {
+  const entries = [];
+  const visit = async (directory) => {
+    for (const name of (await readdir(directory)).sort()) {
+      if (name === "__pycache__") continue;
+      const target = path.join(directory, name); const metadata = await lstat(target); const mode = (metadata.mode & 0o777).toString(8);
+      if (metadata.isSymbolicLink()) { const canonical = await realpath(target); const relative = path.relative(root, canonical); if (relative.startsWith("..") || path.isAbsolute(relative)) throw new Error("runtime link escapes tree"); entries.push(path.relative(root, target) + "\0" + mode + "\0link\0" + await readlink(target)); }
+      else if (metadata.isDirectory()) await visit(target); else if (metadata.isFile()) entries.push(path.relative(root, target) + "\0" + mode + "\0file\0" + await fileDigest(target)); else throw new Error("unsupported runtime entry: " + target);
+    }
+  };
+  await visit(root); return digest(entries.join("\n"));
+};
+
+/** The protected job consumes this exact inventory; it never resolves PyPI. */
+export function verifyExactPublishInventory(candidate, wheelInputs) {
+  if (!candidate || candidate.activation !== "staged" || candidate.platform !== "darwin-arm64") throw new Error("invalid candidate manifest");
+  if (!candidate.python || !/^https:/.test(candidate.python.upstream?.url) || !/^https:\/\/github\.com\/Canner\/WrenAI\/releases\/download\//.test(candidate.python.mirror?.url) || !exactHash(candidate.python.mirror?.sha256) || candidate.python.mirror.sha256 !== candidate.python.upstream?.sha256) throw new Error("invalid exact Python candidate");
+  const pythonFilename = filenameFromUrl(candidate.python.upstream.url);
+  if (!exactName(pythonFilename) || filenameFromUrl(candidate.python.mirror.url) !== pythonFilename) throw new Error("Python mirror filename differs from approved source");
+  if (!Array.isArray(candidate.wheels) || !Array.isArray(wheelInputs) || candidate.wheels.length === 0) throw new Error("missing wheel closure");
+  const mirrorRoot = candidate.python.mirror.url.slice(0, -pythonFilename.length);
+  const seen = new Set(); const inventory = new Map();
+  for (const wheel of wheelInputs) {
+    if (!wheel || !exactName(wheel.filename) || !exactHash(wheel.sha256) || !/^https:/.test(wheel.sourceUrl) || !/^[a-z0-9][a-z0-9._-]*$/.test(wheel.distribution) || !/^[A-Za-z0-9!+._-]+$/.test(wheel.version) || seen.has(wheel.filename)) throw new Error("invalid or duplicate selected wheel inventory");
+    seen.add(wheel.filename); inventory.set(wheel.filename, wheel);
+  }
+  if (inventory.size !== candidate.wheels.length) throw new Error("wheel closure has extra or missing artifacts");
+  const selected = [];
+  for (const wheel of candidate.wheels) {
+    const input = inventory.get(wheel.filename);
+    if (!input || wheel.distribution !== input.distribution || wheel.version !== input.version || wheel.sha256 !== input.sha256 || wheel.sourceUrl !== input.sourceUrl || wheel.url !== mirrorRoot + wheel.filename || filenameFromUrl(wheel.sourceUrl) !== wheel.filename) throw new Error("wheel candidate does not exactly match selected inventory");
+    selected.push(wheel);
+  }
+  if (candidate.wheels[0]?.distribution !== "wrenai" || candidate.wheels[0]?.version !== candidate.compatibility?.wren) throw new Error("candidate does not pin wrenai first");
+  return Object.freeze({ python: Object.freeze({ url: candidate.python.upstream.url, filename: pythonFilename, sha256: candidate.python.upstream.sha256 }), wheels: Object.freeze(selected.map((wheel) => Object.freeze({ url: wheel.sourceUrl, filename: wheel.filename, sha256: wheel.sha256 }))) });
+}
+
+export async function refetchExactPublishAssets(candidate, wheelInputs, assetsDirectory, fetchImpl = fetch) {
+  const approved = verifyExactPublishInventory(candidate, wheelInputs);
+  await mkdir(assetsDirectory, { recursive: true, mode: 0o700 });
+  for (const artifact of [approved.python, ...approved.wheels]) {
+    const response = await fetchImpl(artifact.url); if (!response.ok) throw new Error("approved source fetch failed");
+    const bytes = Buffer.from(await response.arrayBuffer()); if (digest(bytes) !== artifact.sha256) throw new Error("approved source hash changed");
+    await writeFile(path.join(assetsDirectory, artifact.filename), bytes, { mode: 0o600, flag: "wx" });
+  }
+  return approved;
+}
+
+export function approvedManifest(candidate) {
+  verifyExactPublishInventory(candidate, candidate.wheels);
+  return { ...candidate, activation: "approved", licenseApproval: { state: "approved", evidence: "protected-environment-digest" } };
+}
+
+async function generate(output, runtimeTag) {
+  if (!output) throw new Error("usage: managed-wren-release.mjs <output-directory> <runtime-tag>");
+  validateRuntimeTag(runtimeTag);
+  const inputs = JSON.parse(await readFile(path.join(packageRoot, "managed-wren", "release-inputs.json"), "utf8"));
+  for (const artifact of [inputs.python, inputs.wrenai]) if (!artifact || !/^https:/.test(artifact.url) || !exactHash(artifact.sha256) || !exactName(artifact.filename)) throw new Error("invalid exact release input");
+  const wheelInputs = JSON.parse(await readFile(path.join(output, "wheel-inputs.json"), "utf8"));
+  if (!Array.isArray(wheelInputs) || wheelInputs.length === 0) throw new Error("missing selected wheel closure");
+  const wheelLicenses = new Map(wheelInputs.map((wheel) => [wheel.filename, wheel.license]));
+  const wheels = wheelInputs.map((wheel) => {
+    if (!wheel || !/^[a-z0-9][a-z0-9._-]*$/.test(wheel.distribution) || !/^[A-Za-z0-9!+._-]+$/.test(wheel.version) || !exactName(wheel.filename) || !/^https:/.test(wheel.sourceUrl) || filenameFromUrl(wheel.sourceUrl) !== wheel.filename || !exactHash(wheel.sha256)) throw new Error("invalid selected wheel closure");
+    return { distribution: wheel.distribution, version: wheel.version, filename: wheel.filename, sourceUrl: wheel.sourceUrl, sha256: wheel.sha256, url: "https://github.com/Canner/WrenAI/releases/download/" + runtimeTag + "/" + wheel.filename };
+  }).sort((a, b) => a.filename.localeCompare(b.filename));
+  const rootInput = wheelInputs.find((wheel) => wheel.distribution === "wrenai");
+  if (!rootInput || rootInput.version !== inputs.wrenai.version || rootInput.filename !== inputs.wrenai.filename || rootInput.sourceUrl !== inputs.wrenai.url || rootInput.sha256 !== inputs.wrenai.sha256) throw new Error("selected wrenai wheel differs from exact release input");
+  const wrenIndex = wheels.findIndex((wheel) => wheel.distribution === "wrenai" && wheel.version === inputs.wrenai.version);
+  if (wrenIndex < 0) throw new Error("wrenai is absent from the selected wheel closure");
+  const [wrenai] = wheels.splice(wrenIndex, 1); wheels.unshift(wrenai);
+  const sitePackagesPath = path.join(output, "runtime", "venv", "lib", "python3.11", "site-packages");
+  const pythonTreeSha256 = await treeDigest(path.join(output, "runtime", "python")); const packageTreeSha256 = await treeDigest(path.join(sitePackagesPath, "wren")); const sitePackagesTreeSha256 = await treeDigest(sitePackagesPath);
+  const closureSha256 = digest(wheels.map((wheel) => wheel.filename + "\0" + wheel.sha256).sort().join("\n"));
+  const manifest = { schema: 1, activation: "staged", platform: "darwin-arm64", compatibility: { genbi: inputs.compatibility.genbi, profile: inputs.compatibility.profile, wren: inputs.wrenai.version }, python: { implementation: "cpython", version: inputs.python.version, upstream: { release: inputs.python.release, url: inputs.python.url, sha256: inputs.python.sha256 }, mirror: { url: "https://github.com/Canner/WrenAI/releases/download/" + runtimeTag + "/" + inputs.python.filename, sha256: inputs.python.sha256 }, interpreterPath: "python/bin/python3.11" }, wheels, runtime: { pythonArchivePath: "python.tar.gz", venvInterpreterPath: "venv/bin/python", launcherPath: "venv/bin/wren", module: "wren.cli:app", packagePath: "venv/lib/python3.11/site-packages/wren", sitePackagesPath: "venv/lib/python3.11/site-packages", pythonTreeSha256, packageTreeSha256, sitePackagesTreeSha256, closureSha256 }, licenseApproval: { state: "pending" } };
+  verifyExactPublishInventory(manifest, wheelInputs);
+  const inventory = { schema: 1, status: "pending-explicit-approval", components: [{ name: "python-build-standalone", version: "cpython-" + inputs.python.release, declaredLicense: "MPL-2.0", artifact: inputs.python.filename }, { name: "CPython", version: inputs.python.version, declaredLicense: "PSF-2.0", artifact: inputs.python.filename }, ...wheels.map((wheel) => ({ name: wheel.distribution, version: wheel.version, declaredLicense: wheelLicenses.get(wheel.filename) ?? "UNKNOWN", artifact: wheel.filename }))], note: "The protected release environment must approve the completed expanded wheel and bundled-library inventory before public assets or an approved manifest can be emitted." };
+  const provenance = { schema: 1, inputs, selectedWheels: wheelInputs, stagedManifestSha256: digest(stableJson(manifest)), generatedAt: new Date().toISOString() };
+  await mkdir(output, { recursive: true, mode: 0o700 });
+  await writeFile(path.join(output, "managed-wren-manifest.candidate.json"), JSON.stringify(manifest, null, 2) + "\n", { mode: 0o600 });
+  await writeFile(path.join(output, "license-inventory.json"), JSON.stringify(inventory, null, 2) + "\n", { mode: 0o600 });
+  await writeFile(path.join(output, "provenance.json"), JSON.stringify(provenance, null, 2) + "\n", { mode: 0o600 });
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "validate-tag") {
+    if (args.length !== 1) throw new Error("usage: managed-wren-release.mjs validate-tag <runtime-tag>");
+    validateRuntimeTag(args[0]);
+    return;
+  }
+  if (command === "verify-publish") {
+    const [reviewDirectory, assetsDirectory] = args; if (!reviewDirectory || !assetsDirectory) throw new Error("usage: managed-wren-release.mjs verify-publish <review-directory> <assets-directory>");
+    const candidate = JSON.parse(await readFile(path.join(reviewDirectory, "managed-wren-manifest.candidate.json"), "utf8"));
+    const wheelInputs = JSON.parse(await readFile(path.join(reviewDirectory, "wheel-inputs.json"), "utf8"));
+    await refetchExactPublishAssets(candidate, wheelInputs, assetsDirectory);
+    await writeFile(path.join(reviewDirectory, "managed-wren-manifest.json"), JSON.stringify(approvedManifest(candidate), null, 2) + "\n", { mode: 0o600 });
+    return;
+  }
+  await generate(command, args[0]);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main();

--- a/apps/genbi/scripts/managed-wren-release.py
+++ b/apps/genbi/scripts/managed-wren-release.py
@@ -1,0 +1,94 @@
+"""Build managed-runtime review metadata; this script never approves or publishes."""
+
+import argparse
+import email.parser
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import urllib.request
+import zipfile
+
+
+def wheel_inventory(release):
+    rows = []
+    for wheel in sorted((release / "wheels").glob("*.whl")):
+        with zipfile.ZipFile(wheel) as archive:
+            entries = [n for n in archive.namelist() if n.endswith(".dist-info/METADATA")]
+            if len(entries) != 1:
+                raise SystemExit("wheel must have exactly one METADATA entry")
+            meta = email.parser.BytesParser().parsebytes(archive.read(entries[0]))
+        if len(meta.get_all("Name", [])) != 1 or len(meta.get_all("Version", [])) != 1:
+            raise SystemExit("wheel must declare one Name and Version")
+        expressions = meta.get_all("License-Expression", [])
+        if len(expressions) > 1:
+            raise SystemExit("wheel has ambiguous License-Expression")
+        licenses = [v for v in meta.get_all("License", []) if v.strip() and v.strip() != "UNKNOWN"]
+        classifiers = [v for v in meta.get_all("Classifier", []) if v.startswith("License ::")]
+        license_value = "; ".join(expressions or licenses or classifiers) or "UNKNOWN"
+        sha256 = hashlib.sha256(wheel.read_bytes()).hexdigest()
+        with urllib.request.urlopen(
+            "https://pypi.org/pypi/{}/{}/json".format(meta["Name"], meta["Version"]),
+            timeout=30,
+        ) as response:
+            source_release = json.load(response)
+        source = next(
+            (item["url"] for item in source_release["urls"]
+             if item["filename"] == wheel.name and item["digests"]["sha256"] == sha256),
+            None,
+        )
+        if not source:
+            raise SystemExit("could not establish exact source identity for " + wheel.name)
+        rows.append({
+            "filename": wheel.name,
+            "sha256": sha256,
+            "distribution": meta["Name"].lower().replace("-", "_"),
+            "version": meta["Version"],
+            "license": license_value,
+            "sourceUrl": source,
+        })
+    (release / "wheel-inputs.json").write_text(json.dumps(rows))
+    (release / "wheel-license-inventory.json").write_text(
+        json.dumps({"schema": 1, "wheels": rows}, indent=2)
+    )
+
+
+def pbs_inventory(paths, archive_sha256):
+    evidence = [
+        p.strip() for p in paths
+        if any(marker in p.upper() for marker in ("LICENSE", "COPYING", "NOTICE"))
+    ]
+    return {
+        "schema": 1,
+        "archiveSha256": archive_sha256,
+        "bundledLicenseEvidence": [
+            {"path": p, "declaredLicense": "REVIEW_REQUIRED"} for p in evidence
+        ],
+    }
+
+
+def requirements(release):
+    rows = json.loads((release / "wheel-inputs.json").read_text())
+    (release / "requirements.txt").write_text("".join(
+        "{}=={} --hash=sha256:{}\n".format(row["distribution"], row["version"], row["sha256"])
+        for row in rows
+    ))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("wheels", "pbs", "requirements"))
+    parser.add_argument("--release-dir", type=Path, default=Path("release"))
+    args = parser.parse_args()
+    if args.command == "wheels":
+        wheel_inventory(args.release_dir)
+    elif args.command == "pbs":
+        # stdin is the verified archive's tar listing, not extracted file contents.
+        print(json.dumps(pbs_inventory(sys.stdin, os.environ["PYTHON_SHA256"]), indent=2))
+    else:
+        requirements(args.release_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/genbi/scripts/managed-wren-release.test.mjs
+++ b/apps/genbi/scripts/managed-wren-release.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -118,7 +118,6 @@ test("workflow is manual-only, data-binds user input and exposes no raw pre-appr
 
 test("actual workflow approval commands reject missing or stale approval and bind all three review files", async (t) => {
   const root = await temp(t);
-  const { mkdir } = await import("node:fs/promises");
   await mkdir(path.join(root, "release"));
   const names = ["managed-wren-manifest.candidate.json", "pbs-license-inventory.json", "wheel-license-inventory.json"];
   const bytes = names.map((name) => JSON.stringify({ fixture: name }) + "\n");
@@ -137,4 +136,64 @@ test("actual workflow approval commands reject missing or stale approval and bin
     assert.notEqual(run(approval).status, 0);
     await writeFile(path.join(root, "release", names[i]), bytes[i]);
   }
+});
+
+test("actual staging commands derive source identities from the exact input file", async (t) => {
+  const root = await temp(t);
+  const inputDir = path.join(root, "apps/genbi/managed-wren");
+  await mkdir(inputDir, { recursive: true });
+  const changed = { python: { url: "https://example.invalid/changed.tar.gz", sha256: "e".repeat(64) }, wrenai: { version: "99.1.2" } };
+  await writeFile(path.join(inputDir, "release-inputs.json"), JSON.stringify(changed));
+  const workflow = await readFile(path.join(repo, ".github/workflows/managed-wren-runtime.yml"), "utf8");
+  const prelude = workflow.slice(workflow.indexOf("          set -euo pipefail"), workflow.indexOf("          mkdir -p release/wheels"));
+  assert.ok(prelude.includes("release-inputs.json"));
+  const output = execFileSync("/bin/bash", ["-c", prelude + '\nnode -e \'console.log(JSON.stringify(process.argv.slice(1)))\' "$PYTHON_URL" "$PYTHON_SHA256" "$WRENAI_VERSION"'], { cwd: root, encoding: "utf8" });
+  assert.deepEqual(JSON.parse(output), [changed.python.url, changed.python.sha256, changed.wrenai.version]);
+  assert.match(workflow, /--dest release\/wheels "wrenai==\$WRENAI_VERSION"/);
+  assert.match(workflow, /-o release\/python.tar.gz "\$PYTHON_URL"/);
+  assert.match(workflow, /= "\$PYTHON_SHA256"/);
+  assert.match(workflow, /'archiveSha256':os.environ\['PYTHON_SHA256'\]/);
+  assert.doesNotMatch(workflow, /50424fa4|wrenai==0\.13\.0|releases\/download\/20260901/);
+});
+
+test("actual wheel inventory parser respects header boundaries and modern, folded and repeated license fields", async (t) => {
+  const root = await temp(t);
+  const workflow = await readFile(path.join(repo, ".github/workflows/managed-wren-runtime.yml"), "utf8");
+  const snippet = workflow.match(/          python - <<'PY'\n([\s\S]*?)          PY/)[1].split("\n").map((line) => line.slice(10)).join("\n");
+  const bootstrap = `
+import hashlib, io, json, pathlib, urllib.request, zipfile
+root = pathlib.Path('release/wheels')
+root.mkdir(parents=True)
+headers = {
+  'modern': 'License-Expression: MIT OR Apache-2.0\\nLicense: ignored',
+  'folded': 'License: first line\\n  second line',
+  'classified': 'License: UNKNOWN\\nClassifier: Topic :: Database\\nClassifier: License :: OSI Approved :: MIT License\\nClassifier: License :: OSI Approved :: BSD License',
+  'repeated': 'License: first\\nLicense: second',
+  'unknown': '',
+}
+responses = {}
+for name, license_headers in headers.items():
+    filename = name + '-1.0-py3-none-any.whl'
+    target = root / filename
+    metadata = 'Metadata-Version: 2.4\\nName: ' + name + '\\nVersion: 1.0\\n' + license_headers + '\\n\\nName: spoofed\\nVersion: 9.9\\nLicense: SPOOFED\\n'
+    with zipfile.ZipFile(target, 'w') as z:
+        z.writestr(name + '-1.0.dist-info/METADATA', metadata)
+    sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    responses['https://pypi.org/pypi/' + name + '/1.0/json'] = {'urls': [{'url': 'https://files.pythonhosted.org/fixture/' + filename, 'filename': filename, 'digests': {'sha256': sha}}]}
+def fake_urlopen(url, timeout):
+    assert timeout == 30
+    assert url in responses, 'unexpected source identity: ' + url
+    return io.BytesIO(json.dumps(responses[url]).encode())
+urllib.request.urlopen = fake_urlopen
+`;
+  execFileSync("python3", ["-c", bootstrap + "\n" + snippet], { cwd: root });
+  const rows = JSON.parse(await readFile(path.join(root, "release/wheel-inputs.json"), "utf8"));
+  const licenses = Object.fromEntries(rows.map((row) => [row.distribution, row.license]));
+  assert.equal(licenses.modern, "MIT OR Apache-2.0");
+  assert.match(licenses.folded, /first line\n\s+second line/);
+  assert.equal(licenses.repeated, "first; second");
+  assert.match(licenses.classified, /MIT License; License :: OSI Approved :: BSD License/);
+  assert.equal(licenses.unknown, "UNKNOWN");
+  assert.equal(rows.length, 5);
+  assert.ok(rows.every((row) => row.version === "1.0" && !row.license.includes("SPOOFED")));
 });

--- a/apps/genbi/scripts/managed-wren-release.test.mjs
+++ b/apps/genbi/scripts/managed-wren-release.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { approvedManifest, refetchExactPublishAssets, validateRuntimeTag, verifyExactPublishInventory } from "./managed-wren-release.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(here, "../../..");
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+const python = "cpython-3.11.16+fixture-aarch64-apple-darwin-install_only.tar.gz";
+const wheel = "wrenai-0.13.0-py3-none-any.whl";
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+function fixture() {
+  const source = "https://files.pythonhosted.org/packages/fixture/";
+  const mirror = "https://github.com/Canner/WrenAI/releases/download/managed-wren-fixture/";
+  const sources = new Map([[source + python, "python fixture"], [source + wheel, "wheel fixture"]]);
+  const wheels = [{ distribution: "wrenai", version: "0.13.0", filename: wheel, sourceUrl: source + wheel, sha256: hash("wheel fixture"), url: mirror + wheel }];
+  return {
+    candidate: { activation: "staged", platform: "darwin-arm64", compatibility: { wren: "0.13.0" }, python: { upstream: { url: source + python, sha256: hash("python fixture") }, mirror: { url: mirror + python, sha256: hash("python fixture") } }, wheels },
+    inputs: wheels.map(({ url, ...input }) => ({ ...input, license: "Apache-2.0" })),
+    sources,
+  };
+}
+async function temp(t) {
+  const root = await mkdtemp(path.join(tmpdir(), "managed-wren-contract-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+test("exact inventory refetches only approved fixture bytes; approval does not mutate the candidate", async (t) => {
+  const { candidate, inputs, sources } = fixture();
+  const root = await temp(t);
+  const fetched = [];
+  await refetchExactPublishAssets(candidate, inputs, root, async (url) => {
+    fetched.push(url);
+    assert.ok(sources.has(url));
+    return new Response(sources.get(url));
+  });
+  assert.deepEqual(fetched, [...sources.keys()]);
+  assert.equal(await readFile(path.join(root, wheel), "utf8"), "wheel fixture");
+  assert.equal(approvedManifest(candidate).activation, "approved");
+  assert.equal(candidate.activation, "staged");
+});
+
+test("rejects changed hashes, incomplete/extra/duplicate inventories and altered source/mirror identity", () => {
+  const value = fixture();
+  for (const mutate of [
+    (c) => { c.wheels[0].sha256 = "f".repeat(64); },
+    (c, i) => { i.length = 0; },
+    (c, i) => { i.push({ ...i[0], filename: "extra-1.0.whl" }); },
+    (c, i) => { c.wheels.push(clone(c.wheels[0])); i.push(clone(i[0])); },
+    (c) => { c.wheels[0].sourceUrl += "?changed"; },
+    (c) => { c.wheels[0].url = c.wheels[0].url.replace("managed-wren-fixture", "other"); },
+    (c) => { c.python.upstream.sha256 = "f".repeat(64); },
+    (c) => { c.python.mirror.url += ".other"; },
+    (c) => { c.activation = "approved"; },
+    (c) => { c.platform = "linux-x64"; },
+  ]) {
+    const candidate = clone(value.candidate); const inputs = clone(value.inputs);
+    mutate(candidate, inputs);
+    assert.throws(() => verifyExactPublishInventory(candidate, inputs));
+  }
+});
+
+test("invalid inventory fails before any fetch or asset-directory creation", async (t) => {
+  const { candidate, inputs } = fixture();
+  const root = await temp(t); const assets = path.join(root, "assets");
+  inputs[0].sha256 = "e".repeat(64);
+  await assert.rejects(refetchExactPublishAssets(candidate, inputs, assets, () => assert.fail("must not fetch")));
+  assert.deepEqual(await readdir(root), []);
+});
+
+test("changed source bytes or failed HTTP cannot produce an approved asset", async (t) => {
+  const { candidate, inputs } = fixture();
+  const root = await temp(t);
+  for (const [name, response] of [["corrupt", new Response("corrupt")], ["missing", new Response("", { status: 404 })]]) {
+    const assets = path.join(root, name);
+    await assert.rejects(refetchExactPublishAssets(candidate, inputs, assets, async () => response));
+    assert.deepEqual(await readdir(assets), []);
+  }
+});
+
+test("release tags are namespace-bound and cannot inject shell syntax, options or invalid git refs", () => {
+  assert.equal(validateRuntimeTag("managed-wren-v0.0.4"), "managed-wren-v0.0.4");
+  for (const tag of ["", "v0.0.4", "--help", "managed-wren-", "managed-wren-a..b", "managed-wren-a.lock", "managed-wren-a.", "managed-wren-a/b", 'managed-wren-"; exit 0; #', "managed-wren-$(touch bad)", "managed-wren-a\nb", "managed-wren-" + "a".repeat(102)]) {
+    assert.throws(() => validateRuntimeTag(tag));
+    assert.notEqual(spawnSync(process.execPath, [path.join(here, "managed-wren-release.mjs"), "validate-tag", tag]).status, 0);
+  }
+  execFileSync(process.execPath, [path.join(here, "managed-wren-release.mjs"), "validate-tag", "managed-wren-v0.0.4"]);
+});
+
+test("workflow is manual-only, data-binds user input and exposes no raw pre-approval assets", async () => {
+  const workflow = await readFile(path.join(repo, ".github/workflows/managed-wren-runtime.yml"), "utf8");
+  assert.match(workflow, /on:\n  workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /(?:pull_request|push):/);
+  assert.match(workflow, /group: managed-wren-\$\{\{ inputs.runtime_tag \}\}/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  for (const line of workflow.split("\n").filter((line) => line.includes("${{ inputs.runtime_tag }}"))) {
+    assert.match(line.trim(), /^(RUNTIME_TAG:|group:)/);
+  }
+  const [stage, publish] = workflow.split("  publish-approved-runtime:");
+  assert.match(stage, /permissions:\n  contents: read/);
+  assert.match(stage, /path: release\/\*\.json/);
+  assert.doesNotMatch(stage, /GH_TOKEN|contents: write|gh release/);
+  assert.ok(stage.indexOf('validate-tag "$RUNTIME_TAG"') < stage.indexOf("pip download"));
+  assert.match(publish, /needs: stage/);
+  assert.match(publish, /environment: managed-wren-license-approved/);
+  assert.match(publish, /secrets.MANAGED_WREN_APPROVAL_SHA256/);
+  assert.match(publish, /gh release create "\$RUNTIME_TAG" --target "\$GITHUB_SHA" --latest=false/);
+  assert.ok(publish.indexOf('test -n "$APPROVAL_DIGEST"') < publish.indexOf("verify-publish"));
+  assert.ok(publish.indexOf("verify-publish") < publish.indexOf("GH_TOKEN:"));
+});
+
+test("actual workflow approval commands reject missing or stale approval and bind all three review files", async (t) => {
+  const root = await temp(t);
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(path.join(root, "release"));
+  const names = ["managed-wren-manifest.candidate.json", "pbs-license-inventory.json", "wheel-license-inventory.json"];
+  const bytes = names.map((name) => JSON.stringify({ fixture: name }) + "\n");
+  for (let i = 0; i < names.length; i++) await writeFile(path.join(root, "release", names[i]), bytes[i]);
+  const workflow = await readFile(path.join(repo, ".github/workflows/managed-wren-runtime.yml"), "utf8");
+  const lines = workflow.split("\n").filter((line) => line.trimStart().startsWith('test ') && line.includes("$APPROVAL_DIGEST"));
+  assert.equal(lines.length, 2);
+  const command = "set -e\n" + lines.map((line) => line.trim()).join("\n");
+  const run = (approval) => spawnSync("/bin/sh", ["-c", command], { cwd: root, env: { PATH: process.env.PATH, APPROVAL_DIGEST: approval } });
+  assert.notEqual(run("").status, 0);
+  assert.notEqual(run("f".repeat(64)).status, 0);
+  const approval = hash(bytes.join(""));
+  assert.equal(run(approval).status, 0);
+  for (let i = 0; i < names.length; i++) {
+    await writeFile(path.join(root, "release", names[i]), "changed");
+    assert.notEqual(run(approval).status, 0);
+    await writeFile(path.join(root, "release", names[i]), bytes[i]);
+  }
+});

--- a/apps/genbi/scripts/managed-wren-release.test.mjs
+++ b/apps/genbi/scripts/managed-wren-release.test.mjs
@@ -152,48 +152,14 @@ test("actual staging commands derive source identities from the exact input file
   assert.match(workflow, /--dest release\/wheels "wrenai==\$WRENAI_VERSION"/);
   assert.match(workflow, /-o release\/python.tar.gz "\$PYTHON_URL"/);
   assert.match(workflow, /= "\$PYTHON_SHA256"/);
-  assert.match(workflow, /'archiveSha256':os.environ\['PYTHON_SHA256'\]/);
+  assert.match(workflow, /export PYTHON_SHA256/);
+  for (const command of ["wheels", "pbs", "requirements"]) {
+    assert.ok(workflow.includes(`python apps/genbi/scripts/managed-wren-release.py ${command}`));
+  }
+  assert.doesNotMatch(workflow, /python(?:3)?\s+(?:-c\b|-\s*<<)/);
   assert.doesNotMatch(workflow, /50424fa4|wrenai==0\.13\.0|releases\/download\/20260901/);
 });
 
-test("actual wheel inventory parser respects header boundaries and modern, folded and repeated license fields", async (t) => {
-  const root = await temp(t);
-  const workflow = await readFile(path.join(repo, ".github/workflows/managed-wren-runtime.yml"), "utf8");
-  const snippet = workflow.match(/          python - <<'PY'\n([\s\S]*?)          PY/)[1].split("\n").map((line) => line.slice(10)).join("\n");
-  const bootstrap = `
-import hashlib, io, json, pathlib, urllib.request, zipfile
-root = pathlib.Path('release/wheels')
-root.mkdir(parents=True)
-headers = {
-  'modern': 'License-Expression: MIT OR Apache-2.0\\nLicense: ignored',
-  'folded': 'License: first line\\n  second line',
-  'classified': 'License: UNKNOWN\\nClassifier: Topic :: Database\\nClassifier: License :: OSI Approved :: MIT License\\nClassifier: License :: OSI Approved :: BSD License',
-  'repeated': 'License: first\\nLicense: second',
-  'unknown': '',
-}
-responses = {}
-for name, license_headers in headers.items():
-    filename = name + '-1.0-py3-none-any.whl'
-    target = root / filename
-    metadata = 'Metadata-Version: 2.4\\nName: ' + name + '\\nVersion: 1.0\\n' + license_headers + '\\n\\nName: spoofed\\nVersion: 9.9\\nLicense: SPOOFED\\n'
-    with zipfile.ZipFile(target, 'w') as z:
-        z.writestr(name + '-1.0.dist-info/METADATA', metadata)
-    sha = hashlib.sha256(target.read_bytes()).hexdigest()
-    responses['https://pypi.org/pypi/' + name + '/1.0/json'] = {'urls': [{'url': 'https://files.pythonhosted.org/fixture/' + filename, 'filename': filename, 'digests': {'sha256': sha}}]}
-def fake_urlopen(url, timeout):
-    assert timeout == 30
-    assert url in responses, 'unexpected source identity: ' + url
-    return io.BytesIO(json.dumps(responses[url]).encode())
-urllib.request.urlopen = fake_urlopen
-`;
-  execFileSync("python3", ["-c", bootstrap + "\n" + snippet], { cwd: root });
-  const rows = JSON.parse(await readFile(path.join(root, "release/wheel-inputs.json"), "utf8"));
-  const licenses = Object.fromEntries(rows.map((row) => [row.distribution, row.license]));
-  assert.equal(licenses.modern, "MIT OR Apache-2.0");
-  assert.match(licenses.folded, /first line\n\s+second line/);
-  assert.equal(licenses.repeated, "first; second");
-  assert.match(licenses.classified, /MIT License; License :: OSI Approved :: BSD License/);
-  assert.equal(licenses.unknown, "UNKNOWN");
-  assert.equal(rows.length, 5);
-  assert.ok(rows.every((row) => row.version === "1.0" && !row.license.includes("SPOOFED")));
+test("standalone Python metadata helper passes its offline contracts", () => {
+  execFileSync("python3", ["-B", path.join(here, "managed-wren-release.test.py")], { stdio: "pipe" });
 });

--- a/apps/genbi/scripts/managed-wren-release.test.py
+++ b/apps/genbi/scripts/managed-wren-release.test.py
@@ -1,0 +1,151 @@
+"""Offline contracts for the actual metadata script used by the release workflow."""
+
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import runpy
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+
+SCRIPT = Path(__file__).with_name("managed-wren-release.py")
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.release = Path(self.temporary.name)
+        (self.release / "wheels").mkdir()
+        self.responses = {}
+
+    def wheel(self, name, license_headers="", extra_headers="", extra_metadata=False):
+        filename = name + "-1.0-py3-none-any.whl"
+        target = self.release / "wheels" / filename
+        metadata = (
+            "Metadata-Version: 2.4\nName: " + name + "\nVersion: 1.0\n"
+            + extra_headers + license_headers
+            + "\n\nName: spoofed\nVersion: 9.9\nLicense: SPOOFED\n"
+        )
+        with zipfile.ZipFile(target, "w") as archive:
+            archive.writestr(name + "-1.0.dist-info/METADATA", metadata)
+            if extra_metadata:
+                archive.writestr("extra-1.0.dist-info/METADATA", metadata)
+        sha = hashlib.sha256(target.read_bytes()).hexdigest()
+        url = "https://pypi.org/pypi/" + name + "/1.0/json"
+        self.responses[url] = {"urls": [{
+            "url": "https://files.pythonhosted.org/fixture/" + filename,
+            "filename": filename, "digests": {"sha256": sha},
+        }]}
+
+    def fake_urlopen(self, url, timeout):
+        self.assertEqual(timeout, 30)
+        self.assertIn(url, self.responses, "unexpected source identity")
+        return io.BytesIO(json.dumps(self.responses[url]).encode())
+
+    def inventory(self):
+        with patch("urllib.request.urlopen", side_effect=self.fake_urlopen), patch.object(
+            sys, "argv", [str(SCRIPT), "wheels", "--release-dir", str(self.release)]
+        ):
+            runpy.run_path(str(SCRIPT), run_name="__main__")
+
+    def cli(self, command, **kwargs):
+        return subprocess.run(
+            [sys.executable, "-B", str(SCRIPT), command, "--release-dir", str(self.release)],
+            capture_output=True, text=True, **kwargs,
+        )
+
+    def test_header_boundaries_and_license_variants(self):
+        headers = {
+            "modern": "License-Expression: MIT OR Apache-2.0\nLicense: ignored",
+            "folded": "License: first line\n  second line",
+            "classified": "License: UNKNOWN\nClassifier: Topic :: Database\n"
+                          "Classifier: License :: OSI Approved :: MIT License\n"
+                          "Classifier: License :: OSI Approved :: BSD License",
+            "repeated": "License: first\nLicense: second",
+            "unknown": "",
+        }
+        for name, value in headers.items():
+            self.wheel(name, value)
+        self.inventory()
+        rows = json.loads((self.release / "wheel-inputs.json").read_text())
+        licenses = {row["distribution"]: row["license"] for row in rows}
+        self.assertEqual(licenses["modern"], "MIT OR Apache-2.0")
+        self.assertRegex(licenses["folded"], r"first line\n\s+second line")
+        self.assertEqual(licenses["repeated"], "first; second")
+        self.assertEqual(licenses["classified"],
+                         "License :: OSI Approved :: MIT License; License :: OSI Approved :: BSD License")
+        self.assertEqual(licenses["unknown"], "UNKNOWN")
+        self.assertEqual(len(rows), 5)
+        self.assertTrue(all(row["version"] == "1.0" and "SPOOFED" not in row["license"] for row in rows))
+        self.assertEqual(json.loads((self.release / "wheel-license-inventory.json").read_text()),
+                         {"schema": 1, "wheels": rows})
+        for row in rows:
+            self.assertEqual(row["sha256"], hashlib.sha256(
+                (self.release / "wheels" / row["filename"]).read_bytes()).hexdigest())
+            self.assertEqual(row["sourceUrl"], "https://files.pythonhosted.org/fixture/" + row["filename"])
+
+    def test_ambiguous_metadata_is_rejected_before_network(self):
+        for extra_headers, license_headers, extra_metadata in [
+            ("Name: duplicate\n", "", False),
+            ("Version: 2.0\n", "", False),
+            ("", "License-Expression: MIT\nLicense-Expression: BSD", False),
+            ("", "", True),
+        ]:
+            with self.subTest(headers=(extra_headers, license_headers), extra_metadata=extra_metadata):
+                self.wheel("sample", license_headers, extra_headers, extra_metadata)
+                with patch("urllib.request.urlopen", side_effect=AssertionError("must not fetch")), patch.object(
+                    sys, "argv", [str(SCRIPT), "wheels", "--release-dir", str(self.release)]
+                ), self.assertRaises(SystemExit):
+                    runpy.run_path(str(SCRIPT), run_name="__main__")
+                self.assertFalse((self.release / "wheel-inputs.json").exists())
+
+    def test_source_mismatch_cannot_emit_inventory(self):
+        for field in ("filename", "sha256"):
+            with self.subTest(field=field):
+                self.wheel("sample")
+                item = next(iter(self.responses.values()))["urls"][0]
+                if field == "sha256":
+                    item["digests"][field] = "f" * 64
+                else:
+                    item[field] = "different.whl"
+                with self.assertRaisesRegex(SystemExit, "exact source identity"):
+                    self.inventory()
+                self.assertFalse((self.release / "wheel-inputs.json").exists())
+
+    def test_pbs_cli_keeps_digest_and_marks_all_evidence_for_review(self):
+        paths = "python/LICENSE\npython/lib/COPYING\npython/share/notice.txt\npython/bin/python\n"
+        result = self.cli("pbs", input=paths, env={**os.environ, "PYTHON_SHA256": "e" * 64})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), {
+            "schema": 1, "archiveSha256": "e" * 64,
+            "bundledLicenseEvidence": [
+                {"path": p, "declaredLicense": "REVIEW_REQUIRED"}
+                for p in paths.splitlines()[:3]
+            ],
+        })
+        missing = self.cli("pbs", input=paths, env={k: v for k, v in os.environ.items() if k != "PYTHON_SHA256"})
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertEqual(missing.stdout, "")
+
+    def test_requirements_cli_preserves_exact_pins_and_hashes(self):
+        rows = [
+            {"distribution": "wrenai", "version": "0.13.0", "sha256": "a" * 64},
+            {"distribution": "other_pkg", "version": "1.2.3", "sha256": "b" * 64},
+        ]
+        (self.release / "wheel-inputs.json").write_text(json.dumps(rows))
+        result = self.cli("requirements")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.release / "requirements.txt").read_text(),
+                         "wrenai==0.13.0 --hash=sha256:" + "a" * 64 + "\n"
+                         + "other_pkg==1.2.3 --hash=sha256:" + "b" * 64 + "\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add the standalone, manually dispatched managed-Wren release workflow to the default branch so GitHub can register its dispatch entry point. This is a narrow release-engineering prerequisite, not a GenBI application rollout.

- Stage a darwin-arm64 runtime using exact CPython 3.11.16 (python-build-standalone 20260901) and wrenai 0.13.0 inputs. Resolve the complete wheel closure during staging, then record exact source URLs, versions and SHA-256 values.
- Upload review metadata only before approval. Runtime archives and wheel bytes are not included in pre-approval Actions artifacts.
- Require the protected environment `managed-wren-license-approved` and `MANAGED_WREN_APPROVAL_SHA256`, bound to the candidate manifest plus both license inventories, before publication. Missing or stale approval fails closed.
- Re-fetch only the approved exact sources and verify their hashes before publishing. Validate the release-tag namespace, pass workflow input as environment data, serialize matching release tags, and target the workflow commit without marking the runtime release as the repository's latest release.
- Add dependency-free, no-network release contract tests and path-filtered CI.

## Scope and remaining gates

Only the workflow, its standalone helper, exact source inputs and contract checks are included. No application backend, runtime provisioner, production certification row or activation manifest is added.

This PR does not approve redistribution licenses, run the staging workflow, publish release assets, execute a model turn, or activate a runtime. Maintainers must review the complete bundled-library and wheel license evidence and configure the protected environment before publication. The initial license metadata is review input, not legal approval. An approved manifest must still be hash-anchored by a later consumer package.

## Validation

- `node --check apps/genbi/scripts/managed-wren-release.mjs`
- `node --test apps/genbi/scripts/managed-wren-release.test.mjs` — 9 tests passed; includes executing the actual workflow approval checks against missing, stale and changed-inventory fixtures.
- `actionlint .github/workflows/managed-wren-runtime.yml .github/workflows/managed-wren-release-ci.yml`
- Regression fixtures execute the actual workflow input-selection and wheel-inventory code; changed source pins are honored, README body text cannot override headers, and modern/folded/repeated license fields are preserved.
- Diff whitespace and public-artifact hygiene checks passed.

Full release staging and real runtime acceptance are intentionally not claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a managed Wren runtime release process for staging, verifying, and publishing approved runtime packages.
  * Added Darwin ARM64 release configuration with pinned Python and WrenAI versions.
  * Added release evidence, provenance, license, and integrity verification artifacts.

* **Tests**
  * Added automated checks for release configuration usage, package metadata, and license validation.
  * Added contract checks for release workflows, approval controls, and publishing boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->